### PR TITLE
fix for adapter macro called within packages

### DIFF
--- a/dbt/include/global_project/macros/adapters/common.sql
+++ b/dbt/include/global_project/macros/adapters/common.sql
@@ -1,4 +1,5 @@
 {% macro adapter_macro(name) -%}
+  {% set original_name = name %}
   {% if '.' in name %}
     {% set package_name, name = name.split(".", 1) %}
   {% else %}
@@ -10,7 +11,10 @@
   {% elif package_name in context %}
     {% set package_context = context[package_name] %}
   {% else %}
-    {{ exceptions.raise_compiler_error("Bad context for adapter macro: " ~ package_name) }}
+    {% set error_msg %}
+        In adapter_macro: could not find package '{{package_name}}', called with '{{original_name}}'
+    {% endset %}
+    {{ exceptions.raise_compiler_error(error_msg | trim) }}
   {% endif %}
 
   {%- set separator = '__' -%}

--- a/dbt/include/global_project/macros/adapters/common.sql
+++ b/dbt/include/global_project/macros/adapters/common.sql
@@ -1,11 +1,26 @@
 {% macro adapter_macro(name) -%}
+  {% if '.' in name %}
+    {% set package_name, name = name.split(".", 1) %}
+  {% else %}
+    {% set package_name = none %}
+  {% endif %}
+
+  {% if package_name is none %}
+    {% set package_context = context %}
+  {% elif package_name in context %}
+    {% set package_context = context[package_name] %}
+  {% else %}
+    {{ exceptions.raise_compiler_error("Bad context for adapter macro: " ~ package_name) }}
+  {% endif %}
+
   {%- set separator = '__' -%}
   {%- set search_name = adapter.type() + separator + name -%}
   {%- set default_name = 'default' + separator + name -%}
-  {%- if context.get(search_name) is not none -%}
-    {{ context[search_name](*varargs, **kwargs) }}
+
+  {%- if package_context.get(search_name) is not none -%}
+    {{ package_context[search_name](*varargs, **kwargs) }}
   {%- else -%}
-    {{ context[default_name](*varargs, **kwargs) }}
+    {{ package_context[default_name](*varargs, **kwargs) }}
   {%- endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
Fixes `adapter_macro` calls in packages like [this](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/cross_db_utils/dateadd.sql#L2) one.

Previously, dbt would look for the macro in the global context. Now, dbt looks for the macro in the specified package's context.

Usage:
```jinja
{% macro dateadd(datepart, interval, from_date_or_timestamp) %}
  {{ adapter_macro('dbt_utils.dateadd', datepart, interval, from_date_or_timestamp) }}
{% endmacro %}
```


TODO:
 - Revisit when this is merged: https://github.com/fishtown-analytics/dbt-utils/pull/34/files