### PR TITLE
Show more helpful error for misconfigured profile

### DIFF
--- a/dbt/project.py
+++ b/dbt/project.py
@@ -152,7 +152,8 @@ class Project(object):
 
     def compile_and_update_target(self):
         target = self.cfg['target']
-        self.cfg['outputs'][target].update(self.run_environment())
+        run_env = self.run_environment()
+        self.cfg['outputs'][target].update(run_env)
 
     def run_environment(self):
         target_name = self.cfg['target']
@@ -160,9 +161,17 @@ class Project(object):
             target_cfg = self.cfg['outputs'][target_name]
             return self.compile_target(target_cfg)
         else:
-            raise DbtProfileError(
-                    "'target' config was not found in profile entry for "
-                    "'{}'".format(target_name), self)
+
+            outputs = self.cfg.get('outputs', {}).keys()
+            output_names = [" - {}".format(output) for output in outputs]
+
+            msg = ("The profile '{}' does not have a target named '{}'. The "
+                   "valid target names for this profile are:\n{}".format(
+                        self.profile_to_load,
+                        target_name,
+                        "\n".join(output_names)))
+
+            raise DbtProfileError(msg, self)
 
     def get_target(self):
         ctx = self.context().get('env').copy()


### PR DESCRIPTION
dbt would previously fail hard with a key error and a cryptic message. Now it shows something like this:

```
$ dbt compile
Encountered an error while reading profiles:
  ERROR The profile 'default' does not have a target named 'invalid-target'. The valid target names for this profile are:
 - dev
 - nopass
 - bq
Encountered an error:
Could not run dbt
```

The key change here involves calling the `run_environment()` function, which checks for the existence of the `target` in the `outputs` dict, on the line before the target is accessed. Previously, Python was hitting the key error before the function was called, leading to a more cryptic error than desired. Additionally, the error message has been expanded to be more helpful.

Fixes #890.