### PR TITLE
handle empty profiles.yml file

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -31,7 +31,10 @@ def read_profile(profiles_dir):
 
 def read_config(profiles_dir):
     profile = read_profile(profiles_dir)
-    return profile.get('config', {})
+    if profile is None:
+        return {}
+    else:
+        return profile.get('config', {})
 
 
 def send_anonymous_usage_stats(config):

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -224,7 +224,11 @@ def read_profiles(profiles_dir=None):
 
     raw_profiles = dbt.config.read_profile(profiles_dir)
 
-    profiles = {k: v for (k, v) in raw_profiles.items() if k != 'config'}
+    if raw_profiles is None:
+        profiles = {}
+    else:
+        profiles = {k: v for (k, v) in raw_profiles.items() if k != 'config'}
+
     return profiles
 
 


### PR DESCRIPTION
dbt handles the case where a `profiles.yml` file does not exist, but it chokes on the case when `profiles.yml` exists, but is empty.

Previously:
```
$ dbt run
Encountered an error:
'NoneType' object has no attribute 'get'
```

now:
```
$ dbt run
Encountered an error while reading the project:
Could not find profile named 'default'
There are no profiles defined in your profiles.yml file

For more information on configuring profiles, please consult the dbt docs:

https://docs.getdbt.com/docs/configure-your-profile

Encountered an error:
Could not run dbt
```

This was especially frustrating because it happens before logging is initialized, so there isn't a helpful traceback in `logs/dbt.log`. 

Fixes: https://github.com/fishtown-analytics/dbt/issues/551