### PR TITLE
IAM authentication method for redshift adapter

### DIFF
--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -2,7 +2,9 @@ import multiprocessing
 
 from dbt.adapters.postgres import PostgresAdapter
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
-
+import dbt.exceptions
+import boto3
+import psycopg2
 
 drop_lock = multiprocessing.Lock()
 
@@ -18,6 +20,76 @@ class RedshiftAdapter(PostgresAdapter):
         return 'getdate()'
 
     @classmethod
+    def get_redshift_credentials(cls, config):
+        result = config.copy()
+
+        method = result.get('method')
+
+        if method == 'database':
+            return (result)
+
+        elif method == 'iam':
+            cluster_id = result.get('cluster_id')
+            if not cluster_id:
+                error = '`cluster_id` must be set in profile if IAM authentication method selected'
+                raise dbt.exceptions.FailedToConnectException(error)
+
+            client = boto3.client('redshift')
+
+            # replace username and password with temporary redshift credentials
+            try:
+                cluster_creds = client.get_cluster_credentials(DbUser=result.get('user'),
+                                                               DbName=result.get('dbname'),
+                                                               ClusterIdentifier=result.get('cluster_id'),
+                                                               AutoCreate=False)
+                result['user_tmp'] = cluster_creds.get('DbUser')
+                result['pass_tmp'] = cluster_creds.get('DbPassword')
+            except client.exceptions.ClientError as e:
+                error = ('Unable to get temporary Redshift cluster credentials: "{}"'.format(str(e)))
+                raise dbt.exceptions.FailedToConnectException(error)
+
+            return result
+
+        else:
+            error = ('Invalid `method` in profile: "{}"'.format(method))
+            raise dbt.exceptions.FailedToConnectException(error)
+
+    @classmethod
+    def open_connection(cls, connection):
+        if connection.get('state') == 'open':
+            logger.debug('Connection is already open, skipping open.')
+            return connection
+
+        result = connection.copy()
+
+        try:
+            credentials = cls.get_redshift_credentials(connection.get('credentials', {}))
+            user = credentials.get('user_tmp') if credentials.get('user_tmp') else credentials.get('user')
+            password = credentials.get('pass_tmp') if credentials.get('pass_tmp') else credentials.get('pass')
+
+            handle = psycopg2.connect(
+                dbname=credentials.get('dbname'),
+                user=user,
+                host=credentials.get('host'),
+                password=password,
+                port=credentials.get('port'),
+                connect_timeout=10)
+
+            result['handle'] = handle
+            result['state'] = 'open'
+        except psycopg2.Error as e:
+            logger.debug("Got an error when attempting to open a postgres "
+                         "connection: '{}'"
+                         .format(e))
+
+            result['handle'] = None
+            result['state'] = 'fail'
+
+            raise dbt.exceptions.FailedToConnectException(str(e))
+
+        return result
+
+    @classmethod
     def _get_columns_in_table_sql(cls, schema_name, table_name, database):
         # Redshift doesn't support cross-database queries,
         # so we can ignore the `database` argument
