### PR TITLE
Vars & Refs should play nice

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -28,7 +28,6 @@ def main(args=None):
         handle(args)
 
     except RuntimeError as e:
-        raise # tmp, debug
         logger.info("Encountered an error:")
         logger.info(str(e))
         sys.exit(1)

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -28,6 +28,7 @@ def main(args=None):
         handle(args)
 
     except RuntimeError as e:
+        raise # tmp, debug
         logger.info("Encountered an error:")
         logger.info(str(e))
         sys.exit(1)


### PR DESCRIPTION
We often pass ref'd models through vars to deps, eg:

```yml
models:
  snowplow: # open source snowplow package
    vars:
      'snowplow:timezone': 'America/New_York'
      'snowplow:events': "{{ ref('snowplow_events') }}"
      'snowplow:context:web_page': "{{ ref('snowplow_input_web_page_context') }}"
```

Because these `ref` calls aren't in the model itself, current `development` throws a compilation error for code like this. This PR fixes that.