### PR TITLE
check for node name uniqueness across refable resource types

### DIFF
--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -84,16 +84,6 @@ class ModelLoader(ResourceLoader):
 
             to_return.update(project_loaded)
 
-        # Check for duplicate model names
-        names_models = {}
-        for model, attribs in to_return.items():
-            name = attribs['name']
-            existing_name = names_models.get(name)
-            if existing_name is not None:
-                raise dbt.exceptions.CompilationException(
-                    'Found models with the same name: \n- %s\n- %s' % (
-                        model, existing_name))
-            names_models[name] = model
         return to_return
 
     @classmethod

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -79,7 +79,7 @@ class BaseRunner(object):
 
     @classmethod
     def is_refable(cls, node):
-        return node.get('resource_type') in [NodeType.Model, NodeType.Seed]
+        return node.get('resource_type') in NodeType.refable()
 
     @classmethod
     def is_ephemeral(cls, node):

--- a/dbt/node_types.py
+++ b/dbt/node_types.py
@@ -20,6 +20,13 @@ class NodeType(object):
             cls.Seed,
         ]
 
+    @classmethod
+    def refable(cls):
+        return [
+            cls.Model,
+            cls.Seed,
+        ]
+
 
 class RunHookType:
     Start = 'on-run-start'

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -133,7 +133,7 @@ def model_immediate_name(model, non_destructive):
 
 def find_refable_by_name(flat_graph, target_name, target_package):
     return find_by_name(flat_graph, target_name, target_package,
-                        'nodes', [NodeType.Model, NodeType.Seed])
+                        'nodes', NodeType.refable())
 
 
 def find_macro_by_name(flat_graph, target_name, target_package):


### PR DESCRIPTION
fixes: https://github.com/fishtown-analytics/dbt/issues/736

This came up because a view model and a seed file had the same name. Previously, dbt's check for name uniqueness only pertained to models.