@@ -27,65 +99,65 @@ class RedshiftAdapter(PostgresAdapter):
             table_schema_filter = '1=1'
         else:
             table_schema_filter = "table_schema = '{schema_name}'".format(
-                    schema_name=schema_name)
+                schema_name=schema_name)
 
         sql = """
-            with bound_views as (
-                select
+            WITH bound_views AS (
+                SELECT
                     ordinal_position,
                     table_schema,
                     column_name,
                     data_type,
                     character_maximum_length,
-                    numeric_precision || ',' || numeric_scale as numeric_size
+                    numeric_precision || ',' || numeric_scale AS numeric_size
 
-                from information_schema.columns
-                where table_name = '{table_name}'
+                FROM information_schema.columns
+                WHERE table_name = '{table_name}'
             ),
 
-            unbound_views as (
-                select
+            unbound_views AS (
+                SELECT
                     ordinal_position,
                     view_schema,
                     col_name,
-                    case
-                        when col_type ilike 'character varying%' then
+                    CASE
+                        WHEN col_type ILIKE 'character varying%' THEN
                             'character varying'
-                        when col_type ilike 'numeric%' then 'numeric'
-                        else col_type
-                    end as col_type,
-                    case
-                        when col_type like 'character%'
-                        then nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::int
-                        else null
-                    end as character_maximum_length,
-                    case
-                        when col_type like 'numeric%'
-                        then nullif(REGEXP_SUBSTR(col_type, '[0-9,]+'), '')
-                        else null
-                    end as numeric_size
+                        WHEN col_type ILIKE 'numeric%' THEN 'numeric'
+                        ELSE col_type
+                    END AS col_type,
+                    CASE
+                        WHEN col_type LIKE 'character%'
+                        THEN nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::INT
+                        ELSE NULL
+                    END AS character_maximum_length,
+                    CASE
+                        WHEN col_type LIKE 'numeric%'
+                        THEN nullif(REGEXP_SUBSTR(col_type, '[0-9,]+'), '')
+                        ELSE NULL
+                    END AS numeric_size
 
-                from pg_get_late_binding_view_cols()
-                cols(view_schema name, view_name name, col_name name,
-                     col_type varchar, ordinal_position int)
-                where view_name = '{table_name}'
+                FROM pg_get_late_binding_view_cols()
+                cols(view_schema NAME, view_name NAME, col_name NAME,
+                     col_type VARCHAR, ordinal_position INT)
+                WHERE view_name = '{table_name}'
             ),
 
-            unioned as (
-                select * from bound_views
-                union all
-                select * from unbound_views
+            unioned AS (
+                SELECT * FROM bound_views
+                UNION ALL
+                SELECT * FROM unbound_views
             )
 
-            select
+            SELECT
                 column_name,
                 data_type,
                 character_maximum_length,
                 numeric_size
 
-            from unioned
-            where {table_schema_filter}
-            order by ordinal_position
+            FROM unioned
+            WHERE {table_schema_filter}
+            ORDER BY ordinal_position
         """.format(table_name=table_name,
                    table_schema_filter=table_schema_filter).strip()
         return sql

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -4,7 +4,6 @@ from dbt.compat import basestring
 from dbt.contracts.common import validate_with
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
-
 adapter_types = ['postgres', 'redshift', 'snowflake', 'bigquery']
 connection_contract = Schema({
     Required('type'): Any(*adapter_types),
@@ -22,6 +21,18 @@ postgres_credentials_contract = Schema({
     Required('pass'): basestring,
     Required('port'): Any(All(int, Range(min=0, max=65535)), basestring),
     Required('schema'): basestring,
+})
+
+redshift_auth_methods = ['database', 'iam']
+redshift_credentials_contract = Schema({
+    Required('method'): Any(*redshift_auth_methods),
+    Required('dbname'): basestring,
+    Required('host'): basestring,
+    Required('user'): basestring,
+    Optional('pass'): basestring,
+    Required('port'): Any(All(int, Range(min=0, max=65535)), basestring),
+    Required('schema'): basestring,
+    Optional('cluster_id'): basestring,  # TODO: require if 'iam' method selected
 })
 
 snowflake_credentials_contract = Schema({
@@ -46,7 +57,7 @@ bigquery_credentials_contract = Schema({
 
 credentials_mapping = {
     'postgres': postgres_credentials_contract,
-    'redshift': postgres_credentials_contract,
+    'redshift': redshift_credentials_contract,
     'snowflake': snowflake_credentials_contract,
     'bigquery': bigquery_credentials_contract,
 }

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -25,11 +25,11 @@ postgres_credentials_contract = Schema({
 
 redshift_auth_methods = ['database', 'iam']
 redshift_credentials_contract = Schema({
-    Required('method'): Any(*redshift_auth_methods),
+    Optional('method'): Any(*redshift_auth_methods),
     Required('dbname'): basestring,
     Required('host'): basestring,
     Required('user'): basestring,
-    Optional('pass'): basestring,
+    Optional('pass'): basestring, # TODO: require if 'database' method selected
     Required('port'): Any(All(int, Range(min=0, max=65535)), basestring),
     Required('schema'): basestring,
     Optional('cluster_id'): basestring,  # TODO: require if 'iam' method selected

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ google-cloud-bigquery==0.29.0
 requests>=2.18.0
 agate>=1.6,<2
 jsonschema==2.6.0
+boto3>=1.6.23


### PR DESCRIPTION
Per #757 : 
A `method` value is now required in a profile using the `redshift` adapter.
- The `database` method supports username / password as database auth credentials.
- The `iam` method support IAM authentication using boto3's `get_cluster_credentials`. See AWS docs [Using IAM Authentication to Generate Database User Credentials](https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html) for required setup.
