### PR TITLE
Fix/env vars

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -214,6 +214,8 @@ def invoke_dbt(parsed):
         targets = proj.cfg.get('outputs', {}).keys()
         if parsed.target in targets:
             proj.cfg['target'] = parsed.target
+            # make sure we update the target if this is overriden on the cli
+            proj.compile_and_update_target()
         else:
             logger.info("Encountered an error while reading the project:")
             logger.info("  ERROR Specified target {} is not a valid option "

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -80,6 +80,10 @@ class Project(object):
 
         if self.profile_to_load in self.profiles:
             self.cfg.update(self.profiles[self.profile_to_load])
+
+            # overwrite target with compiled values
+            target = self.cfg['target']
+            self.cfg['outputs'][target].update(self.run_environment())
         else:
             raise DbtProjectError(
                 "Could not find profile named '{}'"

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -80,10 +80,8 @@ class Project(object):
 
         if self.profile_to_load in self.profiles:
             self.cfg.update(self.profiles[self.profile_to_load])
+            self.compile_and_update_target()
 
-            # overwrite target with compiled values
-            target = self.cfg['target']
-            self.cfg['outputs'][target].update(self.run_environment())
         else:
             raise DbtProjectError(
                 "Could not find profile named '{}'"
@@ -131,6 +129,10 @@ class Project(object):
             compiled[key] = compiled_val
 
         return compiled
+
+    def compile_and_update_target(self):
+        target = self.cfg['target']
+        self.cfg['outputs'][target].update(self.run_environment())
 
     def run_environment(self):
         target_name = self.cfg['target']

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -120,8 +120,7 @@ class Project(object):
             is_str = isinstance(value, dbt.compat.basestring)
 
             if is_str:
-                node = "config key: '{}'".format(key)
-                compiled_val = dbt.clients.jinja.get_rendered(value, ctx, node)
+                compiled_val = dbt.clients.jinja.get_rendered(value, ctx)
             else:
                 compiled_val = value
 

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -10,6 +10,9 @@ class TestContextVars(DBTIntegrationTest):
         DBTIntegrationTest.setUp(self)
         os.environ["DBT_TEST_013_ENV_VAR"] = "1"
 
+        os.environ["DBT_TEST_013_USER"] = "root"
+        os.environ["DBT_TEST_013_PASS"] = "password"
+
         self.fields = [
             'this',
             'this.name',
@@ -42,13 +45,15 @@ class TestContextVars(DBTIntegrationTest):
         return {
             'test': {
                 'outputs': {
+                    # don't use env_var's here so the integration tests can run
+                    # seed sql statements and the like. default target is used
                     'dev': {
                         'type': 'postgres',
                         'threads': 1,
                         'host': 'database',
                         'port': 5432,
-                        'user': 'root',
-                        'pass': 'password',
+                        'user': "root",
+                        'pass': "password",
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     },
@@ -57,8 +62,9 @@ class TestContextVars(DBTIntegrationTest):
                         'threads': 1,
                         'host': 'database',
                         'port': 5432,
-                        'user': 'root',
-                        'pass': 'password',
+                        # root/password
+                        'user': "{{ env_var('DBT_TEST_013_USER') }}",
+                        'pass': "{{ env_var('DBT_TEST_013_PASS') }}",
                         'dbname': 'dbt',
                         'schema': self.unique_schema()
                     }


### PR DESCRIPTION
Changes in the beginning of 0.9.0 caused environment variables to break. This branch makes them work again, fixes an error message, and adds tests that confirm env vars work in the profiles.yml file