### PR TITLE
quit on first error during compilation

### DIFF
--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -70,6 +70,9 @@ class BaseRunner(object):
 
         self.skip = False
 
+    def raise_on_first_error(self):
+        return False
+
     def is_ephemeral(self):
         return dbt.utils.get_materialization(self.node) == 'ephemeral'
 
@@ -167,6 +170,9 @@ class BaseRunner(object):
 class CompileRunner(BaseRunner):
     print_header = False
 
+    def raise_on_first_error(self):
+        return True
+
     def before_execute(self):
         pass
 
@@ -224,6 +230,10 @@ class CompileRunner(BaseRunner):
 
 
 class ModelRunner(CompileRunner):
+
+    def raise_on_first_error(self):
+        return False
+
     @classmethod
     def try_create_schema(cls, project, adapter):
         profile = project.run_environment()
@@ -307,6 +317,10 @@ class ModelRunner(CompileRunner):
 
 
 class TestRunner(CompileRunner):
+
+    def raise_on_first_error(self):
+        return False
+
     def describe_node(self):
         node_name = self.node.get('name')
         return "test {}".format(node_name)
@@ -351,6 +365,10 @@ class TestRunner(CompileRunner):
 
 
 class ArchiveRunner(CompileRunner):
+
+    def raise_on_first_error(self):
+        return False
+
     def describe_node(self):
         cfg = self.node.get('config', {})
         return "archive {source_schema}.{source_table} --> "\

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -85,7 +85,9 @@ class RunManager(object):
             result = runner.safe_run(flat_graph, existing)
             runner.after_execute(result)
 
-        if result.errored:
+        if result.errored and runner.raise_on_first_error():
+            raise dbt.exceptions.RuntimeException(result.error)
+        elif result.errored:
             logger.info(result.error)
 
         return result


### PR DESCRIPTION
Presently on `development`, `dbt compile` will "skip" dependents after a compilation error, whereas compilation should halt after the first error.

Before:
```
$ dbt compile
Found 3 models, 3 tests, 2 archives, 1 analyses, 14 macros, 2 operations

00:27:38 | Concurrency: 1 threads (target='dev')
00:27:38 |
! Compilation error while compiling model test:
! 'set' is undefined
00:27:39 | 7 of 11 SKIP relation dbt_dbanin.test2............................... [SKIP]
00:27:39 | 8 of 11 SKIP relation dbt_dbanin.ref_enabled......................... [SKIP]
00:27:39 | 9 of 11 SKIP relation dbt_dbanin.ref_disabled........................ [SKIP]
00:27:39 | 10 of 11 SKIP relation dbt_dbanin.lol................................ [SKIP]
00:27:39 | 11 of 11 SKIP relation dbt_dbanin.test3.............................. [SKIP]
00:27:39 | Done.
```

After:
```
$ dbt compile
Found 3 models, 3 tests, 2 archives, 1 analyses, 14 macros, 2 operations

00:29:29 | Concurrency: 1 threads (target='dev')
00:29:29 |
Encountered an error:
! Compilation error while compiling model test:
! 'set' is undefined
```