### PR TITLE
Update exceptions.py

### DIFF
--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -63,7 +63,7 @@ def ref_invalid_args(model, args):
 
 
 def ref_bad_context(model, target_model_name, target_model_package):
-    ref_string = "{{ ref('" + target_model_name + "}') }}}}"
+    ref_string = "{{ ref('" + target_model_name + "') }}}}"
 
     if target_model_package is not None:
         ref_string = ("{{ ref('" + target_model_package +

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -63,7 +63,7 @@ def ref_invalid_args(model, args):
 
 
 def ref_bad_context(model, target_model_name, target_model_package):
-    ref_string = "{{ ref('" + target_model_name + "') }}}}"
+    ref_string = "{{ ref('" + target_model_name + "') }}"
 
     if target_model_package is not None:
         ref_string = ("{{ ref('" + target_model_package +


### PR DESCRIPTION
Removes a typo from the suggested `depends_on` fix.

```
! dbt was unable to infer all dependencies for the model "foo".
This typically happens when ref() is placed within a conditional block.

To fix this, add the following hint to the top of the model "foo":

-- depends_on: {{ ref('bar}') }}}}
```