### PR TITLE
add support for late binding views (Redshift)

### DIFF
--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -342,6 +342,12 @@ class BigQueryAdapter(PostgresAdapter):
             return [ds.name for ds in all_datasets]
 
     @classmethod
+    def get_columns_in_table(cls, profile, schema_name, table_name,
+                             model_name=None):
+        raise dbt.exceptions.NotImplementedException(
+            '`get_columns_in_table` is not implemented for this adapter!')
+
+    @classmethod
     def check_schema_exists(cls, profile, schema, model_name=None):
         conn = cls.get_connection(profile, model_name)
 

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -174,8 +174,7 @@ class DefaultAdapter(object):
                 if col_name in missing_columns]
 
     @classmethod
-    def get_columns_in_table(cls, profile, schema_name, table_name,
-                             model_name=None):
+    def _get_columns_in_table_sql(cls, schema_name, table_name):
         sql = """
         select column_name, data_type, character_maximum_length
         from information_schema.columns
@@ -186,6 +185,13 @@ class DefaultAdapter(object):
             sql += (" AND table_schema = '{schema_name}'"
                     .format(schema_name=schema_name))
 
+        return sql
+
+    @classmethod
+    def get_columns_in_table(cls, profile, schema_name, table_name,
+                             model_name=None):
+
+        sql = cls._get_columns_in_table_sql(schema_name, table_name)
         connection, cursor = cls.add_query(
             profile, sql, model_name)
 

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -18,6 +18,47 @@ class RedshiftAdapter(PostgresAdapter):
         return 'getdate()'
 
     @classmethod
+    def _get_columns_in_table_sql(cls, schema_name, table_name):
+        # TODO : how do we make this a macro?
+        if schema_name is None:
+            table_schema_filter = '1=1'
+        else:
+            table_schema_filter = "table_schema = '{schema_name}'".format(schema_name=schema_name)
+
+        sql = """
+            with bound_views as (
+                select table_schema, column_name, data_type, character_maximum_length
+                from information_schema.columns
+                where table_name = '{table_name}'
+            ),
+
+            unbound_views as (
+                select
+                    view_schema,
+                    col_name,
+                    col_type,
+                    case
+                        when col_type like 'character%' then REGEXP_SUBSTR(col_type, '[0-9]+')::int
+                        else null
+                    end as character_maximum_length
+                from pg_get_late_binding_view_cols()
+                cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int)
+                where view_name = '{table_name}'
+            ),
+
+            unioned as (
+                select * from bound_views
+                union all
+                select * from unbound_views;
+            )
+
+            select column_name, data_type, character_maximum_length
+            from unioned
+            where {table_schema_filter}
+        """.format(table_name=table_name, table_schema_filter=table_schema_filter).strip()
+        return sql
+
+    @classmethod
     def drop(cls, profile, schema, relation, relation_type, model_name=None):
         global drop_lock
 

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -23,7 +23,8 @@ class RedshiftAdapter(PostgresAdapter):
         if schema_name is None:
             table_schema_filter = '1=1'
         else:
-            table_schema_filter = "table_schema = '{schema_name}'".format(schema_name=schema_name)
+            table_schema_filter = "table_schema = '{schema_name}'".format(
+                    schema_name=schema_name)
 
         sql = """
             with bound_views as (
@@ -43,12 +44,14 @@ class RedshiftAdapter(PostgresAdapter):
                     col_name,
                     col_type,
                     case
-                        when col_type like 'character%' then REGEXP_SUBSTR(col_type, '[0-9]+')::int
+                        when col_type like 'character%'
+                          then REGEXP_SUBSTR(col_type, '[0-9]+')::int
                         else null
                     end as character_maximum_length
 
                 from pg_get_late_binding_view_cols()
-                cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int)
+                cols(view_schema name, view_name name, col_name name,
+                     col_type varchar, col_num int)
                 where view_name = '{table_name}'
             ),
 
@@ -61,7 +64,8 @@ class RedshiftAdapter(PostgresAdapter):
             select column_name, data_type, character_maximum_length
             from unioned
             where {table_schema_filter}
