### PR TITLE
Fix thread values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changes
 
+ - Make the `--threads` parameter actually change the number of threads used ([#819](https://github.com/fishtown-analytics/dbt/pull/819))
  - Use Mapping instead of dict as the base class for APIObject ([#756](https://github.com/fishtown-analytics/dbt/pull/756))
  - Write JSON manifest file to disk during compilation ([#761](https://github.com/fishtown-analytics/dbt/pull/761))
  - Add forward and backward graph edges to the JSON manifest file ([#762](https://github.com/fishtown-analytics/dbt/pull/762))

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -145,6 +145,9 @@ class Project(object):
 
             compiled[key] = compiled_val
 
+        if self.args and hasattr(self.args, 'threads') and self.args.threads:
+            compiled['threads'] = self.args.threads
+
         return compiled
 
     def compile_and_update_target(self):

--- a/test/integration/031_thread_count_test/models/do_nothing_1.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_1.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_10.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_10.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_11.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_11.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_12.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_12.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_13.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_13.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_14.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_14.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_15.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_15.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_16.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_16.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_17.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_17.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_18.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_18.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_19.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_19.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_2.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_2.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_20.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_20.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_3.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_3.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_4.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_4.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_5.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_5.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_6.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_6.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_7.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_7.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_8.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_8.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/models/do_nothing_9.sql
+++ b/test/integration/031_thread_count_test/models/do_nothing_9.sql
@@ -1,0 +1,1 @@
+with x as (select pg_sleep(1)) select 1

--- a/test/integration/031_thread_count_test/test_thread_count.py
+++ b/test/integration/031_thread_count_test/test_thread_count.py
@@ -1,0 +1,33 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest, FakeArgs
+
+from dbt.task.test import TestTask
+from dbt.project import read_project
+import os
+
+
+class TestDataTests(DBTIntegrationTest):
+
+    @property
+    def project_config(self):
+        return {}
+
+    @property
+    def profile_config(self):
+        return {
+            'threads': 2,
+        }
+
+    @property
+    def schema(self):
+        return "thread_tests_031"
+
+    @property
+    def models(self):
+        return "test/integration/031_thread_count_test/models"
+
+    @attr(type='postgres')
+    def test_postgres_threading_8x(self):
+        self.use_profile('postgres')
+
+        self.run_dbt(args=['run', '--threads', '16'])


### PR DESCRIPTION
Fix issue #648 by overriding the configured profile information with the command-line arguments. The Project object is the last thing that really knows about both CLI arguments and profiles so this seemed like the best place to override things.

The `do_nothing` sql is a bit funny because `pg_sleep` returns a void type so I couldn't just `select pg_sleep(1)`. I assume there's a better way to do it.