### PR TITLE
Fix/bad integration tests

### DIFF
--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -14,3 +14,17 @@
 
   {%- endif -%}
 {%- endmacro %}
+
+{% macro constant_statement(name=None, status=None, res=None) -%}
+  {%- set sql = render(caller()) -%}
+
+  {%- if name == 'main' -%}
+    {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}
+    {{ write(sql) }}
+  {%- endif -%}
+
+  {%- if name is not none -%}
+    {{ store_result(name, status=status, data=res) }}
+  {%- endif -%}
+
+{%- endmacro %}

--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -15,7 +15,7 @@
   {%- endif -%}
 {%- endmacro %}
 
-{% macro constant_statement(name=None, status=None, res=None) -%}
+{% macro noop_statement(name=None, status=None, res=None) -%}
   {%- set sql = render(caller()) -%}
 
   {%- if name == 'main' -%}

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -17,7 +17,13 @@
 
   -- build model
   {% if should_ignore -%}
-    {% call constant_statement('main', status="PASS", res=[]) -%}
+    {#
+      -- Materializations need to a statement with name='main'.
+      -- We could issue a no-op query here (like `select 1`), but that's wasteful. Instead:
+      --   1) write the sql contents out to the compiled dirs
+      --   2) return a status and result to the caller
+    #}
+    {% call noop_statement('main', status="PASS", res=[]) -%}
       -- Not running : non-destructive mode
       {{ sql }}
     {%- endcall %}

--- a/test/integration/010_permission_tests/seed.sql
+++ b/test/integration/010_permission_tests/seed.sql
@@ -1,6 +1,10 @@
-create schema {schema}_private_010;
 
-create table {schema}_private_010.seed (
+create schema if not exists {schema};
+
+revoke create on database dbt from noaccess;
+revoke usage on schema {schema} from noaccess;
+
+create table {schema}.seed (
 	id BIGSERIAL PRIMARY KEY,
 	first_name VARCHAR(50),
 	last_name VARCHAR(50),
@@ -10,13 +14,13 @@ create table {schema}_private_010.seed (
 );
 
 
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Kathryn', 'Walker', 'kwalker1@ezinearticles.com', 'Female', '194.121.179.35');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Gerald', 'Ryan', 'gryan2@com.com', 'Male', '11.3.212.243');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Bonnie', 'Spencer', 'bspencer3@ameblo.jp', 'Female', '216.32.196.175');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Harold', 'Taylor', 'htaylor4@people.com.cn', 'Male', '253.10.246.136');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Jacqueline', 'Griffin', 'jgriffin5@t.co', 'Female', '16.13.192.220');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Wanda', 'Arnold', 'warnold6@google.nl', 'Female', '232.116.150.64');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Craig', 'Ortiz', 'cortiz7@sciencedaily.com', 'Male', '199.126.106.13');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Gary', 'Day', 'gday8@nih.gov', 'Male', '35.81.68.186');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Rose', 'Wright', 'rwright9@yahoo.co.jp', 'Female', '236.82.178.100');
-insert into {schema}_private_010.seed (first_name, last_name, email, gender, ip_address) values ('Raymond', 'Kelley', 'rkelleya@fc2.com', 'Male', '213.65.166.67');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Kathryn', 'Walker', 'kwalker1@ezinearticles.com', 'Female', '194.121.179.35');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Gerald', 'Ryan', 'gryan2@com.com', 'Male', '11.3.212.243');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Bonnie', 'Spencer', 'bspencer3@ameblo.jp', 'Female', '216.32.196.175');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Harold', 'Taylor', 'htaylor4@people.com.cn', 'Male', '253.10.246.136');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Jacqueline', 'Griffin', 'jgriffin5@t.co', 'Female', '16.13.192.220');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Wanda', 'Arnold', 'warnold6@google.nl', 'Female', '232.116.150.64');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Craig', 'Ortiz', 'cortiz7@sciencedaily.com', 'Male', '199.126.106.13');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Gary', 'Day', 'gday8@nih.gov', 'Male', '35.81.68.186');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Rose', 'Wright', 'rwright9@yahoo.co.jp', 'Female', '236.82.178.100');
+insert into {schema}.seed (first_name, last_name, email, gender, ip_address) values ('Raymond', 'Kelley', 'rkelleya@fc2.com', 'Male', '213.65.166.67');

--- a/test/integration/010_permission_tests/tearDown.sql
+++ b/test/integration/010_permission_tests/tearDown.sql
@@ -1,2 +1,2 @@
 
-drop schema if exists {schema}_private_010 cascade;
+drop schema if exists {schema} cascade;

--- a/test/integration/010_permission_tests/test_permissions.py
+++ b/test/integration/010_permission_tests/test_permissions.py
@@ -28,14 +28,17 @@ class TestPermissions(DBTIntegrationTest):
         failed = False
         self.run_sql('drop schema if exists "{}" cascade'.format(self.unique_schema()))
         try:
