### PR TITLE
Use root project instead of package project in context generator

### DIFF
--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -218,7 +218,7 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     config_dict.update(config.config)
     node['config'] = config_dict
 
-    context = dbt.context.parser.generate(node, package_project_config,
+    context = dbt.context.parser.generate(node, root_project_config,
                                           {"macros": macros})
 
     dbt.clients.jinja.get_rendered(


### PR DESCRIPTION
This bug (introduced by custom schemas) caused models defined in dependency projects to use the schema associated with the default target for a profile.

So,
```
$ dbt run --target prod
```

would use `analytics` for models in the root project, while it would use eg. `dbt_dbanin` for models in dependency packages.

Part of the problem is this line [here](https://github.com/fishtown-analytics/dbt/blob/development/dbt/context/common.py#L254)

@cmcarthur do you think this is a sufficient fix? Kind of a tricky bug here