### PR TITLE
code cleanup, check for missing dep in schema test

### DIFF
--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -284,3 +284,10 @@ def system_error(operation_name):
 
 class RegistryException(Exception):
     pass
+
+
+def raise_dep_not_found(node, node_description, required_pkg):
+    raise_compiler_error(
+        'Error while parsing {}.\nThe required package "{}" was not found. '
+        'Is the package installed?\nHint: You may need to run '
+        '`dbt deps`.'.format(node_description, required_pkg), node=node)

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -453,6 +453,7 @@ def get_parsed_schema_test(test_node, test_type, model_name, config,
 
     package_name = test_node.get('package_name')
     test_namespace = None
+    original_test_type = test_type
     split = test_type.split('.')
 
     if len(split) > 1:
@@ -462,10 +463,8 @@ def get_parsed_schema_test(test_node, test_type, model_name, config,
 
     source_package = projects.get(package_name)
     if source_package is None:
-        dbt.exceptions.raise_compiler_error(
-                'Error while parsing "{}" test on model "{}".\nThe required '
-                'package "{}" was not found. Is the package installed?'.format(
-                    test_type, model_name, test_namespace), node=test_node)
+        desc = '"{}" test on model "{}"'.format(original_test_type, model_name)
+        dbt.exceptions.raise_dep_not_found(test_node, desc, test_namespace)
 
     return parse_schema_test(
         test_node,


### PR DESCRIPTION
This PR cleans up some gross code around schema test parsing. Additionally, it adds a check for schema tests defined in packages which are _not_ present in the context. This can happen if a dbt user forgets to run `dbt deps`, for example.

```
# models/schema.yml

test:
    constraints:
        dbt_utils.not_constant:
            - id
```

If run without a preceding `dbt deps`:

Before:
```
$ dbt test
Encountered an error:
'NoneType' object has no attribute 'get'
```

After:
```
$ dbt test
Encountered an error:
Compilation Error in test schema (models/schema.yml)
  Error while parsing "not_constant" test on model "test".
  The required package "dbt_utils" was not found. Is the package installed?
```

Fixes https://github.com/fishtown-analytics/dbt/issues/655