### PR TITLE
run hooks outside of a transaction

### DIFF
--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -67,7 +67,7 @@ class BigQueryAdapter(PostgresAdapter):
         pass
 
     @classmethod
-    def commit(cls, connection):
+    def commit(cls, profile, connection):
         pass
 
     @classmethod

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -517,6 +517,12 @@ class DefaultAdapter(object):
             return connection, cursor
 
     @classmethod
+    def clear_transaction(cls, profile, conn_name='master'):
+        conn = cls.begin(profile, conn_name)
+        cls.commit(profile, conn)
+        return conn_name
+
+    @classmethod
     def execute_one(cls, profile, sql, model_name=None, auto_begin=False):
         cls.get_connection(profile, model_name)
 

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -32,13 +32,13 @@ class DefaultAdapter(object):
         "truncate",
         "add_query",
         "expand_target_column_types",
+        "quote_schema_and_table",
     ]
 
     raw_functions = [
         "get_status",
         "get_result_from_cursor",
         "quote",
-        "quote_schema_and_table",
     ]
 
     ###
@@ -580,6 +580,6 @@ class DefaultAdapter(object):
         return '"{}"'.format(identifier)
 
     @classmethod
-    def quote_schema_and_table(cls, profile, schema, table):
+    def quote_schema_and_table(cls, profile, schema, table, model_name=None):
         return '{}.{}'.format(cls.quote(schema),
                               cls.quote(table))

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -397,6 +397,10 @@ class DefaultAdapter(object):
         return cls.add_query(profile, 'BEGIN', name, auto_begin=False)
 
     @classmethod
+    def add_commit_query(cls, profile, name):
+        return cls.add_query(profile, 'COMMIT', name, auto_begin=False)
+
+    @classmethod
     def begin(cls, profile, name='master'):
         global connections_in_use
         connection = cls.get_connection(profile, name)
@@ -428,10 +432,10 @@ class DefaultAdapter(object):
 
         connection = cls.get_connection(profile, name, False)
 
-        return cls.commit(connection)
+        return cls.commit(profile, connection)
 
     @classmethod
-    def commit(cls, connection):
+    def commit(cls, profile, connection):
         global connections_in_use
 
         if dbt.flags.STRICT_MODE:
@@ -445,7 +449,7 @@ class DefaultAdapter(object):
                 'it does not have one open!'.format(connection.get('name')))
 
         logger.debug('On {}: COMMIT'.format(connection.get('name')))
-        connection.get('handle').commit()
+        cls.add_commit_query(profile, connection.get('name'))
 
         connection['transaction_open'] = False
         connections_in_use[connection.get('name')] = connection

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -23,14 +23,14 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
         except psycopg2.DatabaseError as e:
             logger.debug('Postgres error: {}'.format(str(e)))
 
-            cls.rollback(connection)
+            cls.release_connection(profile, connection_name)
             raise dbt.exceptions.DatabaseException(
                 dbt.compat.to_string(e).strip())
 
         except Exception as e:
             logger.debug("Error running SQL: %s", sql)
             logger.debug("Rolling back transaction.")
-            cls.rollback(connection)
+            cls.release_connection(profile, connection_name)
             raise dbt.exceptions.RuntimeException(e)
 
     @classmethod

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -29,14 +29,14 @@ class RedshiftAdapter(PostgresAdapter):
             connection = cls.get_connection(profile, model_name)
 
             if connection.get('transaction_open'):
-                cls.commit(connection)
+                cls.commit(profile, connection)
 
             cls.begin(profile, connection.get('name'))
 
             to_return = super(PostgresAdapter, cls).drop(
                 profile, relation, relation_type, model_name)
 
-            cls.commit(connection)
+            cls.commit(profile, connection)
             cls.begin(profile, connection.get('name'))
 
             return to_return

--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -34,7 +34,7 @@ class SnowflakeAdapter(PostgresAdapter):
             if 'Empty SQL statement' in msg:
                 logger.debug("got empty sql statement, moving on")
             elif 'This session does not have a current database' in msg:
-                cls.rollback(connection)
+                cls.release_connection(profile, connection_name)
                 raise dbt.exceptions.FailedToConnectException(
                     ('{}\n\nThis error sometimes occurs when invalid '
                      'credentials are provided, or when your default role '
@@ -42,12 +42,12 @@ class SnowflakeAdapter(PostgresAdapter):
                      'Please double check your profile and try again.')
                     .format(msg))
             else:
