### PR TITLE
throw compiler error for nodes with dots in their names

### DIFF
--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -149,7 +149,13 @@ def find_macro_by_name(flat_graph, target_name, target_package):
 def find_by_name(flat_graph, target_name, target_package, subgraph,
                  nodetype):
     for name, model in flat_graph.get(subgraph).items():
-        resource_type, package_name, node_name = name.split('.')
+        node_parts = name.split('.')
+        if len(node_parts) != 3:
+            node_type = model.get('resource_type', 'node')
+            dbt.exceptions.raise_compiler_error(model,
+                    "{} names cannot contain '.' characters".format(node_type))
+
+        resource_type, package_name, node_name = node_parts
 
         if (resource_type == nodetype and
             ((target_name == node_name) and

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -152,8 +152,8 @@ def find_by_name(flat_graph, target_name, target_package, subgraph,
         node_parts = name.split('.')
         if len(node_parts) != 3:
             node_type = model.get('resource_type', 'node')
-            dbt.exceptions.raise_compiler_error(model,
-                    "{} names cannot contain '.' characters".format(node_type))
+            msg = "{} names cannot contain '.' characters".format(node_type)
+            dbt.exceptions.raise_compiler_error(model, msg)
 
         resource_type, package_name, node_name = node_parts
 


### PR DESCRIPTION
Saw this for an archive definition:

```
archive:
  - source_schema: public
    target_schema: public
    tables:
    - source_table: data
      target_table: "data.archived"
      updated_at: updated_at
      unique_key: unique_key
```

Before:
```
$ dbt run
Encountered an error:
too many values to unpack (expected 3)
```

After:
```
$ dbt run
Encountered an error:
! Compilation error while compiling model data.archived:
! archive names cannot contain '.' characters
```
