### PR TITLE
fix for broken pycryptodome release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ networkx==1.11
 snowplow-tracker==0.7.2
 celery==3.1.23
 voluptuous==0.10.5
+pycryptodome>=3.4.0,<3.5.0
 snowflake-connector-python>=1.4.9
 colorama==0.3.9
 google-cloud-bigquery==0.29.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'celery==3.1.23',
         'voluptuous==0.10.5',
         'snowflake-connector-python>=1.4.9',
+        'pycryptodome>=3.4.0,<3.5.0',  # bug in 3.5.0 -- remove when fixed
         'colorama==0.3.9',
         'google-cloud-bigquery==0.29.0',
         'agate>=1.6,<2',


### PR DESCRIPTION
A bug in pycryptodome 0.3.5 breaks installation of dbt. Pin it to < 3.5.0 as a temporary fix. This dep comes from [snowflake-connector-python](https://github.com/fishtown-analytics/dbt/issues/646)


See also: https://github.com/Legrandin/pycryptodome/pull/143