### PR TITLE
return empty string (instead of None) to avoid polluting rendered sql

### DIFF
--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -128,6 +128,7 @@ def _store_result(sql_results):
             'status': status,
             'data': data
         })
+        return ''
 
     return call
 
@@ -220,6 +221,7 @@ def write(node, target_path, subdirectory):
     def fn(payload):
         node['build_path'] = dbt.writer.write_node(
             node, target_path, subdirectory, payload)
+        return ''
 
     return fn
 


### PR DESCRIPTION
Return an empty string in some context functions so `statement`s don't pollute the macro output with `None` when these functions are called.

FYI, this is useful because now we can return json strings from macros, then deserialize on the calling end. I think this will be part of the eventual implementation of `return()` for macros?

```sql
{% macro get_distinct_column_values(source_ref, column, max_records=100) -%}

    {%- call statement('distinct_values', fetch_result=True) -%}

        select
            {{ column }} as value

        from {{ source_ref }}
        group by 1
        order by count(*) desc
        limit {{ max_records }}

    {%- endcall -%}

    {%- set value_list = load_result('distinct_values') -%}

    {%- if value_list and value_list['data'] -%}
        {%- set values = value_list['data'] | map(attribute=0) | list %}
        {{ values | tojson }}
    {%- else -%}
        []
    {%- endif -%}

{%- endmacro %}
```

Before, this yielded
```
None[["abc"],["def"]]
```
but now it yields
```
[["abc"],["def"]]
```