### PR TITLE
rm freezegun deps - this is only needed in the dev reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 argparse>=1.2.1
-freezegun==0.3.9
 Jinja2>=2.8
 pytz==2017.2
 PyYAML>=3.11

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'scripts/dbt',
     ],
     install_requires=[
-        'freezegun==0.3.9',
         'Jinja2>=2.8',
         'pytz==2017.2',
         'PyYAML>=3.11',


### PR DESCRIPTION
Boto (required by `snowflake-connector-python`) changed their `python-dateutils` dep to < 2.7.0, but freezegun uses >= 2.0. We only uses freezegun in a single integration test, so this can comfortably live in the `dev_requirements.txt` file.

Previous error:
```
pkg_resources.ContextualVersionConflict: (python-dateutil 2.7.0 (/Users/drew/fishtown/dbt/env/lib/python3.6/site-packages), Requirement.parse('python-dateutil<2.7.0,>=2.1'), {'botocore'})
```