### PR TITLE
Ensure that numeric precision is included only if not None

### DIFF
--- a/dbt/schema.py
+++ b/dbt/schema.py
@@ -57,7 +57,10 @@ class Column(object):
     def numeric_type(cls, dtype, size):
         # This could be decimal(...), numeric(...), number(...)
         # Just use whatever was fed in here -- don't try to get too clever
-        return "{}({})".format(dtype, size)
+        if size is None:
+            return dtype
+        else:
+            return "{}({})".format(dtype, size)
 
     def __repr__(self):
         return "<Column {} ({})>".format(self.name, self.data_type)

--- a/test/integration/008_schema_tests_test/seed.sql
+++ b/test/integration/008_schema_tests_test/seed.sql
@@ -3,6 +3,10 @@ create table {schema}.seed (
 	id INTEGER,
 	first_name VARCHAR(11),
 	email VARCHAR(31),
+
+	net_worth NUMERIC(12, 2) DEFAULT '100.00',
+	fav_number NUMERIC DEFAULT '3.14159265',
+
 	ip_address VARCHAR(15),
 	updated_at TIMESTAMP WITHOUT TIME ZONE
 );

--- a/test/unit/test_schema.py
+++ b/test/unit/test_schema.py
@@ -1,0 +1,23 @@
+import unittest
+
+import dbt.schema
+
+
+class TestNumericType(unittest.TestCase):
+
+    def test__numeric_type(self):
+        col = dbt.schema.Column(
+            'fieldname',
+            'numeric',
+            numeric_size='12,2')
+
+        self.assertEqual(col.data_type, 'numeric(12,2)')
+
+    def test__numeric_type_with_no_precision(self):
+        # PostgreSQL, at least, will allow empty numeric precision
+        col = dbt.schema.Column(
+            'fieldname',
+            'numeric',
+            numeric_size=None)
+
+        self.assertEqual(col.data_type, 'numeric')


### PR DESCRIPTION
This pull request ensures that the `numeric_size` of the `Column` is not `None` before using including it in the column type string representation.

----------

While unioning tables together with the _dbt-utils_ `union_table` macro, we were running into syntax errors like the following from SQL generated by DBT:

```
invalid input syntax for integer: none
LINE 54:            "total_tax_due"::numeric(None) as ...`
```

We were initially inclined to go and add a precision to the source table, but the models where this was happening were themselves based on derivative tables. For example, in the above case, `total_tax_due` is defined as an aggregate:

```sql
...
sum(tax_due) AS total_tax_due
...
```

So identifying the precision beforehand is nontrivial.