### PR TITLE
Quote schema in temp tables (#859)

### DIFF
--- a/dbt/adapters/default/impl.py
+++ b/dbt/adapters/default/impl.py
@@ -34,6 +34,7 @@ class DefaultAdapter(object):
         "get_missing_columns",
         "expand_target_column_types",
         "create_schema",
+        "quote_as_configured",
 
         # deprecated -- use versions that take relations instead
         "already_exists",
@@ -726,10 +727,18 @@ class DefaultAdapter(object):
         return '"{}"'.format(identifier)
 
     @classmethod
-    def quote_schema_and_table(cls, profile, project_cfg,
-                               schema, table, model_name=None):
-        return '{}.{}'.format(cls.quote(schema),
-                              cls.quote(table))
+    def quote_as_configured(cls, profile, project_cfg, identifier, quote_key,
+                            model_name=None):
+        """Quote or do not quote the given identifer as configured in the
+        project config for the quote key.
+
+        The quote key should be one of 'database' (on bigquery, 'profile'),
+        'identifier', or 'schema', or it will be treated as if you set `True`.
+        """
+        if project_cfg.get('quoting', {}).get(quote_key, True):
+            return cls.quote(identifier)
+        else:
+            return identifier
 
     @classmethod
     def convert_text_type(cls, agate_table, col_idx):

--- a/dbt/include/global_project/macros/adapters/snowflake.sql
+++ b/dbt/include/global_project/macros/adapters/snowflake.sql
@@ -1,6 +1,6 @@
 {% macro snowflake__create_table_as(temporary, relation, sql) -%}
   {% if temporary %}
-    use schema {{ schema }};
+    use schema {{ adapter.quote_as_configured(schema, 'schema') }};
   {% endif %}
 
   {{ default__create_table_as(temporary, relation, sql) }}

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -1,5 +1,5 @@
 from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestSimpleCopy(DBTIntegrationTest):
@@ -16,9 +16,8 @@ class TestSimpleCopy(DBTIntegrationTest):
     def models(self):
         return self.dir("models")
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__postgres__simple_copy(self):
-        self.use_profile("postgres")
         self.use_default_project({"data-paths": [self.dir("seed-initial")]})
 
         results = self.run_dbt(["seed"])
@@ -36,9 +35,8 @@ class TestSimpleCopy(DBTIntegrationTest):
 
         self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__postgres__dbt_doesnt_run_empty_models(self):
-        self.use_profile("postgres")
         self.use_default_project({"data-paths": [self.dir("seed-initial")]})
 
         results = self.run_dbt(["seed"])
@@ -51,9 +49,8 @@ class TestSimpleCopy(DBTIntegrationTest):
         self.assertFalse("empty" in models.keys())
         self.assertFalse("disabled" in models.keys())
 
-    @attr(type="snowflake")
+    @use_profile("snowflake")
     def test__snowflake__simple_copy(self):
-        self.use_profile("snowflake")
         self.use_default_project({"data-paths": [self.dir("seed-initial")]})
 
         self.run_dbt(["seed"])
@@ -67,9 +64,8 @@ class TestSimpleCopy(DBTIntegrationTest):
 
         self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
-    @attr(type="snowflake")
+    @use_profile("snowflake")
     def test__snowflake__simple_copy__quoting_on(self):
-        self.use_profile("snowflake")
         self.use_default_project({
             "data-paths": [self.dir("seed-initial")],
             "quoting": {"identifier": True},
@@ -93,9 +89,8 @@ class TestSimpleCopy(DBTIntegrationTest):
 
         self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
 
-    @attr(type="snowflake")
+    @use_profile("snowflake")
     def test__snowflake__simple_copy__quoting_off(self):
-        self.use_profile("snowflake")
         self.use_default_project({
             "data-paths": [self.dir("seed-initial")],
             "quoting": {"identifier": False},
@@ -119,9 +114,8 @@ class TestSimpleCopy(DBTIntegrationTest):
 
         self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
-    @attr(type="snowflake")
+    @use_profile("snowflake")
     def test__snowflake__seed__quoting_switch(self):
-        self.use_profile("snowflake")
         self.use_default_project({
             "data-paths": [self.dir("seed-initial")],
             "quoting": {"identifier": False},
@@ -136,9 +130,8 @@ class TestSimpleCopy(DBTIntegrationTest):
         })
         results = self.run_dbt(["seed"], expect_pass=False)
 
-    @attr(type="bigquery")
+    @use_profile("bigquery")
     def test__bigquery__simple_copy(self):
-        self.use_profile("bigquery")
         self.use_default_project({"data-paths": [self.dir("seed-initial")]})
 
         results = self.run_dbt(["seed"])
@@ -160,3 +153,53 @@ class TestSimpleCopy(DBTIntegrationTest):
         self.assertTablesEqual("seed","view_model")
         self.assertTablesEqual("seed","incremental")
         self.assertTablesEqual("seed","materialized")
+
+
+class TestSimpleCopyLowercasedSchema(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "simple_copy_001"
+
+    @staticmethod
+    def dir(path):
+        return "test/integration/001_simple_copy_test/" + path.lstrip("/")
+
+    @property
+    def models(self):
+        return self.dir("models")
+
+    def unique_schema(self):
+        # bypass the forced uppercasing that unique_schema() does on snowflake
+        schema = super(TestSimpleCopyLowercasedSchema, self).unique_schema()
+        return schema.lower()
+
+    @use_profile('snowflake')
+    def test__snowflake__simple_copy(self):
+        self.use_default_project({"data-paths": [self.dir("seed-initial")]})
+
+        self.run_dbt(["seed"])
+        self.run_dbt()
+
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+
+        self.use_default_project({"data-paths": [self.dir("seed-update")]})
+        self.run_dbt(["seed"])
+        self.run_dbt()
+
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+
+    @use_profile("snowflake")
+    def test__snowflake__seed__quoting_switch_schema(self):
+        self.use_default_project({
+            "data-paths": [self.dir("seed-initial")],
+            "quoting": {"identifier": False, "schema": True},
+        })
+
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+
+        self.use_default_project({
+            "data-paths": [self.dir("seed-update")],
+            "quoting": {"identifier": False, "schema": False},
+        })
+        results = self.run_dbt(["seed"], expect_pass=False)


### PR DESCRIPTION
Add an `adapter.quote()` call to make sure the schema gets quoted on snowflake in `create_table_as`, plus a corresponding test (and yes, the test fails without the fix in place!) Fixes #859 
