### PR TITLE
refactor incremental models

### DIFF
--- a/dbt/include/global_project/macros/materializations/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental.sql
@@ -12,43 +12,80 @@
 
 {%- endmacro %}
 
+{% macro dbt__incremental_insert(schema, identifier, dest_cols_csv) %}
+
+   insert into "{{ schema }}"."{{ identifier }}" ({{ dest_cols_csv }})
+   (
+     select {{ dest_cols_csv }}
+     from "{{ identifier }}__dbt_incremental_tmp"
+   );
+
+{% endmacro %}
+
+{% macro debug_state(is_full_refresh, is_non_destructive, existing_type) -%}
+    ERROR - unexpected incremental state
+    Full Refresh? {{ is_full_refresh }}
+    Non Destructive {{ is_non_destructive }}
+    Existing Type? {{ existing_type }}
+{%- endmacro %}
+
+{% macro debug(msg) %}
+  {{ log("         +-> " ~ msg, info=var('verbose', False)) }}
+{% endmacro %}
+
+{% macro handle_state(is_full_refresh, is_non_destructive, existing_type, schema, identifier) %}
+  {% if existing_type is none %}
+    -- no-op
+  {% elif existing_type == 'view' %}
+    {{ debug('Dropping view: ' ~ schema ~ '.' ~ identifier) }}
+    {{ adapter.drop(schema, identifier, 'view') }}
+  {% elif is_full_refresh and is_non_destructive %}
+    {{ debug('Truncating table: ' ~ schema ~ '.' ~ identifier) }}
+    {{ adapter.truncate(schema, identifier) }}
+  {% elif is_full_refresh %}
+    {{ debug('Dropping table: ' ~ schema ~ '.' ~ identifier) }}
+    {{ adapter.drop(schema, identifier, 'table') }}
+  {% elif is_non_destructive %}
+    -- no-op
+  {% elif not is_non_destructive and not is_full_refresh %}
+    -- no-op
+  {% else %}
+    -- this shouldn't happen
+    {{ debug(debug_state(is_full_refresh, is_non_destructive, existing_type)) }}
+    {{ exceptions.raise_compiler_error("Unexpected incremental state") }}
+  {% endif %}
+{% endmacro %}
+
 {% materialization incremental, default -%}
   {%- set sql_where = config.require('sql_where') -%}
   {%- set unique_key = config.get('unique_key') -%}
 
   {%- set identifier = model['name'] -%}
   {%- set tmp_identifier = model['name'] + '__dbt_incremental_tmp' -%}
-
-  {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
   {%- set existing = adapter.query_for_existing(schema) -%}
   {%- set existing_type = existing.get(identifier) -%}
 
-  {%- set exists_as_table = (existing_type == 'table') -%}
-  {%- set should_truncate = (non_destructive_mode and full_refresh_mode and exists_as_table) -%}
-  {%- set should_drop = (not should_truncate and (full_refresh_mode or (existing_type not in (none, 'table')))) -%}
-  {%- set force_create = (flags.FULL_REFRESH and not flags.NON_DESTRUCTIVE) -%}
-
-  -- setup
-  {% if existing_type is none -%}
-    -- noop
-  {%- elif should_truncate -%}
-    {{ adapter.truncate(schema, identifier) }}
-  {%- elif should_drop -%}
-    {{ adapter.drop(schema, identifier, existing_type) }}
-  {%- endif %}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
-
-  -- `BEGIN` happens here:
+  -- BEGIN happens here
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
-  {% if force_create or not adapter.already_exists(schema, identifier) -%}
+  {% if (flags.FULL_REFRESH and not flags.NON_DESTRUCTIVE) or existing_type in (none, 'view') -%}
     {%- call statement('main') -%}
-      {{ create_table_as(False, identifier, sql) }}
+      {{ debug('Building new table...') }}
+      {{ create_table_as(False, tmp_identifier, sql) }}
     {%- endcall -%}
+
+    {{ handle_state(flags.FULL_REFRESH, flags.NON_DESTRUCTIVE, existing_type, schema, identifier) }}
+
+    {{ debug('Renaming `' ~ tmp_identifier ~ '` to `' ~ identifier ~ '`') }}
+    {{ adapter.rename(schema, tmp_identifier, identifier) }}
   {%- else -%}
+    -- this will either truncate (if full-refresh && non-destructive), or no-op
+    -- note: a truncate here will end the open transaction
+    {{ handle_state(flags.FULL_REFRESH, flags.NON_DESTRUCTIVE, existing_type, schema, identifier) }}
+
+    {{ debug('Creating temp table') }}
     {%- call statement() -%}
       create temporary table "{{ tmp_identifier }}" as (
         with dbt_incr_sbq as (
@@ -60,26 +97,25 @@
         );
      {%- endcall -%}
 
+     {{ debug('Expanding column types if required') }}
      {{ adapter.expand_target_column_types(temp_table=tmp_identifier,
                                            to_schema=schema,
                                            to_table=identifier) }}
 
-     {%- call statement('main') -%}
-       {% set dest_columns = adapter.get_columns_in_table(schema, identifier) %}
-       {% set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') %}
+     {% set dest_columns = adapter.get_columns_in_table(schema, identifier) %}
+     {% set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') %}
 
+     {%- call statement(auto_begin=False) -%}
        {% if unique_key is not none -%}
-
+         {{ debug('Deleting duplicated records') }}
          {{ dbt__incremental_delete(schema, model) }}
-
        {%- endif %}
-
-       insert into "{{ schema }}"."{{ identifier }}" ({{ dest_cols_csv }})
-       (
-         select {{ dest_cols_csv }}
-         from "{{ identifier }}__dbt_incremental_tmp"
-       );
      {% endcall %}
+
+     {%- call statement('main', auto_begin=False) -%}
+       {{ debug('Inserting new records') }}
+       {{ dbt__incremental_insert(schema, identifier, dest_cols_csv) }}
+     {%- endcall %}
   {%- endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}


### PR DESCRIPTION
Sample output:

```
22:41:23 | Concurrency: 1 threads (target='dev')
22:41:23 |
22:41:24 | 1 of 1 START incremental model dbt_dbanin.users............. [RUN]
         +-> Building new table...
         +-> Dropping table: dbt_dbanin.users
         +-> Renaming `users__dbt_incremental_tmp` to `users`
22:41:26 | 1 of 1 OK created incremental model dbt_dbanin.users........ [SELECT in 2.66s]
22:41:27 |
22:41:27 | Finished running 1 incremental models in 2.93s.
```

I added a `verbose` var (default=False) which controls those in-model log lines. This branch generally cleans up the incremental model materialization. Additionally, if the `--full-refresh` flag is provided (and a couple other things are true), then the existing table will now be dropped *after* the new table is built.

Fixes https://github.com/fishtown-analytics/dbt/issues/525