### PR TITLE
fix schema tests used in, or defined in packages

### DIFF
--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -471,7 +471,7 @@ def parse_schema_tests(tests, root_project, projects, macros=None):
 
                 for config in configs:
                     package_name = test.get('package_name')
-                    test_namespace = 'dbt'
+                    test_namespace = None
                     split = test_type.split('.')
 
                     if len(split) > 1:
@@ -551,7 +551,11 @@ def parse_schema_test(test_base, model_name, test_config, test_namespace,
     # sort the dict so the keys are rendered deterministically (for tests)
     kwargs = [as_kwarg(key, test_args[key]) for key in sorted(test_args)]
 
-    macro_name = "{}.test_{}".format(test_namespace, test_type)
+    if test_namespace is None:
+        macro_name = "test_{}".format(test_type)
+    else:
+        macro_name = "{}.test_{}".format(test_namespace, test_type)
+
     raw_sql = "{{{{ {macro}(model=ref('{model}'), {kwargs}) }}}}".format(**{
         'model': model_name,
         'macro': macro_name,

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -471,14 +471,20 @@ def parse_schema_tests(tests, root_project, projects, macros=None):
 
                 for config in configs:
                     package_name = test.get('package_name')
+                    test_namespace = 'dbt'
                     split = test_type.split('.')
 
                     if len(split) > 1:
                         test_type = split[1]
                         package_name = split[0]
+                        test_namespace = package_name
 
                     to_add = parse_schema_test(
-                        test, model_name, config, test_type,
+                        test,
+                        model_name,
+                        config,
+                        test_namespace,
+                        test_type,
                         root_project,
                         projects.get(package_name),
                         all_projects=projects,
@@ -533,8 +539,8 @@ def as_kwarg(key, value):
     return "{key}={value}".format(key=key, value=formatted_value)
 
 
-def parse_schema_test(test_base, model_name, test_config, test_type,
-                      root_project_config, package_project_config,
+def parse_schema_test(test_base, model_name, test_config, test_namespace,
+                      test_type, root_project_config, package_project_config,
                       all_projects, macros=None):
 
     if isinstance(test_config, (basestring, int, float, bool)):
@@ -545,13 +551,7 @@ def parse_schema_test(test_base, model_name, test_config, test_type,
     # sort the dict so the keys are rendered deterministically (for tests)
     kwargs = [as_kwarg(key, test_args[key]) for key in sorted(test_args)]
 
-    macro_name = "test_{}".format(test_type)
-
-    if package_project_config.get('name') != \
-       root_project_config.get('name'):
-        macro_name = "{}.{}".format(package_project_config.get('name'),
-                                    macro_name)
-
+    macro_name = "{}.test_{}".format(test_namespace, test_type)
     raw_sql = "{{{{ {macro}(model=ref('{model}'), {kwargs}) }}}}".format(**{
         'model': model_name,
         'macro': macro_name,

--- a/test/integration/008_schema_tests_test/macros/tests.sql
+++ b/test/integration/008_schema_tests_test/macros/tests.sql
@@ -19,7 +19,7 @@
     from {{ model }}
     where {{ field }} in (
         {% for value in values %}
-            {{ value }} {% if not loop.last %} , {% endif %}
+            '{{ value }}' {% if not loop.last %} , {% endif %}
         {% endfor %}
     )
 

--- a/test/integration/008_schema_tests_test/models-custom/schema.yml
+++ b/test/integration/008_schema_tests_test/models-custom/schema.yml
@@ -11,12 +11,12 @@ table_copy:
 
     # fails
     every_value_is_blue:
-      - color
+      - favorite_color
 
     # passes
     rejected_values:
-      - { field: 'color', values: ['orange', 'purple'] }
+      - { field: 'favorite_color', values: ['orange', 'purple'] }
 
     # passes
     dbt_utils.equality:
-      - "{{ ref('seed') }}"
+      - ref('table_copy')

--- a/test/integration/008_schema_tests_test/test_schema_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_tests.py
@@ -89,10 +89,14 @@ class TestCustomSchemaTests(DBTIntegrationTest):
 
     @property
     def project_config(self):
+        # dbt-utils containts a schema test (equality)
+        # dbt-integration-project contains a schema.yml file
+        # both should work!
         return {
             "macro-paths": ["test/integration/008_schema_tests_test/macros"],
             "repositories": [
-                'https://github.com/fishtown-analytics/dbt-utils'
+                'https://github.com/fishtown-analytics/dbt-utils',
+                'https://github.com/fishtown-analytics/dbt-integration-project'
             ]
         }
 
@@ -113,5 +117,9 @@ class TestCustomSchemaTests(DBTIntegrationTest):
         self.run_dbt()
         test_results = self.run_schema_validations()
 
+        rejected_values_table_copy_color__orange__purple
+        expected_failures = ['unique', 'every_value_is_blue']
+
         for result in test_results:
-            print(result.node, result.errored, result.skipped, result.status)
+            if result.errored:
+                self.assertTrue(result.node['name'] in expected_failures)

--- a/test/integration/008_schema_tests_test/test_schema_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_tests.py
@@ -117,7 +117,6 @@ class TestCustomSchemaTests(DBTIntegrationTest):
         self.run_dbt()
         test_results = self.run_schema_validations()
 
-        rejected_values_table_copy_color__orange__purple
         expected_failures = ['unique', 'every_value_is_blue']
 
         for result in test_results:


### PR DESCRIPTION
This needs tests!

Fixes: https://github.com/fishtown-analytics/dbt/issues/596

0.9.0 made it possible to use schema tests defined by macros in packages, eg:

```
test_model:
  constraints:
    dbt_utils.equality:
      - other_model
```

This change caused schema tests _used_ in packages to break, eg:

```
snowplow_sessions:
  constraints:
    not_null:
      - session_id
```

Previously, this code looked for a `test_not_null` macro defined in the package where the `schema.yml` file lives, or: `snowplow.not_null` which does not exist.

Now:
- "namespaced" schema tests like `dbt_utils.equality` will look for `test_equality` in the `dbt_utils` package
- unnamespaced schema tests like `not_null` will not prefix the macro name with a namespace.

So, this covers four cases:
- calling a dbt global package schema test (`not_null`)
- calling a schema test defined in the top-level project
  - explicitly: `internal_analytics.custom_test`
  - implicitly: `custom_test`
- calling a schema test in a package:
  - `dbt_utils.equality`
