### PR TITLE
Rewrite relationships schema test for improved performance

### DIFF
--- a/dbt/include/global_project/macros/schema_tests/relationships.sql
+++ b/dbt/include/global_project/macros/schema_tests/relationships.sql
@@ -1,17 +1,16 @@
 
 {% macro test_relationships(model, field, to, from) %}
 
-
 select count(*)
 from (
 
-    select
-        {{ from }} as id
-
-    from {{ model }}
-    where {{ from }} is not null
-      and {{ from }} not in (select {{ field }}
-                             from {{ to }})
+    select distinct
+        m.{{ from }} as id
+    from {{ model }} m
+    left join {{ to }} t on t.{{ field }} = m.{{ from }}
+    where
+       m.{{ from }} is not null and
+       t.{{ field }} is null
 
 ) validation_errors
 


### PR DESCRIPTION
- Replace WHERE foo NOT IN subquery with LEFT JOIN 
- Use SELECT DISTINCT to avoid double counting if relationships test is applied on fields with non-unique values