### PR TITLE
Include global project

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dbt/include/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include dbt/include/*
+recursive-include dbt/include *.py *.sql *.yml

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from distutils.core import setup
 
 
 package_name = "dbt"


### PR DESCRIPTION
The `dbt/include/` dir is now included with `python setup.py sdist`

I haven't tested with `python setup.py sdist upload -r pypi`, but I believe there's  a test version of pypi where we can confirm that this works.