### PR TITLE
support distyle all/even on redshift

### DIFF
--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -40,7 +40,7 @@ class RedshiftAdapter(PostgresAdapter):
         dist_key = dist.strip().lower()
 
         if dist_key in ['all', 'even']:
-            return 'diststyle({})'.format(dist_key)
+            return 'diststyle {}'.format(dist_key)
         else:
             return 'diststyle key distkey("{}")'.format(dist_key)
 


### PR DESCRIPTION
http://docs.aws.amazon.com/redshift/latest/dg/c_Distribution_examples.html

correct syntax is `diststyle all|even`, not `diststyle (all|even)`