### PR TITLE
bugfix: ignore commented-out schema tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix ephemeral load order bug ([#292](https://github.com/fishtown-analytics/dbt/pull/292), [#285](https://github.com/fishtown-analytics/dbt/pull/285))
 - Fix target paths ([#331](https://github.com/fishtown-analytics/dbt/pull/331), [#329](https://github.com/fishtown-analytics/dbt/issues/329))
+- Ignore commented-out schema tests ([#330](https://github.com/fishtown-analytics/dbt/pull/330), [#328](https://github.com/fishtown-analytics/dbt/issues/328))
 
 ### Changes
 

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -256,6 +256,9 @@ def parse_schema_tests(tests, root_project, projects):
 
         for model_name, test_spec in test_yml.items():
             for test_type, configs in test_spec.get('constraints', {}).items():
+                if configs is None:
+                    continue
+
                 for config in configs:
                     to_add = parse_schema_test(
                         test, model_name, config, test_type,

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -252,9 +252,13 @@ def parse_schema_tests(tests, root_project, projects):
     for test in tests:
         test_yml = yaml.safe_load(test.get('raw_yml'))
 
-        # validate schema test yml structure
+        if test_yml is None:
+            continue
 
         for model_name, test_spec in test_yml.items():
+            if test_spec is None or test_spec.get('constraints') is None:
+                continue
+
             for test_type, configs in test_spec.get('constraints', {}).items():
                 if configs is None:
                     continue

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -937,7 +937,31 @@ model:
     constraints:
         relationships:
 #            - {from: customer_id, to: accounts, field: id}
+
+another_model:
+    constraints:
+#       unique:
+#            - id
 '''
+        }]
+
+        self.assertEquals(
+            dbt.parser.parse_schema_tests(
+                tests,
+                self.root_project_config,
+                {'root': self.root_project_config,
+                 'snowplow': self.snowplow_project_config}),
+            {})
+
+    def test__empty_schema_test(self):
+        tests = [{
+            'name': 'commented_test',
+            'resource_type': 'test',
+            'package_name': 'root',
+            'root_path': get_os_path('/usr/src/app'),
+            'path': 'commented_test.yml',
+            'raw_sql': None,
+            'raw_yml': ''
         }]
 
         self.assertEquals(

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -924,6 +924,29 @@ class ParserTest(unittest.TestCase):
             }
         )
 
+    def test__schema_test_with_comments(self):
+        tests = [{
+            'name': 'commented_test',
+            'resource_type': 'test',
+            'package_name': 'root',
+            'root_path': get_os_path('/usr/src/app'),
+            'path': 'commented_test.yml',
+            'raw_sql': None,
+            'raw_yml': '''
+model:
+    constraints:
+        relationships:
+#            - {from: customer_id, to: accounts, field: id}
+'''
+        }]
+
+        self.assertEquals(
+            dbt.parser.parse_schema_tests(
+                tests,
+                self.root_project_config,
+                {'root': self.root_project_config,
+                 'snowplow': self.snowplow_project_config}),
+            {})
 
     def test__simple_data_test(self):
         tests = [{


### PR DESCRIPTION
Fix for #328 