### PR TITLE
Package management additions

### DIFF
--- a/dbt/clients/registry.py
+++ b/dbt/clients/registry.py
@@ -1,7 +1,7 @@
 import requests
 
 
-DEFAULT_REGISTRY_BASE_URL = 'http://127.0.0.1:4567/'
+DEFAULT_REGISTRY_BASE_URL = 'http://127.0.0.1:35729/'
 
 
 def _get_url(url, registry_base_url=None):

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -92,6 +92,10 @@ class ParsingException(Exception):
     pass
 
 
+class DependencyException(Exception):
+    pass
+
+
 class VersionsNotCompatibleException(ParsingException):
     def __init__(self, msg=None):
         self.msg = msg
@@ -114,6 +118,10 @@ def raise_compiler_error(msg, node=None):
 
 def raise_database_error(msg, node=None):
     raise DatabaseException(msg, node)
+
+
+def raise_dependency_error(msg):
+    raise DependencyException(msg)
 
 
 def ref_invalid_args(model, args):
@@ -219,6 +227,30 @@ def missing_relation(relation_name, model=None):
     raise_compiler_error(
         "Relation {} not found!".format(relation_name),
         model)
+
+
+def package_not_found(package_name):
+    raise_dependency_error(
+        "Package {} was not found in the package index".format(package_name))
+
+
+def package_version_not_found(package_name, version_range, available_versions):
+    base_msg = ('Could not find a matching version for package {}!\n'
+                '  Requested range: {}\n'
+                '  Available versions: {}')
+
+    raise_dependency_error(base_msg.format(package_name,
+                                           version_range,
+                                           available_versions))
+
+
+def incompatible_versions(package_name, versions):
+    version_list = ", ".join(versions)
+
+    raise VersionsNotCompatibleException(
+        'Could not find a satisfactory version of {}:\n'
+        'Specified versions: [{}]'
+        .format(package_name, version_list))
 
 
 def invalid_materialization_argument(name, argument):

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -235,7 +235,7 @@ def package_not_found(package_name):
 
 
 def package_version_not_found(package_name, version_range, available_versions):
-    base_msg = ('Could not find a matching version for package {}!\n'
+    base_msg = ('Could not find a matching version for package {}\n'
                 '  Requested range: {}\n'
                 '  Available versions: {}')
 

--- a/dbt/semver.py
+++ b/dbt/semver.py
@@ -322,6 +322,7 @@ def reduce_versions(*args):
         for version_specifier in version_specifiers:
             to_return = to_return.reduce(version_specifier.to_range())
     except VersionsNotCompatibleException as e:
+        #TODO
         raise VersionsNotCompatibleException(
             'Could not find a satisfactory version from options: {}'
             .format(str(args)))

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -190,8 +190,14 @@ def dependency_projects(project):
                 continue
 
             try:
+                dbt_project_yml_path = os.path.join(full_obj, 'dbt_project.yml')
+                if not os.path.exists(dbt_project_yml_path):
+                    msg = "dbt_project.yml file not found, excluding: {}"
+                    logger.debug(msg.format(full_obj))
+                    continue
+
                 yield dbt.project.read_project(
-                    os.path.join(full_obj, 'dbt_project.yml'),
+                    dbt_project_yml_path,
                     project.profiles_dir,
                     profile_to_load=project.profile_to_load,
                     args=project.args)


### PR DESCRIPTION
This PR refactors some of the in-progress `dbt deps` work and handles errors a little nicer.

Packages are extracted to the correct directory:
```
$ tree dbt_modules/ -L 1
dbt_modules/
├── dbt-utils
├── downloads
└── redshift
```

Invalid version specified for a dep:
```
$ dbt deps
Encountered an error:
Could not find a matching version for package fishtown-analytics/dbt-utils
  Requested range: =2.0.0, =2.0.0
  Available versions: ['1.0.0', '0.9.0']
```

Conflicting versions are specified:
```
$ dbt deps
Encountered an error:
Could not find a satisfactory version of fishtown-analytics/dbt-utils:
Specified versions: [>1.0.0, <1.0.0]
```

Nonexistent package is specified:
```
$ dbt deps
Encountered an error:
Package fishtown-analytics/snowflake was not found in the package index
```

TODO:
 - [x] Extract to correct dir
 - [x] Refactor deps task
 - [x] Nice error messages
 - [ ] Work with local packages
 - [ ] Work with remote repo (github, bitbucket, etc)
 - [ ] Recursively clone deps for non-hub packages?
 - [ ] Specify a required dbt version range in packages