### PR TITLE
Fix for redshift varchar bug

### DIFF
--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -45,7 +45,7 @@ class RedshiftAdapter(PostgresAdapter):
                     col_type,
                     case
                         when col_type like 'character%'
-                          then REGEXP_SUBSTR(col_type, '[0-9]+')::int
+                          then nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::int
                         else null
                     end as character_maximum_length
 

--- a/dbt/adapters/redshift.py
+++ b/dbt/adapters/redshift.py
@@ -45,7 +45,7 @@ class RedshiftAdapter(PostgresAdapter):
                     col_type,
                     case
                         when col_type like 'character%'
-                          then nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::int
+                        then nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::int
                         else null
                     end as character_maximum_length
 


### PR DESCRIPTION
Quick fix -- if you cast a column in a late-binding view with `::varchar`, Redshift will make the col_type `character varying` with no size specified. This change prevents a Redshift error when trying to cast an empty string to an integer.