-                cls.rollback(connection)
+                cls.release_connection(profile, connection_name)
                 raise dbt.exceptions.DatabaseException(msg)
         except Exception as e:
             logger.debug("Error running SQL: %s", sql)
             logger.debug("Rolling back transaction.")
-            cls.rollback(connection)
+            cls.release_connection(profile, connection_name)
             raise dbt.exceptions.RuntimeException(e.msg)
 
     @classmethod

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -251,6 +251,9 @@ def generate(model, project, flat_graph, provider=None):
     pre_hooks = get_hooks(model, context, 'pre-hook')
     post_hooks = get_hooks(model, context, 'post-hook')
 
+    pre_transaction_hooks = get_hooks(model, context, 'pre-transaction-hook')
+    post_transaction_hooks = get_hooks(model, context, 'post-transaction-hook')
+
     db_wrapper = DatabaseWrapper(model, adapter, profile)
 
     context = dbt.utils.merge(context, {
@@ -266,6 +269,8 @@ def generate(model, project, flat_graph, provider=None):
         "model": model,
         "post_hooks": post_hooks,
         "pre_hooks": pre_hooks,
+        "pre_transaction_hooks": pre_transaction_hooks,
+        "post_transaction_hooks": post_transaction_hooks,
         "ref": provider.ref(model, project, profile, schema, flat_graph),
         "schema": schema,
         "sql": model.get('injected_sql'),

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -3,7 +3,7 @@ import os
 import voluptuous
 
 from dbt.adapters.factory import get_adapter
-from dbt.compat import basestring
+from dbt.compat import basestring, to_string
 
 import dbt.clients.jinja
 import dbt.flags
@@ -11,22 +11,9 @@ import dbt.schema
 import dbt.tracking
 import dbt.utils
 
+import dbt.hooks
+
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
-
-
-def get_hooks(model, context, hook_key):
-    hooks = model.get('config', {}).get(hook_key, [])
-
-    if not isinstance(hooks, (list, tuple)):
-        hooks = [hooks]
-
-    wrapped_hooks = []
-    for hook in hooks:
-        if isinstance(hook, dict):
-            hook = json.dumps(hook)
-        wrapped_hooks.append(hook)
-
-    return wrapped_hooks
 
 
 class DatabaseWrapper(object):
@@ -263,8 +250,8 @@ def generate(model, project, flat_graph, provider=None):
     context = {'env': target}
     schema = profile.get('schema', 'public')
 
-    pre_hooks = get_hooks(model, context, 'pre-hook')
-    post_hooks = get_hooks(model, context, 'post-hook')
+    pre_hooks = model.get('config', {}).get('pre-hook')
+    post_hooks = model.get('config', {}).get('post-hook')
 
     db_wrapper = DatabaseWrapper(model, adapter, profile)
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -73,6 +73,10 @@ parsed_graph_contract = Schema({
 })
 
 
+def validate_hook(hook):
+    validate_with(hook_contract, hooks)
+
+
 def validate_nodes(parsed_nodes):
     validate_with(parsed_nodes_contract, parsed_nodes)
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -18,8 +18,6 @@ config_contract = Schema({
     Required('materialized'): basestring,
     Required('post-hook'): list,
     Required('pre-hook'): list,
-    Required('post-transaction-hook'): list,
-    Required('pre-transaction-hook'): list,
     Required('vars'): dict,
 }, extra=ALLOW_EXTRA)
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -12,12 +12,16 @@ from dbt.contracts.graph.unparsed import unparsed_node_contract, \
 
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
+hook_contract = Schema({
+    Required('sql'): basestring,
+    Required('transaction'): bool,
+})
 
 config_contract = Schema({
     Required('enabled'): bool,
     Required('materialized'): basestring,
-    Required('post-hook'): list,
-    Required('pre-hook'): list,
+    Required('post-hook'): [hook_contract],
+    Required('pre-hook'): [hook_contract],
     Required('vars'): dict,
 }, extra=ALLOW_EXTRA)
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -18,6 +18,8 @@ config_contract = Schema({
     Required('materialized'): basestring,
     Required('post-hook'): list,
     Required('pre-hook'): list,
+    Required('post-transaction-hook'): list,
+    Required('pre-transaction-hook'): list,
     Required('vars'): dict,
 }, extra=ALLOW_EXTRA)
 

--- a/dbt/graph/selector.py
+++ b/dbt/graph/selector.py
@@ -1,7 +1,7 @@
 import networkx as nx
 from dbt.logger import GLOBAL_LOGGER as logger
 
-from dbt.utils import is_enabled, get_materialization
+from dbt.utils import is_enabled, get_materialization, coalesce
 from dbt.node_types import NodeType
 
 SELECTOR_PARENTS = '+'
@@ -41,13 +41,6 @@ def parse_spec(node_spec):
         "qualified_node_name": qualified_node_name,
         "raw": node_spec
     }
-
-
-def coalesce(*args):
-    for arg in args:
-        if arg is not None:
-            return arg
-    return None
 
 
 def get_package_names(graph):

--- a/dbt/hooks.py
+++ b/dbt/hooks.py
@@ -38,5 +38,3 @@ def get_hooks(model, hook_key):
 
     wrapped = [get_hook_dict(hook) for hook in hooks]
     return wrapped
-
-

--- a/dbt/hooks.py
+++ b/dbt/hooks.py
@@ -1,0 +1,42 @@
+
+import json
+from dbt.compat import to_string
+
+
+class ModelHookType:
+    PreHook = 'pre-hook'
+    PostHook = 'post-hook'
+    Both = [PreHook, PostHook]
+
+
+def _parse_hook_to_dict(hook_string):
+    try:
+        hook_dict = json.loads(hook_string)
+    except ValueError as e:
+        hook_dict = {"sql": hook_string}
+
+    if 'transaction' not in hook_dict:
+        hook_dict['transaction'] = True
+
+    return hook_dict
+
+
+def get_hook_dict(hook):
+    if isinstance(hook, dict):
+        hook_dict = hook
+    else:
+        hook_dict = _parse_hook_to_dict(to_string(hook))
+
+    return hook_dict
+
+
+def get_hooks(model, hook_key):
+    hooks = model.get('config', {}).get(hook_key, [])
+
+    if not isinstance(hooks, (list, tuple)):
+        hooks = [hooks]
+
+    wrapped = [get_hook_dict(hook) for hook in hooks]
+    return wrapped
+
+

--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -1,4 +1,4 @@
-{% macro statement(name=None, fetch_result=False) -%}
+{% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
   {%- if execute: -%}
     {%- set sql = render(caller()) -%}
 
@@ -7,7 +7,7 @@
       {{ write(sql) }}
     {%- endif -%}
 
-    {%- set _, cursor = adapter.add_query(sql) -%}
+    {%- set _, cursor = adapter.add_query(sql, auto_begin=auto_begin) -%}
     {%- if name is not none -%}
       {%- set result = [] if not fetch_result else adapter.get_result_from_cursor(cursor) -%}
       {{ store_result(name, status=adapter.get_status(cursor), data=result) }}

--- a/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/helpers.sql
@@ -1,6 +1,6 @@
-{% macro run_hooks(hooks) %}
+{% macro run_hooks(hooks, auto_begin=True) %}
   {% for hook in hooks %}
-    {% call statement() %}
+    {% call statement(auto_begin=auto_begin) %}
       {{ hook }};
     {% endcall %}
   {% endfor %}

--- a/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/helpers.sql
@@ -1,8 +1,14 @@
-{% macro run_hooks(hooks, auto_begin=True) %}
+{% macro run_hooks(hooks, inside_transaction=True) %}
   {% for hook in hooks %}
-    {% call statement(auto_begin=auto_begin) %}
-      {{ hook }};
-    {% endcall %}
+    {%- set hook_data = fromjson(render(hook), {}) -%}
+    {%- set hook_is_in_transaction = hook_data.get('transaction', True) -%};
+    {%- set hook_sql = hook_data.get('sql', hook) -%};
+
+    {%- if hook_is_in_transaction == inside_transaction -%}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ hook_sql }}
+      {% endcall %}
+    {%- endif -%}
   {% endfor %}
 {% endmacro %}
 
