### PR TITLE
show output for archival jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - Fix ephemeral load order bug ([#292](https://github.com/fishtown-analytics/dbt/pull/292), [#285](https://github.com/fishtown-analytics/dbt/pull/285))
+- Support composite unique key in archivals ([#324](https://github.com/fishtown-analytics/dbt/pull/324))
 
 ### Changes
 

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -288,6 +288,8 @@ def execute_archive(profile, node, context):
         profile, node_cfg.get('source_schema'), node_cfg.get('source_table'))
 
     if len(source_columns) == 0:
+        source_schema = node_cfg.get('source_schema')
+        source_table = node_cfg.get('source_table')
         raise RuntimeError(
             'Source table "{}"."{}" does not '
             'exist'.format(source_schema, source_table))
@@ -304,8 +306,8 @@ def execute_archive(profile, node, context):
         schema=node_cfg.get('target_schema'),
         table=node_cfg.get('target_table'),
         columns=dest_columns,
-        sort=node_cfg.get('updated_at'),
-        dist=node_cfg.get('unique_key'))
+        sort='dbt_updated_at',
+        dist='scd_id')
 
     # TODO move this to inject_runtime_config, generate archive SQL
     # in wrap step. can't do this right now because we actually need

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -130,7 +130,7 @@ def print_result_line(result, schema_name, index, total):
     if node.get('resource_type') == NodeType.Model:
         print_model_result_line(result, schema_name, index, total)
     elif node.get('resource_type') == NodeType.Test:
-        (result, schema_name, index, total)
+        print_test_result_line(result, schema_name, index, total)
     elif node.get('resource_type') == NodeType.Archive:
         print_archive_result_line(result, index, total)
 

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -96,6 +96,8 @@ def print_start_line(node, schema_name, index, total):
         print_model_start_line(node, schema_name, index, total)
     if node.get('resource_type') == NodeType.Test:
         print_test_start_line(node, schema_name, index, total)
+    if node.get('resource_type') == NodeType.Archive:
+        print_archive_start_line(node, index, total)
 
 
 def print_test_start_line(model, schema_name, index, total):
@@ -114,13 +116,23 @@ def print_model_start_line(model, schema_name, index, total):
     print_fancy_output_line(msg, 'RUN', index, total)
 
 
+def print_archive_start_line(model, index, total):
+    cfg = model.get('config', {})
+    msg = "START archive {source_schema}.{source_table} --> "\
+          "{target_schema}.{target_table}".format(**cfg)
+
+    print_fancy_output_line(msg, 'RUN', index, total)
+
+
 def print_result_line(result, schema_name, index, total):
     node = result.node
 
     if node.get('resource_type') == NodeType.Model:
         print_model_result_line(result, schema_name, index, total)
     elif node.get('resource_type') == NodeType.Test:
-        print_test_result_line(result, schema_name, index, total)
+        (result, schema_name, index, total)
+    elif node.get('resource_type') == NodeType.Archive:
+        print_archive_result_line(result, index, total)
 
 
 def print_test_result_line(result, schema_name, index, total):
@@ -141,6 +153,24 @@ def print_test_result_line(result, schema_name, index, total):
             info=info,
             name=model.get('name')),
         info,
+        index,
+        total,
+        result.execution_time)
+
+
+def print_archive_result_line(result, index, total):
+    model = result.node
+    info = 'OK archived'
+
+    if result.errored:
+        info = 'ERROR archiving'
+
+    cfg = model.get('config', {})
+
+    print_fancy_output_line(
+        "{info} {source_schema}.{source_table} --> "
+        "{target_schema}.{target_table}".format(info=info, **cfg),
+        result.status,
         index,
         total,
         result.execution_time)

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -120,9 +120,9 @@ SCDArchiveTemplate = u"""
             {% for col in get_columns_in_table(source_schema, source_table) %}
                 "{{ col.name }}" {% if not loop.last %},{% endif %}
             {% endfor %},
-            "{{ updated_at }}" as "dbt_updated_at",
-            "{{ unique_key }}" as "dbt_pk",
-            "{{ updated_at }}" as "valid_from",
+            {{ updated_at }} as "dbt_updated_at",
+            {{ unique_key }} as "dbt_pk",
+            {{ updated_at }} as "valid_from",
             null::timestamp as "tmp_valid_to"
         from "{{ source_schema }}"."{{ source_table }}"
 
@@ -134,8 +134,8 @@ SCDArchiveTemplate = u"""
             {% for col in get_columns_in_table(source_schema, source_table) %}
                 "{{ col.name }}" {% if not loop.last %},{% endif %}
             {% endfor %},
