### PR TITLE
improvements for code that runs in hooks

### DIFF
--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -20,6 +20,9 @@ class RuntimeException(RuntimeError, Exception):
         return 'Runtime'
 
     def node_to_string(self, node):
+        if node is None:
+            return "<Unknown>"
+
         return "{} {} ({})".format(
             node.get('resource_type'),
             node.get('name', 'unknown'),

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -53,7 +53,7 @@ class Relation(object):
 
     def final_name(self):
         if self.materialized == 'ephemeral':
-            msg = "final_name() was called on an ephemeral_model"
+            msg = "final_name() was called on an ephemeral model"
             dbt.exceptions.raise_compiler_error(msg, self.node)
         else:
             return self._adapter.quote_schema_and_table(profile=None,

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -53,7 +53,7 @@ class Relation(object):
 
     def final_name(self):
         if self.materialized == 'ephemeral':
-            msg = "rendered_name() called on an ephemeral_model"
+            msg = "final_name() was called on an ephemeral_model"
             dbt.exceptions.raise_compiler_error(msg, self.node)
         else:
             return self._adapter.quote_schema_and_table(profile=None,

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -51,6 +51,15 @@ class Relation(object):
     def _get_table_name(self, node):
         return model_immediate_name(node, dbt.flags.NON_DESTRUCTIVE)
 
+    def final_name(self):
+        if self.materialized == 'ephemeral':
+            msg = "rendered_name() called on an ephemeral_model"
+            dbt.exceptions.raise_compiler_error(msg, self.node)
+        else:
+            return self._adapter.quote_schema_and_table(profile=None,
+                                                        schema=self.schema,
+                                                        table=self.name)
+
     def __repr__(self):
         if self.materialized == 'ephemeral':
             return '__dbt__CTE__{}'.format(self.name)


### PR DESCRIPTION
This adds `final_name`, which is the name of the model outside of a transaction. This is useful for pre-hook and post-hooks that happen outside of the `begin...commit`.

The exception fix in here makes `exceptions.raise_compiler_error` work inside of post-hook macros