### PR TITLE
fix for null output for tests defined in ephemeral dir [development]

### DIFF
--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -160,8 +160,9 @@ class BaseRunner(object):
         schema_name = self.get_schema(self.adapter, self.profile)
 
         node_name = self.node.get('name')
-        dbt.ui.printer.print_skip_line(self.node, schema_name, node_name,
-                                       self.node_index, self.num_nodes)
+        if not self.is_ephemeral_model(self.node):
+            dbt.ui.printer.print_skip_line(self.node, schema_name, node_name,
+                                           self.node_index, self.num_nodes)
 
         node_result = RunModelResult(self.node, skip=True)
         return node_result

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -78,8 +78,12 @@ class BaseRunner(object):
     def raise_on_first_error(self):
         return False
 
-    def is_ephemeral(self):
-        return dbt.utils.get_materialization(self.node) == 'ephemeral'
+    @classmethod
+    def is_ephemeral_model(cls, node):
+        materialized = dbt.utils.get_materialization(node)
+        resource_type = node.get('resource_type')
+
+        return materialized == 'ephemeral' and resource_type == NodeType.Model
 
     def safe_run(self, flat_graph, existing):
         catchable_errors = (dbt.exceptions.CompilationException,
@@ -95,7 +99,7 @@ class BaseRunner(object):
             result.node = compiled_node
 
             # for ephemeral nodes, we only want to compile, not run
-            if not self.is_ephemeral():
+            if not self.is_ephemeral_model(self.node):
                 result = self.run(compiled_node, existing, flat_graph)
 
         except catchable_errors as e:

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -53,14 +53,14 @@ class RunManager(object):
         all_nodes = dbt.utils.flatten_nodes(node_dependency_list)
 
         num_nodes = len([
-            n for n in all_nodes if get_materialization(n) != 'ephemeral'
+            n for n in all_nodes if not Runner.is_ephemeral_model(n)
         ])
 
         node_runners = {}
         i = 0
         for node in all_nodes:
             uid = node.get('unique_id')
-            if get_materialization(node) == 'ephemeral':
+            if Runner.is_ephemeral_model(node):
                 runner = Runner(self.project, adapter, node, 0, 0)
             else:
                 i += 1
@@ -78,12 +78,12 @@ class RunManager(object):
             return runner.on_skip()
 
         # no before/after printing for ephemeral mdoels
-        if not runner.is_ephemeral():
+        if not runner.is_ephemeral_model(runner.node):
             runner.before_execute()
 
         result = runner.safe_run(flat_graph, existing)
 
-        if not runner.is_ephemeral():
+        if not runner.is_ephemeral_model(runner.node):
             runner.after_execute(result)
 
         if result.errored and runner.raise_on_first_error():

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -130,7 +130,8 @@ class RunManager(object):
 
             try:
                 for result in pool.imap_unordered(self.call_runner, args_list):
-                    node_results.append(result)
+                    if not Runner.is_ephemeral_model(result.node):
+                        node_results.append(result)
 
                     node_id = result.node.get('unique_id')
                     flat_graph['nodes'][node_id] = result.node

--- a/test/integration/007_graph_selection_tests/models/emails.sql
+++ b/test/integration/007_graph_selection_tests/models/emails.sql
@@ -1,0 +1,6 @@
+
+{{
+    config(materialized='ephemeral')
+}}
+
+select distinct email from {{ ref('base_users') }}

--- a/test/integration/007_graph_selection_tests/models/schema.yml
+++ b/test/integration/007_graph_selection_tests/models/schema.yml
@@ -1,4 +1,8 @@
 
+emails:
+    constraints:
+        unique:
+            - email
 
 users:
     constraints:

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -23,6 +23,7 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('users_rollup' in created_models)
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
     @attr(type='snowflake')
     def test__snowflake__specific_model(self):
@@ -36,6 +37,7 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('users_rollup' in created_models)
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
 
     @attr(type='postgres')
@@ -50,6 +52,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected", "users_rollup")
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_and_children(self):
@@ -63,6 +66,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected", "users_rollup")
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
 
     @attr(type='postgres')
@@ -77,6 +81,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected", "users_rollup")
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_and_parents(self):
@@ -90,6 +95,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected", "users_rollup")
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)
 
 
     @attr(type='postgres')
