### PR TITLE
handle view <--> table materialization changes

### DIFF
--- a/dbt/include/global_project/macros/materializations/view/view.sql
+++ b/dbt/include/global_project/macros/materializations/view/view.sql
@@ -12,8 +12,22 @@
                                                 type='view') -%}
   {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,
                                                       schema=schema, type='view') -%}
+
+  /*
+     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from
+     a previous run, and we're going to try to drop it immediately. At the end of this
+     materialization, we're going to rename the "old_relation" to this identifier,
+     and then we're going to drop it. In order to make sure we run the correct one of:
+       - drop view ...
+       - drop table ...
+
+     We need to set the type of this relation to be the type of the old_relation, if it exists,
+     or else "view" as a sane default if it does not. Note that if the old_relation does not
+     exist, then there is nothing to move out of the way and subsequentally drop. In that case,
+     this relation will be effectively unused.
+  */
   {%- set backup_relation = api.Relation.create(identifier=backup_identifier,
-                                                schema=schema, type='view') -%}
+                                                schema=schema, type=(old_relation.type or 'view')) -%}
 
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
@@ -52,7 +66,7 @@
   -- cleanup
   {% if not should_ignore -%}
     -- move the existing view out of the way
-    {% if exists_as_view %}
+    {% if old_relation is not none %}
       {{ adapter.rename_relation(target_relation, backup_relation) }}
     {% endif %}
     {{ adapter.rename_relation(intermediate_relation, target_relation) }}
@@ -64,7 +78,10 @@
   #}
   {% if has_transactional_hooks or not should_ignore %}
       {{ adapter.commit() }}
-      {{ drop_relation_if_exists(backup_relation) }}
+  {% endif %}
+
+  {% if not should_ignore %}
+    {{ drop_relation_if_exists(backup_relation) }}
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}

--- a/test/integration/035_changing_relation_type_test/models/model.sql
+++ b/test/integration/035_changing_relation_type_test/models/model.sql
@@ -1,0 +1,5 @@
+
+
+{{ config(materialized=var('materialized'), sql_where='TRUE') }}
+
+select '{{ var("materialized") }}' as materialization

--- a/test/integration/035_changing_relation_type_test/test_changing_relation_type.py
+++ b/test/integration/035_changing_relation_type_test/test_changing_relation_type.py
@@ -1,0 +1,84 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+
+
+class TestChangingRelationType(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "changing_relation_type_035"
+
+    @staticmethod
+    def dir(path):
+        return "test/integration/035_changing_relation_type_test/" + path.lstrip("/")
+
+    @property
+    def models(self):
+        return self.dir("models")
+
+    def swap_types_and_test(self):
+        # test that dbt is able to do intelligent things when changing
+        # between materializations that create tables and views.
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view'])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: table'])
+        self.assertEquals(results[0].node['config']['materialized'], 'table')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view'])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: incremental'])
+        self.assertEquals(results[0].node['config']['materialized'], 'incremental')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view'])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)
+
+    @attr(type="postgres")
+    def test__postgres__switch_materialization(self):
+        self.use_profile("postgres")
+        self.swap_types_and_test()
+
+    @attr(type="snowflake")
+    def test__snowflake__switch_materialization(self):
+        self.use_profile("snowflake")
+        self.swap_types_and_test()
+
+    @attr(type="redshift")
+    def test__redshift__switch_materialization(self):
+        self.use_profile("redshift")
+        self.swap_types_and_test()
+
+    @attr(type="bigquery")
+    def test__bigquery__switch_materialization(self):
+        # BQ has a weird check that prevents the dropping of tables in the view materialization
+        # if --full-refresh is not provided. This is to prevent the clobbering of a date-sharded
+        # table with a view if a model config is accidently changed. We should probably remove that check
+        # and then remove these bq-specific tests
+        self.use_profile("bigquery")
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view'])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: table'])
+        self.assertEquals(results[0].node['config']['materialized'], 'table')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view', "--full-refresh"])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: incremental'])
+        self.assertEquals(results[0].node['config']['materialized'], 'incremental')
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(['run', '--vars', 'materialized: view', "--full-refresh"])
+        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(len(results),  1)


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/891 by loosening the conditional logic checks for existing models.

Previously, dbt failed to handle the case where the model relation already existed if it was of a different type than the one that was expected. This PR changes this behavior, such that an existing relation of an unexpected type will still be handled appropriately by the materialization code.