### PR TITLE
Accept string for postgres port number (#583)

### DIFF
--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -20,7 +20,7 @@ postgres_credentials_contract = Schema({
     Required('host'): basestring,
     Required('user'): basestring,
     Required('pass'): basestring,
-    Required('port'): Any(All(int, Range(min=0, max=65535)), str),
+    Required('port'): Any(All(int, Range(min=0, max=65535)), basestring),
     Required('schema'): basestring,
 })
 

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -20,7 +20,7 @@ postgres_credentials_contract = Schema({
     Required('host'): basestring,
     Required('user'): basestring,
     Required('pass'): basestring,
-    Required('port'): All(int, Range(min=0, max=65535)),
+    Required('port'): Any(All(int, Range(min=0, max=65535)), str),
     Required('schema'): basestring,
 })
 


### PR DESCRIPTION
This is really only useful if using env_vars to supply database creds. Those come through as strings, and `port` is the only option that should be numeric. Psycopg2 handles string port numbers just fine.

Fixes: https://github.com/fishtown-analytics/dbt/issues/583