### PR TITLE
Apiobject subclass mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Betsy Ross (Unreleased)
+
+### Changes
+
+ - Use Mapping instead of dict as the base class for APIObject ([#756](https://github.com/fishtown-analytics/dbt/pull/756))
+
 ## dbt 0.10.1 (Unreleased)
 
 This release focuses on achieving functional parity between all of dbt's adapters. With this release, most dbt functionality should work on every adapter except where noted [here](https://docs.getdbt.com/v0.10/docs/supported-databases#section-caveats).

--- a/dbt/api/object.py
+++ b/dbt/api/object.py
@@ -96,7 +96,10 @@ class APIObject(Mapping):
 
     # most users of APIObject also expect the attributes to be available via
     # dot-notation because the previous implementation assigned to __dict__.
+    # we should consider removing this if we fix all uses to have properties.
     def __getattr__(self, name):
         if name in self._contents:
             return self._contents[name]
-        raise AttributeError('Could not find attribute "{}"'.format(name))
+        raise AttributeError((
+            "'{}' object has no attribute '{}'"
+        ).format(type(self).__name__, name))

--- a/dbt/api/object.py
+++ b/dbt/api/object.py
@@ -1,11 +1,12 @@
 import copy
+from collections import Mapping
 from jsonschema import Draft4Validator
 
 from dbt.exceptions import ValidationException
 from dbt.utils import deep_merge
 
 
-class APIObject(dict):
+class APIObject(Mapping):
     """
     A serializable / deserializable object intended for
     use in a future dbt API.
@@ -24,17 +25,15 @@ class APIObject(dict):
 
     DEFAULTS = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """
-        Create and validate an instance. Note that it's
-        not a good idea to override this.
+        Create and validate an instance. Note that if you override this, you
+        will want to do so by modifying kwargs and only then calling
+        super(NewClass, self).__init__(**kwargs).
         """
-        defaults = copy.deepcopy(self.DEFAULTS)
-        settings = copy.deepcopy(kwargs)
-
-        d = deep_merge(defaults, settings)
-        super(APIObject, self).__init__(*args, **d)
-        self.__dict__ = self
+        super(APIObject, self).__init__()
+        # note: deep_merge does a deep copy on its arguments.
+        self._contents = deep_merge(self.DEFAULTS, kwargs)
         self.validate()
 
     def incorporate(self, **kwargs):
@@ -43,15 +42,13 @@ class APIObject(dict):
         into a new copy of this instance, and return the new
         instance after validating.
         """
-        existing = copy.deepcopy(dict(self))
-        updates = copy.deepcopy(kwargs)
-        return type(self)(**deep_merge(existing, updates))
+        return type(self)(**deep_merge(self._contents, kwargs))
 
     def serialize(self):
         """
         Return a dict representation of this object.
         """
-        return dict(self)
+        return copy.deepcopy(self._contents)
 
     @classmethod
     def deserialize(cls, settings):
@@ -72,10 +69,34 @@ class APIObject(dict):
         errors = []
 
         for error in validator.iter_errors(self.serialize()):
-            errors.append('.'.join(list(map(str, error.path)) + [error.message]))
+            errors.append('.'.join(
+                list(map(str, error.path)) + [error.message])
+            )
 
         if errors:
             raise ValidationException(
                 'Invalid arguments passed to "{}" instance: {}'
                 .format(type(self).__name__,
                         ", ".join(errors)))
+
+    # implement the Mapping protocol:
+    # https://docs.python.org/3/library/collections.abc.html
+    def __getitem__(self, key):
+        return self._contents[key]
+
+    def __iter__(self):
+        return self._contents.__iter__()
+
+    def __len__(self):
+        return self._contents.__len__()
+
+    # implement this because everyone always expects it.
+    def get(self, key, default=None):
+        return self._contents.get(key, default)
+
+    # most users of APIObject also expect the attributes to be available via
+    # dot-notation because the previous implementation assigned to __dict__.
+    def __getattr__(self, name):
+        if name in self._contents:
+            return self._contents[name]
+        raise AttributeError('Could not find attribute "{}"'.format(name))

--- a/dbt/api/object.py
+++ b/dbt/api/object.py
@@ -72,8 +72,7 @@ class APIObject(dict):
         errors = []
 
         for error in validator.iter_errors(self.serialize()):
-            errors.append('property "{}", {}'.format(
-                ".".join(error.path), error.message))
+            errors.append('.'.join(list(map(str, error.path)) + [error.message]))
 
         if errors:
             raise ValidationException(

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import itertools
 import collections
+import copy
 import functools
 
 import dbt.exceptions
@@ -240,10 +241,10 @@ def deep_merge(*args):
         return None
 
     if len(args) == 1:
-        return args[0]
+        return copy.deepcopy(args[0])
 
     lst = list(args)
-    last = lst.pop(len(lst)-1)
+    last = copy.deepcopy(lst.pop(len(lst)-1))
 
     return _deep_merge(deep_merge(*lst), last)
 


### PR DESCRIPTION
Convert the APIObject into a Mapping subclass instead of a dict subclass. The idea here is that we will be able to separate out the underlying dictionary and its schema validation from the use of the APIObject subclasses in the code. I didn't go and convert existing uses and instead tossed in a __getattr__ implementation and a comment, as I didn't want to go too far. However, I think this will make the conversion from voluptuous models to json-schema models a lot nicer, as some of the existing ones are pretty complex and tied to Python data types in a way that json-schema makes it tricky to support. Existing well-behaved code should see no impact, anything relying on writeability of APIObject and its subclasses is probably going to break. Also anything relying on the *args is going to break - I can put that back in but it makes things a tiny bit uglier.

As a bonus, I think this fixes the subclassing / __init__ issue as long as users are careful.

This PR also includes two things we discussed on our call - cleaning up the validation error message and having deep_merge do a deep copy on all its arguments (which in turn makes the rest of APIObject a bit more pleasant).