### PR TITLE
fix __all__ setting for submodules (#777)

### DIFF
--- a/dbt/adapters/bigquery/__init__.py
+++ b/dbt/adapters/bigquery/__init__.py
@@ -2,6 +2,6 @@ from dbt.adapters.bigquery.impl import BigQueryAdapter
 from dbt.adapters.bigquery.relation import BigQueryRelation
 
 __all__ = [
-    BigQueryAdapter,
-    BigQueryRelation,
+    'BigQueryAdapter',
+    'BigQueryRelation',
 ]

--- a/dbt/adapters/default/__init__.py
+++ b/dbt/adapters/default/__init__.py
@@ -2,6 +2,6 @@ from dbt.adapters.default.impl import DefaultAdapter
 from dbt.adapters.default.relation import DefaultRelation
 
 __all__ = [
-    DefaultAdapter,
-    DefaultRelation,
+    'DefaultAdapter',
+    'DefaultRelation',
 ]

--- a/dbt/adapters/postgres/__init__.py
+++ b/dbt/adapters/postgres/__init__.py
@@ -1,5 +1,5 @@
 from dbt.adapters.postgres.impl import PostgresAdapter
 
 __all__ = [
-    PostgresAdapter,
+    'PostgresAdapter',
 ]

--- a/dbt/adapters/redshift/__init__.py
+++ b/dbt/adapters/redshift/__init__.py
@@ -1,5 +1,5 @@
 from dbt.adapters.redshift.impl import RedshiftAdapter
 
 __all__ = [
-    RedshiftAdapter,
+    'RedshiftAdapter',
 ]

--- a/dbt/adapters/snowflake/__init__.py
+++ b/dbt/adapters/snowflake/__init__.py
@@ -2,6 +2,6 @@ from dbt.adapters.snowflake.impl import SnowflakeAdapter
 from dbt.adapters.snowflake.relation import SnowflakeRelation
 
 __all__ = [
-    SnowflakeAdapter,
-    SnowflakeRelation,
+    'SnowflakeAdapter',
+    'SnowflakeRelation',
 ]

--- a/dbt/api/__init__.py
+++ b/dbt/api/__init__.py
@@ -1,5 +1,5 @@
 from dbt.api.object import APIObject
 
 __all__ = [
-    APIObject
+    'APIObject'
 ]


### PR DESCRIPTION
the `__all__` variable in a submodule needs to be set to a list of strings instead of a list of other objects.

This PR fixes this issue so that these modules can use imports in the form of `from modulename import *`.