### PR TITLE
Fix/snowflake create schema

### DIFF
--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -398,6 +398,10 @@ class DefaultAdapter(object):
                                   connection.get('name'))
 
     @classmethod
+    def add_begin_query(cls, profile, name):
+        return cls.add_query(profile, 'BEGIN', name, auto_begin=False)
+
+    @classmethod
     def begin(cls, profile, name='master'):
         global connections_in_use
         connection = cls.get_connection(profile, name)
@@ -410,7 +414,7 @@ class DefaultAdapter(object):
                 'Tried to begin a new transaction on connection "{}", but '
                 'it already had one open!'.format(connection.get('name')))
 
-        cls.add_query(profile, 'BEGIN', name, auto_begin=False)
+        cls.add_begin_query(profile, name)
 
         connection['transaction_open'] = True
         connections_in_use[name] = connection

--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -143,25 +143,29 @@ class SnowflakeAdapter(PostgresAdapter):
             profile, model)
 
     @classmethod
+    def add_begin_query(cls, profile, name):
+        return cls.add_query(profile, 'BEGIN', name, auto_begin=False,
+                             select_schema=False)
+
+    @classmethod
     def create_schema(cls, profile, schema, model_name=None):
         logger.debug('Creating schema "%s".', schema)
         sql = cls.get_create_schema_sql(schema)
-        return super(PostgresAdapter, cls).add_query(
-            profile,
-            sql,
-            model_name)
+        return cls.add_query(profile, sql, model_name, select_schema=False)
 
     @classmethod
-    def add_query(cls, profile, sql, model_name=None, auto_begin=True):
+    def add_query(cls, profile, sql, model_name=None, auto_begin=True,
+                  select_schema=True):
         # snowflake only allows one query per api call.
         queries = sql.strip().split(";")
         cursor = None
 
-        super(PostgresAdapter, cls).add_query(
-            profile,
-            'use schema "{}"'.format(cls.get_default_schema(profile)),
-            model_name,
-            auto_begin)
+        if select_schema:
+            super(PostgresAdapter, cls).add_query(
+                profile,
+                'use schema "{}"'.format(cls.get_default_schema(profile)),
+                model_name,
+                auto_begin)
 
         for individual_query in queries:
             # hack -- after the last ';', remove comments and don't run

--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -143,6 +143,15 @@ class SnowflakeAdapter(PostgresAdapter):
             profile, model)
 
     @classmethod
+    def create_schema(cls, profile, schema, model_name=None):
+        logger.debug('Creating schema "%s".', schema)
+        sql = cls.get_create_schema_sql(schema)
+        return super(PostgresAdapter, cls).add_query(
+            profile,
+            sql,
+            model_name)
+
+    @classmethod
     def add_query(cls, profile, sql, model_name=None, auto_begin=True):
         # snowflake only allows one query per api call.
         queries = sql.strip().split(";")


### PR DESCRIPTION
Snowflake schema creation fails since it tries to `use <schema>` before creating it. This fixes it (so, for example, build-per-PR will work for Snowflake users)