### PR TITLE
fix for overzealous agate boolean casting on seeds

### DIFF
--- a/dbt/clients/agate_helper.py
+++ b/dbt/clients/agate_helper.py
@@ -26,3 +26,6 @@ def as_matrix(table):
     "Return an agate table as a matrix of data sans columns"
 
     return [r.values() for r in table.rows.values()]
+
+def from_csv(abspath):
+    return agate.Table.from_csv(abspath, column_types=DEFAULT_TYPE_TESTER)

--- a/dbt/clients/agate_helper.py
+++ b/dbt/clients/agate_helper.py
@@ -27,5 +27,6 @@ def as_matrix(table):
 
     return [r.values() for r in table.rows.values()]
 
+
 def from_csv(abspath):
     return agate.Table.from_csv(abspath, column_types=DEFAULT_TYPE_TESTER)

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -3,7 +3,6 @@ import os
 import re
 import hashlib
 import collections
-import agate
 
 import dbt.exceptions
 import dbt.flags
@@ -14,6 +13,7 @@ import dbt.hooks
 import jinja2.runtime
 import dbt.clients.jinja
 import dbt.clients.yaml_helper
+import dbt.clients.agate_helper
 
 import dbt.context.parser
 
@@ -737,7 +737,7 @@ def parse_seed_file(file_match, root_dir, package_name):
                                            file_match.get('relative_path')),
     }
     try:
-        table = agate.Table.from_csv(abspath)
+        table = dbt.clients.agate_helper.from_csv(abspath)
     except ValueError as e:
         dbt.exceptions.raise_compiler_error(str(e), node)
     table.original_abspath = abspath


### PR DESCRIPTION
This PR makes seed files use the type testing precedence we set up in `agate_helper`. Previously, agate would aggressively case integer fields as booleans in CSVs if the column only contained zeroes and ones. Now, these fields correctly show up as integers