### PR TITLE
Feature/model aliasing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.1rc2
+current_version = 0.10.2a1
 commit = True
 tag = True
 

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,17 @@ test-integration:
 test-quick:
 	@echo "Integration test run starting..."
 	@time docker-compose run test tox -e integration-postgres-py36 -- -x
+
+clean:
+	rm -f .coverage
+	rm -rf .eggs/
+	rm -rf .tox/
+	rm -rf build/
+	rm -rf dbt.egg-info/
+	rm -f dbt_project.yml
+	rm -rf dist/
+	rm -f htmlcov/*.{css,html,js,json,png}
+	rm -rf logs/
+	rm -rf target/
+	find . -type f -name '*.pyc' -delete
+	find . -type d -name '__pycache__' -depth -delete

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ test-integration:
 	@echo "Integration test run starting..."
 	@time docker-compose run test tox -e integration-postgres-py27,integration-postgres-py36,integration-snowflake-py27,integration-snowflake-py36,integration-bigquery-py27,integration-bigquery-py36
 
-
 test-quick:
 	@echo "Integration test run starting..."
 	@time docker-compose run test tox -e integration-postgres-py36 -- -x

--- a/dbt/adapters/bigquery/relation.py
+++ b/dbt/adapters/bigquery/relation.py
@@ -89,7 +89,7 @@ class BigQueryRelation(DefaultRelation):
         return cls.create(
             project=profile.get('project'),
             schema=node.get('schema'),
-            identifier=node.get('name'),
+            identifier=node.get('alias'),
             **kwargs)
 
     @classmethod

--- a/dbt/adapters/default/relation.py
+++ b/dbt/adapters/default/relation.py
@@ -177,7 +177,7 @@ class DefaultRelation(APIObject):
         return cls.create(
             database=profile.get('dbname'),
             schema=node.get('schema'),
-            identifier=node.get('name'),
+            identifier=node.get('alias'),
             table_name=table_name,
             **kwargs)
 

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -48,5 +48,5 @@ class SnowflakeRelation(DefaultRelation):
         return cls.create(
             database=profile.get('database'),
             schema=node.get('schema'),
-            identifier=node.get('name'),
+            identifier=node.get('alias'),
             **kwargs)

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -1,5 +1,5 @@
-from voluptuous import Schema, Required, All, Any, Length, ALLOW_EXTRA
-from voluptuous import Optional
+from voluptuous import Schema, Required, Optional, All, Any, Length
+from voluptuous import ALLOW_EXTRA
 
 import dbt.exceptions
 
@@ -34,6 +34,7 @@ parsed_node_contract = unparsed_node_contract.extend({
     Required('unique_id'): All(basestring, Length(min=1, max=255)),
     Required('fqn'): All(list, [All(basestring)]),
     Required('schema'): basestring,
+    Optional('alias'): basestring,
 
     Required('refs'): [All(tuple)],
 

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -164,6 +164,10 @@ This typically happens when ref() is placed within a conditional block.
 To fix this, add the following hint to the top of the model "{model_name}":
 
 -- depends_on: {ref_string}"""
+    # This explicitly references model['name'], instead of model['alias'], for
+    # better error messages. Ex. If models foo_users and bar_users are aliased
+    # to 'users', in their respective schemas, then you would want to see
+    # 'bar_users' in your error messge instead of just 'users'.
     error_msg = base_error_msg.format(
         model_name=model['name'],
         model_path=model['path'],

--- a/dbt/include/global_project/macros/materializations/archive/archive.sql
+++ b/dbt/include/global_project/macros/materializations/archive/archive.sql
@@ -127,8 +127,8 @@
     {% endcall %}
   {% endfor %}
 
-  {%- set identifier = model['name'] -%}
-  {%- set tmp_identifier = model['name'] + '__dbt_archival_tmp' -%}
+  {%- set identifier = model['alias'] -%}
+  {%- set tmp_identifier = identifier + '__dbt_archival_tmp' -%}
   {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier, type='table') -%}
 
   {% call statement() %}

--- a/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -1,7 +1,7 @@
 {% macro dbt__incremental_delete(target_relation, tmp_relation) -%}
 
   {%- set unique_key = config.require('unique_key') -%}
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
 
   delete
   from {{ target_relation }}
@@ -16,8 +16,8 @@
   {%- set sql_where = config.require('sql_where') -%}
   {%- set unique_key = config.get('unique_key') -%}
 
-  {%- set identifier = model['name'] -%}
-  {%- set tmp_identifier = model['name'] + '__dbt_incremental_tmp' -%}
+  {%- set identifier = model['alias'] -%}
+  {%- set tmp_identifier = identifier + '__dbt_incremental_tmp' -%}
 
   {%- set existing_relations = adapter.list_relations(schema=schema) -%}
   {%- set old_relation = adapter.get_relation(relations_list=existing_relations,

--- a/dbt/include/global_project/macros/materializations/seed/bigquery.sql
+++ b/dbt/include/global_project/macros/materializations/seed/bigquery.sql
@@ -10,6 +10,6 @@
 {% macro bigquery__load_csv_rows(model) %}
 
   {%- set column_override = model['config'].get('column_types', {}) -%}
-  {{ adapter.load_dataframe(model['schema'], model['name'], model['agate_table'], column_override) }}
+  {{ adapter.load_dataframe(model['schema'], model['alias'], model['agate_table'], column_override) }}
 
 {% endmacro %}

--- a/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -86,7 +86,7 @@
 
 {% materialization seed, default %}
 
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
   {%- set existing_relations = adapter.list_relations(schema=schema) -%}
 

--- a/dbt/include/global_project/macros/materializations/table/bigquery_table.sql
+++ b/dbt/include/global_project/macros/materializations/table/bigquery_table.sql
@@ -28,7 +28,7 @@
 
 {% materialization table, adapter='bigquery' -%}
 
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
   {%- set existing_relations = adapter.list_relations(schema=schema) -%}
   {%- set old_relation = adapter.get_relation(relations_list=existing_relations, identifier=identifier) -%}

--- a/dbt/include/global_project/macros/materializations/table/table.sql
+++ b/dbt/include/global_project/macros/materializations/table/table.sql
@@ -1,5 +1,5 @@
 {% materialization table, default %}
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
   {%- set tmp_identifier = identifier + '__dbt_tmp' -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 

--- a/dbt/include/global_project/macros/materializations/view/bigquery_view.sql
+++ b/dbt/include/global_project/macros/materializations/view/bigquery_view.sql
@@ -1,6 +1,6 @@
 {% materialization view, adapter='bigquery' -%}
 
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 
   {%- set existing_relations = adapter.list_relations(schema=schema) -%}

--- a/dbt/include/global_project/macros/materializations/view/view.sql
+++ b/dbt/include/global_project/macros/materializations/view/view.sql
@@ -1,6 +1,6 @@
 {%- materialization view, default -%}
 
-  {%- set identifier = model['name'] -%}
+  {%- set identifier = model['alias'] -%}
   {%- set tmp_identifier = identifier + '__dbt_tmp' -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -14,6 +14,7 @@ class SourceConfig(object):
     AppendListFields = ['pre-hook', 'post-hook']
     ExtendDictFields = ['vars', 'column_types', 'quoting']
     ClobberFields = [
+        'alias',
         'schema',
         'enabled',
         'materialized',

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -251,17 +251,17 @@ class CompileRunner(BaseRunner):
         def call_get_columns_in_table(schema_name, table_name):
             return adapter.get_columns_in_table(
                 profile, project, schema_name,
-                table_name, model_name=node.get('name'))
+                table_name, model_name=node.get('alias'))
 
         def call_get_missing_columns(from_schema, from_table,
                                      to_schema, to_table):
             return adapter.get_missing_columns(
                 profile, project, from_schema, from_table,
-                to_schema, to_table, node.get('name'))
+                to_schema, to_table, node.get('alias'))
 
         def call_already_exists(schema, table):
             return adapter.already_exists(
-                profile, project, schema, table, node.get('name'))
+                profile, project, schema, table, node.get('alias'))
 
         return {
             "run_started_at": dbt.tracking.active_user.run_started_at,
@@ -385,8 +385,7 @@ class ModelRunner(CompileRunner):
     def describe_node(self):
         materialization = dbt.utils.get_materialization(self.node)
         schema_name = self.node.get('schema')
-        node_name = self.node.get('name')
-
+        node_name = dbt.utils.get_alias(self.node)
         return "{} model {}.{}".format(materialization, schema_name, node_name)
 
     def print_start_line(self):

--- a/dbt/parser.py
+++ b/dbt/parser.py
@@ -223,7 +223,7 @@ def parse_node(node, node_path, root_project_config, package_project_config,
     profile = dbt.utils.get_profile_from_project(root_project_config)
     default_schema = profile.get('schema', 'public')
     node['schema'] = default_schema
-
+    node['alias'] = dbt.utils.get_alias(node)
     context = dbt.context.parser.generate(node, root_project_config,
                                           {"macros": macros})
 

--- a/dbt/ui/printer.py
+++ b/dbt/ui/printer.py
@@ -156,7 +156,7 @@ def print_model_result_line(result, schema_name, index, total):
             info=info,
             model_type=get_materialization(model),
             schema=schema_name,
-            relation=model.get('name')),
+            relation=model.get('alias')),
         status,
         index,
         total,
@@ -187,7 +187,7 @@ def print_seed_result_line(result, schema_name, index, total):
         "{info} seed file {schema}.{relation}".format(
             info=info,
             schema=schema_name,
-            relation=model.get('name')),
+            relation=model.get('alias')),
         status,
         index,
         total,

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -15,6 +15,7 @@ from dbt.clients import yaml_helper
 
 
 DBTConfigKeys = [
+    'alias',
     'schema',
     'enabled',
     'materialized',
@@ -64,7 +65,7 @@ def get_model_name_or_none(model):
     elif isinstance(model, basestring):
         name = model
     elif isinstance(model, dict):
-        name = model.get('name')
+        name = get_alias(model)
     else:
         name = model.nice_name
     return name
@@ -86,7 +87,7 @@ def model_immediate_name(model, non_destructive):
     seeds.
     """
 
-    model_name = model.get('name')
+    model_name = get_alias(model)
     is_incremental = (get_materialization(model) == 'incremental')
     is_seed = is_type(model, 'seed')
 
@@ -296,6 +297,10 @@ def is_blocking_dependency(node):
 
 def get_materialization(node):
     return node.get('config', {}).get('materialized')
+
+
+def get_alias(node):
+    return node.get('config', {}).get('alias', node.get('name'))
 
 
 def is_enabled(node):

--- a/dbt/version.py
+++ b/dbt/version.py
@@ -67,6 +67,6 @@ def is_latest():
     return installed == latest
 
 
-__version__ = '0.10.1rc2'
+__version__ = '0.10.2a1'
 installed = get_version()
 latest = get_latest_version()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 package_name = "dbt"
-package_version = "0.10.1rc2"
+package_version = "0.10.2a1"
 description = """dbt (data build tool) is a command line tool that helps \
 analysts and engineers transform data in their warehouse more effectively"""
 

--- a/test/integration/026_aliases_test/models/foo_alias.sql
+++ b/test/integration/026_aliases_test/models/foo_alias.sql
@@ -1,0 +1,10 @@
+
+{{
+    config(
+        alias='foo',
+        materialized='table'
+    )
+}}
+
+SELECT
+  '{{ this.alias }}'   as "tablename"

--- a/test/integration/026_aliases_test/models/ref_foo_alias.sql
+++ b/test/integration/026_aliases_test/models/ref_foo_alias.sql
@@ -1,0 +1,18 @@
+
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+WITH trigger_ref AS (
+  SELECT
+    *
+  FROM
+    -- we should still be able to ref a model by its filepath
+    {{ ref('foo_alias') }}
+)
+
+SELECT
+  -- this name should still be the filename
+  '{{ this.alias }}' as "tablename"

--- a/test/integration/026_aliases_test/test_aliases.py
+++ b/test/integration/026_aliases_test/test_aliases.py
@@ -1,0 +1,60 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+
+
+class TestAliases(DBTIntegrationTest):
+
+    def setUp(self):
+        DBTIntegrationTest.setUp(self)
+
+    @property
+    def schema(self):
+        return "aliases_026"
+
+    @property
+    def models(self):
+        return "test/integration/026_aliases_test/models"
+
+    @property
+    def profile_config(self):
+        return {
+            'test': {
+                'outputs': {
+                    'dev': {
+                        'type': 'postgres',
+                        'threads': 1,
+                        'host': 'database',
+                        'port': 5432,
+                        'user': "root",
+                        'pass': "password",
+                        'dbname': 'dbt',
+                        'schema': self.unique_schema()
+                    },
+                },
+                'target': 'dev'
+            }
+        }
+
+    @property
+    def query_foo_alias(self):
+        return """
+            select
+                tablename
+            from {schema}.foo
+        """.format(schema=self.unique_schema())
+
+    @property
+    def query_ref_foo_alias(self):
+        return """
+            select
+                tablename
+            from {schema}.ref_foo_alias
+        """.format(schema=self.unique_schema())
+
+    @attr(type='postgres')
+    def test__alias_model_name(self):
+        self.run_dbt(['run'])
+        result = self.run_sql(self.query_foo_alias, fetch='all')[0][0]
+        self.assertEqual(result, 'foo')
+        result = self.run_sql(self.query_ref_foo_alias, fetch='all')[0][0]
+        self.assertEqual(result, 'ref_foo_alias')

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -92,6 +92,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -150,6 +151,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -191,6 +193,7 @@ class ParserTest(unittest.TestCase):
                 {'root': self.root_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -241,6 +244,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.base': {
+                    'alias': 'base',
                     'name': 'base',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -262,6 +266,7 @@ class ParserTest(unittest.TestCase):
                         models, 'base').get('raw_sql')
                 },
                 'model.root.events_tx': {
+                    'alias': 'events_tx',
                     'name': 'events_tx',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -340,6 +345,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.events': {
+                    'alias': 'events',
                     'name': 'events',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -361,6 +367,7 @@ class ParserTest(unittest.TestCase):
                         models, 'events').get('raw_sql')
                 },
                 'model.root.sessions': {
+                    'alias': 'sessions',
                     'name': 'sessions',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -382,6 +389,7 @@ class ParserTest(unittest.TestCase):
                         models, 'sessions').get('raw_sql')
                 },
                 'model.root.events_tx': {
+                    'alias': 'events_tx',
                     'name': 'events_tx',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -403,6 +411,7 @@ class ParserTest(unittest.TestCase):
                         models, 'events_tx').get('raw_sql')
                 },
                 'model.root.sessions_tx': {
+                    'alias': 'sessions_tx',
                     'name': 'sessions_tx',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -424,6 +433,7 @@ class ParserTest(unittest.TestCase):
                         models, 'sessions_tx').get('raw_sql')
                 },
                 'model.root.multi': {
+                    'alias': 'multi',
                     'name': 'multi',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -504,6 +514,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.snowplow.events': {
+                    'alias': 'events',
                     'name': 'events',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -525,6 +536,7 @@ class ParserTest(unittest.TestCase):
                         models, 'events').get('raw_sql')
                 },
                 'model.snowplow.sessions': {
+                    'alias': 'sessions',
                     'name': 'sessions',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -546,6 +558,7 @@ class ParserTest(unittest.TestCase):
                         models, 'sessions').get('raw_sql')
                 },
                 'model.snowplow.events_tx': {
+                    'alias': 'events_tx',
                     'name': 'events_tx',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -567,6 +580,7 @@ class ParserTest(unittest.TestCase):
                         models, 'events_tx').get('raw_sql')
                 },
                 'model.snowplow.sessions_tx': {
+                    'alias': 'sessions_tx',
                     'name': 'sessions_tx',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -588,6 +602,7 @@ class ParserTest(unittest.TestCase):
                         models, 'sessions_tx').get('raw_sql')
                 },
                 'model.root.multi': {
+                    'alias': 'multi',
                     'name': 'multi',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -772,6 +787,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -854,6 +870,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.table': {
+                    'alias': 'table',
                     'name': 'table',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -875,6 +892,7 @@ class ParserTest(unittest.TestCase):
                         models, 'table').get('raw_sql')
                 },
                 'model.root.ephemeral': {
+                    'alias': 'ephemeral',
                     'name': 'ephemeral',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -896,6 +914,7 @@ class ParserTest(unittest.TestCase):
                         models, 'ephemeral').get('raw_sql')
                 },
                 'model.root.view': {
+                    'alias': 'view',
                     'name': 'view',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1045,6 +1064,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.table': {
+                    'alias': 'table',
                     'name': 'table',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1066,6 +1086,7 @@ class ParserTest(unittest.TestCase):
                         models, 'table').get('raw_sql')
                 },
                 'model.root.ephemeral': {
+                    'alias': 'ephemeral',
                     'name': 'ephemeral',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1087,6 +1108,7 @@ class ParserTest(unittest.TestCase):
                         models, 'ephemeral').get('raw_sql')
                 },
                 'model.root.view': {
+                    'alias': 'view',
                     'name': 'view',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1108,6 +1130,7 @@ class ParserTest(unittest.TestCase):
                         models, 'view').get('raw_sql')
                 },
                 'model.snowplow.multi_sort': {
+                    'alias': 'multi_sort',
                     'name': 'multi_sort',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1160,6 +1183,7 @@ class ParserTest(unittest.TestCase):
                  'snowplow': self.snowplow_project_config}),
             {
                 'test.root.not_null_model_one_id': {
+                    'alias': 'not_null_model_one_id',
                     'name': 'not_null_model_one_id',
                     'schema': 'analytics',
                     'resource_type': 'test',
@@ -1181,6 +1205,7 @@ class ParserTest(unittest.TestCase):
                     'raw_sql': not_null_sql,
                 },
                 'test.root.unique_model_one_id': {
+                    'alias': 'unique_model_one_id',
                     'name': 'unique_model_one_id',
                     'schema': 'analytics',
                     'resource_type': 'test',
@@ -1201,6 +1226,7 @@ class ParserTest(unittest.TestCase):
                     'raw_sql': unique_sql,
                 },
                 'test.root.accepted_values_model_one_id__a__b': {
+                    'alias': 'accepted_values_model_one_id__a__b',
                     'name': 'accepted_values_model_one_id__a__b',
                     'schema': 'analytics',
                     'resource_type': 'test',
@@ -1223,6 +1249,7 @@ class ParserTest(unittest.TestCase):
                     'raw_sql': accepted_values_sql,
                 },
                 'test.root.relationships_model_one_id__id__ref_model_two_': {
+                    'alias': 'relationships_model_one_id__id__ref_model_two_',
                     'name': 'relationships_model_one_id__id__ref_model_two_',
                     'schema': 'analytics',
                     'resource_type': 'test',
@@ -1315,6 +1342,7 @@ another_model:
                  'snowplow': self.snowplow_project_config}),
             {
                 'test.root.no_events': {
+                    'alias': 'no_events',
                     'name': 'no_events',
                     'schema': 'analytics',
                     'resource_type': 'test',
@@ -1430,6 +1458,7 @@ another_model:
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',
@@ -1472,6 +1501,7 @@ another_model:
                  'snowplow': self.snowplow_project_config}),
             {
                 'model.root.model_one': {
+                    'alias': 'model_one',
                     'name': 'model_one',
                     'schema': 'analytics',
                     'resource_type': 'model',


### PR DESCRIPTION
I took @abelsonlive 's great PR #651 and merged it on top of the development branch, yesterday (i.e. 0.10.1rc2). I tried to address issues that popped up. While the unit and quick tests pass, I have not tested it against my snowflake databse yet.

$ git merge kickstarter/feature/model-aliasing
CONFLICT (content): Merge conflict in dbt/utils.py
CONFLICT (modify/delete): dbt/include/global_project/macros/materializations/table.sql deleted in HEAD and modified in kickstarter/feature/model-aliasing. Version kickstarter/feature/model-aliasing of dbt/include/global_project/macros/materializations/table.sql left in tree.
CONFLICT (modify/delete): dbt/include/global_project/macros/materializations/bigquery.sql deleted in HEAD and modified in kickstarter/feature/model-aliasing. Version kickstarter/feature/model-aliasing of dbt/include/global_project/macros/materializations/bigquery.sql left in tree.

1. dbt/utils.py

   Some major changes are being introduced in 0.10.1: Implement relations api (#727)
   #727
   5344f54#diff-196bbfafed32edaf1554550f65111f87

   The Relation class was extracted into ...
   ./dbt/api/object.py                   class APIObject(dict)
   ./dbt/adapters/default/relation.py    class DefaultRelation(APIObject)
   ./dbt/adapters/bigquery/relation.py   class BigQueryRelation(DefaultRelation)
   ./dbt/adapters/snowflake/relation.py  class SnowflakeRelation(DefaultRelation)

   Changing node.get('name') to node.get('alias') ...
   ./dbt/adapters/default/relation.py
   ./dbt/adapters/bigquery/relation.py
   ./dbt/adapters/snowflake/relation.py

2. dbt/include/global_project/macros/materializations/table.sql

   This was renamed to ...
   ./dbt/include/global_project/macros/materializations/table/table.sql

3. dbt/include/global_project/macros/materializations/bigquery.sql

   This was split into ...
   ./dbt/include/global_project/macros/materializations/table/bigquery_table.sql
   and ...
   ./dbt/include/global_project/macros/materializations/view/bigquery_view.sql

4. other instances of model['name']

   The following file also mention model['name'] and probably need to change as well ...

   ./dbt/include/global_project/macros/materializations/archive/archive.sql
   ./dbt/include/global_project/macros/materializations/seed/bigquery.sql
   ./dbt/include/global_project/macros/materializations/seed/seed.sql

   Added comentary to ...

   ./dbt/exceptions.py

5. further changes

   Revert model.get('alias') to model.get('name') ...
   print_test_result_line in ./dbt/ui/printer.py (since in this context schema is NOT being used)

   Change model.get('name') to model.get('alias') ...
   print_seed_result_line in ./dbt/ui/printer.py (since in this context schema is also being used)

   Change node.get('name') to node.get('alias') ...
   _node_context in ./dbt/node_runners.py (since in this context schema is also being used)
   call_get_missing_columns in ./dbt/node_runners.py (since in this context schema is also being used)
   call_already_exists in ./dbt/node_runners.py (since in this context schema is also being used)

6. linting

   import lines must be under 80 characters
   https://www.python.org/dev/peps/pep-0328/