### PR TITLE
change req for snowflake to fix crypto install issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ csvkit==0.9.1
 snowplow-tracker==0.7.2
 celery==3.1.23
 voluptuous==0.10.5
-snowflake-connector-python==1.4.9
+snowflake-connector-python>=1.4.9
 colorama==0.3.9
 google-cloud-bigquery==0.26.0


### PR DESCRIPTION
This is breaking AppVeyor and Circle CI

```
From cffi callback <function _verify_callback at 0x06BF2978>:
Traceback (most recent call last):
  File "c:\projects\dbt\.tox\pywin\lib\site-packages\OpenSSL\SSL.py", line 313, in wrapper
    _lib.X509_up_ref(x509)
AttributeError: module 'lib' has no attribute 'X509_up_ref'
````