@@ -18,4 +24,24 @@
   {%- for col in columns %}
     "{{ col.name }}" {{ col.data_type }} {%- if not loop.last %},{% endif %}
   {% endfor -%}
+{% endmacro %}
+
+
+{% macro make_hook_config(sql, inside_transaction) %}
+    {{ {"sql": sql, "transaction": inside_transaction} | tojson }}
+{% endmacro %}
+
+
+{% macro before_begin(sql) %}
+    {{ make_hook_config(sql, inside_transaction=False) }}
+{% endmacro %}
+
+
+{% macro after_commit(sql) %}
+    {{ make_hook_config(sql, inside_transaction=False) }}
+{% endmacro %}
+
+
+{% macro vacuum(tbl) %}
+    {{ after_commit('vacuum ' ~ adapter.quote_schema_and_table(tbl.schema, tbl.name)) }}
 {% endmacro %}

--- a/dbt/include/global_project/macros/materializations/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental.sql
@@ -38,6 +38,7 @@
     {{ adapter.drop(identifier, existing_type) }}
   {%- endif %}
 
+  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
   {{ run_hooks(pre_hooks) }}
 
   -- build model
@@ -80,7 +81,7 @@
   {%- endif %}
 
   {{ run_hooks(post_hooks) }}
-
   {{ adapter.commit() }}
