### PR TITLE
default to dict if no extra ctes provided

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -73,7 +73,7 @@ def recursively_prepend_ctes(model, flat_graph):
     if model.get('all_ctes_injected') is True:
         return (model, model.get('extra_ctes').keys(), flat_graph)
 
-    for cte_id in model.get('extra_ctes').keys():
+    for cte_id in model.get('extra_ctes', {}).keys():
         cte_to_add = flat_graph.get('nodes').get(cte_id)
         cte_to_add, new_prepend_ctes, flat_graph = recursively_prepend_ctes(
             cte_to_add, flat_graph)


### PR DESCRIPTION
this occasionally caused an error for a dbt project i was working with. Unsure how `extra_ctes` could not be in the model dict -- any ideas @cmcarthur?

```
Traceback (most recent call last):
  File "/usr/local/bin/dbt", line 11, in <module>
    load_entry_point('dbt==0.8.0', 'console_scripts', 'dbt')()
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/main.py", line 28, in main
    handle(args)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/main.py", line 46, in handle
    res = run_from_args(parsed)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/main.py", line 100, in run_from_args
    result = task.run()
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/task/run.py", line 20, in run
    results = runner.run_models(self.args.models, self.args.exclude)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/runner.py", line 845, in run_models
    should_run_hooks=True)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/runner.py", line 831, in run_types_from_graph
    on_failure, should_run_hooks)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/runner.py", line 696, in execute_nodes
    for node in nodes_to_execute]):
  File "/usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/multiprocessing/pool.py", line 699, in next
    raise value
  File "/usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/runner.py", line 577, in safe_execute_node
    raise e
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/runner.py", line 535, in safe_execute_node
    node = compiler.compile_node(node, flat_graph)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/compilation.py", line 282, in compile_node
    injected_node, _ = prepend_ctes(compiled_node, flat_graph)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/compilation.py", line 60, in prepend_ctes
    model, _, flat_graph = recursively_prepend_ctes(model, flat_graph)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/compilation.py", line 79, in recursively_prepend_ctes
    cte_to_add, flat_graph)
  File "/usr/local/Cellar/dbt/0.8.0/libexec/lib/python3.6/site-packages/dbt/compilation.py", line 76, in recursively_prepend_ctes
    for cte_id in model.get('extra_ctes').keys():
AttributeError: 'NoneType' object has no attribute 'keys'
```