### PR TITLE
Set TCP keepalive on Redshift (#782)

### DIFF
--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -9,6 +9,9 @@ drop_lock = multiprocessing.Lock()
 
 
 class RedshiftAdapter(PostgresAdapter):
+
+    DEFAULT_TCP_KEEPALIVE = 240
+
     @classmethod
     def type(cls):
         return 'redshift'

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -32,6 +32,9 @@ POSTGRES_CREDENTIALS_CONTRACT = {
         'schema': {
             'type': 'string',
         },
+        'keepalives_idle': {
+            'type': 'integer',
+        },
     },
     'required': ['dbname', 'host', 'user', 'pass', 'port', 'schema'],
 }
@@ -86,6 +89,9 @@ REDSHIFT_CREDENTIALS_CONTRACT = {
             'description': (
                 'If using IAM auth, the ttl for the temporary credentials'
             )
+        },
+        'keepalives_idle': {
+            'type': 'integer',
         },
         'required': ['dbname', 'host', 'user', 'port', 'schema']
     }


### PR DESCRIPTION
Set TCP keepalives on Redshift (and provide it as an option on Postgres). Users can disable setting the  value if they want by explicitly setting the `keepalives_idle` parameter in the connection profile to `0`, which will make it use the system default.

This should fix #782 