### PR TITLE
Bigquery fix concurrent relation loads

### DIFF
--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -182,8 +182,18 @@ class BigQueryAdapter(PostgresAdapter):
 
         bigquery_dataset = cls.get_dataset(
             profile, project_cfg, schema, model_name)
+
+
         all_tables = client.list_tables(
             bigquery_dataset,
+            # BigQuery paginates tables by alphabetizing them, and using
+            # the name of the last table on a page as the key for the
+            # next page. If that key table gets dropped before we run
+            # list_relations, then this will 404. So, we avoid this
+            # situation by not paginating the list of tables.
+            # see: https://github.com/fishtown-analytics/dbt/issues/726
+            # TODO: cache the list of relations up front, and then we
+            #       won't need to do this
             max_results=0)
 
         relation_types = {

--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -182,7 +182,9 @@ class BigQueryAdapter(PostgresAdapter):
 
         bigquery_dataset = cls.get_dataset(
             profile, project_cfg, schema, model_name)
-        all_tables = client.list_tables(bigquery_dataset)
+        all_tables = client.list_tables(
+            bigquery_dataset,
+            max_results=0)
 
         relation_types = {
             'TABLE': 'table',

--- a/dbt/logger.py
+++ b/dbt/logger.py
@@ -71,7 +71,7 @@ def initialize_logger(debug_mode=False, path=None):
 
     if debug_mode:
         stdout_handler.setFormatter(
-            logging.Formatter('%(asctime)-18s: %(message)s'))
+            logging.Formatter('%(asctime)-18s (%(threadName)s): %(message)s'))
         stdout_handler.setLevel(logging.DEBUG)
 
     if path is not None:
@@ -90,7 +90,7 @@ def initialize_logger(debug_mode=False, path=None):
         logdir_handler.addFilter(color_filter)
 
         logdir_handler.setFormatter(
-            logging.Formatter('%(asctime)-18s: %(message)s'))
+            logging.Formatter('%(asctime)-18s (%(threadName)s): %(message)s'))
         logdir_handler.setLevel(logging.DEBUG)
 
         logger.addHandler(logdir_handler)

--- a/dbt/logger.py
+++ b/dbt/logger.py
@@ -1,5 +1,6 @@
 import dbt.compat
 import logging
+import logging.handlers
 import os
 import sys
 


### PR DESCRIPTION
Reopened from #834 -- a branch named `bigquery` already exists, so any branch named `bigquery/*` does not work

Fix for #726 

@drewbanin rather than switching this to use get_relation, i fixed list_relation by making it more atomic (it doesn't paginate at all now). I think there's a case to be made for changing this materialization to use get_relation directly instead, but this keeps the abstraction in place and makes the code work.