### PR TITLE
don't show a stacktrace when throwing compiler error

### DIFF
--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -82,7 +82,7 @@ def compiler_warning(model, msg):
 class Var(object):
     UndefinedVarError = "Required var '{}' not found in config:\nVars "\
                         "supplied to {} = {}"
-    NoneVarError = "Supplied var '{}' is undefined in config:\nVars supplied"\
+    NoneVarError = "Supplied var '{}' is undefined in config:\nVars supplied "\
                    "to {} = {}"
 
     def __init__(self, model, context):

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -112,10 +112,11 @@ class Var(object):
         elif var_name in self.local_vars:
             raw = self.local_vars[var_name]
             if raw is None:
+                model_name = get_model_name_or_none(self.model)
                 compiler_error(
                     self.model,
                     self.NoneVarError.format(
-                        var_name, self.model.nice_name, pretty_vars
+                        var_name, model_name, pretty_vars
                     )
                 )
 


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/400

User will see this:
```
! Compilation error while compiling model fb_ads:
! Supplied var 'ads_table' is undefined in config:
Vars supplied to fb_ads = {
    ....
    "ads_table": null,
    ....
}
```

instead of this:
```
File "/Users/drewfus/fishtown/dbt/dbt/parser.py", line 208, in parse_node
    capture_macros=True)
  File "/Users/drewfus/fishtown/dbt/dbt/clients/jinja.py", line 112, in get_rendered
    return render_template(template, ctx, node)
  File "/Users/drewfus/fishtown/dbt/dbt/clients/jinja.py", line 103, in render_template
    return template.render(ctx)
  File "/Users/drewfus/miniconda3/lib/python3.5/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/drewfus/miniconda3/lib/python3.5/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/drewfus/miniconda3/lib/python3.5/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 12, in top-level template code
  File "/Users/drewfus/miniconda3/lib/python3.5/site-packages/jinja2/sandbox.py", line 427, in call
    return __context.call(__obj, *args, **kwargs)
  File "/Users/drewfus/fishtown/dbt/dbt/utils.py", line 111, in __call__
    var_name, self.model.nice_name, pretty_vars
AttributeError: 'dict' object has no attribute 'nice_name'
```