### PR TITLE
Fix for archival on Redshift (add tests) and maxLength for schema tests

### DIFF
--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -73,7 +73,6 @@ PARSED_NODE_CONTRACT = deep_merge(
             'unique_id': {
                 'type': 'string',
                 'minLength': 1,
-                'maxLength': 255,
             },
             'fqn': {
                 'type': 'array',
@@ -115,7 +114,6 @@ PARSED_NODE_CONTRACT = deep_merge(
                         'items': {
                             'type': 'string',
                             'minLength': 1,
-                            'maxLength': 255,
                             'description': (
                                 'A node unique ID that this depends on.'
                             )
@@ -126,7 +124,6 @@ PARSED_NODE_CONTRACT = deep_merge(
                         'items': {
                             'type': 'string',
                             'minLength': 1,
-                            'maxLength': 255,
                             'description': (
                                 'A macro unique ID that this depends on.'
                             )

--- a/dbt/contracts/graph/unparsed.py
+++ b/dbt/contracts/graph/unparsed.py
@@ -56,7 +56,6 @@ UNPARSED_NODE_CONTRACT = deep_merge(
                     'Name of this node. For models, this is used as the '
                     'identifier in the database.'),
                 'minLength': 1,
-                'maxLength': 127,
             },
             'resource_type': {
                 'enum': [

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -73,6 +73,24 @@ class TestSimpleArchive(DBTIntegrationTest):
 
         self.assertTablesEqual("ARCHIVE_EXPECTED", "archive_actual")
 
+    @attr(type='redshift')
+    def test__redshift__simple_archive(self):
+        self.use_profile('redshift')
+        self.use_default_project()
+        self.run_sql_file("test/integration/004_simple_archive_test/seed.sql")
+
+        results = self.run_dbt(["archive"])
+        self.assertEqual(len(results),  1)
+
+        self.assertTablesEqual("archive_expected","archive_actual")
+
+        self.run_sql_file("test/integration/004_simple_archive_test/invalidate_postgres.sql")
+        self.run_sql_file("test/integration/004_simple_archive_test/update.sql")
+
+        results = self.run_dbt(["archive"])
+        self.assertEqual(len(results),  1)
+
+        self.assertTablesEqual("archive_expected","archive_actual")
 
 class TestSimpleArchiveBigquery(DBTIntegrationTest):
 

--- a/test/integration/008_schema_tests_test/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models/schema.yml
@@ -12,8 +12,19 @@ table_copy:
             - email
 
         accepted_values:
-            - { field: favorite_color, values: ['blue', 'green'] }
+            - field: favorite_color
+              values:
+                  - 'blue'
+                  - 'green'
 
+                  # Include extra (long) options here to ensure that dbt does
+                  # not fail on parsing of really long model names or unique ids
+                  - 'other_long_option_long_option_long_option_1'
+                  - 'other_long_option_long_option_long_option_2'
+                  - 'other_long_option_long_option_long_option_3'
+                  - 'other_long_option_long_option_long_option_4'
+                  - 'other_long_option_long_option_long_option_5'
+                  - 'other_long_option_long_option_long_option_6'
 
 
 table_summary:


### PR DESCRIPTION
Fixes bugs found in the testing of 0.10.2-a2

BQ and Redshift/Postgres/Snowflake have differing `update` statement semantics. I tried to find a SQL statement that would be cross-db compatible to no avail. Redshift/PG does not permit a projection of the destination table name, but BigQuery effectively requires it.

Additionally, we found a bug that added an artificial maxLength for node names and unique_ids. I removed this limit.