### PR TITLE
Disabled compilation rules

### DIFF
--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -127,9 +127,9 @@ def process_refs(flat_graph, current_project):
                     target_model_name,
                     target_model_package)
 
-            if (dbt.utils.is_enabled(node) and
-                    not dbt.utils.is_enabled(target_model)):
+            if (dbt.utils.is_enabled(node) and not dbt.utils.is_enabled(target_model) and dbt.utils.is_type(node, NodeType.Model)):
                 dbt.exceptions.ref_disabled_dependency(node, target_model)
+                # TODO : tests probably shouldn't run for disabled models here?
 
             target_model_id = target_model.get('unique_id')
 

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -127,9 +127,11 @@ def process_refs(flat_graph, current_project):
                     target_model_name,
                     target_model_package)
 
-            if (dbt.utils.is_enabled(node) and not dbt.utils.is_enabled(target_model) and dbt.utils.is_type(node, NodeType.Model)):
-                dbt.exceptions.ref_disabled_dependency(node, target_model)
-                # TODO : tests probably shouldn't run for disabled models here?
+            if dbt.utils.is_enabled(node) and not dbt.utils.is_enabled(target_model):
+                if dbt.utils.is_type(node, NodeType.Model):
+                    dbt.exceptions.ref_disabled_dependency(node, target_model)
+                else:
+                    node.get('config', {})['enabled'] = False
 
             target_model_id = target_model.get('unique_id')
 

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -14,7 +14,7 @@ import dbt.contracts.graph.parsed
 import dbt.contracts.graph.unparsed
 import dbt.contracts.project
 
-from dbt.utils import NodeType, get_materialization, Var
+from dbt.utils import NodeType, Var
 from dbt.compat import basestring, to_string
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -127,7 +127,8 @@ def process_refs(flat_graph, current_project):
                     target_model_name,
                     target_model_package)
 
-            if dbt.utils.is_enabled(node) and not dbt.utils.is_enabled(target_model):
+            if (dbt.utils.is_enabled(node) and not
+                    dbt.utils.is_enabled(target_model)):
                 if dbt.utils.is_type(node, NodeType.Model):
                     dbt.exceptions.ref_disabled_dependency(node, target_model)
                 else:

--- a/test/integration/008_schema_tests_test/models/disabled.sql
+++ b/test/integration/008_schema_tests_test/models/disabled.sql
@@ -1,0 +1,6 @@
+
+{{ config(enabled=False) }}
+
+select 1 as not_unique
+union all
+select 1

--- a/test/integration/008_schema_tests_test/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models/schema.yml
@@ -53,3 +53,10 @@ table_failure_summary:
 
         relationships:
             - { from: favorite_color, to: ref('table_copy'), field: favorite_color }
+
+
+# this will fail if run, but we've disabled this model
+disabled:
+    constraints:
+        unique:
+            - not_unique

--- a/test/integration/008_schema_tests_test/test_schema_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_tests.py
@@ -25,7 +25,6 @@ class TestSchemaTests(DBTIntegrationTest):
         args = FakeArgs()
 
         test_task = TestTask(args, project)
-        print(project)
         return test_task.run()
 
     @attr(type='postgres')


### PR DESCRIPTION
- only fail to compile if ENABLED model depends on DISABLED model
- skip other node types that depend on DISABLED model (ie. tests, analyses)

fixes https://github.com/fishtown-analytics/dbt/issues/334