### PR TITLE
add tox environments that have the user specify what tests should be run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/root/
-commands = /bin/bash -c '{envpython} $(which nosetests) -v --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov  {posargs}'
+commands = /bin/bash -c '{envpython} $(which nosetests) -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -118,7 +118,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/root/
-commands = /bin/bash -c '{envpython} $(which nosetests) -v --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov  {posargs}'
+commands = /bin/bash -c '{envpython} $(which nosetests) -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,26 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
+[testenv:explicit-py27]
+basepython = python2.7
+passenv = *
+setenv =
+    HOME=/root/
+commands = /bin/bash -c '{envpython} $(which nosetests) -v --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov  {posargs}'
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+
+[testenv:explicit-py36]
+basepython = python3.6
+passenv = *
+setenv =
+    HOME=/root/
+commands = /bin/bash -c '{envpython} $(which nosetests) -v --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov  {posargs}'
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+
 [testenv:pywin]
 basepython = {env:PYTHON:}\python.exe
 passenv = *


### PR DESCRIPTION
This adds some environments to tox where the user specifies what tests to run (one each for python 2.7/3.6).

This is mostly useful when you want to locally run some single test in the integration suite and not wait for everything else to finish.