### PR TITLE
Add generated dates (#864)

### DIFF
--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -242,6 +242,23 @@ PARSED_MACROS_CONTRACT = {
     },
 }
 
+
+NODE_EDGE_MAP = {
+    'type': 'object',
+    'additionalProperties': False,
+    'description': 'A map of node relationships',
+    'patternProperties': {
+        '.*': {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+                'description': 'A node name',
+            }
+        }
+    }
+}
+
+
 PARSED_MANIFEST_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,
@@ -253,8 +270,11 @@ PARSED_MANIFEST_CONTRACT = {
         'nodes': PARSED_NODES_CONTRACT,
         'macros': PARSED_MACROS_CONTRACT,
         'generated_at': {
-            'type': 'date-time'
-        }
+            'type': 'string',
+            'format': 'date-time',
+        },
+        'parent_map': NODE_EDGE_MAP,
+        'child_map': NODE_EDGE_MAP,
     },
     'required': ['nodes', 'macros'],
 }
@@ -334,7 +354,8 @@ def build_edges(nodes):
     return forward_edges, backward_edges
 
 
-class ParsedManifest(object):
+class ParsedManifest(APIObject):
+    SCHEMA = PARSED_MANIFEST_CONTRACT
     """The final result of parsing all macros and nodes in a graph."""
     def __init__(self, nodes, macros, generated_at):
         """The constructor. nodes and macros are dictionaries mapping unique
@@ -344,6 +365,8 @@ class ParsedManifest(object):
         self.nodes = nodes
         self.macros = macros
         self.generated_at = generated_at
+        self._contents = {}
+        super(ParsedManifest, self).__init__()
 
     def serialize(self):
         """Convert the parsed manifest to a nested dict structure that we can

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -336,15 +336,13 @@ def build_edges(nodes):
 
 class ParsedManifest(object):
     """The final result of parsing all macros and nodes in a graph."""
-    def __init__(self, nodes, macros, generated_at=None):
+    def __init__(self, nodes, macros, generated_at):
         """The constructor. nodes and macros are dictionaries mapping unique
         IDs to ParsedNode and ParsedMacro objects, respectively. generated_at
         is a text timestamp in RFC 3339 format.
         """
         self.nodes = nodes
         self.macros = macros
-        if generated_at is None:
-            generated_at = timestring()
         self.generated_at = generated_at
 
     def serialize(self):

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -2,6 +2,7 @@ import dbt.exceptions
 
 from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import ParsedManifest
+from dbt.utils import timestring
 
 import dbt.parser
 
@@ -18,7 +19,8 @@ class GraphLoader(object):
         for loader in cls._LOADERS:
             nodes.update(loader.load_all(root_project, all_projects, macros))
 
-        manifest = ParsedManifest(nodes=nodes, macros=macros)
+        manifest = ParsedManifest(nodes=nodes, macros=macros,
+                                  generated_at=timestring())
         manifest = dbt.parser.ParserUtils.process_refs(manifest, root_project)
         return manifest
 

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from dbt.contracts.graph.parsed import ParsedManifest, ParsedNode, ParsedMacro
 from dbt.adapters.factory import get_adapter
 from dbt.clients.system import write_file
 from dbt.compat import bigint

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -115,6 +115,7 @@ class GenerateTask(BaseTask):
             for row in results
         ]
         results = unflatten(results)
+        results['generated_at'] = dbt.utils.timestring()
 
         path = os.path.join(self.project['target-path'], CATALOG_FILENAME)
         write_file(path, json.dumps(results))

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 import hashlib
 import itertools
@@ -460,3 +461,9 @@ def filter_null_values(input):
 
 def add_ephemeral_model_prefix(s):
     return '__dbt__CTE__{}'.format(s)
