### PR TITLE
lazily acquire connections from the pool

### DIFF
--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -143,7 +143,7 @@ class SnowflakeAdapter(PostgresAdapter):
             profile, model)
 
     @classmethod
-    def add_query(cls, profile, sql, model_name=None):
+    def add_query(cls, profile, sql, model_name=None, auto_begin=True):
         # snowflake only allows one query per api call.
         queries = sql.strip().split(";")
         cursor = None
@@ -151,7 +151,8 @@ class SnowflakeAdapter(PostgresAdapter):
         super(PostgresAdapter, cls).add_query(
             profile,
             'use schema "{}"'.format(cls.get_default_schema(profile)),
-            model_name)
+            model_name,
+            auto_begin)
 
         for individual_query in queries:
             # hack -- after the last ';', remove comments and don't run
@@ -163,7 +164,8 @@ class SnowflakeAdapter(PostgresAdapter):
 
             if without_comments == "":
                 continue
+
             connection, cursor = super(PostgresAdapter, cls).add_query(
-                profile, individual_query, model_name)
+                profile, individual_query, model_name, auto_begin)
 
         return connection, cursor


### PR DESCRIPTION
@drewbanin this branch makes it so that dbt will acquire a connection on-demand when an individual model needs it. most ephemeral models (i.e. the ones that don't call already_exists, etc) will no longer require a connection, and compile super fast, can't post the exact results here but i had 16 ephemeral models compile in 8 ms instead of 8 seconds.

Also tested that ephemeral models that call the adapter still work. I'll send you a separate branch for that.