### PR TITLE
fix catalog generation

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -44,7 +44,11 @@ def macro_generator(template, node):
             name = node.get('name')
             module = template.make_module(
                 context, False, context)
-            macro = module.__dict__[dbt.utils.get_dbt_macro_name(name)]
+
+            if node['resource_type'] == NodeType.Operation:
+                macro = module.__dict__[dbt.utils.get_dbt_operation_name(name)]
+            else:
+                macro = module.__dict__[dbt.utils.get_dbt_macro_name(name)]
             module.__dict__.update(context)
 
             try:

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -302,9 +302,6 @@ class Compiler(object):
 
         self._check_resource_uniqueness(flat_graph)
 
-        flat_graph = dbt.parser.process_refs(flat_graph,
-                                             root_project.get('name'))
-
         linked_graph = self.link_graph(linker, flat_graph)
 
         stats = defaultdict(int)

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -340,32 +340,7 @@ def create_adapter(adapter_type, relation_type):
     return AdapterWithContext
 
 
-def _add_model_context(context, node, project_cfg, flat_graph, db_wrapper,
-                       provider):
-
-    # These fields do not apply to operations.
-    if node.get('resource_type') == NodeType.Operation:
-        return context
-
-    target_name = project_cfg.get('target')
-    profile = project_cfg.get('outputs').get(target_name)
-
-    pre_hooks = node.get('config', {}).get('pre-hook')
-    post_hooks = node.get('config', {}).get('post-hook')
-
-    model_context = {
-        "post_hooks": post_hooks,
-        "pre_hooks": pre_hooks,
-        "model": node,
-        "sql": node.get('injected_sql'),
-        "this": get_this_relation(db_wrapper, project_cfg, profile, node),
-        "ref": provider.ref(db_wrapper, node, project_cfg, profile, flat_graph)
-    }
-
-    return dbt.utils.merge(context, model_context)
-
-
-def generate(node, project_cfg, flat_graph, provider=None):
+def generate(model, project_cfg, flat_graph, provider=None):
     """
     Not meant to be called directly. Call with either:
         dbt.context.parser.generate
@@ -382,14 +357,17 @@ def generate(node, project_cfg, flat_graph, provider=None):
     target.pop('pass', None)
     target['name'] = target_name
     adapter = get_adapter(profile)
-    default_schema = profile.get('schema', 'public')
 
     context = {'env': target}
+    schema = profile.get('schema', 'public')
+
+    pre_hooks = model.get('config', {}).get('pre-hook')
+    post_hooks = model.get('config', {}).get('post-hook')
 
     relation_type = create_relation(adapter.Relation,
                                     project_cfg.get('quoting'))
 
-    db_wrapper = DatabaseWrapper(node,
+    db_wrapper = DatabaseWrapper(model,
                                  create_adapter(adapter, relation_type),
                                  profile,
                                  project_cfg)
@@ -403,39 +381,48 @@ def generate(node, project_cfg, flat_graph, provider=None):
             "Column": adapter.Column,
         },
         "column": adapter.Column,
-        "config": provider.Config(node),
+        "config": provider.Config(model),
         "env_var": _env_var,
         "exceptions": dbt.exceptions,
         "execute": provider.execute,
         "flags": dbt.flags,
         "graph": flat_graph,
         "log": log,
+        "model": model,
         "modules": {
             "pytz": pytz,
             "datetime": datetime
         },
+        "post_hooks": post_hooks,
+        "pre_hooks": pre_hooks,
+        "ref": provider.ref(db_wrapper, model, project_cfg,
+                            profile, flat_graph),
         "return": _return,
+        "schema": model.get('schema', schema),
+        "sql": model.get('injected_sql'),
         "sql_now": adapter.date_function(),
         "fromjson": fromjson,
-        "schema": node.get('schema', default_schema),
         "tojson": tojson,
         "target": target,
-        "try_or_compiler_error": try_or_compiler_error(node)
+        "try_or_compiler_error": try_or_compiler_error(model)
     })
+
+    # Operations do not represent database relations, so 'this' does not apply
+    if model.get('resource_type') != NodeType.Operation:
+        context["this"] = get_this_relation(db_wrapper, project_cfg, profile,
+                                            model)
 
     context = _add_tracking(context)
     context = _add_validation(context)
     context = _add_sql_handlers(context)
-    context = _add_model_context(context, node, project_cfg,
-                                 flat_graph, db_wrapper, provider)
 
     # we make a copy of the context for each of these ^^
 
-    context = _add_macros(context, node, flat_graph)
+    context = _add_macros(context, model, flat_graph)
 
-    context["write"] = write(node, project_cfg.get('target-path'), 'run')
-    context["render"] = render(context, node)
-    context["var"] = Var(node, context=context, overrides=cli_var_overrides)
+    context["write"] = write(model, project_cfg.get('target-path'), 'run')
+    context["render"] = render(context, model)
+    context["var"] = Var(model, context=context, overrides=cli_var_overrides)
     context['context'] = context
 
     return context

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -17,7 +17,9 @@ class GraphLoader(object):
         for loader in cls._LOADERS:
             nodes.update(loader.load_all(root_project, all_projects, macros))
 
-        return ParsedManifest(nodes=nodes, macros=macros)
+        manifest = ParsedManifest(nodes=nodes, macros=macros)
+        manifest = dbt.parser.process_refs(manifest, root_project)
+        return manifest
 
     @classmethod
     def register(cls, loader):

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -149,10 +149,15 @@ def find_in_subgraph_by_name(subgraph, target_name, target_package, nodetype):
 
 
 MACRO_PREFIX = 'dbt_macro__'
+OPERATION_PREFIX = 'dbt_operation__'
 
 
 def get_dbt_macro_name(name):
     return '{}{}'.format(MACRO_PREFIX, name)
+
+
+def get_dbt_operation_name(name):
+    return '{}{}'.format(OPERATION_PREFIX, name)
 
 
 def get_materialization_macro_name(materialization_name, adapter_type=None,
@@ -193,7 +198,7 @@ def get_materialization_macro(flat_graph, materialization_name,
 
 def get_operation_macro_name(operation_name, with_prefix=True):
     if with_prefix:
-        return get_dbt_macro_name(operation_name)
+        return get_dbt_operation_name(operation_name)
     else:
         return operation_name
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -29,6 +29,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
     @attr(type='postgres')
     def test_simple_generate(self):
+        self.run_dbt(["deps"])
         self.run_dbt(["docs", "generate"])
         self.assertTrue(os.path.exists('./target/catalog.json'))
 

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -6,6 +6,7 @@ import dbt.flags
 import dbt.parser
 
 from dbt.node_types import NodeType
+from dbt.contracts.graph.parsed import ParsedManifest, ParsedNode, ParsedMacro
 
 def get_os_path(unix_path):
     return os.path.normpath(unix_path)
@@ -680,8 +681,14 @@ class ParserTest(unittest.TestCase):
             }
         }
 
+        manifest = ParsedManifest(
+            nodes={k: ParsedNode(**v) for (k,v) in graph['nodes'].items()},
+            macros={k: ParsedMacro(**v) for (k,v) in graph['macros'].items()},
+        )
+
+        processed_manifest = dbt.parser.process_refs(manifest, 'root')
         self.assertEquals(
-            dbt.parser.process_refs(graph, 'root'),
+            processed_manifest.to_flat_graph(),
             {
                 'macros': {},
                 'nodes': {
@@ -703,7 +710,8 @@ class ParserTest(unittest.TestCase):
                         'path': 'events.sql',
                         'original_file_path': 'events.sql',
                         'root_path': get_os_path('/usr/src/app'),
-                        'raw_sql': 'does not matter'
+                        'raw_sql': 'does not matter',
+                        'agate_table': None,
                     },
                     'model.root.events': {
                         'name': 'events',
@@ -723,7 +731,8 @@ class ParserTest(unittest.TestCase):
                         'path': 'events.sql',
                         'original_file_path': 'events.sql',
                         'root_path': get_os_path('/usr/src/app'),
-                        'raw_sql': 'does not matter'
+                        'raw_sql': 'does not matter',
+                        'agate_table': None,
                     },
                     'model.root.dep': {
                         'name': 'dep',
@@ -743,7 +752,8 @@ class ParserTest(unittest.TestCase):
                         'path': 'multi.sql',
                         'original_file_path': 'multi.sql',
                         'root_path': get_os_path('/usr/src/app'),
-                        'raw_sql': 'does not matter'
+                        'raw_sql': 'does not matter',
+                        'agate_table': None,
                     }
                 }
             }


### PR DESCRIPTION
Fixes some issues around catalog generation/operations

**Changes**:
- Do not add `this` to the context for Operations
- Only add operations to the graph once. Previously, they were added once a Macro node, and once as an Operation node. Similarly, Operation nodes were previously created for code declared in `{% macro %}` blocks.
- Fix missing parent_map and child_map entries. This happened because the manifest was written out before refs were processed
- Run the compilation step before writing out the catalog for `dbt docs generate`. This simplifies the code a whole lot