+
+
+def timestring():
+    """Get the current datetime as an RFC 3339-compliant string"""
+    # isoformat doesn't include the mandatory trailing 'Z' for UTC.
+    return datetime.utcnow().isoformat() + 'Z'

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -321,7 +321,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             {
                 'name': 'id',
                 'index': 1,
-                'type': 'INTEGER',
+                'type': 'INT64',
                 'comment': None,
             },
             {
@@ -384,31 +384,31 @@ class TestDocsGenerate(DBTIntegrationTest):
             {
                 "name": "field_1",
                 "index": 1,
-                "type": "INTEGER",
+                "type": "INT64",
                 "comment": None
             },
             {
                 "name": "field_2",
                 "index": 2,
-                "type": "INTEGER",
+                "type": "INT64",
                 "comment": None
             },
             {
                 "name": "field_3",
                 "index": 3,
-                "type": "INTEGER",
+                "type": "INT64",
                 "comment": None
             },
             {
                 "name": "nested_field.field_4",
                 "index": 4,
-                "type": "INTEGER",
+                "type": "INT64",
                 "comment": None
             },
             {
                 "name": "nested_field.field_5",
                 "index": 5,
-                "type": "INTEGER",
+                "type": "INT64",
                 "comment": None
             }
         ]

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -3,6 +3,8 @@ import os
 
 from test.integration.base import DBTIntegrationTest, use_profile
 
+from freezegun import freeze_time
+
 
 class TestDocsGenerate(DBTIntegrationTest):
     def setUp(self):
@@ -51,6 +53,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         my_schema_name = self.unique_schema()
         self.assertIn(my_schema_name, catalog)
+        self.assertEqual(catalog['generated_at'], '2017-08-16T10:11:12Z')
         my_schema = catalog[my_schema_name]
         self.assertEqual(expected, my_schema)
 
@@ -152,6 +155,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.model': [],
                 'seed.test.seed': ['model.test.model'],
             },
+            'generated_at': '2017-08-16T10:11:12Z',
         }
 
     def verify_manifest(self, expected_manifest):
@@ -162,7 +166,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         self.assertEqual(
             set(manifest),
-            {'nodes', 'macros', 'parent_map', 'child_map'}
+            {'nodes', 'macros', 'parent_map', 'child_map', 'generated_at'}
         )
 
         self.verify_manifest_macros(manifest)
@@ -172,6 +176,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.assertEqual(manifest_without_macros, expected_manifest)
 
     @use_profile('postgres')
+    @freeze_time('2017-08-16T10:11:12Z')
     def test__postgres__run_and_generate(self):
         self.run_and_generate()
         my_schema_name = self.unique_schema()
@@ -231,6 +236,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.verify_manifest(self.expected_seeded_manifest())
 
     @use_profile('snowflake')
+    @freeze_time('2017-08-16T10:11:12Z')
     def test__snowflake__run_and_generate(self):
         self.run_and_generate()
         my_schema_name = self.unique_schema()
@@ -291,6 +297,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.verify_manifest(self.expected_seeded_manifest())
 
     @use_profile('bigquery')
+    @freeze_time('2017-08-16T10:11:12Z')
     def test__bigquery__run_and_generate(self):
         self.run_and_generate()
         my_schema_name = self.unique_schema()
@@ -350,6 +357,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.verify_manifest(self.expected_seeded_manifest())
 
     @use_profile('bigquery')
+    @freeze_time('2017-08-16T10:11:12Z')
     def test__bigquery__nested_models(self):
         self.use_default_project({'source-paths': [self.dir('bq_models')]})
 
@@ -481,6 +489,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.model': ['model.test.seed'],
                 'model.test.seed': []
             },
+            'generated_at': '2017-08-16T10:11:12Z',
         }
         self.verify_manifest(expected_manifest)
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -58,7 +58,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             yesterday, parsed,
             'parsed date {} happened over 24h ago'.format(parsed)
         )
