### PR TITLE
fix csv precision

### DIFF
--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 import dbt.adapters.default
 import dbt.compat
 import dbt.exceptions
-from dbt.utils import max_digits
 import agate
 
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -174,16 +173,8 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
 
     @classmethod
     def convert_number_type(cls, agate_table, col_idx):
-        column = agate_table.columns[col_idx]
-        precision = max_digits(column.values_without_nulls())
-        # agate uses the term Precision but in this context, it is really the
-        # scale - ie. the number of decimal places
-        scale = agate_table.aggregate(agate.MaxPrecision(col_idx))
-
-        if not scale:
-            return "integer"
-
-        return "numeric({}, {})".format(precision, scale)
+        decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
+        return "numeric" if decimals else "integer"
 
     @classmethod
     def convert_boolean_type(cls, agate_table, col_idx):

--- a/dbt/adapters/postgres.py
+++ b/dbt/adapters/postgres.py
@@ -179,8 +179,10 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
         # agate uses the term Precision but in this context, it is really the
         # scale - ie. the number of decimal places
         scale = agate_table.aggregate(agate.MaxPrecision(col_idx))
+
         if not scale:
             return "integer"
+
         return "numeric({}, {})".format(precision, scale)
 
     @classmethod

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -409,7 +409,7 @@ def max_digits(values):
         if value is None:
             continue
         sign, digits, exponent = value.normalize().as_tuple()
-        max_ = max(len(digits), max_)
+        max_ = max(len(digits), -exponent+1, max_)
     return max_
 
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -400,19 +400,6 @@ class memoized(object):
         return functools.partial(self.__call__, obj)
 
 
-def max_digits(values):
-    """Given a series of decimal.Decimal values, find the maximum
-    number of digits (on both sides of the decimal point) used by the
-    values."""
-    max_ = 0
-    for value in values:
-        if value is None:
-            continue
-        sign, digits, exponent = value.normalize().as_tuple()
-        max_ = max(len(digits), -exponent+1, max_)
-    return max_
-
-
 def invalid_ref_fail_unless_test(node, target_model_name,
                                  target_model_package):
     if node.get('resource_type') == NodeType.Test:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,7 +1,5 @@
 import unittest
 
-from decimal import Decimal
-
 import dbt.utils
 
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,5 +1,7 @@
 import unittest
 
+from decimal import Decimal
+
 import dbt.utils
 
 
@@ -41,3 +43,13 @@ class TestMerge(unittest.TestCase):
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
+
+
+class TestMaxDigits(unittest.TestCase):
+
+    def test__simple_cases(self):
+        self.assertEquals(max_digits([Decimal('0.003')]), 4)
+        self.assertEquals(max_digits([Decimal('1.003')]), 4)
+        self.assertEquals(max_digits([Decimal('1003')]), 4)
+        self.assertEquals(max_digits([Decimal('10003')]), 5)
+        self.assertEquals(max_digits([Decimal('0.00003')]), 6)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -48,8 +48,8 @@ class TestMerge(unittest.TestCase):
 class TestMaxDigits(unittest.TestCase):
 
     def test__simple_cases(self):
-        self.assertEquals(max_digits([Decimal('0.003')]), 4)
-        self.assertEquals(max_digits([Decimal('1.003')]), 4)
-        self.assertEquals(max_digits([Decimal('1003')]), 4)
-        self.assertEquals(max_digits([Decimal('10003')]), 5)
-        self.assertEquals(max_digits([Decimal('0.00003')]), 6)
+        self.assertEquals(dbt.utils.max_digits([Decimal('0.003')]), 4)
+        self.assertEquals(dbt.utils.max_digits([Decimal('1.003')]), 4)
+        self.assertEquals(dbt.utils.max_digits([Decimal('1003')]), 4)
+        self.assertEquals(dbt.utils.max_digits([Decimal('10003')]), 5)
+        self.assertEquals(dbt.utils.max_digits([Decimal('0.00003')]), 6)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -43,13 +43,3 @@ class TestMerge(unittest.TestCase):
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
-
-
-class TestMaxDigits(unittest.TestCase):
-
-    def test__simple_cases(self):
-        self.assertEquals(dbt.utils.max_digits([Decimal('0.003')]), 4)
-        self.assertEquals(dbt.utils.max_digits([Decimal('1.003')]), 4)
-        self.assertEquals(dbt.utils.max_digits([Decimal('1003')]), 4)
-        self.assertEquals(dbt.utils.max_digits([Decimal('10003')]), 5)
-        self.assertEquals(dbt.utils.max_digits([Decimal('0.00003')]), 6)


### PR DESCRIPTION
dbt 0.9.2 RC had a bug where we miscalculate the precision required for decimal values like `0.001`. we were attempting to create a `numeric(1,3)` which doesn't make sense -- according to the Postgres docs:

> ```NUMERIC(precision, scale)```
> The scale of a numeric is the count of decimal digits in the fractional part, to the right of the decimal point. The precision of a numeric is the total count of significant digits in the whole number, that is, the number of digits to both sides of the decimal point. So the number 23.5141 has a precision of 6 and a scale of 4. Integers can be considered to have a scale of zero.

So the precision should be 4, not 1. This branch fixes that.
