### PR TITLE
Add warning for missing constraints. Fixes #592

### DIFF
--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -452,8 +452,12 @@ def parse_schema_tests(tests, root_project, projects, macros=None):
         if test_yml is None:
             continue
 
+        no_tests_warning = ("* WARNING: No constraints found for model"
+                            " '{}' in file {}\n")
         for model_name, test_spec in test_yml.items():
             if test_spec is None or test_spec.get('constraints') is None:
+                test_path = test['original_file_path']
+                logger.warn(no_tests_warning.format(model_name, test_path))
                 continue
 
             for test_type, configs in test_spec.get('constraints', {}).items():


### PR DESCRIPTION
Warning for schema tests with no `constraints` block.

```
$ dbt test
* WARNING: No constraints found for model 'test' in file models/schema.yml

Found 20 models, 1 tests, 0 archives.....
```

With `models/schema.yml`:
```yml
test:
    constraint: # Typo, or could be missing entirely
        dbt_utils.equality:
            - test

        equality2:
            - test

        my_project.equality2:
            - test
```