### PR TITLE
Revert "use a subselect instead of a CTE when building incremental models"

### DIFF
--- a/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -60,8 +60,10 @@
      {%- call statement() -%}
 
        {% set tmp_table_sql -%}
-         {# We are using a subselect instead of a CTE here to allow PostgreSQL to use indexes. -#}
-         select * from ({{ sql }}) as dbt_incr_sbq
+         with dbt_incr_sbq as (
+           {{ sql }}
+         )
+         select * from dbt_incr_sbq
          where ({{ sql_where }})
            or ({{ sql_where }}) is null
        {%- endset %}


### PR DESCRIPTION
Reverts fishtown-analytics/dbt#785

this should have been merged to development