-        """.format(table_name=table_name, table_schema_filter=table_schema_filter).strip()
+        """.format(table_name=table_name,
+                   table_schema_filter=table_schema_filter).strip()
         return sql
 
     @classmethod

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -27,7 +27,12 @@ class RedshiftAdapter(PostgresAdapter):
 
         sql = """
             with bound_views as (
-                select table_schema, column_name, data_type, character_maximum_length
+                select
+                    table_schema,
+                    column_name,
+                    data_type,
+                    character_maximum_length
+
                 from information_schema.columns
                 where table_name = '{table_name}'
             ),
@@ -41,6 +46,7 @@ class RedshiftAdapter(PostgresAdapter):
                         when col_type like 'character%' then REGEXP_SUBSTR(col_type, '[0-9]+')::int
                         else null
                     end as character_maximum_length
+
                 from pg_get_late_binding_view_cols()
                 cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int)
                 where view_name = '{table_name}'
@@ -49,7 +55,7 @@ class RedshiftAdapter(PostgresAdapter):
             unioned as (
                 select * from bound_views
                 union all
-                select * from unbound_views;
+                select * from unbound_views
             )
 
             select column_name, data_type, character_maximum_length

--- a/dbt/include/global_project/macros/adapters/redshift.sql
+++ b/dbt/include/global_project/macros/adapters/redshift.sql
@@ -54,7 +54,7 @@
 
 {% macro redshift__create_view_as(identifier, sql) -%}
 
-  {% set bind_qualifier = 'with no schema binding' if config.get('bind', False) else '' %}
+  {% set bind_qualifier = '' if config.get('bind', True) else 'with no schema binding' %}
 
   create view "{{ schema }}"."{{ identifier }}" as (
     {{ sql }}

--- a/dbt/include/global_project/macros/adapters/redshift.sql
+++ b/dbt/include/global_project/macros/adapters/redshift.sql
@@ -54,7 +54,7 @@
 
 {% macro redshift__create_view_as(identifier, sql) -%}
 
-  {% set bind_qualifier = '' if config.get('bind', True) else 'with no schema binding' %}
+  {% set bind_qualifier = '' if config.get('bind', default=True) else 'with no schema binding' %}
 
   create view "{{ schema }}"."{{ identifier }}" as (
     {{ sql }}

--- a/dbt/include/global_project/macros/adapters/redshift.sql
+++ b/dbt/include/global_project/macros/adapters/redshift.sql
@@ -52,6 +52,16 @@
 {%- endmacro %}
 
 
+{% macro redshift__create_view_as(identifier, sql) -%}
+
+  {% set bind_qualifier = 'with no schema binding' if config.get('bind', False) else '' %}
+
+  create view "{{ schema }}"."{{ identifier }}" as (
+    {{ sql }}
+  ) {{ bind_qualifier }};
+{% endmacro %}
+
+
 {% macro redshift__create_archive_table(schema, identifier, columns) -%}
   create table if not exists "{{ schema }}"."{{ identifier }}" (
     {{ column_list_for_create_table(columns) }}

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -20,7 +20,8 @@ class SourceConfig(object):
         'sort',
         'sql_where',
         'unique_key',
-        'sort_type'
+        'sort_type',
+        'bind'
     ]
 
     def __init__(self, active_project, own_project, fqn):

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -22,7 +22,8 @@ DBTConfigKeys = [
     'sort_type',
     'pre-hook',
     'post-hook',
-    'vars'
+    'vars',
+    'bind',
 ]
 
 


### PR DESCRIPTION
For https://github.com/fishtown-analytics/dbt/issues/523

Usage:
```
-- models/my_model.sql
{{
  config(materialized='view', bind=False)
}}


select ...
```

Or:
```yml
# dbt_project.yml

models:
  my_project:
    bind: False
    materialized: view
```

@cmcarthur I went back and forth here... what do you think? Does `bind=False` make sense? Or should it be `materialized='late_binding_view'`? I also thought about making this the default, but I'm afraid that would break many projects in subtle ways.

TODO:
 - [x] Use [PG_GET_LATE_BINDING_VIEW_COLS](http://docs.aws.amazon.com/redshift/latest/dg/PG_GET_LATE_BINDING_VIEW_COLS.html) to fetch columns for these views
 - [x] Play around with this + Spectrum and make sure everything works as expected