### PR TITLE
Expose agate tables in statements

### DIFF
--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -17,6 +17,7 @@ import google.cloud.exceptions
 import google.cloud.bigquery
 
 import time
+import agate
 
 
 class BigQueryAdapter(PostgresAdapter):
@@ -316,7 +317,14 @@ class BigQueryAdapter(PostgresAdapter):
 
     @classmethod
     def execute_and_fetch(cls, profile, sql, model_name, auto_begin=None):
-        return cls.execute(profile, sql, model_name, fetch=True)
+        status, res = cls.execute(profile, sql, model_name, fetch=True)
+        table = cls.get_table_from_response(res)
+        return res, table
+
+    @classmethod
+    def get_table_from_response(cls, resp):
+        rows = [dict(row.items()) for row in resp]
+        return dbt.clients.agate_helper.table_from_data(rows)
 
     @classmethod
     def add_begin_query(cls, profile, name):
@@ -427,7 +435,6 @@ class BigQueryAdapter(PostgresAdapter):
 
     @classmethod
     def convert_number_type(cls, agate_table, col_idx):
-        import agate
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
         return "float64" if decimals else "int64"
 

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -6,6 +6,7 @@ import dbt.compat
 import dbt.exceptions
 import dbt.flags as flags
 import dbt.clients.gcloud
+import dbt.clients.agate_helper
 
 from dbt.adapters.postgres import PostgresAdapter
 from dbt.contracts.connection import validate_connection

--- a/dbt/adapters/bigquery.py
+++ b/dbt/adapters/bigquery.py
@@ -320,7 +320,7 @@ class BigQueryAdapter(PostgresAdapter):
     def execute_and_fetch(cls, profile, sql, model_name, auto_begin=None):
         status, res = cls.execute(profile, sql, model_name, fetch=True)
         table = cls.get_table_from_response(res)
-        return res, table
+        return status, table
 
     @classmethod
     def get_table_from_response(cls, resp):

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -566,8 +566,8 @@ class DefaultAdapter(object):
         _, cursor = cls.execute_one(profile, sql, model_name, auto_begin)
 
         status = cls.get_status(cursor)
