### PR TITLE
custom schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ test-integration:
 	@echo "Integration test run starting..."
 	@time docker-compose run test tox -e integration-postgres-py27,integration-postgres-py35,integration-snowflake-py27,integration-snowflake-py35,integration-bigquery-py27,integration-bigquery-py35
 
-test-it:
-	@echo "Integration test run starting..."
-	@time docker-compose run test tox -e integration-postgres-py27 -- -x
-
 test-new:
 	@echo "Test run starting..."
 	@echo "Changed test files:"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ test-integration:
 	@echo "Integration test run starting..."
 	@time docker-compose run test tox -e integration-postgres-py27,integration-postgres-py35,integration-snowflake-py27,integration-snowflake-py35,integration-bigquery-py27,integration-bigquery-py35
 
+test-it:
+	@echo "Integration test run starting..."
+	@time docker-compose run test tox -e integration-postgres-py27 -- -x
+
 test-new:
 	@echo "Test run starting..."
 	@echo "Changed test files:"

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -142,9 +142,15 @@ class BigQueryAdapter(PostgresAdapter):
         return result
 
     @classmethod
-    def query_for_existing(cls, profile, schema, model_name=None):
-        dataset = cls.get_dataset(profile, schema, model_name)
-        tables = dataset.list_tables()
+    def query_for_existing(cls, profile, schemas, model_name=None):
+        if not isinstance(schemas, (list, tuple)):
+            schemas = [schemas]
+
+        all_tables = []
+        for schema in schemas:
+            dataset = cls.get_dataset(profile, schema, model_name)
+            all_tables.extend(dataset.list_tables())
+
 
         relation_type_lookup = {
             'TABLE': 'table',
@@ -153,7 +159,7 @@ class BigQueryAdapter(PostgresAdapter):
         }
 
         existing = [(table.name, relation_type_lookup.get(table.table_type))
-                    for table in tables]
+                    for table in all_tables]
 
         return dict(existing)
 

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -158,14 +158,13 @@ class BigQueryAdapter(PostgresAdapter):
         return dict(existing)
 
     @classmethod
-    def drop(cls, profile, relation, relation_type, model_name=None):
-        schema = cls.get_default_schema(profile)
+    def drop(cls, profile, schema, relation, relation_type, model_name=None):
         dataset = cls.get_dataset(profile, schema, model_name)
         relation_object = dataset.table(relation)
         relation_object.delete()
 
     @classmethod
-    def rename(cls, profile, from_name, to_name, model_name=None):
+    def rename(cls, profile, schema, from_name, to_name, model_name=None):
         raise dbt.exceptions.NotImplementedException(
             '`rename` is not implemented for this adapter!')
 
@@ -234,10 +233,10 @@ class BigQueryAdapter(PostgresAdapter):
             validate_connection(connection)
 
         model_name = model.get('name')
+        model_schema = model.get('schema')
         model_sql = model.get('injected_sql')
 
