### PR TITLE
fix for schema creation

### DIFF
--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -462,6 +462,9 @@ class DefaultAdapter(object):
     def commit_if_has_connection(cls, profile, name):
         global connections_in_use
 
+        if name is None:
+            name = 'master'
+
         if connections_in_use.get(name) is None:
             return
 
@@ -580,7 +583,11 @@ class DefaultAdapter(object):
     def create_schema(cls, profile, schema, model_name=None):
         logger.debug('Creating schema "%s".', schema)
         sql = cls.get_create_schema_sql(schema)
-        return cls.add_query(profile, sql, model_name)
+        res = cls.add_query(profile, sql, model_name)
+
+        cls.commit_if_has_connection(profile, model_name)
+
+        return res
 
     @classmethod
     def drop_schema(cls, profile, schema, model_name=None):


### PR DESCRIPTION
Before, dbt would not issue the commit for a `create schema...` statement. On postgres/redshift, this behavior is correct. On Snowflake, the commit should be ignored, and `commit()` is a no-op on bq.

Sort of a temporary fix here until we can re-assess how we handle transactions.