### PR TITLE
Set global variable overrides on the command line with --vars

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -295,6 +295,16 @@ def parse_args(args):
         help='Which target to load for the given profile'
     )
 
+    base_subparser.add_argument(
+        '--vars',
+        type=str,
+        default='{}',
+        help="""
+            Supply variables to the project. This argument overrides
+            variables defined in your dbt_project.yml file. This argument
+            should be a YAML string, eg. '{my_variable: my_value}'"""
+    )
+
     sub = subs.add_parser('init', parents=[base_subparser])
     sub.add_argument('project_name', type=str, help='Name of the new project')
     sub.set_defaults(cls=init_task.InitTask, which='init')

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -87,6 +87,12 @@ class Project(object):
                 "Could not find profile named '{}'"
                 .format(self.profile_to_load), self)
 
+        global_vars = dbt.utils.parse_cli_vars(getattr(args, 'vars', '{}'))
+        if 'vars' not in self.cfg['models']:
+            self.cfg['models']['vars'] = {}
+
+        self.cfg['models']['vars'].update(global_vars)
+
     def __str__(self):
         return pprint.pformat({'project': self.cfg, 'profiles': self.profiles})
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -9,6 +9,7 @@ from dbt.include import GLOBAL_DBT_MODULES_PATH
 from dbt.compat import basestring
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
+from dbt.clients import yaml_helper
 
 
 DBTConfigKeys = [
@@ -375,3 +376,19 @@ def invalid_ref_fail_unless_test(node, target_model_name,
             node,
             target_model_name,
             target_model_package)
+
+
+def parse_cli_vars(var_string):
+    try:
+        cli_vars = yaml_helper.load_yaml_text(var_string)
+        var_type = type(cli_vars)
+        if var_type == dict:
+            return cli_vars
+        else:
+            type_name = var_type.__name__
+            dbt.exceptions.raise_compiler_error("The --vars argument must be "
+                "a YAML dictionary, but was of type '{}'".format(type_name))
+    except dbt.exceptions.ValidationException as e:
+        logger.error("The YAML provided in the --vars argument is "
+                     "not valid.\n")
+        raise

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -386,9 +386,10 @@ def parse_cli_vars(var_string):
             return cli_vars
         else:
             type_name = var_type.__name__
-            dbt.exceptions.raise_compiler_error("The --vars argument must be "
-                "a YAML dictionary, but was of type '{}'".format(type_name))
+            dbt.exceptions.raise_compiler_error(
+                "The --vars argument must be a YAML dictionary, but was "
+                "of type '{}'".format(type_name))
     except dbt.exceptions.ValidationException as e:
-        logger.error("The YAML provided in the --vars argument is "
-                     "not valid.\n")
+        logger.error(
+                "The YAML provided in the --vars argument is not valid.\n")
         raise

--- a/test/integration/028_cli_vars/models_complex/complex_model.sql
+++ b/test/integration/028_cli_vars/models_complex/complex_model.sql
@@ -1,0 +1,6 @@
+
+select
+    '{{ var("variable_1") }}'::varchar as var_1,
+    '{{ var("variable_2")[0] }}'::varchar as var_2,
+    '{{ var("variable_3")["value"] }}'::varchar as var_3
+

--- a/test/integration/028_cli_vars/models_complex/schema.yml
+++ b/test/integration/028_cli_vars/models_complex/schema.yml
@@ -1,0 +1,7 @@
+
+complex_model:
+    constraints:
+        accepted_values:
+            - {field: var_1, values: ["abc"]}
+            - {field: var_2, values: ["def"]}
+            - {field: var_3, values: ["jkl"]}

--- a/test/integration/028_cli_vars/models_simple/schema.yml
+++ b/test/integration/028_cli_vars/models_simple/schema.yml
@@ -1,0 +1,5 @@
+
+simple_model:
+    constraints:
+        accepted_values:
+            - {field: simple, values: ["abc"]}

--- a/test/integration/028_cli_vars/models_simple/simple_model.sql
+++ b/test/integration/028_cli_vars/models_simple/simple_model.sql
@@ -1,0 +1,4 @@
+
+select
+    '{{ var("simple") }}'::varchar as simple
+

--- a/test/integration/028_cli_vars/test_cli_vars.py
+++ b/test/integration/028_cli_vars/test_cli_vars.py
@@ -1,0 +1,54 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+import yaml
+
+
+class TestCLIVars(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "cli_vars_028"
+
+    @property
+    def models(self):
+        return "test/integration/028_cli_vars/models_complex"
+
+    @attr(type='postgres')
+    def test__cli_vars_longform(self):
+        self.use_default_project()
+        self.use_profile('postgres')
+
+        cli_vars = {
+            "variable_1": "abc",
+            "variable_2": ["def", "ghi"],
+            "variable_3": {
+                "value": "jkl"
+            }
+        }
+        self.run_dbt(["run", "--vars", yaml.dump(cli_vars)])
+        self.run_dbt(["test"])
+
+
+class TestCLIVarsSimple(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "cli_vars_028"
+
+    @property
+    def models(self):
+        return "test/integration/028_cli_vars/models_simple"
+
+    @attr(type='postgres')
+    def test__cli_vars_shorthand(self):
+        self.use_default_project()
+        self.use_profile('postgres')
+
+        self.run_dbt(["run", "--vars", "simple: abc"])
+        self.run_dbt(["test"])
+
+    @attr(type='postgres')
+    def test__cli_vars_longer(self):
+        self.use_default_project()
+        self.use_profile('postgres')
+
+        self.run_dbt(["run", "--vars", "{simple: abc, unused: def}"])
+        self.run_dbt(["test"])


### PR DESCRIPTION
### What is this?

Variables are a useful way to dynamically configure models and macros. This PR makes these already powerful variables even more flexible by permitting variable declarations on the command line. Now, dbt users can alter the semantics of their dbt runs without changing any code.

### Usage

```
$ dbt run --vars '{"key": "value"}'
```

### Details

The `--vars` argument accepts a YAML dictionary as a string on the command line. YAML is convenient here, because it's a superset of JSON. As such, arbitrarily nested data structures can be provided to dbt as variables using this syntax.

In the majority of cases, variables are _not_ arbitrarily nested. Instead, they're simple key-value pairs. In these scenarios, YAML is convenient because it does not require strict quoting as with JSON.

Both of the following are all valid and equivalent:
```
$ dbt run --vars '{"key": "value", "date": 20180101}'
$ dbt run --vars '{key: value, date: 20180101}'
```

If only one variable is being set, the brackets are optional, eg:
```
$ dbt run --vars 'key: value'
```

There's a useful doc on YAML semantics [here](https://github.com/Animosity/CraftIRC/wiki/Complete-idiot%27s-introduction-to-yaml)

### Precedence

These variables are applied at the "root" level, as though they were defined directly under `models:` in the top-level `dbt_project.yml` file. Variables defined here will take precedence over any variable declarations defined anywhere else in your project or its dependencies.

The order of precedence for variable declaration is now:
1. The variable's default argument (if one is provided)
2. The most specific variable definition in the model's own `dbt_project.yml` file
3. The most specific variable definition in the root `dbt_project.yml` file
4. The CLI `--vars` definition

Notes:
- Item 2 above is only relevant if the model is inside of a package.
- If vars are defined inside of a macro, precedence is determined based on the model(s) which call that macro
