### PR TITLE
detect cycles at end of compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 
 - Graph refactor: fix common issues with load order ([#292](https://github.com/fishtown-analytics/dbt/pull/292))
+- Speedup: detect cycles at the end of compilation ([#307](https://github.com/fishtown-analytics/dbt/pull/307))
 
 ## dbt 0.7.1 (February 28, 2017)
 

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -464,6 +464,11 @@ class Compiler(object):
                         "dependency {} not found in graph!".format(
                             dependency))
 
+        cycle = linker.find_cycles()
+
+        if cycle:
+            raise RuntimeError("Found a cycle: {}".format(cycle))
+
         return wrapped_nodes, written_nodes
 
     def generate_macros(self, all_macros):

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -39,7 +39,6 @@ class Linker(object):
 
         return None
 
-
     def as_topological_ordering(self, limit_to=None):
         try:
             return nx.topological_sort(self.graph, nbunch=limit_to)
@@ -114,11 +113,6 @@ class Linker(object):
         self.graph.add_node(node1)
         self.graph.add_node(node2)
         self.graph.add_edge(node2, node1)
-
-        if len(list(nx.simple_cycles(self.graph))) > 0:
-            raise ValidationException(
-                "Detected a cycle when adding dependency from {} to {}"
-                .format(node1, node2))
 
     def add_node(self, node):
         self.graph.add_node(node)

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -28,6 +28,18 @@ class Linker(object):
     def get_node(self, node):
         return self.graph.node[node]
 
+    def find_cycles(self):
+        try:
+            cycles = nx.algorithms.find_cycle(self.graph)
+        except nx.exception.NetworkXNoCycle:
+            return None
+
+        if cycles:
+            return " --> ".join([".".join(node) for node in cycles])
+
+        return None
+
+
     def as_topological_ordering(self, limit_to=None):
         try:
             return nx.topological_sort(self.graph, nbunch=limit_to)

--- a/test/unit/test_linker.py
+++ b/test/unit/test_linker.py
@@ -70,3 +70,19 @@ class LinkerTest(unittest.TestCase):
             self.linker.dependency(l, r)
 
         self.assertRaises(RuntimeError, self.linker.as_dependency_list, ['ZZZ'])
+
+    def test__find_cycles__cycles(self):
+        actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'A')]
+
+        for (l, r) in actual_deps:
+            self.linker.dependency(l, r)
+
+        self.assertIsNotNone(self.linker.find_cycles())
+
+    def test__find_cycles__no_cycles(self):
+        actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'D')]
+
+        for (l, r) in actual_deps:
+            self.linker.dependency(l, r)
+
+        self.assertIsNone(self.linker.find_cycles())


### PR DESCRIPTION
Cuts 15-20% of compile time off the project I'm using to test.

Snakeviz before this change:

<img width="1176" alt="screen shot 2017-03-02 at 9 15 35 pm" src="https://cloud.githubusercontent.com/assets/846979/23535640/9c712462-ff8d-11e6-9761-e87fdacea318.png">

After:

<img width="1173" alt="screen shot 2017-03-02 at 9 17 54 pm" src="https://cloud.githubusercontent.com/assets/846979/23535654/be65aaf2-ff8d-11e6-81a9-c8a2627310f7.png">
