### PR TITLE
use gpickle r/w in linker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Graph refactor: fix common issues with load order ([#292](https://github.com/fishtown-analytics/dbt/pull/292))
 - Speedup: detect cycles at the end of compilation ([#307](https://github.com/fishtown-analytics/dbt/pull/307))
+- Speedup: write graph file with gpickle instead of yaml ([#306](https://github.com/fishtown-analytics/dbt/pull/306))
 
 ## dbt 0.7.1 (February 28, 2017)
 

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -31,7 +31,7 @@ CompilableEntities = [
     "models", "data tests", "schema tests", "archives", "analyses"
 ]
 
-graph_file_name = 'graph.yml'
+graph_file_name = 'graph.gpickle'
 
 
 def compile_and_print_status(project, args):

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -120,7 +120,7 @@ class Linker(object):
         self.graph.add_node(node, data)
 
     def write_graph(self, outfile):
-        nx.write_yaml(self.graph, outfile)
+        nx.write_gpickle(self.graph, outfile)
 
     def read_graph(self, infile):
-        self.graph = nx.read_yaml(infile)
+        self.graph = nx.read_gpickle(infile)

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -21,7 +21,7 @@ from test.integration.base import FakeArgs
 class GraphTest(unittest.TestCase):
 
     def tearDown(self):
-        nx.write_yaml = self.real_write_yaml
+        nx.write_gpickle = self.real_write_gpickle
         dbt.utils.dependency_projects = self.real_dependency_projects
         dbt.clients.system.find_matching = self.real_find_matching
         dbt.clients.system.load_file_contents = self.real_load_file_contents
@@ -29,11 +29,11 @@ class GraphTest(unittest.TestCase):
     def setUp(self):
         dbt.flags.STRICT_MODE = True
 
-        def mock_write_yaml(graph, outfile):
+        def mock_write_gpickle(graph, outfile):
             self.graph_result = graph
 
-        self.real_write_yaml = nx.write_yaml
-        nx.write_yaml = mock_write_yaml
+        self.real_write_gpickle = nx.write_gpickle
+        nx.write_gpickle = mock_write_gpickle
 
         self.graph_result = None
 


### PR DESCRIPTION
```
(dbt-development-3.6) ✘-1 XXX [master|…1]
20:45 $ echo 'YAML TEST' && time python -m cProfile -o compile_profile.out ~/git/dbt/scripts/dbt compile --profile redshift
YAML TEST
^@Compiled 259 models, 101 tests, 0 archives, 0 analyses

real    0m20.827s
user    0m20.099s
sys     0m0.360s
(dbt-development-3.6) ✔ XXX [master|…1]
20:46 $ echo 'GPICKLE TEST' && time python -m cProfile -o compile_profile_gpickle.out ~/git/dbt/scripts/dbt compile --profile redshift
GPICKLE TEST
Compiled 259 models, 101 tests, 0 archives, 0 analyses

real    0m13.523s
user    0m12.786s
sys     0m0.293s
```

Wall time shows a 7sec speedup.

Snakeviz (YAML):

<img width="1183" alt="screen shot 2017-03-02 at 8 52 18 pm" src="https://cloud.githubusercontent.com/assets/846979/23535113/4f0f652e-ff8a-11e6-903c-0b5ad468292c.png">

Couldn't visualize it with gpickle, but it took 5.166ms to write the graph file vs 7.58s for YAML.