-            "{{ updated_at }}" as "dbt_updated_at",
-            "{{ unique_key }}" as "dbt_pk",
+            {{ updated_at }} as "dbt_updated_at",
+            {{ unique_key }} as "dbt_pk",
             "valid_from",
             "valid_to" as "tmp_valid_to"
         from "{{ target_schema }}"."{{ target_table }}"

--- a/test/integration/004_simple_archive_test/seed.sql
+++ b/test/integration/004_simple_archive_test/seed.sql
@@ -76,5 +76,5 @@ select
     "updated_at" as valid_from,
     null::timestamp as valid_to,
     "updated_at" as dbt_updated_at,
-    md5("id" || '|' || "updated_at"::text) as scd_id
+    md5("id" || '-' || "first_name" || '|' || "updated_at"::text) as scd_id
 from "simple_archive_004"."seed";

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -26,7 +26,7 @@ class TestSimpleArchive(DBTIntegrationTest):
                             "source_table": "seed",
                             "target_table": "archive_actual",
                             "updated_at": "updated_at",
-                            "unique_key": "id"
+                            "unique_key": "id || '-' || first_name"
                         }
                     ]
                 }

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -25,8 +25,8 @@ class TestSimpleArchive(DBTIntegrationTest):
                         {
                             "source_table": "seed",
                             "target_table": "archive_actual",
-                            "updated_at": "updated_at",
-                            "unique_key": "id || '-' || first_name"
+                            "updated_at": '"updated_at"',
+                            "unique_key": '''"id" || '-' || "first_name"'''
                         }
                     ]
                 }

--- a/test/integration/004_simple_archive_test/update.sql
+++ b/test/integration/004_simple_archive_test/update.sql
@@ -26,7 +26,7 @@ select
     "updated_at" as "valid_from",
     null::timestamp as "valid_to",
     "updated_at" as "dbt_updated_at",
-    md5("id" || '|' || "updated_at"::text) as "scd_id"
+    md5("id" || '-' || "first_name" || '|' || "updated_at"::text) as "scd_id"
 from "simple_archive_004"."seed"
 where "id" >= 10 and "id" <= 20;
 
@@ -72,6 +72,6 @@ select
     "updated_at" as "valid_from",
     null::timestamp as "valid_to",
     "updated_at" as "dbt_updated_at",
-    md5("id" || '|' || "updated_at"::text) as "scd_id"
+    md5("id" || '-' || "first_name" || '|' || "updated_at"::text) as "scd_id"
 from "simple_archive_004"."seed"
 where "id" > 20;


### PR DESCRIPTION
Previously:
```
20:49:21 | Running 1 archives
20:49:21 |
20:49:21 |
20:49:21 | Finished running 1 archives in 0.31s.
```

Now:
```
20:59:06 | Running 1 archives
20:59:06 |
20:59:06 | 1 of 1 START archive simple_archive_004.seed --> public.test_archived [RUN]
20:59:06 | 1 of 1 OK archived simple_archive_004.seed --> public.test_archived.. [INSERT 0 9 in 0.06s]
20:59:07 |
20:59:07 | Finished running 1 archives in 0.31s.
```

Fixes for:
https://github.com/fishtown-analytics/dbt/issues/252
https://github.com/fishtown-analytics/dbt/issues/250