### PR TITLE
Upgrade google-cloud-bigquery to 1.5.0 (#806)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ networkx==1.11
 minimal-snowplow-tracker==0.0.1
 snowflake-connector-python>=1.4.9
 colorama==0.3.9
-google-cloud-bigquery==0.29.0
+google-cloud-bigquery>=1.0.0,<2
 requests>=2.18.0,<3
 agate>=1.6,<2
 jsonschema==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'snowflake-connector-python>=1.4.9',
         'requests>=2.18.0,<3',
         'colorama==0.3.9',
-        'google-cloud-bigquery==0.29.0',
+        'google-cloud-bigquery>=1.0.0,<2',
         'agate>=1.6,<2',
         'jsonschema==2.6.0',
         'boto3>=1.6.23'


### PR DESCRIPTION
The removals referenced in the 1.0.0 changelog are `list_dataset_tables` and `create_rows`, we use neither of those.

I set the minimum to 1.0.0 since that's what we discussed, but really we can set anything we want - we could obviously safely go as low as 0.29.0, or raise it if there are new features we want to require.