### PR TITLE
Create schema in archival flow

### DIFF
--- a/dbt/include/global_project/macros/adapters/common.sql
+++ b/dbt/include/global_project/macros/adapters/common.sql
@@ -9,6 +9,10 @@
   {%- endif -%}
 {%- endmacro %}
 
+{% macro create_schema(schema_name) %}
+  create schema if not exists "{{ schema_name }}";
+{% endmacro %}
+
 
 {% macro create_table_as(temporary, identifier, sql) -%}
   {{ adapter_macro('create_table_as', temporary, identifier, sql) }}

--- a/dbt/include/global_project/macros/materializations/archive.sql
+++ b/dbt/include/global_project/macros/materializations/archive.sql
@@ -92,6 +92,10 @@
   ] -%}
 
   {% call statement() %}
+    {{ create_schema(target_schema) }}
+  {% endcall %}
+
+  {% call statement() %}
     {{ create_archive_table(target_schema, target_table, dest_columns) }}
   {% endcall %}
 


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/585


There might be a smarter way to do this -- we could set the node `schema` to the value of `target_schema`, then this will happen automatically through the `node_runner` before_run flow.