### PR TITLE
track package usage for hub site stats

### DIFF
--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -425,6 +425,6 @@ class DepsTask(BaseTask):
             logger.info('  Installed from %s\n', package.nice_version_name())
 
             self.track_package_install(
-                package_name=package.get_project_name(package),
+                package_name=package.name,
                 source_type=package.source_type(),
                 version=package.version_name())

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -57,6 +57,9 @@ class Package(object):
                        .format(self.name, e))
             six.raise_from(dbt.exceptions.DependencyException(new_msg), e)
 
+    def source_type(self):
+        raise NotImplementedError()
+
     def version_name(self):
         raise NotImplementedError()
 
@@ -92,6 +95,9 @@ class RegistryPackage(Package):
                    else VersionSpecifier.from_version_string(v)
                    for v in cls.version_to_list(version)]
         return version or [UnboundedVersionSpecifier()]
+
+    def source_type(self):
+        return 'hub'
 
     @property
     def version(self):
@@ -166,6 +172,9 @@ class GitPackage(Package):
     def _sanitize_version(cls, version):
         return cls.version_to_list(version) or ['master']
 
+    def source_type(self):
+        return 'git'
+
     @property
     def version(self):
         return self._version
@@ -225,6 +234,9 @@ class LocalPackage(Package):
 
     def incorporate(self, _):
         return LocalPackage(self.local)
+
+    def source_type(self):
+        return 'local'
 
     def version_name(self):
         return '<local @ {}>'.format(self.local)
@@ -398,3 +410,11 @@ class DepsTask(BaseTask):
             logger.info('Installing %s', package)
             package.install(self.project)
             logger.info('  Installed from %s\n', package.nice_version_name())
+
+            package_info = {
+                "name": package.get_project_name(package),
+                "source": package.source_type(),
+                "version": package.version_name()
+            }
+
+            dbt.tracking.track_package_install(package_info)

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -5,6 +5,7 @@ import tempfile
 import six
 import yaml
 
+import dbt.utils
 import dbt.project
 import dbt.deprecations
 import dbt.clients.git
@@ -385,10 +386,14 @@ class DepsTask(BaseTask):
 
     def track_package_install(self, package_name, source_type, version):
         version = 'local' if source_type == 'local' else version
+
+        h_package_name = dbt.utils.md5(package_name)
+        h_version = dbt.utils.md5(version)
+
         dbt.tracking.track_package_install({
-            "name": package_name,
+            "name": h_package_name,
             "source": source_type,
-            "version": version
+            "version": h_version
         })
 
     def run(self):

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -383,6 +383,14 @@ class DepsTask(BaseTask):
                     .format(project_name))
             seen.add(project_name)
 
+    def track_package_install(self, package_name, source_type, version):
+        version = 'local' if source_type == 'local' else version
+        dbt.tracking.track_package_install({
+            "name": package_name,
+            "source": source_type,
+            "version": version
+        })
+
     def run(self):
         dbt.clients.system.make_directory(self.project['modules-path'])
         dbt.clients.system.make_directory(DOWNLOADS_PATH)
@@ -411,10 +419,7 @@ class DepsTask(BaseTask):
             package.install(self.project)
             logger.info('  Installed from %s\n', package.nice_version_name())
 
-            package_info = {
-                "name": package.get_project_name(package),
-                "source": package.source_type(),
-                "version": package.version_name()
-            }
-
-            dbt.tracking.track_package_install(package_info)
+            self.track_package_install(
+                package_name=package.get_project_name(package),
+                source_type=package.source_type(),
+                version=package.version_name())

--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -26,6 +26,7 @@ INVOCATION_SPEC = 'iglu:com.dbt/invocation/jsonschema/1-0-0'
 PLATFORM_SPEC = 'iglu:com.dbt/platform/jsonschema/1-0-0'
 RUN_MODEL_SPEC = 'iglu:com.dbt/run_model/jsonschema/1-0-0'
 INVOCATION_ENV_SPEC = 'iglu:com.dbt/invocation_env/jsonschema/1-0-0'
+PACKAGE_INSTALL_SPEC = 'iglu:com.dbt/package_install/jsonschema/1-0-0'
 
 DBT_INVOCATION_ENV = 'DBT_INVOCATION_ENV'
 
@@ -200,6 +201,18 @@ def track_model_run(options):
         category="dbt",
         action='run_model',
         label=active_user.invocation_id,
+        context=context
+    )
+
+
+def track_package_install(options):
+    context = [SelfDescribingJson(PACKAGE_INSTALL_SPEC, options)]
+    track(
+        active_user,
+        category="dbt",
+        action='package',
+        label=active_user.invocation_id,
+        property_='install',
         context=context
     )
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -357,6 +357,7 @@ def get_nodes_by_tags(nodes, match_tags, resource_type):
             matched_nodes.append(node)
     return matched_nodes
 
+
 def md5(string):
     return hashlib.md5(string.encode('utf-8')).hexdigest()
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -357,6 +357,9 @@ def get_nodes_by_tags(nodes, match_tags, resource_type):
             matched_nodes.append(node)
     return matched_nodes
 
+def md5(string):
+    return hashlib.md5(string.encode('utf-8')).hexdigest()
+
 
 def get_hash(model):
     return hashlib.md5(model.get('unique_id').encode('utf-8')).hexdigest()


### PR DESCRIPTION
This PR adds Snowplow tracking for the package name, package version, and installation source (hub/git/local) to dbt. This will help us understand which packages folks are using, and ultimately, will be used to show package usage statistics on the hub site.