### PR TITLE
already_exists & operations

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -1,5 +1,6 @@
 import dbt.compat
 import dbt.exceptions
+from dbt.operations import operations
 
 import jinja2
 import jinja2.sandbox
@@ -42,10 +43,12 @@ def create_macro_capture_env(node):
                 self.node['depends_on']['macros'].append(path)
 
     return jinja2.sandbox.SandboxedEnvironment(
+        extensions=[operations.OperationExtension],
         undefined=ParserMacroCapture)
 
 
-env = jinja2.sandbox.SandboxedEnvironment()
+env = jinja2.sandbox.SandboxedEnvironment(
+        extensions=[operations.OperationExtension])
 
 
 def get_template(string, ctx, node=None, capture_macros=False):

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -31,6 +31,7 @@ def main(args=None):
         handle(args)
 
     except RuntimeError as e:
+        raise
         logger.info("Encountered an error:")
         logger.info(str(e))
         sys.exit(1)

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -422,8 +422,9 @@ class Model(DBTSource):
             if 'sql_where' not in model_config:
                 compiler_error(
                     self,
-                    """sql_where not specified in model materialized as
-                    incremental"""
+                    # TODO - this probably won't be an error now?
+                    "sql_where not specified in model materialized "
+                    "as incremental"
                 )
             raw_sql_where = model_config['sql_where']
             sql_where = self.compile_string(ctx, raw_sql_where)

--- a/dbt/operations/operations.py
+++ b/dbt/operations/operations.py
@@ -1,0 +1,41 @@
+
+import jinja2.nodes
+import jinja2.ext
+
+
+class OperationExtension(jinja2.ext.Extension):
+    tags = set(['op'])
+
+    def __init__(self, environment):
+        super(OperationExtension, self).__init__(environment)
+
+    def parse(self, parser):
+        lineno = next(parser.stream).lineno
+        args = [parser.parse_expression()]
+        body = parser.parse_statements(['name:endop'], drop_needle=True)
+
+        return jinja2.nodes.CallBlock(
+            self.call_method('_operation', args),
+            [],
+            [],
+            body).set_lineno(lineno)
+
+    def _operation(self, operation, caller):
+        return operation(caller())
+
+
+already_exists_sql = """
+{{% if {not_token} already_exists('{schema}', '{table}') %}}
+{contents}
+{{% endif %}}
+"""
+
+
+def if_already_exists(model, does_exist=True):
+    def render(contents):
+        return already_exists_sql.format(
+                schema=model.schema,
+                table=model.name,
+                contents=contents,
+                not_token='not' if not does_exist else '')
+    return render

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -191,6 +191,7 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     context['var'] = lambda *args: ''
     context['target'] = property(lambda x: '', lambda x: x)
     context['this'] = ''
+    context['if_already_exists'] = lambda *args: lambda *args: ''
 
     dbt.clients.jinja.get_rendered(
         node.get('raw_sql'), context, node,

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -231,3 +231,13 @@ def get_pseudo_test_path(node_name, source_path, test_type):
     suffix = [test_type, "{}.sql".format(node_name)]
     pseudo_path_parts = source_path_parts + suffix
     return os.path.join(*pseudo_path_parts)
+
+
+def jinja_identity(func_name):
+    def identity(*args):
+        interp_args = [arg.__repr__() for arg in args]
+        return "{func}({args})".format(
+            func=func_name,
+            args=",".join(interp_args))
+
+    return identity


### PR DESCRIPTION
With this branch, "fast" incremental models can be created using syntax like this:

```sql
{{ config(materialized='incremental', sql_where="TRUE", unique_key='id') }}

with source as (
    -- just generate some ever-growing dataset
    select id
    from generate_series(0, extract(epoch from now() - '2017-03-26 02:00:00')::integer) as id

    {% op if_already_exists(this, True) %}

        where id > (select max(id) from {{ this }})

    {% endop %}
)

select * from source
```

When I started on this branch, I hadn't intended to embark on operations. These operations, or something like them, are actually necessary for query-time interpolation like `already_exists`.

I originally wanted the syntax to look like

```sql
{% if already_exists(this) %}
    where id > (select max(id) from {{ this }})
{% endif %}
```

Problem is, jinja will render that whole block at compile-time. Once we're in the `already_exists` function, there's no way to know anything about the rest of the block. Eg. if there is an `else` statement or if there are other predicates in the `if` statement. So, there's really no way to "fake" this `already_exists` function at compile-time and have it just re-interpolate itself to be executed at runtime. 

I ended up getting the above syntax to work, but we could also do it like this:

```sql
    {% op %}
        {% if already_exists(this) %}
            where id > (select max(id) from {{ this }})
        {% endif %}
    {% endop %}
```

That feels more flexible, but I dislike that two nested tags are required. In this scenario, `op` is really just an alias for `raw`. Feels like the wrong abstraction to me.

Keen to hear your thoughts!

cc @jthandy  @cmcarthur 