### PR TITLE
handle dirs overwriting symlinks

### DIFF
--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -189,8 +189,14 @@ def download(url, path):
 
 
 def rename(from_path, to_path, force=False):
+    is_symlink = path_is_symlink(to_path)
+
     if os.path.exists(to_path) and force:
-        rmdir(to_path)
+        if is_symlink:
+            remove_file(to_path)
+        else:
+            rmdir(to_path)
+
     os.rename(from_path, to_path)
 
 

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -211,7 +211,10 @@ class GitPackage(Package):
     def install(self, project):
         dest_path = self.get_installation_path(project)
         if os.path.exists(dest_path):
-            dbt.clients.system.rmdir(dest_path)
+            if dbt.clients.system.path_is_symlink(dest_path):
+                dbt.clients.system.remove_file(dest_path)
+            else:
+                dbt.clients.system.rmdir(dest_path)
         shutil.move(self._checkout(project), dest_path)
 
 


### PR DESCRIPTION
This PR makes it so dbt doesn't call `rmdir` on a symlink in the process of running `dbt deps`.

Example error:
```
2018-02-28 18:12:55,283: Encountered an error:
2018-02-28 18:12:55,283: Cannot call rmtree on a symbolic link
2018-02-28 18:12:55,289: Traceback (most recent call last):
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 41, in main
    results, succeeded = handle_and_check(args)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 85, in handle_and_check
    task, res = run_from_args(parsed)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 139, in run_from_args
    results = run_from_task(task, proj, parsed)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 147, in run_from_task
    result = task.run()
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 385, in run
    package.install(self.project)
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 214, in install
    dbt.clients.system.rmdir(dest_path)
  File "/Users/drew/fishtown/dbt/dbt/clients/system.py", line 141, in rmdir
    return shutil.rmtree(path, onerror=onerror)
  File "/Users/drew/fishtown/dbt/env/lib/python3.6/shutil.py", line 490, in rmtree
    onerror(os.path.islink, path, sys.exc_info())
  File "/Users/drew/fishtown/dbt/env/lib/python3.6/shutil.py", line 488, in rmtree
    raise OSError("Cannot call rmtree on a symbolic link")
OSError: Cannot call rmtree on a symbolic link
```

This can happen if a "local" package in installed, then that package is swapped out for a git or hub package.