### PR TITLE
compile tests to file, show output line, add build_path

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -312,14 +312,17 @@ class Compiler(object):
                 context,
                 flat_graph)
 
+            injected_node['wrapped_sql'] = wrapped_stmt
+
+
+        if 'wrapped_sql' in injected_node:
             build_path = os.path.join('build',
                                       injected_node.get('package_name'),
                                       injected_node.get('path'))
 
             written_path = self.__write(build_path,
-                                        wrapped_stmt)
+                                        injected_node['wrapped_sql'])
 
-            injected_node['wrapped_sql'] = wrapped_stmt
             injected_node['build_path'] = written_path
 
         return injected_node

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -314,7 +314,6 @@ class Compiler(object):
 
             injected_node['wrapped_sql'] = wrapped_stmt
 
-
         if 'wrapped_sql' in injected_node:
             build_path = os.path.join('build',
                                       injected_node.get('package_name'),

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -143,6 +143,7 @@ def print_test_result_line(result, schema_name, index, total):
         info = "ERROR"
     elif result.status > 0:
         info = 'FAIL {}'.format(result.status)
+        result.fail = True
     elif result.status == 0:
         info = 'PASS'
     else:
@@ -407,16 +408,21 @@ def track_model_run(index, num_nodes, run_model_result):
 
 class RunModelResult(object):
     def __init__(self, node, error=None, skip=False, status=None,
-                 execution_time=0):
+                 failed=None, execution_time=0):
         self.node = node
         self.error = error
         self.skip = skip
+        self.fail = failed
         self.status = status
         self.execution_time = execution_time
 
     @property
     def errored(self):
         return self.error is not None
+
+    @property
+    def failed(self):
+        return self.fail
 
     @property
     def skipped(self):

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.runner import RunManager
+import dbt.utils
 
 THREAD_LIMIT = 9
 
@@ -18,17 +19,4 @@ class RunTask:
 
         results = runner.run_models(self.args.models, self.args.exclude)
 
-        total = len(results)
-        passed = len([r for r in results if not r.errored and not r.skipped])
-        errored = len([r for r in results if r.errored])
-        skipped = len([r for r in results if r.skipped])
-
-        logger.info(
-            "Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}"
-            .format(
-                total=total,
-                passed=passed,
-                errored=errored,
-                skipped=skipped
-            )
-        )
+        logger.info(dbt.utils.get_run_status_line(results))

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -2,6 +2,7 @@ from dbt.runner import RunManager
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 import dbt.utils
 
+
 class TestTask:
     """
     Testing:

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -37,5 +37,3 @@ class TestTask:
             raise RuntimeError("unexpected")
 
         logger.info(dbt.utils.get_run_status_line(results))
-
-        return results

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -26,12 +26,27 @@ class TestTask:
 
         if (self.args.data and self.args.schema) or \
            (not self.args.data and not self.args.schema):
-            res = runner.run_tests(include, exclude, set())
+            results = runner.run_tests(include, exclude, set())
         elif self.args.data:
-            res = runner.run_tests(include, exclude, {'data'})
+            results = runner.run_tests(include, exclude, {'data'})
         elif self.args.schema:
-            res = runner.run_tests(include, exclude, {'schema'})
+            results = runner.run_tests(include, exclude, {'schema'})
         else:
             raise RuntimeError("unexpected")
 
-        return res
+        total = len(results)
+        passed = len([r for r in results if not r.errored and not r.skipped])
+        errored = len([r for r in results if r.errored])
+        skipped = len([r for r in results if r.skipped])
+
+        logger.info(
+            "Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}"
+            .format(
+                total=total,
+                passed=passed,
+                errored=errored,
+                skipped=skipped
+            )
+        )
+
+        return results

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -1,6 +1,6 @@
 from dbt.runner import RunManager
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
-
+import dbt.utils
 
 class TestTask:
     """
@@ -24,8 +24,9 @@ class TestTask:
         include = self.args.models
         exclude = self.args.exclude
 
-        if (self.args.data and self.args.schema) or \
-           (not self.args.data and not self.args.schema):
+        test_types = [self.args.data, self.args.schema]
+
+        if all(test_types) or not any(test_types):
             results = runner.run_tests(include, exclude, set())
         elif self.args.data:
             results = runner.run_tests(include, exclude, {'data'})
@@ -34,19 +35,6 @@ class TestTask:
         else:
             raise RuntimeError("unexpected")
 
-        total = len(results)
-        passed = len([r for r in results if not r.errored and not r.skipped])
-        errored = len([r for r in results if r.errored])
-        skipped = len([r for r in results if r.skipped])
-
-        logger.info(
-            "Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}"
-            .format(
-                total=total,
-                passed=passed,
-                errored=errored,
-                skipped=skipped
-            )
-        )
+        logger.info(dbt.utils.get_run_status_line(results))
 
         return results

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -261,3 +261,18 @@ def get_pseudo_test_path(node_name, source_path, test_type):
     suffix = [test_type, "{}.sql".format(node_name)]
     pseudo_path_parts = source_path_parts + suffix
     return os.path.join(*pseudo_path_parts)
+
+def get_run_status_line(results):
+    total = len(results)
+    passed = len([r for r in results if not r.errored and not r.skipped])
+    errored = len([r for r in results if r.errored])
+    skipped = len([r for r in results if r.skipped])
+
+    return (
+        "Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}"
+        .format(
+            total=total,
+            passed=passed,
+            errored=errored,
+            skipped=skipped
+        ))

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -262,6 +262,7 @@ def get_pseudo_test_path(node_name, source_path, test_type):
     pseudo_path_parts = source_path_parts + suffix
     return os.path.join(*pseudo_path_parts)
 
+
 def get_run_status_line(results):
     total = len(results)
     errored = len([r for r in results if r.errored or r.failed])

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -264,9 +264,9 @@ def get_pseudo_test_path(node_name, source_path, test_type):
 
 def get_run_status_line(results):
     total = len(results)
-    passed = len([r for r in results if not r.errored and not r.skipped])
-    errored = len([r for r in results if r.errored])
+    errored = len([r for r in results if r.errored or r.failed])
     skipped = len([r for r in results if r.skipped])
+    passed = total - errored - skipped
 
     return (
         "Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}"


### PR DESCRIPTION
A regression caused schema tests to not be written to the target directory. This also caused `build_path` to not be set for tests, resulting in:

```
13:48:39 | 1 of 1 ERROR unique_model_1_b........................................ [ERROR in 0.01s]
Error executing None <------------ bad
column "b" does not exist
LINE 6:         b as unique_field
```

So, output looks good now, tests are compiled to files, and a summary line is printed after `dbt test` (as with `dbt run`).

```
....
Done. PASS=0 ERROR=1 SKIP=0 TOTAL=1
```

fixes https://github.com/fishtown-analytics/dbt/issues/333