-            self.run_dbt(['run', '--target', 'noaccess'])
+            self.run_dbt(['run', '--target', 'noaccess'], expect_pass=False)
         except RuntimeError:
             failed = True
 
         self.assertTrue(failed)
 
+        self.run_sql_file("test/integration/010_permission_tests/seed.sql")
+
         # now it should work!
-        self.run_sql('create schema "{}"'.format(self.unique_schema()))
-        self.run_sql('grant usage on schema "{}" to noaccess'.format(self.unique_schema()))
+        self.run_sql('grant create on database dbt to noaccess'.format(self.unique_schema()))
+        self.run_sql('grant usage, create on schema "{}" to noaccess'.format(self.unique_schema()))
+        self.run_sql('grant select on all tables in schema "{}" to noaccess'.format(self.unique_schema()))
 
         self.run_dbt(['run', '--target', 'noaccess'])

--- a/test/integration/016_macro_tests/macros/my_macros.sql
+++ b/test/integration/016_macro_tests/macros/my_macros.sql
@@ -10,4 +10,6 @@
 
 {% macro with_ref() %}
 
+    {{ ref('table') }}
+
 {% endmacro %}

--- a/test/integration/016_macro_tests/seed.sql
+++ b/test/integration/016_macro_tests/seed.sql
@@ -8,11 +8,17 @@ create table {schema}.expected_local_macro (
 	bar2 TEXT
 );
 
+create table {schema}.seed (
+	id integer,
+	updated_at timestamp
+);
+
 insert into {schema}.expected_dep_macro (foo, bar)
 values ('arg1', 'arg2');
 
 insert into {schema}.expected_local_macro (foo2, bar2)
 values ('arg1', 'arg2'), ('arg3', 'arg4');
 
-
+insert into {schema}.seed (id, updated_at)
+values (1, '2017-01-01'), (2, '2017-01-02');
 

--- a/test/integration/016_macro_tests/test_macros.py
+++ b/test/integration/016_macro_tests/test_macros.py
@@ -62,7 +62,7 @@ class TestInvalidMacros(DBTIntegrationTest):
     def test_invalid_macro(self):
 
         try:
-            self.run_dbt(["run"])
+            self.run_dbt(["run"], expect_pass=False)
             self.assertTrue(False,
                             'compiling bad macro should raise a runtime error')
 

--- a/test/integration/021_concurrency_test/test_concurrency.py
+++ b/test/integration/021_concurrency_test/test_concurrency.py
@@ -21,7 +21,7 @@ class TestConcurrency(DBTIntegrationTest):
         self.use_profile('postgres')
         self.run_sql_file("test/integration/021_concurrency_test/seed.sql")
 
-        self.run_dbt()
+        self.run_dbt(expect_pass=False)
 
         self.assertTablesEqual("seed", "view")
         self.assertTablesEqual("seed", "dep")
@@ -32,7 +32,7 @@ class TestConcurrency(DBTIntegrationTest):
 
         self.run_sql_file("test/integration/021_concurrency_test/update.sql")
 
-        self.run_dbt()
+        self.run_dbt(expect_pass=False)
 
         self.assertTablesEqual("seed", "view")
         self.assertTablesEqual("seed", "dep")
@@ -47,7 +47,7 @@ class TestConcurrency(DBTIntegrationTest):
         self.use_profile('snowflake')
         self.run_sql_file("test/integration/021_concurrency_test/seed.sql")
 
-        self.run_dbt()
+        self.run_dbt(expect_pass=False)
 
         self.assertTablesEqual("seed", "view")
         self.assertTablesEqual("seed", "dep")
@@ -56,7 +56,7 @@ class TestConcurrency(DBTIntegrationTest):
 
         self.run_sql_file("test/integration/021_concurrency_test/update.sql")
 
-        self.run_dbt()
+        self.run_dbt(expect_pass=False)
 
         self.assertTablesEqual("seed", "view")
         self.assertTablesEqual("seed", "dep")

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -264,13 +264,17 @@ class DBTIntegrationTest(unittest.TestCase):
     def profile_config(self):
         return {}
 
-    def run_dbt(self, args=None):
+    def run_dbt(self, args=None, expect_pass=True):
         if args is None:
             args = ["run"]
 
         args = ["--strict"] + args
         logger.info("Invoking dbt with {}".format(args))
-        return dbt.handle(args)
+
+        res, success =  dbt.handle_and_check(args)
+        self.assertEqual(success, expect_pass, "dbt exit state did not match expected")
+
+        return res
 
     def run_dbt_and_check(self, args=None):
         if args is None:


### PR DESCRIPTION
Some of these tests didn't actually test anything because model failed but the exception was handled in dbt. This branch assumes that dbt runs will "pass" (ie. exit_code = 0), and any unexpected failures are now asserted.

I had to change a couple of tests as a result (they now actually test things). Additionally, `--non-destructive` was broken but the tests indicated otherwise. This is now fixed