### PR TITLE
Fix for pre-hooks outside of transactions

### DIFF
--- a/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/helpers.sql
@@ -1,5 +1,10 @@
 {% macro run_hooks(hooks, inside_transaction=True) %}
   {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
+    {% if not inside_transaction and loop.first %}
+      {% call statement(auto_begin=inside_transaction) %}
+        commit;
+      {% endcall %}
+    {% endif %}
     {% call statement(auto_begin=inside_transaction) %}
       {{ hook.get('sql') }}
     {% endcall %}

--- a/test/integration/014_hook_tests/test_model_hooks.py
+++ b/test/integration/014_hook_tests/test_model_hooks.py
@@ -95,8 +95,21 @@ class TestPrePostModelHooks(DBTIntegrationTest):
             'macro-paths': ['test/integration/014_hook_tests/macros'],
             'models': {
                 'test': {
-                    'pre-hook': MODEL_PRE_HOOK,
-                    'post-hook': MODEL_POST_HOOK,
+                    'pre-hook': [
+                        # inside transaction (runs second)
+                        MODEL_PRE_HOOK,
+
+                        # outside transaction (runs first)
+                        {"sql": "vacuum {{ this.schema }}.on_model_hook", "transaction": False},
+                    ],
+
+                    'post-hook':[
+                        # outside transaction (runs second)
+                        {"sql": "vacuum {{ this.schema }}.on_model_hook", "transaction": False},
+
+                        # inside transaction (runs first)
+                        MODEL_POST_HOOK,
+                    ]
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/fishtown-analytics/dbt/issues/576

psycopg2 auto-issues a `begin` when a connection is created. As a result, pre-hooks for models will fail if they need to run outside of a transaction (ie. `vacuum`).

This PR sneaks a `commit;` call in before the first non-transaction hook. We could alternatively fix this by immediately committing any new psycopg2 conns, but I'm disinclined to poke that bear.

For pre-hooks, this `commit` will run first-thing for the model. For post-hooks, it will run after all in-transaction hooks have completed.

If there's no open transaction, the db will return:
```
# Postgres
WARNING:  there is no transaction in progress
COMMIT

# Redshift
COMMIT

# Snowflake
```
1 Statement executed successfully.
```

None of these are error conditions, and hooks are not implemented for BigQuery.