-        self.assertGreater(
+        self.assertGreaterEqual(
             now, parsed,
             'parsed date {} happened in the future'.format(parsed)
         )

--- a/test/integration/034_redshift_test/test_late_binding_view.py
+++ b/test/integration/034_redshift_test/test_late_binding_view.py
@@ -1,0 +1,21 @@
+import json
+import os
+
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+
+
+class TestLateBindingView(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return 'late_binding_view_033'
+
+    @staticmethod
+    def dir(path):
+        return os.path.normpath(
+            os.path.join('test/integration/033_redshift_test', path)
+        )
+
+    @property
+    def models(self):
+        return self.dir("models")

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -5,6 +5,8 @@ import os
 
 import dbt.flags
 from dbt.contracts.graph.parsed import ParsedNode, ParsedManifest
+from dbt.utils import timestring
+import freezegun
 
 class ManifestTest(unittest.TestCase):
     def setUp(self):
@@ -151,17 +153,21 @@ class ManifestTest(unittest.TestCase):
             ),
         }
 
+    @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test__no_nodes(self):
         manifest = ParsedManifest(nodes={}, macros={})
         self.assertEqual(
             manifest.serialize(),
-            {'nodes': {}, 'macros': {}, 'parent_map': {}, 'child_map': {}}
+            {'nodes': {}, 'macros': {}, 'parent_map': {}, 'child_map': {},
+             'generated_at': '2018-02-14T09:15:13Z'}
         )
 
+    @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test__nested_nodes(self):
         nodes = copy.copy(self.nested_nodes)
         manifest = ParsedManifest(nodes=nodes, macros={})
         serialized = manifest.serialize()
+        self.assertEqual(serialized['generated_at'], '2018-02-14T09:15:13Z')
         parent_map = serialized['parent_map']
         child_map = serialized['child_map']
         # make sure there aren't any extra/missing keys.

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -155,7 +155,8 @@ class ManifestTest(unittest.TestCase):
 
     @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test__no_nodes(self):
-        manifest = ParsedManifest(nodes={}, macros={})
+        manifest = ParsedManifest(nodes={}, macros={},
+                                  generated_at=timestring())
         self.assertEqual(
             manifest.serialize(),
             {'nodes': {}, 'macros': {}, 'parent_map': {}, 'child_map': {},
@@ -165,7 +166,8 @@ class ManifestTest(unittest.TestCase):
     @freezegun.freeze_time('2018-02-14T09:15:13Z')
     def test__nested_nodes(self):
         nodes = copy.copy(self.nested_nodes)
-        manifest = ParsedManifest(nodes=nodes, macros={})
+        manifest = ParsedManifest(nodes=nodes, macros={},
+                                  generated_at=timestring())
         serialized = manifest.serialize()
         self.assertEqual(serialized['generated_at'], '2018-02-14T09:15:13Z')
         parent_map = serialized['parent_map']
@@ -226,7 +228,8 @@ class ManifestTest(unittest.TestCase):
 
     def test__to_flat_graph(self):
         nodes = copy.copy(self.nested_nodes)
-        manifest = ParsedManifest(nodes=nodes, macros={})
+        manifest = ParsedManifest(nodes=nodes, macros={},
+                                  generated_at=timestring())
         flat_graph = manifest.to_flat_graph()
         flat_nodes = flat_graph['nodes']
         self.assertEqual(set(flat_graph), set(['nodes', 'macros']))

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -4,6 +4,7 @@ import os
 
 import dbt.flags
 from dbt.parser import ModelParser, MacroParser, DataTestParser, SchemaParser, ParserUtils
+from dbt.utils import timestring
 
 from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import ParsedManifest, ParsedNode, ParsedMacro
@@ -702,6 +703,7 @@ class ParserTest(unittest.TestCase):
         manifest = ParsedManifest(
             nodes={k: ParsedNode(**v) for (k,v) in graph['nodes'].items()},
             macros={k: ParsedMacro(**v) for (k,v) in graph['macros'].items()},
+            generated_at=timestring(),
         )
 
         processed_manifest = ParserUtils.process_refs(manifest, 'root')


### PR DESCRIPTION
Add a field named `generated_at` to the root of the catalog and the manifest, which contains an RFC3339-formatted timestamp.