### PR TITLE
cache snowflake column defs in tests

### DIFF
--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -26,9 +26,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("seed","view_model")
-        self.assertTablesEqual("seed","incremental")
-        self.assertTablesEqual("seed","materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         results = self.run_dbt(["seed"])
@@ -36,9 +34,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("seed","view_model")
-        self.assertTablesEqual("seed","incremental")
-        self.assertTablesEqual("seed","materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
     @attr(type="postgres")
     def test__postgres__dbt_doesnt_run_empty_models(self):
@@ -63,17 +59,13 @@ class TestSimpleCopy(DBTIntegrationTest):
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertTablesEqual("seed", "view_model")
-        self.assertTablesEqual("seed", "incremental")
-        self.assertTablesEqual("seed", "materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertTablesEqual("seed", "view_model")
-        self.assertTablesEqual("seed", "incremental")
-        self.assertTablesEqual("seed", "materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
     @attr(type="snowflake")
     def test__snowflake__simple_copy__quoting_on(self):
@@ -88,9 +80,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("seed", "view_model")
-        self.assertTablesEqual("seed", "incremental")
-        self.assertTablesEqual("seed", "materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
         self.use_default_project({
             "data-paths": [self.dir("seed-update")],
@@ -101,9 +91,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("seed", "view_model")
-        self.assertTablesEqual("seed", "incremental")
-        self.assertTablesEqual("seed", "materialized")
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
     @attr(type="snowflake")
     def test__snowflake__simple_copy__quoting_off(self):
@@ -118,9 +106,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("SEED", "VIEW_MODEL")
-        self.assertTablesEqual("SEED", "INCREMENTAL")
-        self.assertTablesEqual("SEED", "MATERIALIZED")
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
         self.use_default_project({
             "data-paths": [self.dir("seed-update")],
@@ -131,9 +117,7 @@ class TestSimpleCopy(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  6)
 
-        self.assertTablesEqual("SEED", "VIEW_MODEL")
-        self.assertTablesEqual("SEED", "INCREMENTAL")
-        self.assertTablesEqual("SEED", "MATERIALIZED")
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
     @attr(type="snowflake")
     def test__snowflake__seed__quoting_switch(self):

--- a/test/integration/002_varchar_widening_test/test_varchar_widening.py
+++ b/test/integration/002_varchar_widening_test/test_varchar_widening.py
@@ -43,13 +43,11 @@ class TestVarcharWidening(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  2)
 
-        self.assertTablesEqual("SEED", "incremental")
-        self.assertTablesEqual("SEED", "materialized")
+        self.assertManyTablesEqual(["SEED", "incremental", "materialized"])
 
         self.run_sql_file("test/integration/002_varchar_widening_test/update.sql")
 
         results = self.run_dbt()
         self.assertEqual(len(results),  2)
 
-        self.assertTablesEqual("SEED", "incremental")
-        self.assertTablesEqual("SEED", "materialized")
+        self.assertManyTablesEqual(["SEED", "incremental", "materialized"])

--- a/test/integration/003_simple_reference_test/test_simple_reference.py
+++ b/test/integration/003_simple_reference_test/test_simple_reference.py
@@ -62,15 +62,10 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertEqual(len(results),  7)
 
         # Copies should match
-        self.assertTablesEqual("SEED", "incremental_copy")
-        self.assertTablesEqual("SEED", "materialized_copy")
-        self.assertTablesEqual("SEED", "view_copy")
-
-        # Summaries should match
-        self.assertTablesEqual("SUMMARY_EXPECTED", "incremental_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "materialized_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "view_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "ephemeral_summary")
+        self.assertManyTablesEqual(
+            ["SEED", "incremental_copy", "materialized_copy", "view_copy"],
+            ["SUMMARY_EXPECTED", "incremental_summary", "materialized_summary", "view_summary", "ephemeral_summary"]
+        )
 
         self.run_sql_file(
             "test/integration/003_simple_reference_test/update.sql")
@@ -78,16 +73,10 @@ class TestSimpleReference(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  7)
 
-        # Copies should match
-        self.assertTablesEqual("SEED", "incremental_copy")
-        self.assertTablesEqual("SEED", "materialized_copy")
-        self.assertTablesEqual("SEED", "view_copy")
-
-        # Summaries should match
-        self.assertTablesEqual("SUMMARY_EXPECTED", "incremental_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "materialized_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "view_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "ephemeral_summary")
+        self.assertManyTablesEqual(
+            ["SEED", "incremental_copy", "materialized_copy", "view_copy"],
+            ["SUMMARY_EXPECTED", "incremental_summary", "materialized_summary", "view_summary", "ephemeral_summary"]
+        )
 
     @attr(type='postgres')
     def test__postgres__simple_reference_with_models(self):
@@ -181,11 +170,10 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertEqual(len(results),  3)
 
         # Copies should match
-        self.assertTablesEqual("SEED", "materialized_copy")
-
-        # Summaries should match
-        self.assertTablesEqual("SUMMARY_EXPECTED", "materialized_summary")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "ephemeral_summary")
+        self.assertManyTablesEqual(
+            ["SEED", "materialized_copy"],
+            ["SUMMARY_EXPECTED", "materialized_summary", "ephemeral_summary"]
+        )
 
         created_models = self.get_models_in_schema()
 

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -66,8 +66,10 @@ class TestGraphSelection(DBTIntegrationTest):
         results = self.run_dbt(['run', '--models', 'users+'])
         self.assertEqual(len(results),  2)
 
-        self.assertTablesEqual("SEED", "users")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "users_rollup")
+        self.assertManyTablesEqual(
+            ["SEED", "users"],
+            ["SUMMARY_EXPECTED", "users_rollup"]
+        )
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('emails' in created_models)
@@ -97,8 +99,11 @@ class TestGraphSelection(DBTIntegrationTest):
         results = self.run_dbt(['run', '--models', '+users_rollup'])
         self.assertEqual(len(results),  2)
 
-        self.assertTablesEqual("SEED", "users")
-        self.assertTablesEqual("SUMMARY_EXPECTED", "users_rollup")
+        self.assertManyTablesEqual(
+            ["SEED", "users"],
+            ["SUMMARY_EXPECTED", "users_rollup"]
+        )
+
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('emails' in created_models)
@@ -132,7 +137,7 @@ class TestGraphSelection(DBTIntegrationTest):
         )
         self.assertEqual(len(results),  1)
 
-        self.assertTablesEqual("SEED", "users")
+        self.assertManyTablesEqual(["SEED", "users"])
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('users_rollup' in created_models)

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -36,5 +36,4 @@ class TestEphemeral(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results), 2)
 
-        self.assertTablesEqual("SEED", "dependent")
-        self.assertTablesEqual("SEED", "double_dependent")
+        self.assertManyTablesEqual(["SEED", "dependent", "double_dependent"])

--- a/test/integration/021_concurrency_test/test_concurrency.py
+++ b/test/integration/021_concurrency_test/test_concurrency.py
@@ -52,17 +52,11 @@ class TestConcurrency(DBTIntegrationTest):
         results = self.run_dbt(expect_pass=False)
         self.assertEqual(len(results), 7)
 
-        self.assertTablesEqual("SEED", "view_model")
-        self.assertTablesEqual("SEED", "dep")
-        self.assertTablesEqual("SEED", "table_a")
-        self.assertTablesEqual("SEED", "table_b")
+        self.assertManyTablesEqual(["SEED", "view_model", "dep", "table_a", "table_b"])
 
         self.run_sql_file("test/integration/021_concurrency_test/update.sql")
 
         results = self.run_dbt(expect_pass=False)
         self.assertEqual(len(results), 7)
 
-        self.assertTablesEqual("SEED", "view_model")
-        self.assertTablesEqual("SEED", "dep")
-        self.assertTablesEqual("SEED", "table_a")
-        self.assertTablesEqual("SEED", "table_b")
+        self.assertManyTablesEqual(["SEED", "view_model", "dep", "table_a", "table_b"])

--- a/test/integration/030_statement_test/test_statements.py
+++ b/test/integration/030_statement_test/test_statements.py
@@ -38,7 +38,7 @@ class TestStatements(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results), 1)
 
-        self.assertTablesEqual("statement_actual","statement_expected")
+        self.assertManyTablesEqual(["statement_actual", "statement_expected"])
 
     @attr(type="bigquery")
     def test_bigquery_statements(self):

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -405,6 +405,25 @@ class DBTIntegrationTest(unittest.TestCase):
                 print(e)
                 raise e
 
+    def get_many_table_columns(self, tables, schema):
+        sql = """
+                select table_name, column_name, data_type, character_maximum_length
+                from information_schema.columns
+                where table_schema ilike '{schema_filter}'
+                  and ({table_filter})
+                order by column_name asc"""
+
+
+        table_filters = ["table_name ilike '{}'".format(table.replace('"', '')) for table in tables]
+        table_filters_s = " OR ".join(table_filters)
+
+        sql = sql.format(
+                schema_filter=schema,
+                table_filter=table_filters_s)
+
+        columns = self.run_sql(sql, fetch='all')
+        return sorted(columns, key=lambda x: "{}.{}".format(x[0], x[1]))
+
     def get_table_columns(self, table, schema=None):
         schema = self.unique_schema() if schema is None else schema
         columns = self.adapter.get_columns_in_table(
@@ -415,6 +434,17 @@ class DBTIntegrationTest(unittest.TestCase):
         )
         return sorted(((c.name, c.dtype, c.char_size) for c in columns),
                       key=lambda x: x[0])
+
+    def get_table_columns_as_dict(self, tables, schema=None):
+        col_matrix = self.get_many_table_columns(tables, schema)
+        res = {}
+        for row in col_matrix:
+            table_name = row[0]
+            col_def = row[1:]
+            if table_name not in res:
+                res[table_name] = []
+            res[table_name].append(col_def)
+        return res
 
     def get_models_in_schema(self, schema=None):
         schema = self.unique_schema() if schema is None else schema
@@ -433,8 +463,9 @@ class DBTIntegrationTest(unittest.TestCase):
 
         return {model_name: materialization for (model_name, materialization) in result}
 
-    def _assertTablesEqualSql(self, table_a_schema, table_a, table_b_schema, table_b):
-        columns = self.get_table_columns(table_a, table_a_schema)
+    def _assertTablesEqualSql(self, table_a_schema, table_a, table_b_schema, table_b, columns=None):
+        if columns is None:
+            columns = self.get_table_columns(table_a, table_a_schema)
 
         if self.adapter_type == 'snowflake':
             columns_csv = ", ".join(['"{}"'.format(record[0]) for record in columns])
@@ -487,6 +518,39 @@ class DBTIntegrationTest(unittest.TestCase):
             sql
         )
 
+    def assertManyTablesEqual(self, *args):
+        schema = self.unique_schema()
+
+        all_tables = []
+        for table_equivalencies in args:
+            all_tables += list(table_equivalencies)
+
+        all_cols = self.get_table_columns_as_dict(all_tables, schema)
+
+        for table_equivalencies in args:
+            first_table = table_equivalencies[0]
+            base_result = all_cols[first_table]
+
+            for other_table in table_equivalencies[1:]:
+                other_result = all_cols[other_table]
+
+                self.assertEquals(base_result, other_result)
+
+                self.assertTableRowCountsEqual(first_table, other_table)
+                sql = self._assertTablesEqualSql(schema, first_table,
+                                                 schema, other_table,
+                                                 columns=base_result)
+                result = self.run_sql(sql, fetch='one')
+
+                self.assertEquals(
+                    result[0],
+                    0,
+                    sql
+                )
+
+                self.assertTrue(len(base_result) > 0)
+                self.assertTrue(len(other_result) > 0)
+
     def assertTableRowCountsEqual(self, table_a, table_b,
                                   table_a_schema=None, table_b_schema=None):
         table_a_schema = self.unique_schema() \
@@ -495,23 +559,32 @@ class DBTIntegrationTest(unittest.TestCase):
         table_b_schema = self.unique_schema() \
                          if table_b_schema is None else table_b_schema
 
-        table_a_result = self.run_sql(
-            'SELECT COUNT(*) FROM {}.{}'
-            .format(self.adapter.quote(table_a_schema),
-                    self.adapter.quote(table_a)), fetch='one')
-        table_b_result = self.run_sql(
-            'SELECT COUNT(*) FROM {}.{}'
-            .format(self.adapter.quote(table_b_schema),
-                    self.adapter.quote(table_b)), fetch='one')
+        cmp_query = """
+            with table_a as (
 
-        self.assertEquals(
-            table_a_result[0],
-            table_b_result[0],
-            "Row count of table {} ({}) doesn't match row count of table {} ({})".format(
+                select count(*) as num_rows from {}.{}
+
+            ), table_b as (
+
+                select count(*) as num_rows from {}.{}
+
+            )
+
+            select table_a.num_rows - table_b.num_rows as difference
+            from table_a, table_b
+
+        """.format(self.adapter.quote(table_a_schema),
+                   self.adapter.quote(table_a),
+                   self.adapter.quote(table_b_schema),
+                   self.adapter.quote(table_b))
+
+
+        res = self.run_sql(cmp_query, fetch='one')
+
+        self.assertEquals(int(res[0]), 0, "Row count of table {} doesn't match row count of table {}. ({} rows different)".format(
                 table_a,
-                table_a_result[0],
                 table_b,
-                table_b_result[0]
+                res[0]
             )
         )
 


### PR DESCRIPTION
This PR knocks about 15-20 minutes off of the Snowflake integration test runtime! The key change here was caching column definitions for consecutive tests. Previously, a call to `assertTablesEqual(table_a, table_b)` would:

1. query for columns in table_a (via assertTableColumnsEqual)
2. query for columns in table_b (via assertTableColumnsEqual)
3. query for columns in table_a again (via _assertTablesEqualSql)

Now, the columns for table_a and table_b are fetched in a single query, then passed around within the scope of the function. Moreover, the tests previously featured code like this:

```
self.assertTablesEqual('seed', 'example_1')
self.assertTablesEqual('seed', 'example_2')
self.assertTablesEqual('seed', 'example_3')
```

This code previously required 3 queries per test, or 9 queries total. Now, these tests can be combined into:

```
self.assertManyTablesEqual({
  'seed': [
    'example_1',
    'example_2',
    'example_3'
  ]
})
```

Here, all four sets of column definitions are grabbed in a single query. That means that one query runs instead of nine!