### PR TITLE
Include project metadata in the manifest (#906)

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -223,10 +223,9 @@ class Compiler(object):
     def compile(self):
         linker = Linker()
 
-        root_project = self.project.cfg
         all_projects = self.get_all_projects()
 
-        manifest = dbt.loader.GraphLoader.load_all(root_project, all_projects)
+        manifest = dbt.loader.GraphLoader.load_all(self.project, all_projects)
 
         self.write_manifest_file(manifest)
 

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -23,7 +23,7 @@ class GraphLoader(object):
         tests, patches = SchemaTestLoader.load_all(root_project, all_projects)
 
         manifest = Manifest(nodes=nodes, macros=macros, docs=docs,
-                            generated_at=timestring())
+                            generated_at=timestring(), project=root_project)
         manifest.add_nodes(tests)
         manifest.patch_nodes(patches)
 

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -12,7 +12,8 @@ class GraphLoader(object):
     _LOADERS = []
 
     @classmethod
-    def load_all(cls, root_project, all_projects):
+    def load_all(cls, project_obj, all_projects):
+        root_project = project_obj.cfg
         macros = MacroLoader.load_all(root_project, all_projects)
         macros.update(OperationLoader.load_all(root_project, all_projects))
         nodes = {}
@@ -23,7 +24,7 @@ class GraphLoader(object):
         tests, patches = SchemaTestLoader.load_all(root_project, all_projects)
 
         manifest = Manifest(nodes=nodes, macros=macros, docs=docs,
-                            generated_at=timestring(), project=root_project)
+                            generated_at=timestring(), project=project_obj)
         manifest.add_nodes(tests)
         manifest.patch_nodes(patches)
 

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -145,14 +145,13 @@ def assert_no_duplicate_unique_ids(catalog):
 
 
 class GenerateTask(BaseTask):
-    def _get_manifest(self, project):
-        compiler = dbt.compilation.Compiler(project)
+    def _get_manifest(self):
+        compiler = dbt.compilation.Compiler(self.project)
         compiler.initialize()
 
-        root_project = project.cfg
         all_projects = compiler.get_all_projects()
 
-        manifest = dbt.loader.GraphLoader.load_all(root_project, all_projects)
+        manifest = dbt.loader.GraphLoader.load_all(self.project, all_projects)
         return manifest
 
     def run(self):
@@ -160,7 +159,7 @@ class GenerateTask(BaseTask):
             DOCS_INDEX_FILE_PATH,
             os.path.join(self.project['target-path'], 'index.html'))
 
-        manifest = self._get_manifest(self.project)
+        manifest = self._get_manifest()
         profile = self.project.run_environment()
         adapter = get_adapter(profile)
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -540,6 +540,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'seed.test.seed': ['model.test.model'],
             },
             'docs': {},
+            'metadata': {
+                'project_id': '098f6bcd4621d373cade4e832627b4f6',
+                'user_id': None,
+                'send_anonymous_usage_stats': False,
+            },
         }
 
     def expected_postgres_references_manifest(self):
@@ -794,6 +799,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.view_summary': ['model.test.ephemeral_summary'],
                 'seed.test.seed': [],
             },
+            'metadata': {
+                'project_id': '098f6bcd4621d373cade4e832627b4f6',
+                'user_id': None,
+                'send_anonymous_usage_stats': False,
+            },
         }
 
     def expected_bigquery_nested_manifest(self):
@@ -897,6 +907,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.seed': []
             },
             'docs': {},
+            'metadata': {
+                'project_id': '098f6bcd4621d373cade4e832627b4f6',
+                'user_id': None,
+                'send_anonymous_usage_stats': False,
+            },
         }
 
     def expected_redshift_incremental_view_manifest(self):
@@ -1000,6 +1015,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                 "seed.test.seed": ["model.test.model"]
             },
             'docs': {},
+            'metadata': {
+                'project_id': '098f6bcd4621d373cade4e832627b4f6',
+                'user_id': None,
+                'send_anonymous_usage_stats': False,
+            },
         }
 
     def verify_manifest(self, expected_manifest):
@@ -1011,7 +1031,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.assertEqual(
             set(manifest),
             {'nodes', 'macros', 'parent_map', 'child_map', 'generated_at',
-             'docs'}
+             'docs', 'metadata'}
         )
 
         self.verify_manifest_macros(manifest)


### PR DESCRIPTION
Add project metadata (`project_id`, `user_id`, and `send_anonymous_usage_stats`) to the manifest.

It's worth noting that `user_id` is always `None` if `send_anonymous_usage_stats` is `False`, because when we set the do not track flag we get rid of the user ID.