### PR TITLE
put "this" var back into operation context

### DIFF
--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -409,11 +409,16 @@ def generate(model, project_cfg, flat_graph, provider=None):
 
     # Operations do not represent database relations, so there should be no
     # 'this' variable in the context for operations. The Operation branch
-    # below should be removed in a future release.
+    # below should be removed in a future release. The fake relation below
+    # mirrors the historical implementation, without causing errors around
+    # the missing 'alias' attribute for operations
     #
     # https://github.com/fishtown-analytics/dbt/issues/878
     if model.get('resource_type') == NodeType.Operation:
-        this = db_wrapper.adapter.Relation.create_from_node(profile, model)
+        this = db_wrapper.adapter.Relation.create(
+                schema=target['schema'],
+                identifier=model['name']
+        )
     else:
         this = get_this_relation(db_wrapper, project_cfg, profile, model)
 

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -407,10 +407,17 @@ def generate(model, project_cfg, flat_graph, provider=None):
         "try_or_compiler_error": try_or_compiler_error(model)
     })
 
-    # Operations do not represent database relations, so 'this' does not apply
-    if model.get('resource_type') != NodeType.Operation:
-        context["this"] = get_this_relation(db_wrapper, project_cfg, profile,
-                                            model)
+    # Operations do not represent database relations, so there should be no
+    # 'this' variable in the context for operations. The Operation branch
+    # below should be removed in a future release.
+    #
+    # https://github.com/fishtown-analytics/dbt/issues/878
+    if model.get('resource_type') == NodeType.Operation:
+        this = db_wrapper.adapter.Relation.create_from_node(profile, model)
+    else:
+        this = get_this_relation(db_wrapper, project_cfg, profile, model)
+
+    context["this"] = this
 
     context = _add_tracking(context)
     context = _add_validation(context)


### PR DESCRIPTION
We had removed this context variable for operations in 0.10.2, but this represents a breaking change to the context. We _should_ remove `this` eventually, but we should do it in a minor release.