### PR TITLE
return from adapter macro

### DIFF
--- a/dbt/include/global_project/macros/adapters/common.sql
+++ b/dbt/include/global_project/macros/adapters/common.sql
@@ -22,9 +22,9 @@
   {%- set default_name = 'default' + separator + name -%}
 
   {%- if package_context.get(search_name) is not none -%}
-    {{ package_context[search_name](*varargs, **kwargs) }}
+    {{ return(package_context[search_name](*varargs, **kwargs)) }}
   {%- else -%}
-    {{ package_context[default_name](*varargs, **kwargs) }}
+    {{ return(package_context[default_name](*varargs, **kwargs)) }}
   {%- endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/635

This PR uses `return` to return a value from the `adapter_macro`. In practice, this means that cross-database macros implemented in eg. `dbt-utils` will be able to return non-string values like lists or dictionaries.