### PR TITLE
sets schema for node before parsing raw sql

### DIFF
--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -218,6 +218,11 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     config_dict.update(config.config)
     node['config'] = config_dict
 
+    # Set this temporarily so get_rendered() below has access to a schema
+    profile = dbt.utils.get_profile_from_project(root_project_config)
+    default_schema = profile.get('schema', 'public')
+    node['schema'] = default_schema
+
     context = dbt.context.parser.generate(node, root_project_config,
                                           {"macros": macros})
 
@@ -232,7 +237,6 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     adapter.release_connection(profile, node.get('name'))
 
     # Special macro defined in the global project
-    default_schema = context.get('schema')
     schema_override = config.config.get('schema')
     get_schema = context.get('generate_schema_name', lambda x: default_schema)
     node['schema'] = get_schema(schema_override)

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -67,6 +67,12 @@ def coalesce(*args):
     return None
 
 
+def get_profile_from_project(project):
+    target_name = project.get('target', {})
+    profile = project.get('outputs', {}).get(target_name, {})
+    return profile
+
+
 def get_model_name_or_none(model):
     if model is None:
         name = '<None>'


### PR DESCRIPTION
Previously, the parsing step would issue queries that looked like:

```
select tablename as name, 'table' as type from pg_tables
where schemaname in ('None')
union all
select viewname as name, 'view' as type from pg_views
where schemaname in ('None')
```