-        df = cls.get_result_from_cursor(cursor)
-        return status, df
+        table  = cls.get_result_from_cursor(cursor)
+        return status, table
 
     @classmethod
     def execute(cls, profile, sql, model_name=None, auto_begin=False,

--- a/dbt/adapters/default.py
+++ b/dbt/adapters/default.py
@@ -566,7 +566,7 @@ class DefaultAdapter(object):
         _, cursor = cls.execute_one(profile, sql, model_name, auto_begin)
 
         status = cls.get_status(cursor)
-        table  = cls.get_result_from_cursor(cursor)
+        table = cls.get_result_from_cursor(cursor)
         return status, table
 
     @classmethod

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -6,6 +6,7 @@ import dbt.adapters.default
 import dbt.compat
 import dbt.exceptions
 from dbt.utils import max_digits
+import agate
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -173,7 +174,6 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
 
     @classmethod
     def convert_number_type(cls, agate_table, col_idx):
-        import agate
         column = agate_table.columns[col_idx]
         precision = max_digits(column.values_without_nulls())
         # agate uses the term Precision but in this context, it is really the

--- a/dbt/clients/agate_helper.py
+++ b/dbt/clients/agate_helper.py
@@ -1,0 +1,28 @@
+
+import agate
+
+DEFAULT_TYPE_TESTER = agate.TypeTester(types=[
+    agate.data_types.Number(),
+    agate.data_types.Date(),
+    agate.data_types.DateTime(),
+    agate.data_types.Boolean(),
+    agate.data_types.Text()
+])
+
+
+def table_from_data(data):
+    "Convert list of dictionaries into an Agate table"
+
+    return agate.Table.from_object(data, column_types=DEFAULT_TYPE_TESTER)
+
+
+def empty_table():
+    "Returns an empty Agate table. To be used in place of None"
+
+    return agate.Table(rows=[])
+
+
+def as_matrix(table):
+    "Return an agate table as a matrix of data sans columns"
+
+    return [r.values() for r in table.rows.values()]

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -6,6 +6,7 @@ from dbt.adapters.factory import get_adapter
 from dbt.compat import basestring, to_string
 
 import dbt.clients.jinja
+import dbt.clients.agate_helper
 import dbt.flags
 import dbt.schema
 import dbt.tracking
@@ -129,10 +130,14 @@ def _env_var(var, default=None):
 
 
 def _store_result(sql_results):
-    def call(name, status, data=[]):
+    def call(name, status, agate_table=None):
+        if agate_table is None:
+            agate_table = dbt.clients.agate_helper.empty_table()
+
         sql_results[name] = dbt.utils.AttrDict({
             'status': status,
-            'data': data
+            'data': dbt.clients.agate_helper.as_matrix(agate_table),
+            'table': agate_table
         })
         return ''
 

--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -1,6 +1,6 @@
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
   {% set status = None %}
-  {% set result = None %}
+  {% set res = None %}
 
   {%- if execute: -%}
     {%- set sql = render(caller()) -%}
@@ -10,13 +10,12 @@
       {{ write(sql) }}
     {%- endif -%}
 
-    {%- set status, result = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}
-  {%- endif -%}
+    {%- set status, res = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}
+    {%- if name is not none -%}
+      {{ store_result(name, status=status, agate_table=res) }}
+    {%- endif -%}
 
-  {%- if name is not none -%}
-    {{ store_result(name, status=status, agate_table=result) }}
   {%- endif -%}
-
 {%- endmacro %}
 
 {% macro noop_statement(name=None, status=None, res=None) -%}

--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -1,7 +1,4 @@
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
-  {% set status = None %}
-  {% set res = None %}
-
   {%- if execute: -%}
     {%- set sql = render(caller()) -%}
 

--- a/dbt/include/global_project/macros/core.sql
+++ b/dbt/include/global_project/macros/core.sql
@@ -1,4 +1,7 @@
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
+  {% set status = None %}
+  {% set result = None %}
+
   {%- if execute: -%}
     {%- set sql = render(caller()) -%}
 
@@ -7,12 +10,13 @@
       {{ write(sql) }}
     {%- endif -%}
 
-    {%- set status, res = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}
-    {%- if name is not none -%}
-      {{ store_result(name, status=status, data=res) }}
-    {%- endif -%}
-
+    {%- set status, result = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}
   {%- endif -%}
+
+  {%- if name is not none -%}
+    {{ store_result(name, status=status, agate_table=result) }}
+  {%- endif -%}
+
 {%- endmacro %}
 
 {% macro noop_statement(name=None, status=None, res=None) -%}
@@ -24,7 +28,7 @@
   {%- endif -%}
 
   {%- if name is not none -%}
-    {{ store_result(name, status=status, data=res) }}
+    {{ store_result(name, status=status, agate_table=res) }}
   {%- endif -%}
 
 {%- endmacro %}

--- a/dbt/include/global_project/macros/materializations/view.sql
+++ b/dbt/include/global_project/macros/materializations/view.sql
@@ -23,7 +23,7 @@
       --   1) write the sql contents out to the compiled dirs
       --   2) return a status and result to the caller
     #}
-    {% call noop_statement('main', status="PASS", res=[]) -%}
+    {% call noop_statement('main', status="PASS", res=None) -%}
       -- Not running : non-destructive mode
       {{ sql }}
     {%- endcall %}

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -443,20 +443,20 @@ class TestRunner(CompileRunner):
                                         self.num_nodes)
 
     def execute_test(self, test):
-        res, rows = self.adapter.execute_and_fetch(
+        res, table = self.adapter.execute_and_fetch(
             self.profile,
             test.get('wrapped_sql'),
             test.get('name'),
             auto_begin=True)
 
-        num_rows = len(rows)
+        num_rows = len(table.rows)
         if num_rows > 1:
-            num_cols = len(rows[0])
+            num_cols = len(table.columns)
             raise RuntimeError(
                 "Bad test {name}: Returned {rows} rows and {cols} cols"
                 .format(name=test.get('name'), rows=num_rows, cols=num_cols))
 
-        return rows[0][0]
+        return table[0][0]
 
     def before_execute(self):
         self.print_start_line()

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -450,7 +450,7 @@ class TestRunner(CompileRunner):
             auto_begin=True)
 
         num_rows = len(table.rows)
-        if num_rows != 1:
+        if num_rows > 1:
             num_cols = len(table.columns)
             raise RuntimeError(
                 "Bad test {name}: Returned {rows} rows and {cols} cols"

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -450,7 +450,7 @@ class TestRunner(CompileRunner):
             auto_begin=True)
 
         num_rows = len(table.rows)
-        if num_rows > 1:
+        if num_rows != 1:
             num_cols = len(table.columns)
             raise RuntimeError(
                 "Bad test {name}: Returned {rows} rows and {cols} cols"


### PR DESCRIPTION
This PR exposes an `agate` dataframe in statement results. In turn, access to query results will be much easier for dbt users to work worth. This PR also makes dbt use `agate` under the hood for data-fetching during `dbt test`.