### PR TITLE
warnings and helpful errors for unsupported bq functionality

### DIFF
--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -83,7 +83,8 @@ class BigQueryAdapter(PostgresAdapter):
         creds = google.oauth2.service_account.Credentials
 
         if method == 'oauth':
-            return google.auth.default()
+            credentials, project_id = google.auth.default()
+            return credentials
 
         elif method == 'service-account':
             keyfile = config.get('keyfile')
@@ -178,6 +179,13 @@ class BigQueryAdapter(PostgresAdapter):
 
         model_name = model.get('name')
         model_sql = cls.format_sql_for_bigquery(model.get('injected_sql'))
+
+        materialization = dbt.utils.get_materialization(model)
+        allowed_materializations = ['view', 'ephemeral']
+
+        if materialization not in allowed_materializations:
+            msg = "Unsupported materialization: {}".format(materialization)
+            raise dbt.exceptions.RuntimeException(msg)
 
         schema = cls.get_default_schema(profile)
         dataset = cls.get_dataset(profile, schema, model_name)
@@ -276,9 +284,18 @@ class BigQueryAdapter(PostgresAdapter):
         return dataset
 
     @classmethod
+    def warning_on_hooks(cls, hook_type):
+        dbt.ui.printer.print_timestamped_line("{} is not supported in "
+                "bigquery and will be ignored".format(hook_type),
+                dbt.ui.printer.COLOR_FG_YELLOW)
+
+    @classmethod
     def add_query(cls, profile, sql, model_name=None, auto_begin=True):
-        raise dbt.exceptions.NotImplementedException(
-            '`add_query` is not implemented for this adapter!')
+        if model_name in ['on-run-start', 'on-run-end']:
+            cls.warning_on_hooks(model_name)
+        else:
+            raise dbt.exceptions.NotImplementedException(
+                '`add_query` is not implemented for this adapter!')
 
     @classmethod
     def is_cancelable(cls):

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -285,9 +285,9 @@ class BigQueryAdapter(PostgresAdapter):
 
     @classmethod
     def warning_on_hooks(cls, hook_type):
-        dbt.ui.printer.print_timestamped_line("{} is not supported in "
-                "bigquery and will be ignored".format(hook_type),
-                dbt.ui.printer.COLOR_FG_YELLOW)
+        msg = "{} is not supported in bigquery and will be ignored"
+        dbt.ui.printer.print_timestamped_line(msg.format(hook_type),
+                                              dbt.ui.printer.COLOR_FG_YELLOW)
 
     @classmethod
     def add_query(cls, profile, sql, model_name=None, auto_begin=True):


### PR DESCRIPTION
This branch shows more helpful warnings / errors for unsupported dbt operations in bigquery.

```
Found 2 models, 2 tests, 0 archives, 0 analyses, 10 macros, 2 operations

10:08:58 | on-run-start is not supported in bigquery and will be ignored
10:08:58 | Concurrency: 1 threads (target='dev')
10:08:58 |
10:08:58 | 1 of 1 START table model dbt_dbanin.sql_submissions.................. [RUN]
10:08:59 | 1 of 1 ERROR creating table model dbt_dbanin.sql_submissions......... [ERROR in 0.96s]
Unsupported materialization: table
10:08:59 | on-run-end is not supported in bigquery and will be ignored
10:08:59 |
10:08:59 | Finished running 1 ephemeral models, 1 table models in 1.16s.

Completed with 1 errors:
 - ERROR in model bq_project.sql_submissions (target/build/bq_project/hn/base/sql_submissions.sql)

Done. PASS=1 ERROR=1 SKIP=0 TOTAL=2
```

Fixes: https://github.com/fishtown-analytics/dbt/issues/471