### PR TITLE
run hooks in correct order, fixes #590

### DIFF
--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -15,6 +15,7 @@ from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 hook_contract = Schema({
     Required('sql'): basestring,
     Required('transaction'): bool,
+    Required('index'): int,
 })
 
 config_contract = Schema({

--- a/dbt/contracts/graph/unparsed.py
+++ b/dbt/contracts/graph/unparsed.py
@@ -1,4 +1,4 @@
-from voluptuous import Schema, Required, All, Any, Length
+from voluptuous import Schema, Required, All, Any, Length, Optional
 
 from dbt.compat import basestring
 from dbt.contracts.common import validate_with
@@ -15,6 +15,7 @@ unparsed_base_contract = Schema({
     Required('path'): basestring,
     Required('original_file_path'): basestring,
     Required('raw_sql'): basestring,
+    Optional('index'): int,
 })
 
 unparsed_node_contract = unparsed_base_contract.extend({

--- a/dbt/hooks.py
+++ b/dbt/hooks.py
@@ -21,12 +21,13 @@ def _parse_hook_to_dict(hook_string):
     return hook_dict
 
 
-def get_hook_dict(hook):
+def get_hook_dict(hook, index):
     if isinstance(hook, dict):
         hook_dict = hook
     else:
         hook_dict = _parse_hook_to_dict(to_string(hook))
 
+    hook_dict['index'] = index
     return hook_dict
 
 
@@ -36,5 +37,5 @@ def get_hooks(model, hook_key):
     if not isinstance(hooks, (list, tuple)):
         hooks = [hooks]
 
-    wrapped = [get_hook_dict(hook) for hook in hooks]
+    wrapped = [get_hook_dict(hook, i) for i, hook in enumerate(hooks)]
     return wrapped

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -291,11 +291,14 @@ class ModelRunner(CompileRunner):
             model_name = compiled.get('name')
             statement = compiled['wrapped_sql']
 
-            hook_dict = dbt.hooks.get_hook_dict(statement)
+            hook_index = hook.get('index', len(hooks))
+            hook_dict = dbt.hooks.get_hook_dict(statement, index=hook_index)
             compiled_hooks.append(hook_dict)
 
-        for hook in compiled_hooks:
 
+        ordered_hooks = sorted(compiled_hooks, key=lambda h: h.get('index', 0))
+
+        for hook in ordered_hooks:
             if dbt.flags.STRICT_MODE:
                 dbt.contracts.graph.parsed.validate_hook(hook)
 

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -295,7 +295,6 @@ class ModelRunner(CompileRunner):
             hook_dict = dbt.hooks.get_hook_dict(statement, index=hook_index)
             compiled_hooks.append(hook_dict)
 
-
         ordered_hooks = sorted(compiled_hooks, key=lambda h: h.get('index', 0))
 
         for hook in ordered_hooks:

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -380,7 +380,8 @@ def load_and_parse_run_hook_type(root_project, all_projects, hook_type,
                 'path': hook_path,
                 'original_file_path': hook_path,
                 'package_name': project_name,
-                'raw_sql': hook
+                'raw_sql': hook,
+                'index': i
             })
 
     tags = {hook_type}

--- a/test/integration/014_hook_tests/test_run_hooks.py
+++ b/test/integration/014_hook_tests/test_run_hooks.py
@@ -34,8 +34,19 @@ class TestPrePostRunHooks(DBTIntegrationTest):
         return {
             'macro-paths': ['test/integration/014_hook_tests/macros'],
 
-            "on-run-start": "{{ custom_run_hook('start', target, run_started_at, invocation_id) }}",
-            "on-run-end": "{{ custom_run_hook('end', target, run_started_at, invocation_id) }}",
+            # The create and drop table statements here validate that these hooks run
+            # in the same order that they are defined. Drop before create is an error.
+            # Also check that the table does not exist below.
+            "on-run-start": [
+                "{{ custom_run_hook('start', target, run_started_at, invocation_id) }}",
+                "create table {schema}.start_hook_order_test ( id int )",
+                "drop table {schema}.start_hook_order_test",
+            ]
+            "on-run-end": [
+                "{{ custom_run_hook('end', target, run_started_at, invocation_id) }}",
+                "create table {schema}.end_hook_order_test ( id int )",
+                "drop table {schema}.end_hook_order_test",
+            ]
         }
 
     @property
@@ -76,3 +87,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
 
         self.check_hooks('start')
         self.check_hooks('end')
+
+
+        self.assertTableDoesNotExist("start_hook_order_test")
+        self.assertTableDoesNotExist("end_hook_order_test")

--- a/test/integration/014_hook_tests/test_run_hooks.py
+++ b/test/integration/014_hook_tests/test_run_hooks.py
@@ -39,13 +39,13 @@ class TestPrePostRunHooks(DBTIntegrationTest):
             # Also check that the table does not exist below.
             "on-run-start": [
                 "{{ custom_run_hook('start', target, run_started_at, invocation_id) }}",
-                "create table {schema}.start_hook_order_test ( id int )",
-                "drop table {schema}.start_hook_order_test",
-            ]
+                "create table {{ target.schema }}.start_hook_order_test ( id int )",
+                "drop table {{ target.schema }}.start_hook_order_test",
+            ],
             "on-run-end": [
                 "{{ custom_run_hook('end', target, run_started_at, invocation_id) }}",
-                "create table {schema}.end_hook_order_test ( id int )",
-                "drop table {schema}.end_hook_order_test",
+                "create table {{ target.schema }}.end_hook_order_test ( id int )",
+                "drop table {{ target.schema }}.end_hook_order_test",
             ]
         }
 


### PR DESCRIPTION
in 0.9.0, `on-run-start` and `on-run-end` hooks are stored in a dictionary between parsing and running. This means that the order of hook execution is not guaranteed to be the order in which the hooks are defined.

This PR adds an `index` to hook dicts. The dictionary of hooks is sorted by this index before running. This ensures that hooks run in the same order that they're defined.