### PR TITLE
handle yaml errors

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -1,19 +1,31 @@
 import os.path
 import yaml
+import yaml.scanner
 
-import dbt.project as project
+import dbt.exceptions
+
+from dbt.logger import GLOBAL_LOGGER as logger
 
 
-def read_config(profiles_dir):
+def read_profile(profiles_dir):
     # TODO: validate profiles_dir
     path = os.path.join(profiles_dir, 'profiles.yml')
 
     if os.path.isfile(path):
-        with open(path, 'r') as f:
-            profile = yaml.safe_load(f)
-            return profile.get('config', {})
+        try:
+            with open(path, 'r') as f:
+                return yaml.safe_load(f)
+        except (yaml.scanner.ScannerError,
+                yaml.YAMLError) as e:
+            raise dbt.exceptions.ValidationException(
+                '  Could not read {}\n\n{}'.format(path, str(e)))
 
     return {}
+
+
+def read_config(profiles_dir):
+    profile = read_profile(profiles_dir)
+    return profile.get('config')
 
 
 def send_anonymous_usage_stats(profiles_dir):

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -141,6 +141,7 @@ def invoke_dbt(parsed):
         logger.info("Valid profiles:")
 
         all_profiles = project.read_profiles(parsed.profiles_dir).keys()
+
         for profile in all_profiles:
             logger.info(" - {}".format(profile))
 
@@ -172,7 +173,8 @@ def invoke_dbt(parsed):
             logger.info("  ERROR Specified target {} is not a valid option "
                         "for profile {}"
                         .format(parsed.target, proj.profile_to_load))
-            logger.info("Valid targets are: {}".format(targets))
+            logger.info("Valid targets are: {}".format(
+                ', '.join(targets)))
             dbt.tracking.track_invalid_invocation(
                 project=proj,
                 args=parsed,

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -174,19 +174,10 @@ def read_profiles(profiles_dir=None):
     if profiles_dir is None:
         profiles_dir = default_profiles_dir
 
-    profiles = {}
-    paths = [
-        os.path.join(profiles_dir, 'profiles.yml')
-    ]
-    for path in paths:
-        if os.path.isfile(path):
-            with open(path, 'r') as f:
-                m = yaml.safe_load(f)
-                valid_profiles = {k: v for (k, v) in m.items()
-                                  if k != 'config'}
-                profiles.update(valid_profiles)
+    raw_profiles = dbt.config.read_profile(profiles_dir)
 
-    return profiles
+    return {k: v for (k, v) in raw_profiles.items()
+            if k != 'config'}
 
 
 def read_project(filename, profiles_dir=None, validate=True,


### PR DESCRIPTION
dbt was showing a stack trace on invalid yaml in profiles.yml. this fixes that. the error now looks like:

```
09:04 $ dbt test --data --profile postgres --target cmcarthur
Encountered an error:
  Could not read /Users/connor/.dbt/profiles.yml

while scanning a simple key
  in "/Users/connor/.dbt/profiles.yml", line 12, column 3
could not find expected ':'
  in "/Users/connor/.dbt/profiles.yml", line 12, column 13
```