### PR TITLE
context for hook errors

### DIFF
--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -256,7 +256,12 @@ class ModelRunner(CompileRunner):
     @classmethod
     def before_run(cls, project, adapter, flat_graph):
         cls.try_create_schema(project, adapter)
-        cls.run_hooks(project, adapter, flat_graph, RunHookType.Start)
+        try:
+            cls.run_hooks(project, adapter, flat_graph, RunHookType.Start)
+        except dbt.exceptions.RuntimeException as e:
+            msg = "Database error while running {}"
+            logger.info(msg.format(RunHookType.Start))
+            raise
 
     @classmethod
     def print_results_line(cls, results, execution_time):
@@ -270,7 +275,12 @@ class ModelRunner(CompileRunner):
 
     @classmethod
     def after_run(cls, project, adapter, results, flat_graph, elapsed):
-        cls.run_hooks(project, adapter, flat_graph, RunHookType.End)
+        try:
+            cls.run_hooks(project, adapter, flat_graph, RunHookType.End)
+        except dbt.exceptions.RuntimeException as e:
+            msg = "Database error while running {}"
+            logger.info(msg.format(RunHookType.End))
+            raise
         cls.print_results_line(results, elapsed)
 
     def describe_node(self):

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -254,14 +254,17 @@ class ModelRunner(CompileRunner):
             adapter.commit_if_has_connection(profile, model_name)
 
     @classmethod
+    def safe_run_hooks(cls, project, adapter, flat_graph, hook_type):
+        try:
+            cls.run_hooks(project, adapter, flat_graph, hook_type)
+        except dbt.exceptions.RuntimeException as e:
+            logger.info("Database error while running {}".format(hook_type))
+            raise
+
+    @classmethod
     def before_run(cls, project, adapter, flat_graph):
         cls.try_create_schema(project, adapter)
-        try:
-            cls.run_hooks(project, adapter, flat_graph, RunHookType.Start)
-        except dbt.exceptions.RuntimeException as e:
-            msg = "Database error while running {}"
-            logger.info(msg.format(RunHookType.Start))
-            raise
+        cls.safe_run_hooks(project, adapter, flat_graph, RunHookType.Start)
 
     @classmethod
     def print_results_line(cls, results, execution_time):
@@ -275,12 +278,7 @@ class ModelRunner(CompileRunner):
 
     @classmethod
     def after_run(cls, project, adapter, results, flat_graph, elapsed):
-        try:
-            cls.run_hooks(project, adapter, flat_graph, RunHookType.End)
-        except dbt.exceptions.RuntimeException as e:
-            msg = "Database error while running {}"
-            logger.info(msg.format(RunHookType.End))
-            raise
+        cls.safe_run_hooks(project, adapter, flat_graph, RunHookType.End)
         cls.print_results_line(results, elapsed)
 
     def describe_node(self):


### PR DESCRIPTION
This now looks like:
```
Found 3 models, 3 tests, 2 archives, 1 analyses, 14 macros, 2 operations

Database error while running on-run-start
Encountered an error:
schema "badschema" does not exist
LINE 1: create table if not exists badschema.prehook_test (id int)
                                   ^
```

For https://github.com/fishtown-analytics/dbt/issues/456