### PR TITLE
Bump/psycopg2 2.7.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse>=1.2.1
 Jinja2>=2.8
 pytz==2017.2
 PyYAML>=3.11
-psycopg2-binary==2.7.5
+psycopg2==2.7.5
 sqlparse==0.2.3
 networkx==1.11
 snowplow-tracker==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse>=1.2.1
 Jinja2>=2.8
 pytz==2017.2
 PyYAML>=3.11
-psycopg2==2.7.1
+psycopg2-binary==2.7.5
 sqlparse==0.2.3
 networkx==1.11
 snowplow-tracker==0.7.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Jinja2>=2.8',
         'pytz==2017.2',
         'PyYAML>=3.11',
-        'psycopg2==2.7.1',
+        'psycopg2-binary==2.7.5',
         'sqlparse==0.2.3',
         'networkx==1.11',
         'snowplow-tracker==0.7.2',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Jinja2>=2.8',
         'pytz==2017.2',
         'PyYAML>=3.11',
-        'psycopg2-binary==2.7.5',
+        'psycopg2==2.7.5',
         'sqlparse==0.2.3',
         'networkx==1.11',
         'snowplow-tracker==0.7.2',


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/773, https://github.com/fishtown-analytics/dbt/issues/704

We originally intended to use the `psycopg2-binary` dep, but it sounds like that's not ready for production workloads yet. Via [the installation docs](http://initd.org/psycopg/docs/install.html#binary-install-from-pypi):

> Note The -binary package is meant for beginners to start playing with Python and PostgreSQL without the need to meet the build requirements. If you are the maintainer of a publish package depending on psycopg2 you shouldn’t use psycopg2-binary as a module dependency. For production use you are advised to use the source distribution.

This PR bumps the dep to 2.7.5, which should alleviate issues with installation on Fedora/Arch/etc. It also contains fixes around the `closed` attribute on connections, which we will likely need to use to manage long-running queries that result in disconnected cursors.
