### PR TITLE
move schema creation to after hooks

### DIFF
--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -340,8 +340,8 @@ class ModelRunner(CompileRunner):
 
     @classmethod
     def before_run(cls, project, adapter, flat_graph):
-        cls.create_schemas(project, adapter, flat_graph)
         cls.safe_run_hooks(project, adapter, flat_graph, RunHookType.Start)
+        cls.create_schemas(project, adapter, flat_graph)
 
     @classmethod
     def print_results_line(cls, results, execution_time):


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/604

This PR moves schema creation to _after_ the `on-run-start` hooks. This makes it possible to add a hook to resume a Snowflake warehouse, for instance. This hook could look like:

```
on-run-start:
  - alter warehouse {{ target.warehouse }} resume;
```

Note: This _could_ break existing projects if there is code in the `on-run-start` hooks that expects the dbt schema to exist. In this case, a line can be inserted into the `on-run-start` section to create the schema.