### PR TITLE
always delete the __dbt_tmp relation if exists

### DIFF
--- a/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/helpers.sql
@@ -19,3 +19,11 @@
     "{{ col.name }}" {{ col.data_type }} {%- if not loop.last %},{% endif %}
   {% endfor -%}
 {% endmacro %}
+
+
+{% macro drop_if_exists(existing, name) %}
+  {% set existing_type = existing.get(name) %}
+  {% if existing_type is not none %}
+    {{ adapter.drop(name, existing_type) }}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/global_project/macros/materializations/table.sql
+++ b/dbt/include/global_project/macros/materializations/table.sql
@@ -5,6 +5,8 @@
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
+  {{ drop_if_exists(existing, tmp_identifier) }}
+
   -- setup
   {% if non_destructive_mode -%}
     {% if existing_type == 'table' -%}
@@ -43,10 +45,7 @@
   {% if non_destructive_mode -%}
     -- noop
   {%- else -%}
-    {%- if existing_type is not none -%}
-      {{ adapter.drop(identifier, existing_type) }}
-    {%- endif %}
-
+    {{ drop_if_exists(existing, identifier) }}
     {{ adapter.rename(tmp_identifier, identifier) }}
   {%- endif %}
 

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -6,6 +6,8 @@
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
+  {{ drop_if_exists(existing, tmp_identifier) }}
+
   {{ run_hooks(pre_hooks) }}
 
   -- build model
@@ -23,10 +25,7 @@
   {% if non_destructive_mode and existing_type == 'view' -%}
     -- noop
   {%- else -%}
-    {% if existing_type is not none -%}
-      {{ adapter.drop(identifier, existing_type) }}
-    {%- endif %}
-
+    {{ drop_if_exists(existing, identifier) }}
     {{ adapter.rename(tmp_identifier, identifier) }}
   {%- endif %}
 

--- a/test/integration/017_runtime_materialization_tests/create_view__dbt_tmp.sql
+++ b/test/integration/017_runtime_materialization_tests/create_view__dbt_tmp.sql
@@ -1,0 +1,4 @@
+
+create view {schema}.view__dbt_tmp as (
+    select 1 as id
+);

--- a/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
+++ b/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
@@ -74,3 +74,13 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTablesEqual("seed","view")
         self.assertTablesEqual("seed","incremental")
         self.assertTablesEqual("seed","materialized")
+
+
+    @attr(type='postgres')
+    def test_delete__dbt_tmp_relation(self):
+        # This creates a __dbt_tmp view - make sure it doesn't interfere with the dbt run
+        self.run_sql_file("test/integration/017_runtime_materialization_tests/create_view__dbt_tmp.sql")
+        self.run_dbt(['run', '--model', 'view'])
+
+        self.assertTableDoesNotExist('view__dbt_tmp')
+        self.assertTablesEqual("seed","view")


### PR DESCRIPTION
- added a help macro for dropping relations
- always drop `__dbt_tmp` relations if they exists

This caused problems if a previous run abandoned `__dbt_tmp` relations. You'd either need to drop the whole schema or manually delete each relation, which is tedious