### PR TITLE
env var context function

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -6,7 +6,7 @@ import jinja2.sandbox
 import jinja2.nodes
 import jinja2.ext
 
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 
 
 def create_macro_validation_extension(node):
@@ -110,3 +110,7 @@ def render_template(template, ctx, node=None):
 def get_rendered(string, ctx, node=None, capture_macros=False):
     template = get_template(string, ctx, node, capture_macros)
     return render_template(template, ctx, node)
+
+
+def undefined_error(msg):
+    raise jinja2.exceptions.UndefinedError(msg)

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -9,7 +9,8 @@ import dbt.include
 import dbt.wrapper
 import dbt.tracking
 
-from dbt.utils import This, Var, get_materialization, NodeType, is_type
+from dbt.utils import This, Var, get_materialization, is_type
+from dbt.node_types import NodeType
 
 from dbt.linker import Linker
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -5,7 +5,8 @@ import jinja2.runtime
 import dbt.exceptions
 
 from dbt.compat import basestring
-from dbt.utils import NodeType, get_materialization
+from dbt.utils import get_materialization
+from dbt.node_types import NodeType
 
 from dbt.contracts.common import validate_with
 from dbt.contracts.graph.unparsed import unparsed_node_contract, \

--- a/dbt/contracts/graph/unparsed.py
+++ b/dbt/contracts/graph/unparsed.py
@@ -3,7 +3,7 @@ from voluptuous import Schema, Required, All, Any, Length
 from dbt.compat import basestring
 from dbt.contracts.common import validate_with
 
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 
 unparsed_base_contract = Schema({
     # identifiers

--- a/dbt/graph/selector.py
+++ b/dbt/graph/selector.py
@@ -2,7 +2,8 @@
 import networkx as nx
 from dbt.logger import GLOBAL_LOGGER as logger
 
-from dbt.utils import NodeType, is_enabled, get_materialization
+from dbt.utils import is_enabled, get_materialization
+from dbt.node_types import NodeType
 
 SELECTOR_PARENTS = '+'
 SELECTOR_CHILDREN = '+'

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -1,7 +1,7 @@
 import dbt.exceptions
 import dbt.parser
 
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 
 
 class GraphLoader(object):

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -6,7 +6,8 @@ from dbt.compat import basestring
 import dbt.flags
 
 from dbt.templates import BaseCreateTemplate
-from dbt.utils import split_path, NodeType
+from dbt.utils import split_path
+from dbt.node_types import NodeType
 import dbt.project
 from dbt.utils import deep_merge, DBTConfigKeys, compiler_error
 

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -1,7 +1,8 @@
 
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.exceptions import NotImplementedException
-from dbt.utils import RunHookType, NodeType, get_nodes_by_tags
+from dbt.utils import get_nodes_by_tags
+from dbt.node_types import NodeType, RunHookType
 
 import dbt.utils
 import dbt.tracking

--- a/dbt/node_types.py
+++ b/dbt/node_types.py
@@ -1,0 +1,25 @@
+
+class NodeType(object):
+    Base = 'base'
+    Model = 'model'
+    Analysis = 'analysis'
+    Test = 'test'
+    Archive = 'archive'
+    Macro = 'macro'
+    Operation = 'operation'
+
+    @classmethod
+    def executable(cls):
+        return [
+            cls.Model,
+            cls.Test,
+            cls.Archive,
+            cls.Analysis,
+            cls.Operation
+        ]
+
+
+class RunHookType:
+    Start = 'on-run-start'
+    End = 'on-run-end'
+    Both = [Start, End]

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -14,7 +14,8 @@ import dbt.contracts.graph.parsed
 import dbt.contracts.graph.unparsed
 import dbt.contracts.project
 
-from dbt.utils import NodeType, Var
+from dbt.utils import Var
+from dbt.node_types import NodeType, RunHookType
 from dbt.compat import basestring, to_string
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -380,7 +381,7 @@ def load_and_parse_run_hook_type(root_project, all_projects, hook_type):
 
 def load_and_parse_run_hooks(root_project, all_projects):
     hook_nodes = {}
-    for hook_type in dbt.utils.RunHookType.Both:
+    for hook_type in RunHookType.Both:
         project_hooks = load_and_parse_run_hook_type(root_project,
                                                      all_projects,
                                                      hook_type)

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -8,6 +8,8 @@ from voluptuous import Required, Invalid
 import dbt.deprecations
 import dbt.contracts.connection
 import dbt.clients.yaml_helper
+import dbt.clients.jinja
+import dbt.compat
 from dbt.logger import GLOBAL_LOGGER as logger
 
 default_project_cfg = {
@@ -108,10 +110,28 @@ class Project(object):
         else:
             return False
 
+    def compile_target(self, target_cfg):
+        ctx = self.base_context()
+
+        compiled = {}
+        for (key, value) in target_cfg.items():
+            is_str = isinstance(value, dbt.compat.basestring)
+
+            if is_str:
+                compiled_value = dbt.clients.jinja.get_rendered(value, ctx)
+            else:
+                compiled_value = value
+
+            compiled[key] = compiled_value
+
+        return compiled
+
+
     def run_environment(self):
         target_name = self.cfg['target']
         if target_name in self.cfg['outputs']:
-            return self.cfg['outputs'][target_name]
+            target_cfg = self.cfg['outputs'][target_name]
+            return self.compile_target(target_cfg)
         else:
             raise DbtProfileError(
                     "'target' config was not found in profile entry for "
@@ -122,11 +142,31 @@ class Project(object):
         ctx['name'] = self.cfg['target']
         return ctx
 
+    def get_env_var(self, var, default=None):
+        if var in os.environ:
+            return os.environ[var]
+        elif default is not None:
+            return default
+        else:
+            msg = "Env var required but not provided: '{}'".format(var)
+            dbt.exceptions.raise_compiler_error(node=None, msg=msg)
+
+    def base_context(self):
+        return {
+            'env_var': self.get_env_var
+        }
+
     def context(self):
         target_cfg = self.run_environment()
         filtered_target = copy.deepcopy(target_cfg)
         filtered_target.pop('pass', None)
-        return {'env': filtered_target}
+
+        ctx = self.base_context()
+        ctx.update({
+            'env': filtered_target
+        })
+
+        return ctx
 
     def validate(self):
         self.handle_deprecations()
@@ -155,7 +195,7 @@ class Project(object):
                     ", ".join(valid_types)), self)
 
         validator = validator.extend({
-            Required('type'): str,
+            Required('type'): dbt.compat.basestring,
             Required('threads'): int,
         })
 
@@ -186,8 +226,8 @@ def read_profiles(profiles_dir=None):
 
     raw_profiles = dbt.config.read_profile(profiles_dir)
 
-    return {k: v for (k, v) in raw_profiles.items()
-            if k != 'config'}
+    profiles = {k: v for (k, v) in raw_profiles.items() if k != 'config'}
+    return profiles
 
 
 def read_project(filename, profiles_dir=None, validate=True,

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -118,14 +118,14 @@ class Project(object):
             is_str = isinstance(value, dbt.compat.basestring)
 
             if is_str:
-                compiled_value = dbt.clients.jinja.get_rendered(value, ctx)
+                node = "config key: '{}'".format(key)
+                compiled_val = dbt.clients.jinja.get_rendered(value, ctx, node)
             else:
-                compiled_value = value
+                compiled_val = value
 
-            compiled[key] = compiled_value
+            compiled[key] = compiled_val
 
         return compiled
-
 
     def run_environment(self):
         target_name = self.cfg['target']
@@ -149,7 +149,7 @@ class Project(object):
             return default
         else:
             msg = "Env var required but not provided: '{}'".format(var)
-            dbt.exceptions.raise_compiler_error(node=None, msg=msg)
+            dbt.clients.jinja.undefined_error(msg)
 
     def base_context(self):
         return {

--- a/dbt/task/archive.py
+++ b/dbt/task/archive.py
@@ -1,7 +1,7 @@
 from dbt.runner import RunManager
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.node_runners import ArchiveRunner
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 
 import dbt.ui.printer
 

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.runner import RunManager
 from dbt.node_runners import CompileRunner
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 import dbt.ui.printer
 
 

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.runner import RunManager
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 from dbt.node_runners import ModelRunner
 
 import dbt.ui.printer

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -1,7 +1,7 @@
 from dbt.runner import RunManager
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.node_runners import TestRunner
-from dbt.utils import NodeType
+from dbt.node_types import NodeType
 import dbt.ui.printer
 
 

--- a/dbt/ui/printer.py
+++ b/dbt/ui/printer.py
@@ -1,6 +1,7 @@
 
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.utils import get_materialization, NodeType
+from dbt.utils import get_materialization
+from dbt.node_types import NodeType
 import dbt.ui.colors
 
 import time

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -3,11 +3,13 @@ import json
 import hashlib
 import itertools
 
-import dbt.project
 from dbt.include import GLOBAL_DBT_MODULES_PATH
-
 from dbt.compat import basestring
 from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.node_types import NodeType
+
+import dbt.clients.jinja
+
 
 DBTConfigKeys = [
     'enabled',
@@ -21,32 +23,6 @@ DBTConfigKeys = [
     'post-hook',
     'vars'
 ]
-
-
-class NodeType(object):
-    Base = 'base'
-    Model = 'model'
-    Analysis = 'analysis'
-    Test = 'test'
-    Archive = 'archive'
-    Macro = 'macro'
-    Operation = 'operation'
-
-    @classmethod
-    def executable(cls):
-        return [
-            cls.Model,
-            cls.Test,
-            cls.Archive,
-            cls.Analysis,
-            cls.Operation
-        ]
-
-
-class RunHookType:
-    Start = 'on-run-start'
-    End = 'on-run-end'
-    Both = [Start, End]
 
 
 class This(object):
@@ -189,6 +165,7 @@ def find_model_by_fqn(models, fqn):
 
 
 def dependency_projects(project):
+    import dbt.project
     module_paths = [
         GLOBAL_DBT_MODULES_PATH,
         os.path.join(project['project-root'], project['modules-path'])

--- a/test/integration/013_context_var_tests/models/context.sql
+++ b/test/integration/013_context_var_tests/models/context.sql
@@ -25,7 +25,6 @@ select
 
     -- runtime variables
     '{{ run_started_at }}' as run_started_at,
-    '{{ invocation_id }}'  as invocation_id
+    '{{ invocation_id }}'  as invocation_id,
 
-
-
+    '{{ env_var("DBT_TEST_013_ENV_VAR") }}' as env_var

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -2,11 +2,14 @@ from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest
 
 import dbt.flags
+import os
 
 class TestContextVars(DBTIntegrationTest):
 
     def setUp(self):
         DBTIntegrationTest.setUp(self)
+        os.environ["DBT_TEST_013_ENV_VAR"] = "1"
+        os.environ["DBT_TEST_013_PASSWORD"] = "password"
 
         self.fields = [
             'this',
@@ -23,7 +26,8 @@ class TestContextVars(DBTIntegrationTest):
             'target.user',
             'target.pass',
             'run_started_at',
-            'invocation_id'
+            'invocation_id',
+            'env_var'
         ]
 
     @property
@@ -45,7 +49,7 @@ class TestContextVars(DBTIntegrationTest):
                         'host': 'database',
                         'port': 5432,
                         'user': 'root',
-                        'pass': 'password',
+                        'pass': '{{ env_var("DBT_TEST_013_PASSWORD") }}',
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     },
@@ -55,7 +59,7 @@ class TestContextVars(DBTIntegrationTest):
                         'host': 'database',
                         'port': 5432,
                         'user': 'root',
-                        'pass': 'password',
+                        'pass': '{{ env_var("DBT_TEST_013_PASSWORD") }}',
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     }
@@ -95,6 +99,8 @@ class TestContextVars(DBTIntegrationTest):
         self.assertEqual(ctx['target.user'], 'root')
         self.assertEqual(ctx['target.pass'], '')
 
+        self.assertEqual(ctx['env_var'], '1')
+
     @attr(type='postgres')
     def test_env_vars_prod(self):
         self.run_dbt(['run', '--target', 'prod'])
@@ -114,3 +120,4 @@ class TestContextVars(DBTIntegrationTest):
         self.assertEqual(ctx['target.type'], 'postgres')
         self.assertEqual(ctx['target.user'], 'root')
         self.assertEqual(ctx['target.pass'], '')
+        self.assertEqual(ctx['env_var'], '1')

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -9,7 +9,6 @@ class TestContextVars(DBTIntegrationTest):
     def setUp(self):
         DBTIntegrationTest.setUp(self)
         os.environ["DBT_TEST_013_ENV_VAR"] = "1"
-        os.environ["DBT_TEST_013_PASSWORD"] = "password"
 
         self.fields = [
             'this',
@@ -49,7 +48,7 @@ class TestContextVars(DBTIntegrationTest):
                         'host': 'database',
                         'port': 5432,
                         'user': 'root',
-                        'pass': '{{ env_var("DBT_TEST_013_PASSWORD") }}',
+                        'pass': 'password',
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     },
@@ -59,7 +58,7 @@ class TestContextVars(DBTIntegrationTest):
                         'host': 'database',
                         'port': 5432,
                         'user': 'root',
-                        'pass': '{{ env_var("DBT_TEST_013_PASSWORD") }}',
+                        'pass': 'password',
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     }


### PR DESCRIPTION
Adds an `env_var` function to grab system environment variables. Can be used in the dbt profile, or in models.

```
profile:
  target: dev
  outputs:
    dev:
      type: postgres
      host: localhost
      user: {{ env_var('DBT_USER') }}
      pass: {{ env_var('DBT_PASSWORD') }}
      ....
```

For https://github.com/fishtown-analytics/dbt/issues/450
