### PR TITLE
refactor schema tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include include *

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -52,6 +52,9 @@ def exception_handler(connection, cursor, model_name, query):
                 RELATION_PERMISSION_DENIED_MESSAGE.format(**error_data))
         else:
             raise e
+    except psycopg2.DataError as e:
+        raise RuntimeError("Data Error: {} while building {}.{}".format(
+            str(e), schema, model_name))
     except Exception as e:
         handle.rollback()
         logger.debug("Error running SQL: %s", query)

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -476,7 +476,10 @@ class Compiler(object):
         models_and_schemas.update(schemas_map)
 
         written_tests = []
-        for schema_test in schemas_map.keys():
+        for schema_test, raw_query in schemas_map.items():
+
+            if raw_query is None:
+                continue
 
             query = self.add_cte_to_rendered_query(
                 linker, schema_test, models_and_schemas

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -1,0 +1,35 @@
+
+import os
+
+GLOBAL_PROJECT_DIRNAME = 'global_project'
+
+
+def get_dbt_root_path():
+    "return the root path of the dbt module"
+
+    try:
+        here = __file__
+
+        if os.path.islink(here):
+            here = os.path.realpath(here)
+
+        path = os.path.dirname(os.path.abspath(here))
+        dbt_root_path = os.path.normpath(os.path.join(path, '..'))
+
+    except Exception as e:
+        raise RuntimeError("Couldn't determine include path")
+
+    return dbt_root_path
+
+
+def get_include_path():
+    "return the static include path for the dbt module"
+
+    root_path = get_dbt_root_path()
+    return os.path.join(root_path, "include")
+
+
+def get_global_project_path():
+    "get the path to the actual global project"
+    include_path = get_include_path()
+    return os.path.join(include_path, GLOBAL_PROJECT_DIRNAME)

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -623,7 +623,14 @@ class SchemaTest(DBTSource):
 
     def render(self):
         provided_args = self.get_args_for_macro()
-        return self.macro(**provided_args)
+        try:
+            return self.macro(**provided_args)
+        except TypeError as e:
+            import ipdb; ipdb.set_trace()
+            compiler_warning(self,
+                             'invalid arguments provided to {}'.format(
+                                 self.macro_name))
+            return None
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -649,6 +656,12 @@ class SchemaFile(DBTSource):
                     compiler_error(
                         self,
                         "no constraints given to test: '{}.{}'"
+                        .format(model_name, constraint_type)
+                    )
+                if not isinstance(constraint_data, list):
+                    compiler_error(
+                        self,
+                        "constraints given to test are not a list: '{}.{}'"
                         .format(model_name, constraint_type)
                     )
                 for params in constraint_data:

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -1,7 +1,7 @@
 import os.path
 import yaml
 import jinja2
-import six 
+import six
 import re
 
 import dbt.schema_tester
@@ -623,14 +623,7 @@ class SchemaTest(DBTSource):
 
     def render(self):
         provided_args = self.get_args_for_macro()
-        try:
-            return self.macro(**provided_args)
-        except TypeError as e:
-            import ipdb; ipdb.set_trace()
-            compiler_warning(self,
-                             'invalid arguments provided to {}'.format(
-                                 self.macro_name))
-            return None
+        return self.macro(**provided_args)
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -596,7 +596,7 @@ class SchemaTest(DBTSource):
         key = re.sub('[^0-9a-zA-Z]+', '_', self.unique_option_key())
         test_name = self.get_test_name()
 
-        filename = "{model_name}_{test_name}_{key}".format(
+        filename = "{test_name}_{model_name}_{key}".format(
             model_name=self.model_name,
             test_name=test_name,
             key=key

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -605,11 +605,6 @@ class RunManager(object):
             data = graph.node[node]
             if data.get('dbt_run_type') == model_type:
                 model_nodes.append(node)
-            else:
-                if 'dbt_run_type' not in data:
-                    import ipdb; ipdb.set_trace()
-
-                pass
 
         model_only_graph = graph.subgraph(model_nodes)
         selected_nodes = dbt.graph.selector.select_nodes(self.project,

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -600,10 +600,16 @@ class RunManager(object):
         if exclude_spec is None:
             exclude_spec = []
 
-        model_nodes = [
-            n for n in graph.nodes()
-            if graph.node[n]['dbt_run_type'] == model_type
-        ]
+        model_nodes = []
+        for node in graph.nodes():
+            data = graph.node[node]
+            if data.get('dbt_run_type') == model_type:
+                model_nodes.append(node)
+            else:
+                if 'dbt_run_type' not in data:
+                    import ipdb; ipdb.set_trace()
+
+                pass
 
         model_only_graph = graph.subgraph(model_nodes)
         selected_nodes = dbt.graph.selector.select_nodes(self.project,

--- a/dbt/schema_tester.py
+++ b/dbt/schema_tester.py
@@ -69,8 +69,6 @@ class SchemaTester(object):
     def __init__(self, project):
         self.project = project
 
-        self.test_started_at = datetime.datetime.now()
-
     def get_target(self):
         target_cfg = self.project.run_environment()
         return dbt.targets.get_target(target_cfg)
@@ -106,13 +104,3 @@ class SchemaTester(object):
                         "got {}".format(len(result)))
                 else:
                     return result[0]
-
-    def validate_schema(self, schema_test):
-            sql = schema_test.render()
-            num_rows = self.execute_query(model, sql)
-            if num_rows == 0:
-                logger.info("  OK")
-                yield True
-            else:
-                logger.info("  FAILED ({})".format(num_rows))
-                yield False

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 
 import dbt.project
+import dbt.loader
 from dbt.logger import GLOBAL_LOGGER as logger
 
 DBTConfigKeys = [
@@ -125,21 +126,31 @@ def find_model_by_fqn(models, fqn):
     )
 
 
-def dependency_projects(project):
-    for obj in os.listdir(project['modules-path']):
-        full_obj = os.path.join(project['modules-path'], obj)
-        if os.path.isdir(full_obj):
-            try:
-                yield dbt.project.read_project(
-                    os.path.join(full_obj, 'dbt_project.yml'),
-                    project.profiles_dir,
-                    profile_to_load=project.profile_to_load,
-                    args=project.args)
-            except dbt.project.DbtProjectError as e:
-                logger.info(
-                    "Error reading dependency project at {}".format(full_obj)
-                )
-                logger.info(str(e))
+def dependency_projects(project, include_global=True):
+    if include_global:
+        module_paths = [
+            dbt.loader.get_include_path(),
+            project['modules-path']
+        ]
+    else:
+        module_paths = [project['modules-path']]
+
+    for module_path in module_paths:
+        for obj in os.listdir(module_path):
+            full_obj = os.path.join(module_path, obj)
+            if os.path.isdir(full_obj):
+                try:
+                    yield dbt.project.read_project(
+                        os.path.join(full_obj, 'dbt_project.yml'),
+                        project.profiles_dir,
+                        profile_to_load=project.profile_to_load,
+                        args=project.args)
+                except dbt.project.DbtProjectError as e:
+                    logger.info(
+                        "Error reading dependency project at {}".format(
+                            full_obj)
+                    )
+                    logger.info(str(e))
 
 
 def split_path(path):

--- a/include/global_project/dbt_project.yml
+++ b/include/global_project/dbt_project.yml
@@ -1,0 +1,6 @@
+
+
+name: dbt
+version: 1.0
+
+macro-paths: ["macros"]

--- a/include/global_project/macros/schema_tests.sql
+++ b/include/global_project/macros/schema_tests.sql
@@ -1,0 +1,103 @@
+
+{% macro test_not_null(model, arg) %}
+
+with validation as (
+
+    select
+        {{ arg }} as not_null_field
+
+    from {{ ref(model) }}
+
+)
+
+select count(*)
+from validation
+where not_null_field is null
+
+{% endmacro %}
+
+{% macro test_unique(model, arg) %}
+
+with validation as (
+
+    select
+        {{ arg }} as unique_field
+
+    from {{ ref(model) }}
+    where {{ arg }} is not null
+
+),
+
+validation_errors as (
+
+    select
+        unique_field
+
+    from validation
+    group by unique_field
+    having count(*) > 1
+
+)
+
+select count(*)
+from validation_errors
+
+{% endmacro %}
+
+{% macro test_accepted_values(model, field, values) %}
+
+with all_values as (
+
+    select distinct
+        {{ field }} as value_field
+
+    from {{ ref(model) }}
+
+),
+
+validation_errors as (
+
+    select
+        value_field
+
+    from all_values
+    where value_field not in (
+        {% for value in values -%}
+
+            '{{ value }}' {% if not loop.last -%} , {%- endif %}
+
+        {%- endfor %}
+    )
+)
+
+select count(*)
+from validation_errors
+
+{% endmacro %}
+
+{% macro test_relationships(model, from, to, field) %}
+
+with parent as (
+
+    select
+        {{ field }} as id
+
+    from {{ ref(model) }}
+
+),
+
+child as (
+
+    select
+        {{ field }} as id
+
+    from {{ ref(to) }}
+
+)
+
+select count(*)
+from child
+where id is not null
+  and id not in (select id from parent)
+
+{% endmacro %}


### PR DESCRIPTION
- use "globally" scoped macros instead of hardcoded sql in python files
- supports user-defined schema tests (via macros) https://github.com/analyst-collective/dbt/issues/200
- supports tests on ephemeral models https://github.com/analyst-collective/dbt/issues/282

To create a custom schema test, create macros prefixed with `test_`. The `test_` macros *must* take `model` as the first argument. If the test takes a single argument (as with not null & unique tests), then the second argument should be called `arg`. Otherwise, the remaining arguments can be named as you like. Test configurations stated in `schema.yml` will be mapped to the macro arguments as long as the names match. For example:


```sql
-- macros/tests.sql
{% macro test_something(model, arg) %}

select *
from {{ ref(model) }}

where id = '{{ arg }}'

{% endmacro %}


{% macro test_something_complicated(model, first_argument, another_argument) %}

select *
from {{ ref(model) }}

where id = '{{ first_argument }}'
   or id = '{{ another_argument }}'

{% endmacro %}
```

```yml
some_model:
  constraints:
    my_project.test_something:
      - abc
      - def

    my_project.test_something_complicated:
      - {first_argument: abc, another_argument: def}
```

TODO:
- [x] handle errors more gracefully
- [ ] unit/integration test