+  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
 
 {%- endmaterialization %}

--- a/dbt/include/global_project/macros/materializations/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental.sql
@@ -38,8 +38,10 @@
     {{ adapter.drop(identifier, existing_type) }}
   {%- endif %}
 
-  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
   {% if force_create or not adapter.already_exists(schema, identifier) -%}
@@ -80,8 +82,11 @@
      {% endcall %}
   {%- endif %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
   {{ adapter.commit() }}
-  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 
 {%- endmaterialization %}

--- a/dbt/include/global_project/macros/materializations/table.sql
+++ b/dbt/include/global_project/macros/materializations/table.sql
@@ -14,6 +14,7 @@
     {%- endif %}
   {%- endif %}
 
+  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
   {{ run_hooks(pre_hooks) }}
 
   -- build model
@@ -51,4 +52,6 @@
   {%- endif %}
 
   {{ adapter.commit() }}
+
+  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
 {% endmaterialization %}

--- a/dbt/include/global_project/macros/materializations/table.sql
+++ b/dbt/include/global_project/macros/materializations/table.sql
@@ -14,8 +14,10 @@
     {%- endif %}
   {%- endif %}
 
-  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
   {% call statement('main') -%}
@@ -38,7 +40,7 @@
     {%- endif -%}
   {%- endcall %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   -- cleanup
   {% if non_destructive_mode -%}
@@ -51,7 +53,8 @@
     {{ adapter.rename(tmp_identifier, identifier) }}
   {%- endif %}
 
+  -- `COMMIT` happens here
   {{ adapter.commit() }}
 
-  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 {% endmaterialization %}

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -6,6 +6,7 @@
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
+  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
   {{ run_hooks(pre_hooks) }}
 
   -- build model
@@ -31,5 +32,7 @@
   {%- endif %}
 
   {{ adapter.commit() }}
+
+  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
 
 {%- endmaterialization -%}

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -6,8 +6,8 @@
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
-  {{ run_hooks(pre_transaction_hooks, auto_begin=False) }}
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks | rejectattr('transaction'), auto_begin=False) }}
+  {{ run_hooks(pre_hooks | selectattr('transaction')) }}
 
   -- build model
   {% if non_destructive_mode and existing_type == 'view' -%}
@@ -18,7 +18,7 @@
     {%- endcall %}
   {%- endif %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks | selectattr('transaction')) }}
 
   -- cleanup
   {% if non_destructive_mode and existing_type == 'view' -%}
@@ -33,6 +33,6 @@
 
   {{ adapter.commit() }}
 
-  {{ run_hooks(post_transaction_hooks, auto_begin=False) }}
+  {{ run_hooks(post_hooks | rejectattr('transaction'), auto_begin=False) }}
 
 {%- endmaterialization -%}

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -10,7 +10,7 @@ from dbt.utils import split_path, deep_merge, DBTConfigKeys
 class SourceConfig(object):
     ConfigKeys = DBTConfigKeys
 
