### PR TITLE
fix run levels for tests, models that depend on ephemeral models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support composite unique key in archivals ([#324](https://github.com/fishtown-analytics/dbt/pull/324))
 - Fix target paths ([#331](https://github.com/fishtown-analytics/dbt/pull/331), [#329](https://github.com/fishtown-analytics/dbt/issues/329))
 - Ignore commented-out schema tests ([#330](https://github.com/fishtown-analytics/dbt/pull/330), [#328](https://github.com/fishtown-analytics/dbt/issues/328))
+- Fix run levels ([#343](https://github.com/fishtown-analytics/dbt/pull/343), [#340](https://github.com/fishtown-analytics/dbt/issues/340), [#338](https://github.com/fishtown-analytics/dbt/issues/338))
 
 ### Changes
 

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -6,7 +6,8 @@ import dbt.project
 import dbt.utils
 
 from dbt.model import Model
-from dbt.utils import This, Var, is_enabled, get_materialization, NodeType
+from dbt.utils import This, Var, is_enabled, get_materialization, NodeType, \
+    is_type
 
 from dbt.linker import Linker
 from dbt.runtime import RuntimeContext
@@ -256,7 +257,7 @@ class Compiler(object):
                 logger.info("Compiler error in {}".format(model.get('path')))
                 logger.info("Enabled models:")
                 for n, m in all_models.items():
-                    if m.get('resource_type') == NodeType.Model:
+                    if is_type(m, NodeType.Model):
                         logger.info(" - {}".format(m.get('unique_id')))
                 raise e
 
@@ -382,7 +383,7 @@ class Compiler(object):
                 # data tests get wrapped in count(*)
                 # TODO : move this somewhere more reasonable
                 if 'data' in injected_node['tags'] and \
-                        injected_node.get('resource_type') == NodeType.Test:
+                        is_type(injected_node, NodeType.Test):
                     injected_node['wrapped_sql'] = (
                         "select count(*) from (\n{test_sql}\n) sbq").format(
                         test_sql=injected_node['injected_sql'])
@@ -393,7 +394,7 @@ class Compiler(object):
 
                 wrapped_graph['nodes'][name] = injected_node
 
-            elif injected_node.get('resource_type') == NodeType.Archive:
+            elif is_type(injected_node, NodeType.Archive):
                 # unfortunately we do everything automagically for
                 # archives. in the future it'd be nice to generate
                 # the SQL at the parser level.

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -1,8 +1,7 @@
 import networkx as nx
 from collections import defaultdict
 
-import dbt.compilation
-from dbt.utils import NodeType
+from dbt.utils import NodeType, is_blocking_dependency
 
 
 def from_file(graph_file):
@@ -58,16 +57,6 @@ class Linker(object):
                 "{}".format(cycle)
             )
 
-    def is_blocking_dependency(self, node_data):
-        # sorting by # ancestors works, but only if we strictly consider
-        # non-ephemeral models
-
-        if 'dbt_run_type' not in node_data or 'materialized' not in node_data:
-            return False
-
-        return node_data['dbt_run_type'] == NodeType.Model \
-            and node_data['materialized'] != 'ephemeral'
-
     def as_dependency_list(self, limit_to=None):
         """returns a list of list of nodes, eg. [[0,1], [2], [4,5,6]]. Each
         element contains nodes whose dependenices are subsumed by the union of
@@ -92,7 +81,7 @@ class Linker(object):
             num_ancestors = len([
                 ancestor for ancestor in
                 nx.ancestors(self.graph, node)
-                # if self.is_blocking_dependency(self.graph[ancestor])
+                if is_blocking_dependency(self.get_node(ancestor))
             ])
             depth_nodes[num_ancestors].append(node)
 

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -1,7 +1,7 @@
 import networkx as nx
 from collections import defaultdict
 
-from dbt.utils import NodeType, is_blocking_dependency
+import dbt.utils
 
 
 def from_file(graph_file):
@@ -81,7 +81,7 @@ class Linker(object):
             num_ancestors = len([
                 ancestor for ancestor in
                 nx.ancestors(self.graph, node)
-                if is_blocking_dependency(self.get_node(ancestor))
+                if dbt.utils.is_blocking_dependency(self.get_node(ancestor))
             ])
             depth_nodes[num_ancestors].append(node)
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -207,12 +207,21 @@ def to_string(s):
         return s
 
 
+def is_blocking_dependency(node):
+    return (is_type(node, NodeType.Model) and
+            get_materialization(node) != 'ephemeral')
+
+
 def get_materialization(node):
     return node.get('config', {}).get('materialized')
 
 
 def is_enabled(node):
     return node.get('config', {}).get('enabled') is True
+
+
+def is_type(node, _type):
+    return node.get('resource_type') == _type
 
 
 def get_pseudo_test_path(node_name, source_path, test_type):

--- a/test/unit/test_linker.py
+++ b/test/unit/test_linker.py
@@ -1,11 +1,21 @@
+import mock
 import unittest
 
+import dbt.utils
+
 from dbt.compilation import Linker
+
 
 class LinkerTest(unittest.TestCase):
 
     def setUp(self):
+        self.real_is_blocking_dependency = dbt.utils.is_blocking_dependency
         self.linker = Linker()
+
+        dbt.utils.is_blocking_dependency = mock.MagicMock(return_value=True)
+
+    def tearDown(self):
+        dbt.utils.is_blocking_dependency = self.real_is_blocking_dependency
 
     def test_linker_add_node(self):
         expected_nodes = ['A', 'B', 'C']
@@ -69,7 +79,8 @@ class LinkerTest(unittest.TestCase):
         for (l, r) in actual_deps:
             self.linker.dependency(l, r)
 
-        self.assertRaises(RuntimeError, self.linker.as_dependency_list, ['ZZZ'])
+        self.assertRaises(RuntimeError,
+                          self.linker.as_dependency_list, ['ZZZ'])
 
     def test__find_cycles__cycles(self):
         actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'A')]


### PR DESCRIPTION
Tests:

- ran `dbt test` on a project, tests ran in bunches of 8
- ran `dbt run` on a project with lots of ephemeral models, they correctly ran in bunches of 8

someday i hope to refactor this code to make it testable, but today is not that day