### PR TITLE
whitelist loggers instead of blacklisting nonexhaustively

### DIFF
--- a/dbt/logger.py
+++ b/dbt/logger.py
@@ -39,6 +39,7 @@ logging.captureWarnings(True)
 
 initialized = False
 
+
 def make_log_dir_if_missing(log_dir):
     import dbt.clients.system
     dbt.clients.system.make_directory(log_dir)

--- a/dbt/logger.py
+++ b/dbt/logger.py
@@ -5,14 +5,6 @@ import sys
 
 import colorama
 
-# disable logs from other modules, excepting CRITICAL logs
-logging.getLogger('botocore').setLevel(logging.CRITICAL)
-logging.getLogger('contracts').setLevel(logging.CRITICAL)
-logging.getLogger('requests').setLevel(logging.CRITICAL)
-logging.getLogger('urllib3').setLevel(logging.CRITICAL)
-logging.getLogger('google').setLevel(logging.CRITICAL)
-logging.getLogger('snowflake.connector').setLevel(logging.CRITICAL)
-logging.getLogger('parsedatetime').setLevel(logging.CRITICAL)
 
 # Colorama needs some help on windows because we're using logger.info
 # intead of print(). If the Windows env doesn't have a TERM var set,
@@ -36,12 +28,16 @@ stdout_handler = logging.StreamHandler(colorama_stdout)
 stdout_handler.setFormatter(logging.Formatter('%(message)s'))
 stdout_handler.setLevel(logging.INFO)
 
-logger = logging.getLogger()
+logger = logging.getLogger('dbt')
 logger.addHandler(stdout_handler)
 logger.setLevel(logging.DEBUG)
+logging.getLogger().setLevel(logging.CRITICAL)
+
+# Redirect warnings through our logging setup
+# They will be logged to a file below
+logging.captureWarnings(True)
 
 initialized = False
-
 
 def make_log_dir_if_missing(log_dir):
     import dbt.clients.system
@@ -89,6 +85,11 @@ def initialize_logger(debug_mode=False, path=None):
         logdir_handler.setLevel(logging.DEBUG)
 
         logger.addHandler(logdir_handler)
+
+        # Log Python warnings to file
+        warning_logger = logging.getLogger('py.warnings')
+        warning_logger.addHandler(logdir_handler)
+        warning_logger.setLevel(logging.DEBUG)
 
     initialized = True
 

--- a/scripts/dbt
+++ b/scripts/dbt
@@ -4,5 +4,4 @@ import dbt.main
 import logging
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     dbt.main.main(sys.argv[1:])


### PR DESCRIPTION
This PR whitelists the dbt logger and blacklists all other loggers. This fixes an immediate issue with `warnings` generated by agate, but also is generally a better strategy than the one we previously had in place.

This should also silence random warnings that were seen by Windows users but were unreproducible on mac/Linux.

Warnings generated by dependencies of dbt will be written to the specified log file.