### PR TITLE
Warn for unused resource (model/seeds) config paths in project file

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -5,12 +5,19 @@ import dbt.clients.yaml_helper
 import dbt.clients.system
 
 from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.utils import DBTConfigKeys
 
 
 INVALID_PROFILE_MESSAGE = """
 dbt encountered an error while trying to read your profiles.yml file.
 
 {error_string}
+"""
+
+UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE = """\
+WARNING: Configuration paths exist in your dbt_project.yml file which do not \
+apply to any resources.
+There are {} unused configuration paths:\
 """
 
 
@@ -43,3 +50,65 @@ def send_anonymous_usage_stats(config):
 
 def colorize_output(config):
     return config.get('use_colors', True)
+
+
+def get_config_paths(config, path=None, paths=None):
+    if path is None:
+        path = []
+
+    if paths is None:
+        paths = []
+
+    for key, value in config.items():
+        if isinstance(value, dict):
+            if key in DBTConfigKeys:
+                if path not in paths:
+                    paths.append(path)
+            else:
+                get_config_paths(value, path + [key], paths)
+        else:
+            if path not in paths:
+                paths.append(path)
+
+    return paths
+
+
+def get_project_resource_config_paths(project):
+    resource_config_paths = {}
+    for resource_type in ['models', 'seeds']:
+        if resource_type in project:
+            resource_config_paths[resource_type] = get_config_paths(
+                project[resource_type])
+    return resource_config_paths
+
+
+def is_config_used(config_path, fqns):
+    for fqn in fqns:
+        if len(config_path) <= len(fqn) and fqn[:len(config_path)] == config_path:
+            return True
+    return False
+
+
+def get_unused_resource_config_paths(resource_config_paths, resource_fqns):
+    unused_resource_config_paths = []
+    for resource_type, config_paths in resource_config_paths.items():
+        for config_path in config_paths:
+            if not is_config_used(config_path, resource_fqns[resource_type]):
+                unused_resource_config_paths.append(
+                    [resource_type] + config_path)
+    return unused_resource_config_paths
+
+
+def warn_for_unused_resource_config_paths(resource_config_paths, resource_fqns):
+    unused_resource_config_paths = get_unused_resource_config_paths(
+        resource_config_paths, resource_fqns)
+    if len(unused_resource_config_paths) == 0:
+        return
+    logger.info(
+        dbt.ui.printer.yellow(UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE.format(
+            len(unused_resource_config_paths))))
+    for unused_resource_config_path in unused_resource_config_paths:
+        logger.info(
+            dbt.ui.printer.yellow(" - {}".format(
+                ".".join(unused_resource_config_path))))
+    logger.info("")

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -83,9 +83,10 @@ def get_project_resource_config_paths(project):
 
 
 def is_config_used(config_path, fqns):
-    for fqn in fqns:
-        if len(config_path) <= len(fqn) and fqn[:len(config_path)] == config_path:
-            return True
+    if fqns:
+        for fqn in fqns:
+            if len(config_path) <= len(fqn) and fqn[:len(config_path)] == config_path:
+                return True
     return False
 
 
@@ -93,7 +94,7 @@ def get_unused_resource_config_paths(resource_config_paths, resource_fqns):
     unused_resource_config_paths = []
     for resource_type, config_paths in resource_config_paths.items():
         for config_path in config_paths:
-            if not is_config_used(config_path, resource_fqns[resource_type]):
+            if not is_config_used(config_path, resource_fqns.get(resource_type)):
                 unused_resource_config_paths.append(
                     [resource_type] + config_path)
     return unused_resource_config_paths

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -76,9 +76,8 @@ def get_config_paths(config, path=None, paths=None):
 def get_project_resource_config_paths(project):
     resource_config_paths = {}
     for resource_type in ['models', 'seeds']:
-        if resource_type in project:
-            resource_config_paths[resource_type] = get_config_paths(
-                project[resource_type])
+        resource_config_paths[resource_type] = get_config_paths(
+            project[resource_type])
     return resource_config_paths
 
 

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -28,6 +28,7 @@ default_project_cfg = {
     'outputs': {'default': {}},
     'target': 'default',
     'models': {},
+    'seeds': {},
     'quoting': {},
     'profile': None,
     'packages': [],

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -103,7 +103,7 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(dbt.config.colorize_output(config))
 
     def test__no_unused_resource_config_paths(self):
-        resource_config = {'models': model_config}
+        resource_config = {'models': model_config, 'seeds': {}}
         resource_config_paths = dbt.config.get_project_resource_config_paths(
             resource_config)
         resource_fqns = {'models': model_fqns}
@@ -111,7 +111,7 @@ class ConfigTest(unittest.TestCase):
             resource_config_paths, resource_fqns)) == 0)
 
     def test__unused_resource_config_paths(self):
-        resource_config = {'models': model_config['my_package_name']}
+        resource_config = {'models': model_config['my_package_name'], 'seeds': {}}
         resource_config_paths = dbt.config.get_project_resource_config_paths(
             resource_config)
         resource_fqns = {'models': model_fqns}


### PR DESCRIPTION
Finds all model configurations specified in all projects (including installed packages) and checks whether they are applied to at least one model.
If they are not applied (i.e. "unused"), a warning is logged.
Addresses  #691