-    AppendListFields = ['pre-hook', 'post-hook']
+    AppendListFields = ['pre-hook', 'post-hook', 'pre-transaction-hook', 'post-transaction-hook']
     ExtendDictFields = ['vars']
     ClobberFields = [
         'enabled',
@@ -83,7 +83,7 @@ class SourceConfig(object):
 
         # make sure we're not clobbering an array of hooks with a single hook
         # string
-        hook_fields = ['pre-hook', 'post-hook']
+        hook_fields = ['pre-hook', 'post-hook', 'pre-transaction-hook', 'post-transaction-hook']
         for hook_field in hook_fields:
             if hook_field in config:
                 config[hook_field] = self.__get_hooks(config, hook_field)

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -10,7 +10,7 @@ from dbt.utils import split_path, deep_merge, DBTConfigKeys
 class SourceConfig(object):
     ConfigKeys = DBTConfigKeys
 
-    AppendListFields = ['pre-hook', 'post-hook', 'pre-transaction-hook', 'post-transaction-hook']
+    AppendListFields = ['pre-hook', 'post-hook']
     ExtendDictFields = ['vars']
     ClobberFields = [
         'enabled',
@@ -83,7 +83,7 @@ class SourceConfig(object):
 
         # make sure we're not clobbering an array of hooks with a single hook
         # string
-        hook_fields = ['pre-hook', 'post-hook', 'pre-transaction-hook', 'post-transaction-hook']
+        hook_fields = ['pre-hook', 'post-hook']
         for hook_field in hook_fields:
             if hook_field in config:
                 config[hook_field] = self.__get_hooks(config, hook_field)
@@ -91,22 +91,13 @@ class SourceConfig(object):
         self.in_model_config.update(config)
 
     def __get_hooks(self, relevant_configs, key):
-        hooks = []
-
         if key not in relevant_configs:
             return []
 
-        new_hooks = relevant_configs[key]
-        if type(new_hooks) not in [list, tuple]:
-            new_hooks = [new_hooks]
+        hooks = relevant_configs[key]
+        if not isinstance(hooks, (list, tuple)):
+            hooks = [hooks]
 
-        for hook in new_hooks:
-            if not isinstance(hook, basestring):
-                name = ".".join(self.fqn)
-                dbt.exceptions.raise_compiler_error(
-                    "{} for model {} is not a string!".format(key, name))
-
-            hooks.append(hook)
         return hooks
 
     def smart_update(self, mutable_config, new_configs):

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -221,6 +221,12 @@ def parse_node(node, node_path, root_project_config, package_project_config,
         node.get('raw_sql'), context, node,
         capture_macros=True)
 
+    # Clean up any open connections opened by adapter functions that hit the db
+    db_wrapper = context['adapter']
+    adapter = db_wrapper.adapter
+    profile = db_wrapper.profile
+    adapter.release_connection(profile, node.get('name'))
+
     # Overwrite node config
     config_dict = node.get('config', {})
     config_dict.update(config.config)

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -22,7 +22,7 @@ import dbt.contracts.project
 from dbt.node_types import NodeType, RunHookType
 from dbt.compat import basestring, to_string
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.utils import get_pseudo_test_path
+from dbt.utils import get_pseudo_test_path, coalesce
 
 
 def get_path(resource_type, package_name, resource_name):
@@ -187,14 +187,9 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     logger.debug("Parsing {}".format(node_path))
     node = copy.deepcopy(node)
 
-    if tags is None:
-        tags = set()
-
-    if fqn_extra is None:
-        fqn_extra = []
-
-    if macros is None:
-        macros = {}
+    tags = coalesce(tags, set())
+    fqn_extra = coalesce(tags, [])
+    macros = coalesce(macros, {})
 
     node.update({
         'refs': [],

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -188,7 +188,7 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     node = copy.deepcopy(node)
 
     tags = coalesce(tags, set())
-    fqn_extra = coalesce(tags, [])
+    fqn_extra = coalesce(fqn_extra, [])
     macros = coalesce(macros, {})
 
     node.update({

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -43,6 +43,13 @@ class This(object):
         return self.schema_table(self.schema, self.table)
 
 
+def coalesce(*args):
+    for arg in args:
+        if arg is not None:
+            return arg
+    return None
+
+
 def get_model_name_or_none(model):
     if model is None:
         name = '<None>'

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -20,8 +20,6 @@ DBTConfigKeys = [
     'sort_type',
     'pre-hook',
     'post-hook',
-    'pre-transaction-hook',
-    'post-transaction-hook',
     'vars'
 ]
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -20,6 +20,8 @@ DBTConfigKeys = [
     'sort_type',
     'pre-hook',
     'post-hook',
+    'pre-transaction-hook',
+    'post-transaction-hook',
     'vars'
 ]
 


### PR DESCRIPTION
This is required to get `vacuum` working in post- hooks. Pre/Post hooks can now be:
 - a string
 - a json string containing a "sql" string key and a "transaction" key

All of the following are valid:
```
{{ config(
    'post-hook': [
        'select 1 -- inside transaction',
        {"sql": "select 2 -- inside transaction", "transaction": true},
        {"sql": "vacuum {{ this }}", "transaction": false},
        '{{ after_commit("vacuum " ~ adapter.quote_schema_and_table(this.schema, this.name)) }}',
        '{{ vacuum(this) }} -- this is a macro which expands to a post-transaction json string'
    ]
) }}
```