-        schema = cls.get_default_schema(profile)
-        dataset = cls.get_dataset(profile, schema, model_name)
+        dataset = cls.get_dataset(profile, model_schema, model_name)
 
         if materialization == 'view':
             res = cls.materialize_as_view(profile, dataset, model_name,

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -151,7 +151,6 @@ class BigQueryAdapter(PostgresAdapter):
             dataset = cls.get_dataset(profile, schema, model_name)
             all_tables.extend(dataset.list_tables())
 
-
         relation_type_lookup = {
             'TABLE': 'table',
             'VIEW': 'view',

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -314,12 +314,22 @@ class BigQueryAdapter(PostgresAdapter):
             dataset.delete()
 
     @classmethod
+    def get_existing_schemas(cls, profile, model_name=None):
+        conn = cls.get_connection(profile, model_name)
+
+        client = conn.get('handle')
+
+        with cls.exception_handler(profile, 'list dataset', model_name):
+            all_datasets = client.list_datasets()
+            return [ds.name for ds in all_datasets]
+
+    @classmethod
     def check_schema_exists(cls, profile, schema, model_name=None):
         conn = cls.get_connection(profile, model_name)
 
         client = conn.get('handle')
 
-        with cls.exception_handler(profile, 'create dataset', model_name):
+        with cls.exception_handler(profile, 'get dataset', model_name):
             all_datasets = client.list_datasets()
             return any([ds.name == schema for ds in all_datasets])
 

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -109,42 +109,42 @@ class DefaultAdapter(object):
         return data
 
     @classmethod
-    def drop(cls, profile, relation, relation_type, model_name=None):
+    def drop(cls, profile, schema, relation, relation_type, model_name=None):
         if relation_type == 'view':
-            return cls.drop_view(profile, relation, model_name)
+            return cls.drop_view(profile, schema, relation, model_name)
         elif relation_type == 'table':
-            return cls.drop_table(profile, relation, model_name)
+            return cls.drop_table(profile, schema, relation, model_name)
         else:
             raise RuntimeError(
                 "Invalid relation_type '{}'"
                 .format(relation_type))
 
     @classmethod
-    def drop_view(cls, profile, view, model_name):
-        sql = ('drop view if exists {} cascade'
-               .format(cls._get_quoted_identifier(profile, view)))
+    def drop_view(cls, profile, schema, view, model_name):
+        relation = cls.quote_schema_and_table(profile, schema, view)
+        sql = 'drop view if exists {} cascade'.format(relation)
 
         connection, cursor = cls.add_query(profile, sql, model_name)
 
     @classmethod
-    def drop_table(cls, profile, table, model_name):
-        sql = ('drop table if exists {} cascade'
-               .format(cls._get_quoted_identifier(profile, table)))
+    def drop_table(cls, profile, schema, table, model_name):
+        relation = cls.quote_schema_and_table(profile, schema, table)
+        sql = 'drop table if exists {} cascade'.format(relation)
 
         connection, cursor = cls.add_query(profile, sql, model_name)
 
     @classmethod
-    def truncate(cls, profile, table, model_name=None):
-        sql = ('truncate table {}'
-               .format(cls._get_quoted_identifier(profile, table)))
+    def truncate(cls, profile, schema, table, model_name=None):
+        relation = cls.quote_schema_and_table(profile, schema, table)
+        sql = 'truncate table {}'.format(relation)
 
         connection, cursor = cls.add_query(profile, sql, model_name)
 
     @classmethod
-    def rename(cls, profile, from_name, to_name, model_name=None):
-        sql = ('alter table {} rename to {}'
-               .format(cls._get_quoted_identifier(profile, from_name),
-                       cls.quote(to_name)))
+    def rename(cls, profile, schema, from_name, to_name, model_name=None):
+        from_relation = cls.quote_schema_and_table(profile, schema, from_name)
+        to_relation = cls.quote(to_name)
+        sql = 'alter table {} rename to {}'.format(from_relation, to_relation)
 
         connection, cursor = cls.add_query(profile, sql, model_name)
 
@@ -580,11 +580,6 @@ class DefaultAdapter(object):
         Alias for `table_exists`.
         """
         return cls.table_exists(profile, schema, table, model_name)
-
-    @classmethod
-    def _get_quoted_identifier(cls, profile, identifier):
-        return cls.quote_schema_and_table(
-            profile, cls.get_default_schema(profile), identifier)
 
     @classmethod
     def quote(cls, identifier):

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -74,7 +74,7 @@ class DefaultAdapter(object):
             '`alter_column_type` is not implemented for this adapter!')
 
     @classmethod
-    def query_for_existing(cls, profile, schema, model_name=None):
+    def query_for_existing(cls, profile, schemas, model_name=None):
         raise dbt.exceptions.NotImplementedException(
             '`query_for_existing` is not implemented for this adapter!')
 

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -120,18 +120,19 @@ class DefaultAdapter(object):
                 .format(relation_type))
 
     @classmethod
-    def drop_view(cls, profile, schema, view, model_name):
-        relation = cls.quote_schema_and_table(profile, schema, view)
-        sql = 'drop view if exists {} cascade'.format(relation)
+    def drop_relation(cls, profile, schema, rel_name, rel_type, model_name):
+        relation = cls.quote_schema_and_table(profile, schema, rel_name)
+        sql = 'drop {} if exists {} cascade'.format(rel_type, relation)
 
         connection, cursor = cls.add_query(profile, sql, model_name)
 
     @classmethod
-    def drop_table(cls, profile, schema, table, model_name):
-        relation = cls.quote_schema_and_table(profile, schema, table)
-        sql = 'drop table if exists {} cascade'.format(relation)
+    def drop_view(cls, profile, schema, view, model_name):
+        cls.drop_relation(profile, schema, view, 'view', model_name)
 
-        connection, cursor = cls.add_query(profile, sql, model_name)
+    @classmethod
+    def drop_table(cls, profile, schema, table, model_name):
+        cls.drop_relation(profile, schema, view, 'table', model_name)
 
     @classmethod
     def truncate(cls, profile, schema, table, model_name=None):

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -79,6 +79,11 @@ class DefaultAdapter(object):
             '`query_for_existing` is not implemented for this adapter!')
 
     @classmethod
+    def get_existing_schemas(cls, profile, model_name=None):
+        raise dbt.exceptions.NotImplementedException(
+            '`get_existing_schemas` is not implemented for this adapter!')
+
+    @classmethod
     def check_schema_exists(cls, profile, schema):
         raise dbt.exceptions.NotImplementedException(
             '`check_schema_exists` is not implemented for this adapter!')

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -132,7 +132,7 @@ class DefaultAdapter(object):
 
     @classmethod
     def drop_table(cls, profile, schema, table, model_name):
-        cls.drop_relation(profile, schema, view, 'table', model_name)
+        cls.drop_relation(profile, schema, table, 'table', model_name)
 
     @classmethod
     def truncate(cls, profile, schema, table, model_name=None):

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -107,14 +107,19 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
         return connection, cursor
 
     @classmethod
-    def query_for_existing(cls, profile, schema, model_name=None):
+    def query_for_existing(cls, profile, schemas, model_name=None):
+        if not isinstance(schemas, (list, tuple)):
+            schemas = [schemas]
+
+        schema_list = ",".join(["'{}'".format(schema) for schema in schemas])
+
         sql = """
         select tablename as name, 'table' as type from pg_tables
-        where schemaname = '{schema}'
+        where schemaname in ({schema_list})
         union all
         select viewname as name, 'view' as type from pg_views
-        where schemaname = '{schema}'
-        """.format(schema=schema).strip()  # noqa
+        where schemaname in ({schema_list})
+        """.format(schema_list=schema_list).strip()  # noqa
 
         connection, cursor = cls.add_query(profile, sql, model_name,
                                            auto_begin=False)

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -126,6 +126,16 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
         return dict(existing)
 
     @classmethod
+    def get_existing_schemas(cls, profile, model_name=None):
+        sql = "select distinct nspname from pg_namespace"
+
+        connection, cursor = cls.add_query(profile, sql, model_name,
+                                           auto_begin=False)
+        results = cursor.fetchall()
+
+        return [row[0] for row in results]
+
+    @classmethod
     def check_schema_exists(cls, profile, schema, model_name=None):
         sql = """
         select count(*) from pg_namespace where nspname = '{schema}'

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -18,7 +18,7 @@ class RedshiftAdapter(PostgresAdapter):
         return 'getdate()'
 
     @classmethod
-    def drop(cls, profile, relation, relation_type, model_name=None):
+    def drop(cls, profile, schema, relation, relation_type, model_name=None):
         global drop_lock
 
         to_return = None
@@ -34,7 +34,7 @@ class RedshiftAdapter(PostgresAdapter):
             cls.begin(profile, connection.get('name'))
 
             to_return = super(PostgresAdapter, cls).drop(
-                profile, relation, relation_type, model_name)
+                profile, schema, relation, relation_type, model_name)
 
             cls.commit(profile, connection)
             cls.begin(profile, connection.get('name'))

--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -178,8 +178,9 @@ class SnowflakeAdapter(PostgresAdapter):
         cursor = None
 
         if select_schema and schema is None:
-            raise dbt.exceptions.InternalException("`add_query` was called "
-                    "with `select_schema`, but no `schema` was provided!")
+            msg = ("`add_query` was called with `select_schema`, but no "
+                   "`schema` was provided!")
+            raise dbt.exceptions.InternalException(msg)
 
         elif select_schema:
             super(PostgresAdapter, cls).add_query(

--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -147,6 +147,17 @@ class SnowflakeAdapter(PostgresAdapter):
         return cls.add_query(profile, sql, model_name, select_schema=False)
 
     @classmethod
+    def get_existing_schemas(cls, profile, model_name=None):
+        sql = "select distinct SCHEMA_NAME from INFORMATION_SCHEMA.SCHEMATA"
+
+        connection, cursor = cls.add_query(profile, sql, model_name,
+                                           select_schema=False,
+                                           auto_begin=False)
+        results = cursor.fetchall()
+
+        return [row[0] for row in results]
+
+    @classmethod
     def check_schema_exists(cls, profile, schema, model_name=None):
         sql = """
         select count(*)

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -249,6 +249,7 @@ def generate(model, project, flat_graph, provider=None):
 
     context = {'env': target}
     schema = profile.get('schema', 'public')
+    schema_prefix = profile.get('schema_prefix', "{}_".format(schema))
 
     pre_hooks = model.get('config', {}).get('pre-hook')
     post_hooks = model.get('config', {}).get('post-hook')
@@ -270,6 +271,7 @@ def generate(model, project, flat_graph, provider=None):
         "pre_hooks": pre_hooks,
         "ref": provider.ref(model, project, profile, schema, flat_graph),
         "schema": schema,
+        "schema_prefix": schema_prefix,
         "sql": model.get('injected_sql'),
         "sql_now": adapter.date_function(),
         "fromjson": fromjson(model),

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -269,7 +269,7 @@ def generate(model, project, flat_graph, provider=None):
         "model": model,
         "post_hooks": post_hooks,
         "pre_hooks": pre_hooks,
-        "ref": provider.ref(model, project, profile, schema, flat_graph),
+        "ref": provider.ref(model, project, profile, flat_graph),
         "schema": model.get('schema', schema),
         "schema_prefix": schema_prefix,
         "sql": model.get('injected_sql'),

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -79,9 +79,9 @@ def _add_macros(context, model, flat_graph):
             macros_to_add['global'].append(macro_map)
 
     # Load global macros before local macros -- local takes precedence
-    for precedence in ['global', 'local']:
-        for macro_map in macros_to_add[precedence]:
-            context.update(macro_map)
+    unprefixed_macros = macros_to_add['global'] + macros_to_add['local']
+    for macro_map in unprefixed_macros:
+        context.update(macro_map)
 
     return context
 

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -270,14 +270,14 @@ def generate(model, project, flat_graph, provider=None):
         "post_hooks": post_hooks,
         "pre_hooks": pre_hooks,
         "ref": provider.ref(model, project, profile, schema, flat_graph),
-        "schema": schema,
+        "schema": model.get('schema', schema),
         "schema_prefix": schema_prefix,
         "sql": model.get('injected_sql'),
         "sql_now": adapter.date_function(),
         "fromjson": fromjson(model),
         "target": target,
         "this": dbt.utils.This(
-            schema,
+            model.get('schema', schema),
             dbt.utils.model_immediate_name(model, dbt.flags.NON_DESTRUCTIVE),
             model.get('name')
         )

--- a/dbt/context/parser.py
+++ b/dbt/context/parser.py
@@ -7,7 +7,7 @@ import dbt.context.common
 execute = False
 
 
-def ref(model, project, profile, schema, flat_graph):
+def ref(model, project, profile, flat_graph):
 
     def ref(*args):
         if len(args) == 1 or len(args) == 2:

--- a/dbt/context/runtime.py
+++ b/dbt/context/runtime.py
@@ -14,7 +14,7 @@ from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 execute = True
 
 
-def ref(model, project, profile, schema, flat_graph):
+def ref(model, project, profile, flat_graph):
     current_project = project.get('name')
 
     def do_ref(*args):
@@ -54,6 +54,7 @@ def ref(model, project, profile, schema, flat_graph):
         else:
             adapter = get_adapter(profile)
             table = target_model.get('name')
+            schema = target_model.get('schema')
 
             return adapter.quote_schema_and_table(profile, schema, table)
 

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -22,7 +22,6 @@ postgres_credentials_contract = Schema({
     Required('pass'): basestring,
     Required('port'): All(int, Range(min=0, max=65535)),
     Required('schema'): basestring,
-    Optional('schema_prefix'): basestring,
 })
 
 snowflake_credentials_contract = Schema({
@@ -31,7 +30,6 @@ snowflake_credentials_contract = Schema({
     Required('password'): basestring,
     Required('database'): basestring,
     Required('schema'): basestring,
-    Optional('schema_prefix'): basestring,
     Required('warehouse'): basestring,
     Optional('role'): basestring,
 })
@@ -41,7 +39,6 @@ bigquery_credentials_contract = Schema({
     Required('method'): Any(*bigquery_auth_methods),
     Required('project'): basestring,
     Required('schema'): basestring,
-    Optional('schema_prefix'): basestring,
     Optional('keyfile'): basestring,
     Optional('keyfile_json'): object,
     Optional('timeout_seconds'): int,

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -22,6 +22,7 @@ postgres_credentials_contract = Schema({
     Required('pass'): basestring,
     Required('port'): All(int, Range(min=0, max=65535)),
     Required('schema'): basestring,
+    Optional('schema_prefix'): basestring,
 })
 
 snowflake_credentials_contract = Schema({
@@ -30,6 +31,7 @@ snowflake_credentials_contract = Schema({
     Required('password'): basestring,
     Required('database'): basestring,
     Required('schema'): basestring,
+    Optional('schema_prefix'): basestring,
     Required('warehouse'): basestring,
     Optional('role'): basestring,
 })
@@ -39,6 +41,7 @@ bigquery_credentials_contract = Schema({
     Required('method'): Any(*bigquery_auth_methods),
     Required('project'): basestring,
     Required('schema'): basestring,
+    Optional('schema_prefix'): basestring,
     Optional('keyfile'): basestring,
     Optional('keyfile_json'): object,
     Optional('timeout_seconds'): int,

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -29,6 +29,7 @@ parsed_node_contract = unparsed_node_contract.extend({
     # identifiers
     Required('unique_id'): All(basestring, Length(min=1, max=255)),
     Required('fqn'): All(list, [All(basestring)]),
+    Required('schema'): basestring,
 
     Required('refs'): [All(tuple)],
 

--- a/dbt/include/global_project/macros/etc/get_custom_schema.sql
+++ b/dbt/include/global_project/macros/etc/get_custom_schema.sql
@@ -1,0 +1,54 @@
+
+{#
+    Renders a schema name given a custom schema name. If the custom
+    schema name is none, then the resulting schema is just the "schema"
+    value in the specified target. If a schema override is specified, then
+    the resulting schema is the default schema concatenated with the 
+    custom schema.
+
+    This macro can be overriden in projects to define different semantics
+    for rendering a schema name.
+
+    Arguments:
+    custom_schema_name: The custom schema name specified for a model, or none
+
+#}
+{% macro generate_schema_name(custom_schema_name=none) -%}
+
+    {%- set default_schema = target.schema -%}
+    {%- if custom_schema_name is none -%}
+
+        {{ default_schema }}
+
+    {%- else -%}
+
+        {{ default_schema }}_{{ custom_schema_name | trim }}
+
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{#
+    Renders a schema name given a custom schema name. In production, this macro
+    will render out the overriden schema name for a model. Otherwise, the default
+    schema specified in the active target is used.
+
+    Arguments:
+    custom_schema_name: The custom schema name specified for a model, or none
+
+#}
+{% macro generate_schema_name_for_env(custom_schema_name=none) -%}
+
+    {%- set default_schema = target.schema -%}
+    {%- if target.name == 'prod' and custom_schema_name is not none -%}
+
+        {{ custom_schema_name | trim }}
+
+    {%- else -%}
+
+        {{ default_schema }}
+
+    {%- endif -%}
+
+{%- endmacro %}

--- a/dbt/include/global_project/macros/materializations/bigquery.sql
+++ b/dbt/include/global_project/macros/materializations/bigquery.sql
@@ -7,7 +7,7 @@
   {%- set existing_type = existing.get(identifier) -%}
 
   {%- if existing_type is not none -%}
-    {{ adapter.drop(identifier, existing_type) }}
+    {{ adapter.drop(schema, identifier, existing_type) }}
   {%- endif -%}
 
   -- build model
@@ -25,7 +25,7 @@
   {%- set existing_type = existing.get(identifier) -%}
 
   {%- if existing_type is not none -%}
-    {{ adapter.drop(identifier, existing_type) }}
+    {{ adapter.drop(schema, identifier, existing_type) }}
   {%- endif -%}
 
   -- build model

--- a/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/helpers.sql
@@ -41,9 +41,9 @@
 {% endmacro %}
 
 
-{% macro drop_if_exists(existing, name) %}
+{% macro drop_if_exists(existing, schema, name) %}
   {% set existing_type = existing.get(name) %}
   {% if existing_type is not none %}
-    {{ adapter.drop(name, existing_type) }}
+    {{ adapter.drop(schema, name, existing_type) }}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/global_project/macros/materializations/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental.sql
@@ -33,9 +33,9 @@
   {% if existing_type is none -%}
     -- noop
   {%- elif should_truncate -%}
-    {{ adapter.truncate(identifier) }}
+    {{ adapter.truncate(schema, identifier) }}
   {%- elif should_drop -%}
-    {{ adapter.drop(identifier, existing_type) }}
+    {{ adapter.drop(schema, identifier, existing_type) }}
   {%- endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/dbt/include/global_project/macros/materializations/table.sql
+++ b/dbt/include/global_project/macros/materializations/table.sql
@@ -5,14 +5,14 @@
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
-  {{ drop_if_exists(existing, tmp_identifier) }}
+  {{ drop_if_exists(existing, schema, tmp_identifier) }}
 
   -- setup
   {% if non_destructive_mode -%}
     {% if existing_type == 'table' -%}
-      {{ adapter.truncate(identifier) }}
+      {{ adapter.truncate(schema, identifier) }}
     {% elif existing_type == 'view' -%}
-      {{ adapter.drop(identifier, existing_type) }}
+      {{ adapter.drop(schema, identifier, existing_type) }}
     {%- endif %}
   {%- endif %}
 
@@ -48,8 +48,8 @@
   {% if non_destructive_mode -%}
     -- noop
   {%- else -%}
-    {{ drop_if_exists(existing, identifier) }}
-    {{ adapter.rename(tmp_identifier, identifier) }}
+    {{ drop_if_exists(existing, schema, identifier) }}
+    {{ adapter.rename(schema, tmp_identifier, identifier) }}
   {%- endif %}
 
   -- `COMMIT` happens here

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -7,7 +7,7 @@
   {%- set existing_type = existing.get(identifier) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ drop_if_exists(existing, tmp_identifier) }}
+  {{ drop_if_exists(existing, schema, tmp_identifier) }}
 
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
@@ -27,8 +27,8 @@
   {% if non_destructive_mode and existing_type == 'view' -%}
     -- noop
   {%- else -%}
-    {{ drop_if_exists(existing, identifier) }}
-    {{ adapter.rename(tmp_identifier, identifier) }}
+    {{ drop_if_exists(existing, schema, identifier) }}
+    {{ adapter.rename(schema, tmp_identifier, identifier) }}
   {%- endif %}
 
   -- `COMMIT` happens here

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -110,7 +110,8 @@ class SchemaTestLoader(ResourceLoader):
             root_project=root_project,
             all_projects=all_projects,
             root_dir=project.get('project-root'),
-            relative_dirs=project.get('source-paths', []))
+            relative_dirs=project.get('source-paths', []),
+            macros=macros)
 
 
 class DataTestLoader(ResourceLoader):
@@ -135,7 +136,8 @@ class ArchiveLoader(ResourceLoader):
     def load_project(cls, root_project, all_projects, project, project_name,
                      macros):
         return dbt.parser.parse_archives_from_projects(root_project,
-                                                       all_projects)
+                                                       all_projects,
+                                                       macros)
 
 
 class RunHookLoader(ResourceLoader):

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -13,6 +13,7 @@ class SourceConfig(object):
     AppendListFields = ['pre-hook', 'post-hook']
     ExtendDictFields = ['vars']
     ClobberFields = [
+        'schema',
         'enabled',
         'materialized',
         'dist',

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -232,9 +232,10 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     adapter.release_connection(profile, node.get('name'))
 
     # Special macro defined in the global project
-    f_get_schema = context['generate_schema_name']
+    default_schema = context.get('schema')
     schema_override = config.config.get('schema')
-    node['schema'] = f_get_schema(schema_override)
+    get_schema = context.get('generate_schema_name', lambda x: default_schema)
+    node['schema'] = get_schema(schema_override)
 
     # Overwrite node config
     config_dict = node.get('config', {})
@@ -353,7 +354,7 @@ def get_hooks(all_projects, hook_type):
 
 
 def load_and_parse_run_hook_type(root_project, all_projects, hook_type,
-                                 macros):
+                                 macros=None):
 
     if dbt.flags.STRICT_MODE:
         dbt.contracts.project.validate_list(all_projects)
@@ -431,7 +432,7 @@ def load_and_parse_macros(package_name, root_project, all_projects, root_dir,
     return result
 
 
-def parse_schema_tests(tests, root_project, projects, macros):
+def parse_schema_tests(tests, root_project, projects, macros=None):
     to_return = {}
 
     for test in tests:
@@ -530,7 +531,7 @@ def as_kwarg(key, value):
 
 def parse_schema_test(test_base, model_name, test_config, test_type,
                       root_project_config, package_project_config,
-                      all_projects, macros):
+                      all_projects, macros=None):
 
     if isinstance(test_config, (basestring, int, float, bool)):
         test_args = {'arg': test_config}
@@ -579,7 +580,7 @@ def parse_schema_test(test_base, model_name, test_config, test_type,
 
 
 def load_and_parse_yml(package_name, root_project, all_projects, root_dir,
-                       relative_dirs, macros):
+                       relative_dirs, macros=None):
     extension = "[!.#~]*.yml"
 
     if dbt.flags.STRICT_MODE:
@@ -615,7 +616,7 @@ def load_and_parse_yml(package_name, root_project, all_projects, root_dir,
     return parse_schema_tests(result, root_project, all_projects, macros)
 
 
-def parse_archives_from_projects(root_project, all_projects, macros):
+def parse_archives_from_projects(root_project, all_projects, macros=None):
     archives = []
     to_return = {}
 

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -431,7 +431,7 @@ def load_and_parse_macros(package_name, root_project, all_projects, root_dir,
     return result
 
 
-def parse_schema_tests(tests, root_project, projects):
+def parse_schema_tests(tests, root_project, projects, macros):
     to_return = {}
 
     for test in tests:
@@ -476,7 +476,8 @@ def parse_schema_tests(tests, root_project, projects):
                         test, model_name, config, test_type,
                         root_project,
                         projects.get(package_name),
-                        all_projects=projects)
+                        all_projects=projects,
+                        macros=macros)
 
                     if to_add is not None:
                         to_return[to_add.get('unique_id')] = to_add
@@ -529,7 +530,7 @@ def as_kwarg(key, value):
 
 def parse_schema_test(test_base, model_name, test_config, test_type,
                       root_project_config, package_project_config,
-                      all_projects):
+                      all_projects, macros):
 
     if isinstance(test_config, (basestring, int, float, bool)):
         test_args = {'arg': test_config}
@@ -573,11 +574,12 @@ def parse_schema_test(test_base, model_name, test_config, test_type,
                       all_projects,
                       tags={'schema'},
                       fqn_extra=None,
-                      fqn=fqn_override)
+                      fqn=fqn_override,
+                      macros=macros)
 
 
 def load_and_parse_yml(package_name, root_project, all_projects, root_dir,
-                       relative_dirs):
+                       relative_dirs, macros):
     extension = "[!.#~]*.yml"
 
     if dbt.flags.STRICT_MODE:
@@ -610,10 +612,10 @@ def load_and_parse_yml(package_name, root_project, all_projects, root_dir,
             'raw_yml': file_contents
         })
 
-    return parse_schema_tests(result, root_project, all_projects)
+    return parse_schema_tests(result, root_project, all_projects, macros)
 
 
-def parse_archives_from_projects(root_project, all_projects):
+def parse_archives_from_projects(root_project, all_projects, macros):
     archives = []
     to_return = {}
 
@@ -630,7 +632,8 @@ def parse_archives_from_projects(root_project, all_projects):
             node_path,
             root_project,
             all_projects.get(archive.get('package_name')),
-            all_projects)
+            all_projects,
+            macros=macros)
 
     return to_return
 

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -231,13 +231,10 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     profile = db_wrapper.profile
     adapter.release_connection(profile, node.get('name'))
 
+    # Special macro defined in the global project
+    f_get_schema = context['generate_schema_name']
     schema_override = config.config.get('schema')
-    if schema_override:
-        schema_prefix = context['schema_prefix']
-        schema = "{}{}".format(schema_prefix, schema_override)
-    else:
-        schema = context['schema']
-    node['schema'] = schema
+    node['schema'] = f_get_schema(schema_override)
 
     # Overwrite node config
     config_dict = node.get('config', {})

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -231,6 +231,14 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     profile = db_wrapper.profile
     adapter.release_connection(profile, node.get('name'))
 
+    schema_override = config.config.get('schema')
+    if schema_override:
+        schema_prefix = context['schema_prefix']
+        schema = "{}{}".format(schema_prefix, schema_override)
+    else:
+        schema = context['schema']
+    node['schema'] = schema
+
     # Overwrite node config
     config_dict = node.get('config', {})
     config_dict.update(config.config)

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -97,14 +97,6 @@ class RunManager(object):
                 runners.append(node_runners[unique_id])
         return runners
 
-    def get_existing(self, adapter, profile, schemas):
-        existing = {}
-        for schema in schemas:
-            new_existing = adapter.query_for_existing(profile, schema)
-            existing.update(new_existing)
-
-        return existing
-
     def execute_nodes(self, linker, Runner, flat_graph, node_dependency_list):
         profile = self.project.run_environment()
         adapter = get_adapter(profile)
@@ -117,8 +109,8 @@ class RunManager(object):
         dbt.ui.printer.print_timestamped_line(concurrency_line)
         dbt.ui.printer.print_timestamped_line("")
 
-        schemas = Runner.get_model_schemas(flat_graph)
-        existing = self.get_existing(adapter, profile, schemas)
+        schemas = list(Runner.get_model_schemas(flat_graph))
+        existing = adapter.query_for_existing(profile, schemas)
         node_runners = self.get_runners(Runner, adapter, node_dependency_list)
 
         pool = ThreadPool(num_threads)

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -4,8 +4,6 @@ import time
 from dbt.adapters.factory import get_adapter
 from dbt.logger import GLOBAL_LOGGER as logger
 
-from dbt.utils import get_materialization
-
 import dbt.clients.jinja
 import dbt.compilation
 import dbt.exceptions
@@ -98,7 +96,6 @@ class RunManager(object):
             if unique_id in node_runners:
                 runners.append(node_runners[unique_id])
         return runners
-
 
     def get_existing(self, adapter, profile, schemas):
         existing = {}

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -110,7 +110,10 @@ class RunManager(object):
         dbt.ui.printer.print_timestamped_line("")
 
         schemas = list(Runner.get_model_schemas(flat_graph))
-        existing = adapter.query_for_existing(profile, schemas)
+        if len(schemas) > 0:
+            existing = adapter.query_for_existing(profile, schemas)
+        else:
+            existing = {}
         node_runners = self.get_runners(Runner, adapter, node_dependency_list)
 
         pool = ThreadPool(num_threads)

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -9,7 +9,6 @@ from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.adapters.factory import get_adapter
 import dbt.exceptions
 
-# Jesus lol todo
 
 class Seeder:
     def __init__(self, project):

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -9,6 +9,7 @@ from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.adapters.factory import get_adapter
 import dbt.exceptions
 
+# Jesus lol todo
 
 class Seeder:
     def __init__(self, project):

--- a/dbt/ui/printer.py
+++ b/dbt/ui/printer.py
@@ -102,8 +102,8 @@ def print_skip_line(model, schema, relation, index, num_models):
     print_fancy_output_line(msg, yellow('SKIP'), index, num_models)
 
 
-def print_cancel_line(model, schema):
-    msg = 'CANCEL query {}.{}'.format(schema, model)
+def print_cancel_line(model):
+    msg = 'CANCEL query {}'.format(model)
     print_fancy_output_line(msg, red('CANCEL'), index=None, total=None)
 
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -11,6 +11,7 @@ from dbt.node_types import NodeType
 
 
 DBTConfigKeys = [
+    'schema',
     'enabled',
     'materialized',
     'dist',

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -30,6 +30,7 @@ class ExitCodes(object):
     UnhandledError = 2
 
 
+# TODO : make ref work like this.... ok.
 class This(object):
     def __init__(self, schema, table, name):
         self.schema = schema

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -31,7 +31,6 @@ class ExitCodes(object):
     UnhandledError = 2
 
 
-# TODO : make ref work like this.... ok.
 class This(object):
     def __init__(self, schema, table, name):
         self.schema = schema

--- a/test/integration/024_custom_schema_test/macros/schema.sql
+++ b/test/integration/024_custom_schema_test/macros/schema.sql
@@ -1,0 +1,6 @@
+
+{% macro generate_schema_name(schema_name) -%}
+
+    {{ schema_name }}_{{ target.schema }}_macro
+
+{%- endmacro %}

--- a/test/integration/024_custom_schema_test/models/view_1.sql
+++ b/test/integration/024_custom_schema_test/models/view_1.sql
@@ -1,0 +1,3 @@
+
+
+select * from "{{ target.schema }}"."seed"

--- a/test/integration/024_custom_schema_test/models/view_2.sql
+++ b/test/integration/024_custom_schema_test/models/view_2.sql
@@ -1,0 +1,4 @@
+
+{{ config(schema='custom') }}
+
+select * from {{ ref('view_1') }}

--- a/test/integration/024_custom_schema_test/models/view_3.sql
+++ b/test/integration/024_custom_schema_test/models/view_3.sql
@@ -1,0 +1,30 @@
+
+{{ config(schema='test') }}
+
+
+with v1 as (
+
+    select * from {{ ref('view_1') }}
+
+),
+
+v2 as (
+
+    select * from {{ ref('view_2') }}
+
+),
+
+combined as (
+
+    select last_name from v1
+    union all
+    select last_name from v2
+
+)
+
+select
+    last_name,
+    count(*) as count
+
+from combined
+group by 1

--- a/test/integration/024_custom_schema_test/seed.sql
+++ b/test/integration/024_custom_schema_test/seed.sql
@@ -1,0 +1,25 @@
+
+drop table if exists "{schema}"."seed" cascade;
+create table "{schema}"."seed" (
+	id BIGSERIAL PRIMARY KEY,
+	first_name VARCHAR(50),
+	last_name VARCHAR(50),
+	email VARCHAR(50),
+	gender VARCHAR(50),
+	ip_address VARCHAR(20)
+);
+
+drop table if exists "{schema}"."agg" cascade;
+create table "{schema}"."agg" (
+	last_name VARCHAR(50),
+	count BIGINT
+);
+
+
+insert into "{schema}"."seed" (first_name, last_name, email, gender, ip_address) values
+('Jack', 'Hunter', 'jhunter0@pbs.org', 'Male', '59.80.20.168'),
+('Kathryn', 'Walker', 'kwalker1@ezinearticles.com', 'Female', '194.121.179.35'),
+('Gerald', 'Ryan', 'gryan2@com.com', 'Male', '11.3.212.243');
+
+insert into "{schema}"."agg" (last_name, count) values
+('Hunter', 2), ('Walker', 2), ('Ryan', 2);

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -28,54 +28,6 @@ class TestCustomSchema(DBTIntegrationTest):
         self.assertTablesEqual("agg","view_3", schema, xf_schema)
 
 
-class TestCustomSchemaWithPrefix(DBTIntegrationTest):
-
-    @property
-    def schema(self):
-        return "custom_schema_024"
-
-    @property
-    def models(self):
-        return "test/integration/024_custom_schema_test/models"
-
-    @property
-    def profile_config(self, schema=None, schema_prefix=None):
-        return {
-            'test': {
-                'outputs': {
-                    'my-target': {
-                        'type': 'postgres',
-                        'threads': 1,
-                        'host': 'database',
-                        'port': 5432,
-                        'user': 'root',
-                        'pass': 'password',
-                        'dbname': 'dbt',
-                        'schema': self.unique_schema(),
-                        # do this to avoid conflicts between tests
-                        'schema_prefix': "analytics_{}_".format(self.unique_schema()),
-                    }
-                },
-                'target': 'my-target'
-            }
-        }
-
-    @attr(type='postgres')
-    def test__postgres__custom_schema_with_prefix(self):
-        self.use_default_project()
-        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
-
-        self.run_dbt()
-
-        schema = self.unique_schema()
-        v2_schema = "analytics_{}_custom".format(schema)
-        xf_schema = "analytics_{}_test".format(schema)
-
-        self.assertTablesEqual("seed","view_1", schema, schema)
-        self.assertTablesEqual("seed","view_2", schema, v2_schema)
-        self.assertTablesEqual("agg","view_3", schema, xf_schema)
-
-
 class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
 
     @property
@@ -100,8 +52,6 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
                         'pass': 'password',
                         'dbname': 'dbt',
                         'schema': self.unique_schema(),
-                        # do this to avoid conflicts between tests
-                        'schema_prefix': "analytics_{}_".format(self.unique_schema()),
                     }
                 },
                 'target': 'my-target'
@@ -124,9 +74,65 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
         self.run_dbt()
 
         schema = self.unique_schema()
-        v1_schema = "analytics_{}_dbt_test".format(schema)
-        v2_schema = "analytics_{}_custom".format(schema)
-        xf_schema = "analytics_{}_test".format(schema)
+        v1_schema = "{}_dbt_test".format(schema)
+        v2_schema = "{}_custom".format(schema)
+        xf_schema = "{}_test".format(schema)
+
+        self.assertTablesEqual("seed","view_1", schema, v1_schema)
+        self.assertTablesEqual("seed","view_2", schema, v2_schema)
+        self.assertTablesEqual("agg","view_3", schema, xf_schema)
+
+
+class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "custom_schema_024"
+
+    @property
+    def models(self):
+        return "test/integration/024_custom_schema_test/models"
+
+    @property
+    def profile_config(self):
+        return {
+            'test': {
+                'outputs': {
+                    'prod': {
+                        'type': 'postgres',
+                        'threads': 1,
+                        'host': 'database',
+                        'port': 5432,
+                        'user': 'root',
+                        'pass': 'password',
+                        'dbname': 'dbt',
+                        'schema': self.unique_schema(),
+                    }
+                },
+                'target': 'prod'
+            }
+        }
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['test/integration/024_custom_schema_test/macros'],
+            'models': {
+                'schema': 'dbt_test'
+            }
+        }
+
+    @attr(type='postgres')
+    def test__postgres__custom_schema_from_macro(self):
+        self.use_default_project()
+        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
+
+        self.run_dbt()
+
+        schema = self.unique_schema()
+        v1_schema = "dbt_test_{}_macro".format(schema)
+        v2_schema = "custom_{}_macro".format(schema)
+        xf_schema = "test_{}_macro".format(schema)
 
         self.assertTablesEqual("seed","view_1", schema, v1_schema)
         self.assertTablesEqual("seed","view_2", schema, v2_schema)

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -1,0 +1,133 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+
+
+class TestCustomSchema(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "custom_schema_024"
+
+    @property
+    def models(self):
+        return "test/integration/024_custom_schema_test/models"
+
+    @attr(type='postgres')
+    def test__postgres__custom_schema_no_prefix(self):
+        self.use_default_project()
+        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
+
+        self.run_dbt()
+
+        schema = self.unique_schema()
+        v2_schema = "{}_custom".format(schema)
+        xf_schema = "{}_test".format(schema)
+
+        self.assertTablesEqual("seed","view_1")
+        self.assertTablesEqual("seed","view_2", schema, v2_schema)
+        self.assertTablesEqual("agg","view_3", schema, xf_schema)
+
+
+class TestCustomSchemaWithPrefix(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "custom_schema_024"
+
+    @property
+    def models(self):
+        return "test/integration/024_custom_schema_test/models"
+
+    @property
+    def profile_config(self, schema=None, schema_prefix=None):
+        return {
+            'test': {
+                'outputs': {
+                    'my-target': {
+                        'type': 'postgres',
+                        'threads': 1,
+                        'host': 'database',
+                        'port': 5432,
+                        'user': 'root',
+                        'pass': 'password',
+                        'dbname': 'dbt',
+                        'schema': self.unique_schema(),
+                        # do this to avoid conflicts between tests
+                        'schema_prefix': "analytics_{}_".format(self.unique_schema()),
+                    }
+                },
+                'target': 'my-target'
+            }
+        }
+
+    @attr(type='postgres')
+    def test__postgres__custom_schema_with_prefix(self):
+        self.use_default_project()
+        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
+
+        self.run_dbt()
+
+        schema = self.unique_schema()
+        v2_schema = "analytics_{}_custom".format(schema)
+        xf_schema = "analytics_{}_test".format(schema)
+
+        self.assertTablesEqual("seed","view_1", schema, schema)
+        self.assertTablesEqual("seed","view_2", schema, v2_schema)
+        self.assertTablesEqual("agg","view_3", schema, xf_schema)
+
+
+class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "custom_schema_024"
+
+    @property
+    def models(self):
+        return "test/integration/024_custom_schema_test/models"
+
+    @property
+    def profile_config(self):
+        return {
+            'test': {
+                'outputs': {
+                    'my-target': {
+                        'type': 'postgres',
+                        'threads': 1,
+                        'host': 'database',
+                        'port': 5432,
+                        'user': 'root',
+                        'pass': 'password',
+                        'dbname': 'dbt',
+                        'schema': self.unique_schema(),
+                        # do this to avoid conflicts between tests
+                        'schema_prefix': "analytics_{}_".format(self.unique_schema()),
+                    }
+                },
+                'target': 'my-target'
+            }
+        }
+
+    @property
+    def project_config(self):
+        return {
+            "models": {
+                "schema": "dbt_test"
+            }
+        }
+
+    @attr(type='postgres')
+    def test__postgres__custom_schema_with_prefix(self):
+        self.use_default_project()
+        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
+
+        self.run_dbt()
+
+        schema = self.unique_schema()
+        v1_schema = "analytics_{}_dbt_test".format(schema)
+        v2_schema = "analytics_{}_custom".format(schema)
+        xf_schema = "analytics_{}_test".format(schema)
+
+        self.assertTablesEqual("seed","view_1", schema, v1_schema)
+        self.assertTablesEqual("seed","view_2", schema, v2_schema)
+        self.assertTablesEqual("agg","view_3", schema, xf_schema)

--- a/test/unit/test_compiler.py
+++ b/test/unit/test_compiler.py
@@ -49,6 +49,7 @@ class CompilerTest(unittest.TestCase):
             'nodes': {
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root_project', 'view'],
@@ -79,6 +80,7 @@ class CompilerTest(unittest.TestCase):
                 },
                 'model.root.ephemeral': {
                     'name': 'ephemeral',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral',
                     'fqn': ['root_project', 'ephemeral'],
@@ -129,6 +131,7 @@ class CompilerTest(unittest.TestCase):
             'nodes': {
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root_project', 'view'],
@@ -155,6 +158,7 @@ class CompilerTest(unittest.TestCase):
                 },
                 'model.root.view_no_cte': {
                     'name': 'view_no_cte',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view_no_cte',
                     'fqn': ['root_project', 'view_no_cte'],
@@ -217,6 +221,7 @@ class CompilerTest(unittest.TestCase):
             'nodes': {
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root_project', 'view'],
@@ -245,6 +250,7 @@ class CompilerTest(unittest.TestCase):
                 },
                 'model.root.ephemeral': {
                     'name': 'ephemeral',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral',
                     'fqn': ['root_project', 'ephemeral'],
@@ -301,6 +307,7 @@ class CompilerTest(unittest.TestCase):
             'nodes': {
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root_project', 'view'],
@@ -329,6 +336,7 @@ class CompilerTest(unittest.TestCase):
                 },
                 'model.root.ephemeral': {
                     'name': 'ephemeral',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral',
                     'fqn': ['root_project', 'ephemeral'],
@@ -355,6 +363,7 @@ class CompilerTest(unittest.TestCase):
                 },
                 'model.root.ephemeral_level_two': {
                     'name': 'ephemeral_level_two',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral_level_two',
                     'fqn': ['root_project', 'ephemeral_level_two'],

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -32,6 +32,7 @@ class ParserTest(unittest.TestCase):
                 'test': {
                     'type': 'postgres',
                     'host': 'localhost',
+                    'schema': 'analytics',
                 }
             }
         }
@@ -45,6 +46,7 @@ class ParserTest(unittest.TestCase):
                 'test': {
                     'type': 'postgres',
                     'host': 'localhost',
+                    'schema': 'analytics',
                 }
             }
         }
@@ -85,6 +87,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'model_one'],
@@ -142,6 +145,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'nested', 'path', 'model_one'],
@@ -182,6 +186,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'model_one'],
@@ -231,6 +236,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.base': {
                     'name': 'base',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.base',
                     'fqn': ['root', 'base'],
@@ -251,6 +257,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.events_tx': {
                     'name': 'events_tx',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.events_tx',
                     'fqn': ['root', 'events_tx'],
@@ -328,6 +335,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.events': {
                     'name': 'events',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.events',
                     'fqn': ['root', 'events'],
@@ -348,6 +356,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.sessions': {
                     'name': 'sessions',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.sessions',
                     'fqn': ['root', 'sessions'],
@@ -368,6 +377,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.events_tx': {
                     'name': 'events_tx',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.events_tx',
                     'fqn': ['root', 'events_tx'],
@@ -388,6 +398,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.sessions_tx': {
                     'name': 'sessions_tx',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.sessions_tx',
                     'fqn': ['root', 'sessions_tx'],
@@ -408,6 +419,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.multi': {
                     'name': 'multi',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.multi',
                     'fqn': ['root', 'multi'],
@@ -487,6 +499,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.snowplow.events': {
                     'name': 'events',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.events',
                     'fqn': ['snowplow', 'events'],
@@ -507,6 +520,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.sessions': {
                     'name': 'sessions',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.sessions',
                     'fqn': ['snowplow', 'sessions'],
@@ -527,6 +541,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.events_tx': {
                     'name': 'events_tx',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.events_tx',
                     'fqn': ['snowplow', 'events_tx'],
@@ -547,6 +562,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.sessions_tx': {
                     'name': 'sessions_tx',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.sessions_tx',
                     'fqn': ['snowplow', 'sessions_tx'],
@@ -567,6 +583,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.multi': {
                     'name': 'multi',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.multi',
                     'fqn': ['root', 'multi'],
@@ -595,6 +612,7 @@ class ParserTest(unittest.TestCase):
             'nodes': {
                 'model.snowplow.events': {
                     'name': 'events',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.events',
                     'fqn': ['snowplow', 'events'],
@@ -614,6 +632,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.events': {
                     'name': 'events',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.events',
                     'fqn': ['root', 'events'],
@@ -633,6 +652,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.dep': {
                     'name': 'dep',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.dep',
                     'fqn': ['root', 'dep'],
@@ -660,6 +680,7 @@ class ParserTest(unittest.TestCase):
                 'nodes': {
                     'model.snowplow.events': {
                         'name': 'events',
+                        'schema': 'analytics',
                         'resource_type': 'model',
                         'unique_id': 'model.snowplow.events',
                         'fqn': ['snowplow', 'events'],
@@ -679,6 +700,7 @@ class ParserTest(unittest.TestCase):
                     },
                     'model.root.events': {
                         'name': 'events',
+                        'schema': 'analytics',
                         'resource_type': 'model',
                         'unique_id': 'model.root.events',
                         'fqn': ['root', 'events'],
@@ -698,6 +720,7 @@ class ParserTest(unittest.TestCase):
                     },
                     'model.root.dep': {
                         'name': 'dep',
+                        'schema': 'analytics',
                         'resource_type': 'model',
                         'unique_id': 'model.root.dep',
                         'fqn': ['root', 'dep'],
@@ -744,6 +767,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'model_one'],
@@ -825,6 +849,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.table': {
                     'name': 'table',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.table',
                     'fqn': ['root', 'table'],
@@ -845,6 +870,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.ephemeral': {
                     'name': 'ephemeral',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral',
                     'fqn': ['root', 'ephemeral'],
@@ -865,6 +891,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root', 'view'],
@@ -1013,6 +1040,7 @@ class ParserTest(unittest.TestCase):
             {
                 'model.root.table': {
                     'name': 'table',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.table',
                     'fqn': ['root', 'table'],
@@ -1033,6 +1061,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.ephemeral': {
                     'name': 'ephemeral',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.ephemeral',
                     'fqn': ['root', 'ephemeral'],
@@ -1053,6 +1082,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.root.view': {
                     'name': 'view',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.view',
                     'fqn': ['root', 'view'],
@@ -1073,6 +1103,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.disabled': {
                     'name': 'disabled',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.disabled',
                     'fqn': ['snowplow', 'disabled'],
@@ -1093,6 +1124,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.package': {
                     'name': 'package',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.package',
                     'fqn': ['snowplow', 'views', 'package'],
@@ -1113,6 +1145,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'model.snowplow.multi_sort': {
                     'name': 'multi_sort',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.snowplow.multi_sort',
                     'fqn': ['snowplow', 'views', 'multi_sort'],
@@ -1164,6 +1197,7 @@ class ParserTest(unittest.TestCase):
             {
                 'test.root.not_null_model_one_id': {
                     'name': 'not_null_model_one_id',
+                    'schema': 'analytics',
                     'resource_type': 'test',
                     'unique_id': 'test.root.not_null_model_one_id',
                     'fqn': ['root', 'schema_test', 'not_null_model_one_id'],
@@ -1184,6 +1218,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'test.root.unique_model_one_id': {
                     'name': 'unique_model_one_id',
+                    'schema': 'analytics',
                     'resource_type': 'test',
                     'unique_id': 'test.root.unique_model_one_id',
                     'fqn': ['root', 'schema_test', 'unique_model_one_id'],
@@ -1203,6 +1238,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'test.root.accepted_values_model_one_id__a__b': {
                     'name': 'accepted_values_model_one_id__a__b',
+                    'schema': 'analytics',
                     'resource_type': 'test',
                     'unique_id': 'test.root.accepted_values_model_one_id__a__b', # noqa
                     'fqn': ['root', 'schema_test',
@@ -1224,6 +1260,7 @@ class ParserTest(unittest.TestCase):
                 },
                 'test.root.relationships_model_one_id__id__ref_model_two_': {
                     'name': 'relationships_model_one_id__id__ref_model_two_',
+                    'schema': 'analytics',
                     'resource_type': 'test',
                     'unique_id': 'test.root.relationships_model_one_id__id__ref_model_two_', # noqa
                     'fqn': ['root', 'schema_test',
@@ -1315,6 +1352,7 @@ another_model:
             {
                 'test.root.no_events': {
                     'name': 'no_events',
+                    'schema': 'analytics',
                     'resource_type': 'test',
                     'unique_id': 'test.root.no_events',
                     'fqn': ['root', 'no_events'],
@@ -1429,6 +1467,7 @@ another_model:
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'model_one'],
@@ -1470,6 +1509,7 @@ another_model:
             {
                 'model.root.model_one': {
                     'name': 'model_one',
+                    'schema': 'analytics',
                     'resource_type': 'model',
                     'unique_id': 'model.root.model_one',
                     'fqn': ['root', 'model_one'],


### PR DESCRIPTION
Specify custom schemas for models

**TODO:**
- [x] add integration tests
  - [x] in-config
  - [x] in-project
  - [x] in-project overridden by in-config
- [x] make sure this works with temp tables (I think it does)
- [ ] docs docs docs

**Usage**
This branch uses a macro to generate model schema names, and users can override this macro to create alternative schema behavior.

This branch uses a macro called `generate_schema_name` to get a schema name for a model. By default, this macro just concatenates the `schema` defined in the active `profile` with the `schema` defined in the model config, if any.

To override this behavior, users can create a macro in their own project called `generate_schema_name`. In practice, this would look like:

```
-- All models will be generated in the `public` schema, always.
{% macro generate_schema_name(schema_name) -%}
    public
{%- endmacro %}
```

A more useful strategy uses the `profile` schema in development, and the custom model schema in production. The macro to do that looks like this:

```
{% macro generate_schema_name_for_env(custom_schema_name=none) -%}
    {%- set default_schema = target.schema -%}
    {%- if target.name == 'prod' and custom_schema_name is not none -%}
        {{ custom_schema_name | trim }}
    {%- else -%}
        {{ default_schema }}
    {%- endif -%}
{%- endmacro %}
```

Since I think this will be a common strategy, I went ahead and added this to the global project too. So, to use the "default in dev, custom in prod" strategy, users should create `macros/generate_schema.sql` with these contents:

```
{% macro generate_schema_name(schema_name) -%}
    {{ generate_schema_name_for_env(schema_name) }}
{%- endmacro %}
```