@@ -104,6 +110,7 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('users_rollup' in created_models)
+        self.assertFalse('emails' in created_models)
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_with_exclusion(self):
@@ -117,3 +124,4 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('users_rollup' in created_models)
+        self.assertFalse('emails' in created_models)

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -28,7 +28,6 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
 
         self.use_default_project()
         self.project = read_project('dbt_project.yml')
-        self.expected_ephemeral = []
 
     def run_schema_and_assert(self, include, exclude, expected_tests):
         self.use_profile('postgres')
@@ -47,7 +46,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         print(test_results)
 
         ran_tests = sorted([test.node.get('name') for test in test_results])
-        expected_sorted = sorted(expected_tests + self.expected_ephemeral)
+        expected_sorted = sorted(expected_tests)
 
         self.assertEqual(ran_tests, expected_sorted)
 
@@ -56,7 +55,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             None,
-            ['base_users',
+            ['unique_emails_email',
              'unique_table_id',
              'unique_users_id',
              'unique_users_rollup_gender']
@@ -67,7 +66,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['users'],
             None,
-            ['base_users', 'unique_users_id']
+            ['unique_users_id']
         )
 
     @attr(type='postgres')
@@ -75,7 +74,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['users+'],
             None,
-            ['base_users', 'unique_users_id', 'unique_users_rollup_gender']
+            ['unique_users_id', 'unique_users_rollup_gender']
         )
 
     @attr(type='postgres')
@@ -83,7 +82,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['+users_rollup'],
             None,
-            ['base_users', 'unique_users_id', 'unique_users_rollup_gender']
+            ['unique_users_id', 'unique_users_rollup_gender']
         )
 
     @attr(type='postgres')
@@ -91,7 +90,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['+users_rollup'],
             ['users_rollup'],
-            ['base_users', 'unique_users_id']
+            ['unique_users_id']
         )
 
     @attr(type='postgres')
@@ -99,7 +98,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             ['users_rollup'],
-            ['base_users', 'unique_table_id', 'unique_users_id']
+            ['unique_emails_email', 'unique_table_id', 'unique_users_id']
         )
 
     @attr(type='postgres')
@@ -109,7 +108,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             None,
             # TODO: change this. there's no way to select only direct ancestors
             # atm.
-            ['base_users', 'unique_users_rollup_gender']
+            ['unique_users_rollup_gender']
         )
 
     @attr(type='postgres')
@@ -117,7 +116,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['*'],
             ['users'],
-            ['base_users', 'unique_table_id', 'unique_users_rollup_gender']
+            ['unique_emails_email', 'unique_table_id', 'unique_users_rollup_gender']
         )
 
     @attr(type='postgres')
@@ -141,5 +140,5 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             ['dbt_integration_project'],
-            ['base_users', 'unique_users_id', 'unique_users_rollup_gender']
+            ['unique_emails_email', 'unique_users_id', 'unique_users_rollup_gender']
         )


### PR DESCRIPTION
Previously, `schema.yml` files defined in models configured with `materialized: ephemeral` were effectively ignored by the dbt runner. dbt did not distinguish between ephemeral models and tests. 
 While it's a little strange that tests even have a `materialized` config, they are "resources" and adhere to the same contract as models. This branch fixes https://github.com/fishtown-analytics/dbt/issues/501

Before:
```
Found 3 models, 1 tests, 0 archives, 0 analyses, 30 macros, 0 operations

14:32:34 | Concurrency: 1 threads (target='dev')
14:32:34 |

Completed successfully

Done. PASS=2 ERROR=0 SKIP=0 TOTAL=2
```

After:
```
Found 3 models, 1 tests, 0 archives, 0 analyses, 30 macros, 0 operations

14:32:34 | Concurrency: 1 threads (target='dev')
14:32:34 |
14:32:34 | 1 of 1 START test unique_events_generate_series...................... [RUN]
14:32:37 | 1 of 1 PASS unique_events_generate_series............................ [PASS in 3.18s]

Completed successfully

Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
```