### PR TITLE
use a subselect instead of a CTE when building incremental models

### DIFF
--- a/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -60,10 +60,8 @@
      {%- call statement() -%}
 
        {% set tmp_table_sql -%}
-         with dbt_incr_sbq as (
-           {{ sql }}
-         )
-         select * from dbt_incr_sbq
+         {# We are using a subselect instead of a CTE here to allow PostgreSQL to use indexes. -#}
+         select * from ({{ sql }}) as dbt_incr_sbq
          where ({{ sql_where }})
            or ({{ sql_where }}) is null
        {%- endset %}


### PR DESCRIPTION
(must faster on postgresql due to the CTE optimization fence)