### PR TITLE
Write run results to disk (#829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add a 'generated_at' field to both the manifest and the catalog. ([#887](https://github.com/fishtown-analytics/dbt/pull/877))
 - Version 2 of schema.yml, which allows users to create table and column comments that end up in the manifest ([#880](https://github.com/fishtown-analytics/dbt/pull/880))
 - Add `docs` blocks that users can put into `.md` files and `doc()` value for schema v2 description fields ([#888](https://github.com/fishtown-analytics/dbt/pull/888))
+- Write out a 'run_results.json' after dbt invocations. ([#904](https://github.com/fishtown-analytics/dbt/pull/904))
 
 ## dbt 0.10.2 - Betsy Ross (August 3, 2018)
 

--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -117,6 +117,12 @@ def write_file(path, contents=''):
     return True
 
 
+def write_json(path, data):
+    make_directory(os.path.dirname(path))
+    dbt.compat.write_json(path, data)
+    return True
+
+
 def _windows_rmdir_readonly(func, path, exc):
     exception_val = exc[1]
     if exception_val.errno == errno.EACCES:

--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -1,5 +1,6 @@
 import errno
 import fnmatch
+import json
 import os
 import os.path
 import shutil
@@ -119,9 +120,7 @@ def write_file(path, contents=''):
 
 
 def write_json(path, data):
-    make_directory(os.path.dirname(path))
-    dbt.compat.write_json(path, data, cls=dbt.utils.JSONEncoder)
-    return True
+    return write_file(path, json.dumps(data, cls=dbt.utils.JSONEncoder))
 
 
 def _windows_rmdir_readonly(func, path, exc):

--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -11,6 +11,7 @@ import stat
 
 import dbt.compat
 import dbt.exceptions
+import dbt.utils
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -119,7 +120,7 @@ def write_file(path, contents=''):
 
 def write_json(path, data):
     make_directory(os.path.dirname(path))
-    dbt.compat.write_json(path, data)
+    dbt.compat.write_json(path, data, cls=dbt.utils.JSONEncoder)
     return True
 
 

--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -1,4 +1,5 @@
 import codecs
+import json
 
 WHICH_PYTHON = None
 
@@ -43,10 +44,18 @@ def to_string(s):
             return str(s)
 
 
-def write_file(path, s):
+def _open(path, mode):
     if WHICH_PYTHON == 2:
-        with codecs.open(path, 'w', encoding='utf-8') as f:
-            return f.write(to_string(s))
+        return codecs.open(path, mode, encoding='utf-8')
     else:
-        with open(path, 'w') as f:
-            return f.write(to_string(s))
+        return open(path, 'w')
+
+
+def write_file(path, s):
+    with _open(path, 'w') as fp:
+        return fp.write(to_string(s))
+
+
+def write_json(path, data):
+    with _open(path, 'w') as fp:
+        json.dump(data, fp)

--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -56,6 +56,6 @@ def write_file(path, s):
         return fp.write(to_string(s))
 
 
-def write_json(path, data):
+def write_json(path, data, **kwargs):
     with _open(path, 'w') as fp:
-        json.dump(data, fp)
+        json.dump(data, fp, **kwargs)

--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -44,18 +44,10 @@ def to_string(s):
             return str(s)
 
 
-def _open(path, mode):
-    if WHICH_PYTHON == 2:
-        return codecs.open(path, mode, encoding='utf-8')
-    else:
-        return open(path, 'w')
-
-
 def write_file(path, s):
-    with _open(path, 'w') as fp:
-        return fp.write(to_string(s))
-
-
-def write_json(path, data, **kwargs):
-    with _open(path, 'w') as fp:
-        json.dump(data, fp, **kwargs)
+    if WHICH_PYTHON == 2:
+        with codecs.open(path, 'w', encoding='utf-8') as f:
+            return f.write(to_string(s))
+    else:
+        with open(path, 'w') as f:
+            return f.write(to_string(s))

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -21,7 +21,7 @@ import dbt.flags
 import dbt.loader
 from dbt.contracts.graph.compiled import CompiledNode, CompiledGraph
 
-from dbt.clients.system import write_file
+from dbt.clients.system import write_json
 from dbt.logger import GLOBAL_LOGGER as logger
 
 graph_file_name = 'graph.gpickle'
@@ -90,13 +90,6 @@ class Compiler(object):
         dbt.clients.system.make_directory(self.project['target-path'])
         dbt.clients.system.make_directory(self.project['modules-path'])
 
-    def __write(self, build_filepath, payload):
-        target_path = os.path.join(self.project['target-path'], build_filepath)
-
-        write_file(target_path, payload)
-
-        return target_path
-
     def compile_node(self, node, manifest):
         logger.debug("Compiling {}".format(node.get('unique_id')))
 
@@ -157,7 +150,7 @@ class Compiler(object):
         """
         filename = manifest_file_name
         manifest_path = os.path.join(self.project['target-path'], filename)
-        write_file(manifest_path, json.dumps(manifest.serialize()))
+        write_json(manifest_path, manifest.serialize())
 
     def write_graph_file(self, linker):
         filename = graph_file_name

--- a/dbt/contracts/graph/manifest.py
+++ b/dbt/contracts/graph/manifest.py
@@ -81,11 +81,14 @@ PARSED_MANIFEST_CONTRACT = {
         'generated_at': {
             'type': 'string',
             'format': 'date-time',
+            'description': (
+                'The time at which the manifest was generated'
+            ),
         },
         'parent_map': NODE_EDGE_MAP,
         'child_map': NODE_EDGE_MAP,
     },
-    'required': ['nodes', 'macros', 'docs'],
+    'required': ['nodes', 'macros', 'docs', 'generated_at'],
 }
 
 

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -1,5 +1,5 @@
 from dbt.api import APIObject
-from dbt.utils import deep_merge, timestring
+from dbt.utils import deep_merge
 from dbt.node_types import NodeType
 from dbt.exceptions import raise_duplicate_resource_name, \
     raise_patch_targets_not_found

--- a/dbt/contracts/results.py
+++ b/dbt/contracts/results.py
@@ -110,7 +110,7 @@ EXECUTION_RESULT_CONTRACT = {
             ),
         }
     },
-    'required': ['results', 'manifest', 'generated_at'],
+    'required': ['results', 'generated_at', 'elapsed_time'],
 }
 
 
@@ -123,4 +123,3 @@ class ExecutionResult(APIObject):
             'generated_at': self.generated_at,
             'elapsed_time': self.elapsed_time,
         }
-

--- a/dbt/contracts/results.py
+++ b/dbt/contracts/results.py
@@ -1,0 +1,126 @@
+from dbt.api.object import APIObject
+from dbt.utils import deep_merge
+from dbt.contracts.graph.manifest import COMPILE_RESULT_NODE_CONTRACT
+from dbt.contracts.graph.parsed import PARSED_NODE_CONTRACT
+from dbt.contracts.graph.compiled import COMPILED_NODE_CONTRACT
+from dbt.contracts.graph.manifest import PARSED_MANIFEST_CONTRACT
+
+RUN_MODEL_RESULT_CONTRACT = {
+    'type': 'object',
+    'additionalProperties': False,
+    'description': 'The result of a single node being run',
+    'properties': {
+        'error': {
+            'type': ['string', 'null'],
+            'description': 'The error string, or None if there was no error',
+        },
+        'skip': {
+            'type': 'boolean',
+            'description': 'True if this node was skipped',
+        },
+        # This is assigned by dbt.ui.printer.print_test_result_line, if a test
+        # has no error and a non-zero status
+        'fail': {
+            'type': ['boolean', 'null'],
+            'description': 'On tests, true if the test failed',
+        },
+        'status': {
+            'type': ['string', 'null', 'number'],
+            'description': 'The status result of the node execution',
+        },
+        'execution_time': {
+            'type': 'number',
+            'description': 'The execution time, in seconds',
+        },
+        'node': COMPILE_RESULT_NODE_CONTRACT,
+    },
+    'required': ['node'],
+}
+
+
+def named_property(name, doc=None):
+    def get_prop(self):
+        return self._contents.get(name)
+
+    def set_prop(self, value):
+        self._contents[name] = value
+        self.validate()
+
+    return property(get_prop, set_prop, doc=doc)
+
+
+class RunModelResult(APIObject):
+    SCHEMA = RUN_MODEL_RESULT_CONTRACT
+
+    def __init__(self, node, error=None, skip=False, status=None, failed=None,
+                 execution_time=0):
+        super(RunModelResult, self).__init__(node=node, error=error, skip=skip,
+                                             status=status, fail=failed,
+                                             execution_time=execution_time)
+
+    # these all get set after the fact, generally
+    error = named_property('error',
+                           'If there was an error, the text of that error')
+    skip = named_property('skip', 'True if the model was skipped')
+    fail = named_property('fail', 'True if this was a test and it failed')
+    status = named_property('status', 'The status of the model execution')
+    execution_time = named_property('execution_time',
+                                    'The time in seconds to execute the model')
+
+    @property
+    def errored(self):
+        return self.error is not None
+
+    @property
+    def failed(self):
+        return self.fail
+
+    @property
+    def skipped(self):
+        return self.skip
+
+    def serialize(self):
+        result = super(RunModelResult, self).serialize()
+        result['node'] = self.node.serialize()
+        return result
+
+
+EXECUTION_RESULT_CONTRACT = {
+    'type': 'object',
+    'additionalProperties': False,
+    'description': 'The result of a single dbt invocation',
+    'properties': {
+        'results': {
+            'type': 'array',
+            'items': RUN_MODEL_RESULT_CONTRACT,
+            'description': 'An array of results, one per model',
+        },
+        'generated_at': {
+            'type': 'string',
+            'format': 'date-time',
+            'description': (
+                'The time at which the execution result was generated'
+            ),
+        },
+        'elapsed_time': {
+            'type': 'number',
+            'description': (
+                'The time elapsed from before_run to after_run (hooks are not '
+                'included)'
+            ),
+        }
+    },
+    'required': ['results', 'manifest', 'generated_at'],
+}
+
+
+class ExecutionResult(APIObject):
+    SCHEMA = EXECUTION_RESULT_CONTRACT
+
+    def serialize(self):
+        return {
+            'results': [r.serialize() for r in self.results],
+            'generated_at': self.generated_at,
+            'elapsed_time': self.elapsed_time,
+        }
+

--- a/dbt/contracts/results.py
+++ b/dbt/contracts/results.py
@@ -25,7 +25,7 @@ RUN_MODEL_RESULT_CONTRACT = {
             'description': 'On tests, true if the test failed',
         },
         'status': {
-            'type': ['string', 'null', 'number'],
+            'type': ['string', 'null', 'number', 'boolean'],
             'description': 'The status result of the node execution',
         },
         'execution_time': {

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -4,6 +4,7 @@ from dbt.exceptions import NotImplementedException
 from dbt.utils import get_nodes_by_tags
 from dbt.node_types import NodeType, RunHookType
 from dbt.adapters.factory import get_adapter
+from dbt.contracts.results import RunModelResult
 
 import dbt.clients.jinja
 import dbt.context.runtime
@@ -37,37 +38,6 @@ def track_model_run(index, num_nodes, run_model_result):
         "model_id": dbt.utils.get_hash(run_model_result.node),
         "hashed_contents": dbt.utils.get_hashed_contents(run_model_result.node),  # noqa
     })
-
-
-class RunModelResult(object):
-    def __init__(self, node, error=None, skip=False, status=None,
-                 failed=None, execution_time=0):
-        self.node = node
-        self.error = error
-        self.skip = skip
-        self.fail = failed
-        self.status = status
-        self.execution_time = execution_time
-
-    @property
-    def errored(self):
-        return self.error is not None
-
-    @property
-    def failed(self):
-        return self.fail
-
-    @property
-    def skipped(self):
-        return self.skip
-
-
-class RunOperationResult(RunModelResult):
-    def __init__(self, node, error=None, skip=False, status=None,
-                 failed=None, execution_time=0, returned=None):
-        super(RunOperationResult, self).__init__(node, error, skip, status,
-                                                 failed, execution_time)
-        self.returned = returned
 
 
 class BaseRunner(object):

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from dbt.adapters.factory import get_adapter
-from dbt.clients.system import write_file
+from dbt.clients.system import write_json
 from dbt.compat import bigint
 from dbt.include import DOCS_INDEX_FILE_PATH
 import dbt.ui.printer
@@ -180,7 +180,7 @@ class GenerateTask(BaseTask):
         results['generated_at'] = dbt.utils.timestring()
 
         path = os.path.join(self.project['target-path'], CATALOG_FILENAME)
-        write_file(path, json.dumps(results))
+        write_json(path, results)
 
         dbt.ui.printer.print_timestamped_line(
             'Catalog written to {}'.format(os.path.abspath(path))

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from decimal import Decimal
 import os
 import hashlib
 import itertools
+import json
 import collections
 import copy
 import functools
@@ -441,3 +443,14 @@ def timestring():
     """Get the current datetime as an RFC 3339-compliant string"""
     # isoformat doesn't include the mandatory trailing 'Z' for UTC.
     return datetime.utcnow().isoformat() + 'Z'
+
+
+class JSONEncoder(json.JSONEncoder):
+    """A 'custom' json encoder that does normal json encoder things, but also
+    handles `Decimal`s. Naturally, this can lose precision because they get
+    converted to floats.
+    """
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return super(JSONEncoder, self).default(obj)

--- a/test/integration/029_docs_generate_tests/ref_models/docs.md
+++ b/test/integration/029_docs_generate_tests/ref_models/docs.md
@@ -1,0 +1,17 @@
+{% docs ephemeral_summary %}
+A summmary table of the ephemeral copy of the seed data
+{% enddocs %}
+
+{% docs summary_first_name %}
+The first name being summarized
+{% enddocs %}
+
+{% docs summary_count %}
+The number of instances of the first name
+{% enddocs %}
+
+{% docs view_summary %}
+A view of the summary of the ephemeral copy of the seed data
+{% enddocs %}
+
+

--- a/test/integration/029_docs_generate_tests/ref_models/ephemeral_copy.sql
+++ b/test/integration/029_docs_generate_tests/ref_models/ephemeral_copy.sql
@@ -1,0 +1,7 @@
+{{
+  config(
+    materialized = "ephemeral"
+  )
+}}
+
+select * from {{ this.schema }}.seed

--- a/test/integration/029_docs_generate_tests/ref_models/ephemeral_summary.sql
+++ b/test/integration/029_docs_generate_tests/ref_models/ephemeral_summary.sql
@@ -1,0 +1,9 @@
+{{
+  config(
+    materialized = "table"
+  )
+}}
+
+select first_name, count(*) as ct from {{ref('ephemeral_copy')}}
+group by first_name
+order by first_name asc

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+  - name: ephemeral_summary
+    description: "{{ doc('ephemeral_summary') }}"
+    columns: &summary_columns
+      - name: first_name
+        description: "{{ doc('summary_first_name') }}"
+      - name: ct
+        description: "{{ doc('summary_count') }}"
+  - name: view_summary
+    description: "{{ doc('view_summary') }}"
+    columns: *summary_columns

--- a/test/integration/029_docs_generate_tests/ref_models/view_summary.sql
+++ b/test/integration/029_docs_generate_tests/ref_models/view_summary.sql
@@ -1,0 +1,8 @@
+{{
+  config(
+    materialized = "view"
+  )
+}}
+
+select first_name, ct from {{ref('ephemeral_summary')}}
+order by ct asc

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -4,6 +4,14 @@ from datetime import datetime, timedelta
 
 from test.integration.base import DBTIntegrationTest, use_profile
 
+DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+class AnyFloat(object):
+    """Any float. Use this in assertEqual() calls to assert that it is a float.
+    """
+    def __eq__(self, other):
+        return isinstance(other, float)
+
 
 class TestDocsGenerate(DBTIntegrationTest):
     def setUp(self):
@@ -34,34 +42,357 @@ class TestDocsGenerate(DBTIntegrationTest):
             }
         }
 
-    def run_and_generate(self, extra=None):
+    def run_and_generate(self, extra=None, seed_count=1, model_count=1):
         project = {"data-paths": [self.dir("seed")]}
         if extra:
             project.update(extra)
         self.use_default_project(project)
 
-        self.assertEqual(len(self.run_dbt(["seed"])), 1)
-        self.assertEqual(len(self.run_dbt()), 1)
+        self.assertEqual(len(self.run_dbt(["seed"])), seed_count)
+        self.run_start_time = datetime.utcnow()
+        self.assertEqual(len(self.run_dbt()), model_count)
+        self.generate_start_time = datetime.utcnow()
         self.run_dbt(['docs', 'generate'])
 
-    def assertRecent(self, timestr):
-        """Given a timestring in '%Y-%m-%dT%H:%M:%SZ' format (ISO8601), assert
-        that it represents a time before now and a time after 24h ago.
+    def assertBetween(self, timestr, start, end=None):
+        if end is None:
+            end = datetime.utcnow()
 
-        We can't just set the time via freezegun.freeze_time because that
-        breaks SSL, and a lot of these tests use SSL.
-        """
-        now = datetime.utcnow()
-        yesterday = now + timedelta(days=-1)
-        parsed = datetime.strptime(timestr, '%Y-%m-%dT%H:%M:%S.%fZ')
-        self.assertLess(
-            yesterday, parsed,
-            'parsed date {} happened over 24h ago'.format(parsed)
+        parsed = datetime.strptime(timestr, DATEFMT)
+
+        self.assertLessEqual(start, parsed,
+            'parsed date {} happened before {}'.format(
+                parsed,
+                start.strftime(DATEFMT))
         )
-        self.assertGreaterEqual(
-            now, parsed,
-            'parsed date {} happened in the future'.format(parsed)
+        self.assertGreaterEqual(end, parsed,
+            'parsed date {} happened after {}'.format(
+                parsed,
+                end.strftime(DATEFMT))
         )
+
+    def _expected_catalog(self, id_type, text_type, time_type, view_type,
+                          table_type, case=None):
+        if case is None:
+            case = lambda x: x
+
+        my_schema_name = self.unique_schema()
+        expected_cols = [
+            {
+                'name': case('id'),
+                'index': 1,
+                'type': id_type,
+                'comment': None,
+            },
+            {
+                'name': case('first_name'),
+                'index': 2,
+                'type': text_type,
+                'comment': None,
+            },
+            {
+                'name': case('email'),
+                'index': 3,
+                'type': text_type,
+                'comment': None,
+            },
+            {
+                'name': case('ip_address'),
+                'index': 4,
+                'type': text_type,
+                'comment': None,
+            },
+            {
+                'name': case('updated_at'),
+                'index': 5,
+                'type': time_type,
+                'comment': None,
+            },
+        ]
+        return {
+            case('model'): {
+                'unique_id': 'model.test.model',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': case('model'),
+                    'type': view_type,
+                    'comment': None,
+                },
+                'columns': expected_cols,
+            },
+            case('seed'): {
+                'unique_id': 'seed.test.seed',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': case('seed'),
+                    'type': table_type,
+                    'comment': None,
+                },
+                'columns': expected_cols,
+            },
+        }
+
+
+    def expected_postgres_catalog(self):
+        return self._expected_catalog(
+            id_type='integer',
+            text_type='text',
+            time_type='timestamp without time zone',
+            view_type='VIEW',
+            table_type='BASE TABLE'
+        )
+
+    def expected_postgres_references_catalog(self):
+        my_schema_name = self.unique_schema()
+
+        summary_columns = [
+            {
+                'name': 'first_name',
+                'index': 1,
+                'type': 'text',
+                'comment': None,
+            },
+            {
+                'name': 'ct',
+                'index': 2,
+                'type': 'bigint',
+                'comment': None,
+            },
+        ]
+        return {
+            'seed': {
+                'unique_id': 'seed.test.seed',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': 'seed',
+                    'type': 'BASE TABLE',
+                    'comment': None,
+                },
+                'columns': [
+                    {
+                        'name': 'id',
+                        'index': 1,
+                        'type': 'integer',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'first_name',
+                        'index': 2,
+                        'type': 'text',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'email',
+                        'index': 3,
+                        'type': 'text',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'ip_address',
+                        'index': 4,
+                        'type': 'text',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'updated_at',
+                        'index': 5,
+                        'type': 'timestamp without time zone',
+                        'comment': None,
+                    },
+                ],
+            },
+            'ephemeral_summary': {
+                'unique_id': 'model.test.ephemeral_summary',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': 'ephemeral_summary',
+                    'type': 'BASE TABLE',
+                    'comment': None,
+                },
+                'columns': summary_columns,
+            },
+            'view_summary': {
+                'unique_id': 'model.test.view_summary',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': 'view_summary',
+                    'type': 'VIEW',
+                    'comment': None,
+                },
+                'columns': summary_columns,
+            },
+        }
+
+    def expected_snowflake_catalog(self):
+        return self._expected_catalog(
+            id_type='NUMBER',
+            text_type='TEXT',
+            time_type='TIMESTAMP_NTZ',
+            view_type='VIEW',
+            table_type='BASE TABLE',
+            case=lambda x: x.upper())
+
+    def expected_bigquery_catalog(self):
+        return self._expected_catalog(
+            id_type='INT64',
+            text_type='STRING',
+            time_type='DATETIME',
+            view_type='view',
+            table_type='table'
+        )
+
+    def expected_bigquery_nested_catalog(self):
+        my_schema_name = self.unique_schema()
+        expected_cols = [
+            {
+                "name": "field_1",
+                "index": 1,
+                "type": "INT64",
+                "comment": None
+            },
+            {
+                "name": "field_2",
+                "index": 2,
+                "type": "INT64",
+                "comment": None
+            },
+            {
+                "name": "field_3",
+                "index": 3,
+                "type": "INT64",
+                "comment": None
+            },
+            {
+                "name": "nested_field.field_4",
+                "index": 4,
+                "type": "INT64",
+                "comment": None
+            },
+            {
+                "name": "nested_field.field_5",
+                "index": 5,
+                "type": "INT64",
+                "comment": None
+            }
+        ]
+        return {
+            "model": {
+                'unique_id': 'model.test.model',
+                "metadata": {
+                    "schema": my_schema_name,
+                    "name": "model",
+                    "type": "view",
+                    "comment": None
+                },
+                "columns": expected_cols
+            },
+            "seed": {
+                'unique_id': 'model.test.seed',
+                "metadata": {
+                "schema": my_schema_name,
+                "name": "seed",
+                "type": "view",
+                "comment": None
+                },
+                "columns": expected_cols
+            }
+        }
+
+    def expected_redshift_catalog(self):
+        return self._expected_catalog(
+            id_type='integer',
+            text_type='character varying',
+            time_type='timestamp without time zone',
+            view_type='VIEW',
+            table_type='BASE TABLE'
+        )
+
+    def expected_redshift_incremental_catalog(self):
+        my_schema_name = self.unique_schema()
+        return {
+            'model': {
+                'unique_id': 'model.test.model',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': 'model',
+                    'type': 'LATE BINDING VIEW',
+                    'comment': None,
+                },
+                'columns': [
+                    {
+                        'name': 'id',
+                        'index': 1,
+                        'type': 'integer',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'first_name',
+                        'index': 2,
+                        'type': 'character varying(5)',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'email',
+                        'index': 3,
+                        'type': 'character varying(23)',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'ip_address',
+                        'index': 4,
+                        'type': 'character varying(14)',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'updated_at',
+                        'index': 5,
+                        'type': 'timestamp without time zone',
+                        'comment': None,
+                    },
+                ],
+            },
+            'seed': {
+                'unique_id': 'seed.test.seed',
+                'metadata': {
+                    'schema': my_schema_name,
+                    'name': 'seed',
+                    'type': 'BASE TABLE',
+                    'comment': None,
+                },
+                'columns': [
+                    {
+                        'name': 'id',
+                        'index': 1,
+                        'type': 'integer',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'first_name',
+                        'index': 2,
+                        'type': 'character varying',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'email',
+                        'index': 3,
+                        'type': 'character varying',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'ip_address',
+                        'index': 4,
+                        'type': 'character varying',
+                        'comment': None,
+                    },
+                    {
+                        'name': 'updated_at',
+                        'index': 5,
+                        'type': 'timestamp without time zone',
+                        'comment': None,
+                    },
+                ],
+            },
+        }
 
     def verify_catalog(self, expected):
         self.assertTrue(os.path.exists('./target/catalog.json'))
@@ -72,7 +403,10 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
         self.assertIn(my_schema_name, catalog)
         self.assertIn('generated_at', catalog)
-        self.assertRecent(catalog.pop('generated_at'))
+        self.assertBetween(
+            catalog.pop('generated_at'),
+            start=self.generate_start_time,
+        )
         my_schema = catalog[my_schema_name]
         self.assertEqual(expected, my_schema)
 
@@ -208,275 +542,265 @@ class TestDocsGenerate(DBTIntegrationTest):
             'docs': {},
         }
 
-    def verify_manifest(self, expected_manifest):
-        self.assertTrue(os.path.exists('./target/manifest.json'))
-
-        with open('./target/manifest.json') as fp:
-            manifest = json.load(fp)
-
-        self.assertEqual(
-            set(manifest),
-            {'nodes', 'macros', 'parent_map', 'child_map', 'generated_at',
-             'docs'}
-        )
-
-        self.verify_manifest_macros(manifest)
-        manifest_without_extras = {
-            k: v for k, v in manifest.items()
-            if k not in {'macros', 'generated_at'}
-        }
-        self.assertEqual(manifest_without_extras, expected_manifest)
-
-    @use_profile('postgres')
-    def test__postgres__run_and_generate(self):
-        self.run_and_generate()
+    def expected_postgres_references_manifest(self):
         my_schema_name = self.unique_schema()
-        expected_cols = [
-            {
-                'name': 'id',
-                'index': 1,
-                'type': 'integer',
-                'comment': None,
-            },
-            {
-                'name': 'first_name',
-                'index': 2,
-                'type': 'text',
-                'comment': None,
-            },
-            {
-                'name': 'email',
-                'index': 3,
-                'type': 'text',
-                'comment': None,
-            },
-            {
-                'name': 'ip_address',
-                'index': 4,
-                'type': 'text',
-                'comment': None,
-            },
-            {
-                'name': 'updated_at',
-                'index': 5,
-                'type': 'timestamp without time zone',
-                'comment': None,
-            },
-        ]
-        expected_catalog = {
-            'model': {
-                'unique_id': 'model.test.model',
-                'metadata': {
+        docs_path = self.dir('ref_models/docs.md')
+        docs_file = open(docs_path).read().lstrip()
+        return {
+            'nodes': {
+                'model.test.ephemeral_copy': {
+                    'alias': 'ephemeral_copy',
+                    'columns': [],
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'ephemeral',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': []},
+                    'description': '',
+                    'empty': False,
+                    'fqn': ['test', 'ephemeral_copy'],
+                    'name': 'ephemeral_copy',
+                    'original_file_path': self.dir('ref_models/ephemeral_copy.sql'),
+                    'package_name': 'test',
+                    'path': 'ephemeral_copy.sql',
+                    'raw_sql': (
+                        '{{\n  config(\n    materialized = "ephemeral"\n  )\n}}'
+                        '\n\nselect * from {{ this.schema }}.seed'
+                    ),
+                    'refs': [],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
                     'schema': my_schema_name,
-                    'name': 'model',
-                    'type': 'VIEW',
-                    'comment': None,
+                    'tags': [],
+                    'unique_id': 'model.test.ephemeral_copy'
                 },
-                'columns': expected_cols,
-            },
-            'seed': {
-                'unique_id': 'seed.test.seed',
-                'metadata': {
+                'model.test.ephemeral_summary': {
+                    'alias': 'ephemeral_summary',
+                    'columns': [
+                        {
+                            'description': 'The first name being summarized',
+                            'name': 'first_name'
+                        },
+                        {
+                            'description': 'The number of instances of the first name',
+                            'name': 'ct'
+                        },
+                    ],
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'table',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {
+                        'macros': [],
+                        'nodes': ['model.test.ephemeral_copy']
+                    },
+                    'description': 'A summmary table of the ephemeral copy of the seed data',
+                    'docrefs': [
+                        {
+                            'column_name': 'first_name',
+                            'documentation_name': 'summary_first_name',
+                            'documentation_package': ''
+                        },
+                        {
+                            'column_name': 'ct',
+                            'documentation_name': 'summary_count',
+                            'documentation_package': ''
+                        },
+                        {
+                            'documentation_name': 'ephemeral_summary',
+                            'documentation_package': ''
+                        }
+                    ],
+                    'empty': False,
+                    'fqn': ['test',
+                    'ephemeral_summary'],
+                    'name': 'ephemeral_summary',
+                    'original_file_path': self.dir('ref_models/ephemeral_summary.sql'),
+                    'package_name': 'test',
+                    'patch_path': self.dir('ref_models/schema.yml'),
+                    'path': 'ephemeral_summary.sql',
+                    'raw_sql': (
+                        '{{\n  config(\n    materialized = "table"\n  )\n}}\n\n'
+                        'select first_name, count(*) as ct from '
+                        "{{ref('ephemeral_copy')}}\ngroup by first_name\n"
+                        'order by first_name asc'
+                    ),
+                    'refs': [['ephemeral_copy']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
                     'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'model.test.ephemeral_summary'},
+                'model.test.view_summary': {
+                    'alias': 'view_summary',
+                    'columns': [
+                        {
+                            'description': 'The first name being summarized',
+                            'name': 'first_name'
+                        },
+                        {
+                            'description': 'The number of instances of the first name',
+                            'name': 'ct'
+                        },
+                    ],
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {
+                        'macros': [],
+                        'nodes': ['model.test.ephemeral_summary']
+                    },
+                    'description': 'A view of the summary of the ephemeral copy of the seed data',
+                    'docrefs': [
+                        {
+                            'column_name': 'first_name',
+                            'documentation_name': 'summary_first_name',
+                            'documentation_package': ''
+                        },
+                        {
+                            'column_name': 'ct',
+                            'documentation_name': 'summary_count',
+                            'documentation_package': ''
+                        },
+                        {
+                            'documentation_name': 'view_summary',
+                            'documentation_package': ''
+                        }
+                    ],
+                    'empty': False,
+                    'fqn': ['test', 'view_summary'],
+                    'name': 'view_summary',
+                    'original_file_path': self.dir('ref_models/view_summary.sql'),
+                    'package_name': 'test',
+                    'patch_path': self.dir('ref_models/schema.yml'),
+                    'path': 'view_summary.sql',
+                    'raw_sql': (
+                        '{{\n  config(\n    materialized = "view"\n  )\n}}\n\n'
+                        'select first_name, ct from '
+                        "{{ref('ephemeral_summary')}}\norder by ct asc"
+                    ),
+                    'refs': [['ephemeral_summary']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'model.test.view_summary'
+                },
+                'seed.test.seed': {
+                    'alias': 'seed',
+                    'columns': [],
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'seed',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': []},
+                    'description': '',
+                    'empty': False,
+                    'fqn': ['test', 'seed'],
                     'name': 'seed',
-                    'type': 'BASE TABLE',
-                    'comment': None,
+                    'original_file_path': self.dir('seed/seed.csv'),
+                    'package_name': 'test',
+                    'path': 'seed.csv',
+                    'raw_sql': '-- csv --',
+                    'refs': [],
+                    'resource_type': 'seed',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'seed.test.seed'
+                }
+            },
+            'docs': {
+                'test.ephemeral_summary': {
+                    'block_contents': (
+                        'A summmary table of the ephemeral copy of the seed data'
+                    ),
+                    'file_contents': docs_file,
+                    'name': 'ephemeral_summary',
+                    'original_file_path': docs_path,
+                    'package_name': 'test',
+                    'path': 'docs.md',
+                    'resource_type': 'documentation',
+                    'root_path': os.getcwd(),
+                    'unique_id': 'test.ephemeral_summary'
                 },
-                'columns': expected_cols,
+                'test.summary_count': {
+                    'block_contents': 'The number of instances of the first name',
+                    'file_contents': docs_file,
+                    'name': 'summary_count',
+                    'original_file_path': docs_path,
+                    'package_name': 'test',
+                    'path': 'docs.md',
+                    'resource_type': 'documentation',
+                    'root_path': os.getcwd(),
+                    'unique_id': 'test.summary_count'
+                },
+                'test.summary_first_name': {
+                    'block_contents': 'The first name being summarized',
+                    'file_contents': docs_file,
+                    'name': 'summary_first_name',
+                    'original_file_path': docs_path,
+                    'package_name': 'test',
+                    'path': 'docs.md',
+                    'resource_type': 'documentation',
+                    'root_path': os.getcwd(),
+                    'unique_id': 'test.summary_first_name'
+                },
+                'test.view_summary': {
+                    'block_contents': (
+                        'A view of the summary of the ephemeral copy of the '
+                        'seed data'
+                    ),
+                    'file_contents': docs_file,
+                    'name': 'view_summary',
+                    'original_file_path': docs_path,
+                    'package_name': 'test',
+                    'path': 'docs.md',
+                    'resource_type': 'documentation',
+                    'root_path': os.getcwd(),
+                    'unique_id': 'test.view_summary'
+                },
+            },
+            'child_map': {
+                'model.test.ephemeral_copy': ['model.test.ephemeral_summary'],
+                'model.test.ephemeral_summary': ['model.test.view_summary'],
+                'model.test.view_summary': [],
+                'seed.test.seed': [],
+            },
+            'parent_map': {
+                'model.test.ephemeral_copy': [],
+                'model.test.ephemeral_summary': ['model.test.ephemeral_copy'],
+                'model.test.view_summary': ['model.test.ephemeral_summary'],
+                'seed.test.seed': [],
             },
         }
-        self.verify_catalog(expected_catalog)
-        self.verify_manifest(self.expected_seeded_manifest())
 
-    @use_profile('snowflake')
-    def test__snowflake__run_and_generate(self):
-        self.run_and_generate()
-        my_schema_name = self.unique_schema()
-        expected_cols = [
-            {
-                'name': 'ID',
-                'index': 1,
-                'type': 'NUMBER',
-                'comment': None,
-            },
-            {
-                'name': 'FIRST_NAME',
-                'index': 2,
-                'type': 'TEXT',
-                'comment': None,
-            },
-            {
-                'name': 'EMAIL',
-                'index': 3,
-                'type': 'TEXT',
-                'comment': None,
-            },
-            {
-                'name': 'IP_ADDRESS',
-                'index': 4,
-                'type': 'TEXT',
-                'comment': None,
-            },
-            {
-                'name': 'UPDATED_AT',
-                'index': 5,
-                'type': 'TIMESTAMP_NTZ',
-                'comment': None,
-            },
-        ]
-        expected_catalog = {
-            'MODEL': {
-                'unique_id': 'model.test.model',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'MODEL',
-                    'type': 'VIEW',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-            'SEED': {
-                'unique_id': 'seed.test.seed',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'SEED',
-                    'type': 'BASE TABLE',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-        }
-
-        self.verify_catalog(expected_catalog)
-        self.verify_manifest(self.expected_seeded_manifest())
-
-    @use_profile('bigquery')
-    def test__bigquery__run_and_generate(self):
-        self.run_and_generate()
-        my_schema_name = self.unique_schema()
-        expected_cols = [
-            {
-                'name': 'id',
-                'index': 1,
-                'type': 'INT64',
-                'comment': None,
-            },
-            {
-                'name': 'first_name',
-                'index': 2,
-                'type': 'STRING',
-                'comment': None,
-            },
-            {
-                'name': 'email',
-                'index': 3,
-                'type': 'STRING',
-                'comment': None,
-            },
-            {
-                'name': 'ip_address',
-                'index': 4,
-                'type': 'STRING',
-                'comment': None,
-            },
-            {
-                'name': 'updated_at',
-                'index': 5,
-                'type': 'DATETIME',
-                'comment': None,
-            },
-        ]
-        expected_catalog = {
-            'model': {
-                'unique_id': 'model.test.model',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'model',
-                    'type': 'view',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-            'seed': {
-                'unique_id': 'seed.test.seed',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'seed',
-                    'type': 'table',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-        }
-        self.verify_catalog(expected_catalog)
-        self.verify_manifest(self.expected_seeded_manifest())
-
-    @use_profile('bigquery')
-    def test__bigquery__nested_models(self):
-        self.use_default_project({'source-paths': [self.dir('bq_models')]})
-
-        self.assertEqual(len(self.run_dbt()), 2)
-        self.run_dbt(['docs', 'generate'])
-
-        my_schema_name = self.unique_schema()
-        expected_cols = [
-            {
-                "name": "field_1",
-                "index": 1,
-                "type": "INT64",
-                "comment": None
-            },
-            {
-                "name": "field_2",
-                "index": 2,
-                "type": "INT64",
-                "comment": None
-            },
-            {
-                "name": "field_3",
-                "index": 3,
-                "type": "INT64",
-                "comment": None
-            },
-            {
-                "name": "nested_field.field_4",
-                "index": 4,
-                "type": "INT64",
-                "comment": None
-            },
-            {
-                "name": "nested_field.field_5",
-                "index": 5,
-                "type": "INT64",
-                "comment": None
-            }
-        ]
-        catalog = {
-            "model": {
-                'unique_id': 'model.test.model',
-                "metadata": {
-                    "schema": my_schema_name,
-                    "name": "model",
-                    "type": "view",
-                    "comment": None
-                },
-                "columns": expected_cols
-            },
-            "seed": {
-                'unique_id': 'model.test.seed',
-                "metadata": {
-                    "schema": my_schema_name,
-                    "name": "seed",
-                    "type": "view",
-                    "comment": None
-                },
-                "columns": expected_cols
-            }
-        }
-        self.verify_catalog(catalog)
+    def expected_bigquery_nested_manifest(self):
         model_sql_path = self.dir('bq_models/model.sql')
         seed_sql_path = self.dir('bq_models/seed.sql')
-        expected_manifest = {
+        my_schema_name = self.unique_schema()
+        return {
             'nodes': {
                'model.test.model': {
                     'alias': 'model',
@@ -574,160 +898,11 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'docs': {},
         }
-        self.verify_manifest(expected_manifest)
 
-    @use_profile('redshift')
-    def test__redshift__run_and_generate(self):
-        self.run_and_generate()
-        my_schema_name = self.unique_schema()
-        expected_cols = [
-            {
-                'name': 'id',
-                'index': 1,
-                'type': 'integer',
-                'comment': None,
-            },
-            {
-                'name': 'first_name',
-                'index': 2,
-                'type': 'character varying',
-                'comment': None,
-            },
-            {
-                'name': 'email',
-                'index': 3,
-                'type': 'character varying',
-                'comment': None,
-            },
-            {
-                'name': 'ip_address',
-                'index': 4,
-                'type': 'character varying',
-                'comment': None,
-            },
-            {
-                'name': 'updated_at',
-                'index': 5,
-                'type': 'timestamp without time zone',
-                'comment': None,
-            },
-        ]
-        expected_catalog = {
-            'model': {
-                'unique_id': 'model.test.model',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'model',
-                    'type': 'VIEW',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-            'seed': {
-                'unique_id': 'seed.test.seed',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'seed',
-                    'type': 'BASE TABLE',
-                    'comment': None,
-                },
-                'columns': expected_cols,
-            },
-        }
-        self.verify_catalog(expected_catalog)
-        self.verify_manifest(self.expected_seeded_manifest())
-
-    @use_profile('redshift')
-    def test__redshift__incremental_view(self):
-        self.run_and_generate({'source-paths': [self.dir('rs_models')]})
-        my_schema_name = self.unique_schema()
-        expected_catalog = {
-            'model': {
-                'unique_id': 'model.test.model',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'model',
-                    'type': 'LATE BINDING VIEW',
-                    'comment': None,
-                },
-                'columns': [
-                    {
-                        'name': 'id',
-                        'index': 1,
-                        'type': 'integer',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'first_name',
-                        'index': 2,
-                        'type': 'character varying(5)',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'email',
-                        'index': 3,
-                        'type': 'character varying(23)',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'ip_address',
-                        'index': 4,
-                        'type': 'character varying(14)',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'updated_at',
-                        'index': 5,
-                        'type': 'timestamp without time zone',
-                        'comment': None,
-                    },
-                ],
-            },
-            'seed': {
-                'unique_id': 'seed.test.seed',
-                'metadata': {
-                    'schema': my_schema_name,
-                    'name': 'seed',
-                    'type': 'BASE TABLE',
-                    'comment': None,
-                },
-                'columns': [
-                    {
-                        'name': 'id',
-                        'index': 1,
-                        'type': 'integer',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'first_name',
-                        'index': 2,
-                        'type': 'character varying',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'email',
-                        'index': 3,
-                        'type': 'character varying',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'ip_address',
-                        'index': 4,
-                        'type': 'character varying',
-                        'comment': None,
-                    },
-                    {
-                        'name': 'updated_at',
-                        'index': 5,
-                        'type': 'timestamp without time zone',
-                        'comment': None,
-                    },
-                ],
-            },
-        }
-        self.verify_catalog(expected_catalog)
+    def expected_redshift_incremental_view_manifest(self):
         model_sql_path = self.dir('rs_models/model.sql')
-        expected_manifest = {
+        my_schema_name = self.unique_schema()
+        return {
             "nodes": {
                 "model.test.model": {
                     "name": "model",
@@ -826,4 +1001,368 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'docs': {},
         }
-        self.verify_manifest(expected_manifest)
+
+    def verify_manifest(self, expected_manifest):
+        self.assertTrue(os.path.exists('./target/manifest.json'))
+
+        with open('./target/manifest.json') as fp:
+            manifest = json.load(fp)
+
+        self.assertEqual(
+            set(manifest),
+            {'nodes', 'macros', 'parent_map', 'child_map', 'generated_at',
+             'docs'}
+        )
+
+        self.verify_manifest_macros(manifest)
+        manifest_without_extras = {
+            k: v for k, v in manifest.items()
+            if k not in {'macros', 'generated_at'}
+        }
+        self.assertBetween(
+            manifest['generated_at'],
+            start=self.run_start_time,
+            end=self.generate_start_time
+        )
+        self.assertEqual(manifest_without_extras, expected_manifest)
+
+    def expected_run_results(self):
+        """
+        The expected results of this run.
+        """
+        schema = self.unique_schema()
+        compiled_sql = '\n\nselect * from "{}".seed'.format(schema)
+        status = 'CREATE VIEW'
+
+        if self.adapter_type == 'snowflake':
+            status = 'SUCCESS 1'
+
+        if self.adapter_type == 'bigquery':
+            status = 'OK'
+            compiled_sql = '\n\nselect * from `{}`.`{}`.seed'.format(
+                self._profile['project'], schema
+            )
+
+        return [
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'model',
+                    'build_path': os.path.normpath(
+                        'target/compiled/test/model.sql'
+                    ),
+                    'columns': [
+                        {'description': 'The user ID number', 'name': 'id'},
+                        {'description': "The user's first name", 'name': 'first_name'},
+                        {'description': "The user's email", 'name': 'email'},
+                        {'description': "The user's IP address", 'name': 'ip_address'},
+                        {'description': "The last time this user's email was updated", 'name': 'updated_at'}
+                    ],
+                    'compiled': True,
+                    'compiled_sql': compiled_sql,
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {
+                        'macros': [],
+                        'nodes': ['seed.test.seed']
+                    },
+                    'description': 'The test model',
+                    'docrefs': [],
+                    'empty': False,
+                    'extra_ctes': {},
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'model'],
+                    'injected_sql': compiled_sql,
+                    'name': 'model',
+                    'original_file_path': self.dir('models/model.sql'),
+                    'package_name': 'test',
+                    'patch_path': self.dir('models/schema.yml'),
+                    'path': 'model.sql',
+                    'raw_sql': "{{\n    config(\n        materialized='view'\n    )\n}}\n\nselect * from {{ ref('seed') }}",
+                    'refs': [['seed']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
+                    'schema': schema,
+                    'tags': [],
+                    'unique_id': 'model.test.model',
+                    'wrapped_sql': 'None'
+                },
+                'skip': False,
+                'status': status,
+            }
+        ]
+
+    def expected_postgres_references_run_results(self):
+        my_schema_name = self.unique_schema()
+        ephemeral_compiled_sql = (
+            '\n\nselect first_name, count(*) as ct from '
+            '__dbt__CTE__ephemeral_copy\ngroup by first_name\n'
+            'order by first_name asc'
+        )
+        cte_sql = (
+            ' __dbt__CTE__ephemeral_copy as (\n\n\nselect * from {}.seed\n)'
+        ).format(my_schema_name)
+
+        ephemeral_injected_sql = (
+            '\n\nwith{}select first_name, count(*) as ct from '
+            '__dbt__CTE__ephemeral_copy\ngroup by first_name\n'
+            'order by first_name asc'
+        ).format(cte_sql)
+
+        view_compiled_sql = (
+            '\n\nselect first_name, ct from "{}".ephemeral_summary\n'
+            'order by ct asc'
+        ).format(my_schema_name)
+
+        return [
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'ephemeral_summary',
+                    'build_path': os.path.normpath(
+                        'target/compiled/test/ephemeral_summary.sql'
+                    ),
+                    'columns': [
+                        {
+                            'description': 'The first name being summarized',
+                            'name': 'first_name'
+                        },
+                        {
+                            'description': 'The number of instances of the first name',
+                            'name': 'ct'
+                        },
+                    ],
+                    'compiled': True,
+                    'compiled_sql': ephemeral_compiled_sql,
+                    'config': {
+                        'enabled': True,
+                        'materialized': 'table',
+                        'pre-hook': [],
+                        'post-hook': [],
+                        'vars': {},
+                        'column_types': {},
+                        'quoting': {}
+                    },
+                    'depends_on': {
+                        'nodes': ['model.test.ephemeral_copy'],
+                        'macros': []
+                    },
+                    'description': (
+                        'A summmary table of the ephemeral copy of the seed data'
+                    ),
+                    'docrefs': [
+                        {
+                            'column_name': 'first_name',
+                            'documentation_name': 'summary_first_name',
+                            'documentation_package': ''
+                        },
+                        {
+                            'column_name': 'ct',
+                            'documentation_name': 'summary_count',
+                            'documentation_package': ''
+                        },
+                        {
+                            'documentation_name': 'ephemeral_summary',
+                            'documentation_package': ''
+                        }
+                    ],
+                    'empty': False,
+                    'extra_ctes': {
+                        'model.test.ephemeral_copy': cte_sql,
+                    },
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'ephemeral_summary'],
+                    'injected_sql': ephemeral_injected_sql,
+                    'name': 'ephemeral_summary',
+                    'original_file_path': self.dir('ref_models/ephemeral_summary.sql'),
+                    'package_name': 'test',
+                    'patch_path': self.dir('ref_models/schema.yml'),
+                    'path': 'ephemeral_summary.sql',
+                    'raw_sql': (
+                        '{{\n  config(\n    materialized = "table"\n  )\n}}\n'
+                        '\nselect first_name, count(*) as ct from '
+                        "{{ref('ephemeral_copy')}}\ngroup by first_name\n"
+                        'order by first_name asc'
+                    ),
+                    'refs': [['ephemeral_copy']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'model.test.ephemeral_summary',
+                    'wrapped_sql': 'None',
+                },
+                'skip': False,
+                'status': 'SELECT 1',
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'view_summary',
+                    'build_path': os.path.normpath(
+                        'target/compiled/test/view_summary.sql'
+                    ),
+                    'alias': 'view_summary',
+                    'columns': [
+                        {
+                            'description': 'The first name being summarized',
+                            'name': 'first_name'
+                        },
+                        {
+                            'description': 'The number of instances of the first name',
+                            'name': 'ct'
+                        },
+                    ],
+                    'compiled': True,
+                    'compiled_sql': view_compiled_sql,
+                    'config': {
+                        'enabled': True,
+                        'materialized': 'view',
+                        'pre-hook': [],
+                        'post-hook': [],
+                        'vars': {},
+                        'column_types': {},
+                        'quoting': {}
+                    },
+                    'depends_on': {
+                        'nodes': ['model.test.ephemeral_summary'],
+                        'macros': []
+                    },
+                    'description': (
+                        'A view of the summary of the ephemeral copy of the '
+                        'seed data'
+                    ),
+                    'docrefs': [
+                        {
+                            'column_name': 'first_name',
+                            'documentation_name': 'summary_first_name',
+                            'documentation_package': ''
+                        },
+                        {
+                            'column_name': 'ct',
+                            'documentation_name': 'summary_count',
+                            'documentation_package': ''
+                        },
+                        {
+                            'documentation_name': 'view_summary',
+                            'documentation_package': ''
+                        }
+                    ],
+                    'empty': False,
+                    'extra_ctes': {},
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'view_summary'],
+                    'injected_sql': view_compiled_sql,
+                    'name': 'view_summary',
+                    'original_file_path': self.dir('ref_models/view_summary.sql'),
+                    'package_name': 'test',
+                    'patch_path': self.dir('ref_models/schema.yml'),
+                    'path': 'view_summary.sql',
+                    'raw_sql': (
+                        '{{\n  config(\n    materialized = "view"\n  )\n}}\n\n'
+                        'select first_name, ct from '
+                        "{{ref('ephemeral_summary')}}\norder by ct asc"
+                    ),
+                    'refs': [['ephemeral_summary']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'model.test.view_summary',
+                    'wrapped_sql': 'None',
+                },
+                'skip': False,
+                'status': 'CREATE VIEW',
+            },
+        ]
+
+    def verify_run_results(self, expected_run_results):
+        with open('./target/run_results.json') as fp:
+            run_result = json.load(fp)
+
+        self.assertIn('generated_at', run_result)
+        self.assertIn('elapsed_time', run_result)
+        self.assertBetween(
+            run_result['generated_at'],
+            start=self.run_start_time,
+            end=self.generate_start_time
+        )
+        self.assertGreater(run_result['elapsed_time'], 0)
+        self.assertTrue(
+            isinstance(run_result['elapsed_time'], float),
+            "run_result['elapsed_time'] is of type {}, expected float".format(
+                str(type(run_result['elapsed_time'])))
+        )
+        self.assertEqual(run_result['results'], expected_run_results)
+
+    @use_profile('postgres')
+    def test__postgres__run_and_generate(self):
+        self.run_and_generate()
+        self.verify_catalog(self.expected_postgres_catalog())
+        self.verify_manifest(self.expected_seeded_manifest())
+        self.verify_run_results(self.expected_run_results())
+
+    @use_profile('postgres')
+    def test__postgres_references(self):
+        self.run_and_generate(
+            {'source-paths': [self.dir('ref_models')]},
+            model_count=2
+        )
+
+        self.verify_catalog(self.expected_postgres_references_catalog())
+        self.verify_manifest(self.expected_postgres_references_manifest())
+        self.verify_run_results(self.expected_postgres_references_run_results())
+
+    @use_profile('snowflake')
+    def test__snowflake__run_and_generate(self):
+        self.run_and_generate()
+
+        self.verify_catalog(self.expected_snowflake_catalog())
+        self.verify_manifest(self.expected_seeded_manifest())
+        self.verify_run_results(self.expected_run_results())
+
+    @use_profile('bigquery')
+    def test__bigquery__run_and_generate(self):
+        self.run_and_generate()
+
+        self.verify_catalog(self.expected_bigquery_catalog())
+        self.verify_manifest(self.expected_seeded_manifest())
+        self.verify_run_results(self.expected_run_results())
+
+    @use_profile('bigquery')
+    def test__bigquery__nested_models(self):
+        self.use_default_project({'source-paths': [self.dir('bq_models')]})
+
+        self.run_start_time = datetime.utcnow()
+        self.assertEqual(len(self.run_dbt()), 2)
+        self.generate_start_time = datetime.utcnow()
+        self.run_dbt(['docs', 'generate'])
+
+        self.verify_catalog(self.expected_bigquery_nested_catalog())
+        self.verify_manifest(self.expected_bigquery_nested_manifest())
+
+    @use_profile('redshift')
+    def test__redshift__run_and_generate(self):
+        self.run_and_generate()
+        self.verify_catalog(self.expected_redshift_catalog())
+        self.verify_manifest(self.expected_seeded_manifest())
+        self.verify_run_results(self.expected_run_results())
+
+    @use_profile('redshift')
+    def test__redshift__incremental_view(self):
+        self.run_and_generate({'source-paths': [self.dir('rs_models')]})
+        self.verify_catalog(self.expected_redshift_incremental_catalog())
+        self.verify_manifest(self.expected_redshift_incremental_view_manifest())


### PR DESCRIPTION
Per discussion, we'll be writing the run results to a separate file from the manifest itself. The run results include the compiled node, so the compiled sql is in there.

The actual code changes are small, the tests are just very verbose.