### PR TITLE
Fix/snowflake custom schema

### DIFF
--- a/dbt/adapters/snowflake.py
+++ b/dbt/adapters/snowflake.py
@@ -147,7 +147,11 @@ class SnowflakeAdapter(PostgresAdapter):
     def create_schema(cls, profile, schema, model_name=None):
         logger.debug('Creating schema "%s".', schema)
         sql = cls.get_create_schema_sql(schema)
-        return cls.add_query(profile, sql, model_name, select_schema=False)
+        res = cls.add_query(profile, sql, model_name, select_schema=False)
+
+        cls.commit_if_has_connection(profile, model_name)
+
+        return res
 
     @classmethod
     def get_existing_schemas(cls, profile, model_name=None):

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -318,6 +318,13 @@ class ModelRunner(CompileRunner):
     def create_schemas(cls, project, adapter, flat_graph):
         profile = project.run_environment()
         required_schemas = cls.get_model_schemas(flat_graph)
+
+        # Snowflake needs to issue a "use {schema}" query, where schema
+        # is the one defined in the profile. Create this schema if it
+        # does not exist, otherwise subsequent queries will fail. Generally,
+        # dbt expects that this schema will exist anyway.
+        required_schemas.add(adapter.get_default_schema(profile))
+
         existing_schemas = set(adapter.get_existing_schemas(profile))
 
         for schema in (required_schemas - existing_schemas):


### PR DESCRIPTION
Currently, setting a custom schema for _all_ models will cause an error on Snowflake.

```yml
# dbt_project.yml
models:
    my_project:
        schema: other_schema
```

dbt will correctly create a schema called `other_schema` (or similar) here. But subsequent queries will begin with `use schema {target-schema}` which very well might not exist yet.

This PR will always create the schema defined in the `profiles.yml`, preventing this issue from occurring.