### PR TITLE
Improve circleci flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,11 +113,27 @@ workflows:
   test-everything:
     jobs:
       - unit
-      - integration-snowflake-py36
-      - integration-snowflake-py27
       - integration-postgres-py36
+          requires:
+            - unit
       - integration-postgres-py27
-      - integration-redshift-py36
+          requires:
+            - unit
       - integration-redshift-py27
-      - integration-bigquery-py36
+          requires:
+            - integration-postgres-py27
       - integration-bigquery-py27
+          requires:
+            - integration-postgres-py27
+      - integration-snowflake-py27
+          requires:
+            - integration-postgres-py27
+      - integration-redshift-py36
+          requires:
+            - integration-postgres-py36
+      - integration-bigquery-py36
+          requires:
+            - integration-postgres-py36
+      - integration-snowflake-py36
+          requires:
+            - integration-postgres-py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,27 +113,27 @@ workflows:
   test-everything:
     jobs:
       - unit
-      - integration-postgres-py36
+      - integration-postgres-py36:
           requires:
             - unit
-      - integration-postgres-py27
+      - integration-postgres-py27:
           requires:
             - unit
-      - integration-redshift-py27
+      - integration-redshift-py27:
           requires:
             - integration-postgres-py27
-      - integration-bigquery-py27
+      - integration-bigquery-py27:
           requires:
             - integration-postgres-py27
-      - integration-snowflake-py27
+      - integration-snowflake-py27:
           requires:
             - integration-postgres-py27
-      - integration-redshift-py36
+      - integration-redshift-py36:
           requires:
             - integration-postgres-py36
-      - integration-bigquery-py36
+      - integration-bigquery-py36:
           requires:
             - integration-postgres-py36
-      - integration-snowflake-py36
+      - integration-snowflake-py36:
           requires:
             - integration-postgres-py36


### PR DESCRIPTION
This adds some dependency stuff to our new CircleCI flow. Instead of running each test at once in parallel, do unit tests -> Postgres tests -> all other tests. I've added a screenshot of the resulting dependency graph.

This means that now we won't run any more tests if unit tests/pep8 fail and we won't waste time on the super slow snowflake tests if Postgres tests fail. Hopefully it'll save us some container use in the long run.

I've included a screenshot of what the CircleCI "workflows" graph looks like with this change.
<img width="739" alt="circleci-graph" src="https://user-images.githubusercontent.com/452302/42699703-849d39e0-868f-11e8-92f0-5e29033489d8.png">
