### PR TITLE
Fix/seed bq

### DIFF
--- a/dbt/include/global_project/macros/materializations/seed/bigquery.sql
+++ b/dbt/include/global_project/macros/materializations/seed/bigquery.sql
@@ -3,8 +3,8 @@
     -- no-op
 {% endmacro %}
 
-{% macro bigquery__reset_csv_table(model, full_refresh, existing) %}
-    {{ drop_if_exists(existing, model['schema'], model['name']) }}
+{% macro bigquery__reset_csv_table(model, full_refresh, old_relation) %}
+    {{ adapter.drop_relation(old_relation) }}
 {% endmacro %}
 
 {% macro bigquery__load_csv_rows(model) %}

--- a/test/integration/022_bigquery_test/test_simple_bigquery_view.py
+++ b/test/integration/022_bigquery_test/test_simple_bigquery_view.py
@@ -27,7 +27,9 @@ class TestSimpleBigQueryRun(DBTIntegrationTest):
     def test__bigquery_simple_run(self):
         self.use_profile('bigquery')
         self.use_default_project()
+        # make sure seed works twice. Full-refresh is a no-op
         self.run_dbt(['seed'])
+        self.run_dbt(['seed', '--full-refresh'])
         self.run_dbt()
 
         # The 'dupe' model should fail, but all others should pass


### PR DESCRIPTION
We ripped out the `drop_if_exists` macro, and instead are operating on relations. This code never got updated. Our integration tests didn't catch it because this error would only occur if `reset_csv_table` was called -- something that doesn't happen on the first run of `dbt seed`.