### PR TITLE
Include column names in test manifest (#922)

### DIFF
--- a/dbt/contracts/graph/manifest.py
+++ b/dbt/contracts/graph/manifest.py
@@ -135,9 +135,7 @@ def _sort_values(dct):
     """Given a dictionary, sort each value. This makes output deterministic,
     which helps for tests.
     """
-    for v in dct.values():
-        v.sort()
-    return dct
+    return {k: sorted(v) for k, v in dct.items()}
 
 
 def build_edges(nodes):

--- a/dbt/contracts/graph/manifest.py
+++ b/dbt/contracts/graph/manifest.py
@@ -131,6 +131,15 @@ class CompileResultNode(CompiledNode):
     SCHEMA = COMPILE_RESULT_NODE_CONTRACT
 
 
+def _sort_values(dct):
+    """Given a dictionary, sort each value. This makes output deterministic,
+    which helps for tests.
+    """
+    for v in dct.values():
+        v.sort()
+    return dct
+
+
 def build_edges(nodes):
     """Build the forward and backward edges on the given list of ParsedNodes
     and return them as two separate dictionaries, each mapping unique IDs to
@@ -143,7 +152,7 @@ def build_edges(nodes):
         backward_edges[node.unique_id] = node.depends_on_nodes[:]
         for unique_id in node.depends_on_nodes:
             forward_edges[unique_id].append(node.unique_id)
-    return forward_edges, backward_edges
+    return _sort_values(forward_edges), _sort_values(backward_edges)
 
 
 class Manifest(APIObject):

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -232,6 +232,13 @@ PARSED_NODE_CONTRACT = deep_merge(
                     'In seeds, the path to the source file used during build.'
                 ),
             },
+            'column_name': {
+                'type': 'string',
+                'description': (
+                    'In tests parsed from a v2 schema, the column the test is '
+                    'associated with (if there is one)'
+                )
+            },
         },
         'required': UNPARSED_NODE_CONTRACT['required'] + [
             'unique_id', 'fqn', 'schema', 'refs', 'depends_on', 'empty',

--- a/dbt/contracts/graph/unparsed.py
+++ b/dbt/contracts/graph/unparsed.py
@@ -70,7 +70,7 @@ UNPARSED_NODE_CONTRACT = deep_merge(
                     # we need this if parse_node is going to handle archives.
                     NodeType.Archive,
                 ]
-            }
+            },
         },
         'required': UNPARSED_BASE_CONTRACT['required'] + [
             'resource_type', 'name']

--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -41,11 +41,13 @@ class BaseParser(object):
     def parse_node(cls, node, node_path, root_project_config,
                    package_project_config, all_projects,
                    tags=None, fqn_extra=None, fqn=None, macros=None,
-                   agate_table=None, archive_config=None):
+                   agate_table=None, archive_config=None, column_name=None):
         """Parse a node, given an UnparsedNode and any other required information.
 
         agate_table should be set if the node came from a seed file.
         archive_config should be set if the node is an Archive node.
+        column_name should be set if the node is a Test node associated with a
+        particular column.
         """
         logger.debug("Parsing {}".format(node_path))
 
@@ -96,6 +98,10 @@ class BaseParser(object):
         node['schema'] = default_schema
         default_alias = node.get('name')
         node['alias'] = default_alias
+
+        # if there's a column, it should end up part of the ParsedNode
+        if column_name is not None:
+            node['column_name'] = column_name
 
         # make a manifest with just the macros to get the context
         manifest = Manifest(macros=macros, nodes={}, docs={},

--- a/dbt/parser/schemas.py
+++ b/dbt/parser/schemas.py
@@ -169,7 +169,7 @@ class SchemaParser(BaseParser):
 
     @classmethod
     def build_parsed_node(cls, unparsed, model_name, test_namespace, test_type,
-                          root_project, all_projects, macros):
+                          root_project, all_projects, macros, column_name):
         """Given an UnparsedNode with a node type of Test and some extra
         information, build a ParsedNode representing the test.
         """
@@ -198,12 +198,13 @@ class SchemaParser(BaseParser):
                               tags=['schema'],
                               fqn_extra=None,
                               fqn=fqn_override,
-                              macros=macros)
+                              macros=macros,
+                              column_name=column_name)
 
     @classmethod
     def build_node(cls, model_name, package_name, test_type, test_args,
                    root_dir, original_file_path, root_project, all_projects,
-                   macros):
+                   macros, column_name=None):
         """From the various components that are common to both v1 and v2 schema,
         build a ParsedNode representing a test case.
         """
@@ -222,7 +223,7 @@ class SchemaParser(BaseParser):
 
         parsed = cls.build_parsed_node(unparsed, model_name, test_namespace,
                                        original_test_type, root_project,
-                                       all_projects, macros)
+                                       all_projects, macros, column_name)
         return parsed
 
     @classmethod
@@ -394,7 +395,7 @@ class SchemaParser(BaseParser):
                 )
                 node = cls.build_node(
                     model_name, package_name, test_type, test_args, root_dir,
-                    path, root_project, all_projects, macros
+                    path, root_project, all_projects, macros, column_name
                 )
                 yield 'test', node
 

--- a/test/integration/029_docs_generate_tests/macros/dummy_test.sql
+++ b/test/integration/029_docs_generate_tests/macros/dummy_test.sql
@@ -1,0 +1,9 @@
+
+{% macro test_nothing(model) %}
+
+-- a silly test to make sure that table-level tests show up in the manifest
+-- without a column_name field
+select 0
+
+{% endmacro %}
+

--- a/test/integration/029_docs_generate_tests/models/schema.yml
+++ b/test/integration/029_docs_generate_tests/models/schema.yml
@@ -6,6 +6,9 @@ models:
     columns:
       - name: id
         description: The user ID number
+        tests:
+          - unique
+          - not_null
       - name: first_name
         description: The user's first name
       - name: email
@@ -14,3 +17,5 @@ models:
         description: The user's IP address
       - name: updated_at
         description: The last time this user's email was updated
+    tests:
+      - test.test_nothing

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -628,9 +628,9 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'child_map': {
                 'model.test.model': [
-                    'test.test.unique_model_id',
                     'test.test.not_null_model_id',
                     'test.test.test_nothing_model_',
+                    'test.test.unique_model_id',
                 ],
                 'seed.test.seed': ['model.test.model'],
                 'test.test.not_null_model_id': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 import os
 from datetime import datetime, timedelta

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -43,7 +43,10 @@ class TestDocsGenerate(DBTIntegrationTest):
         }
 
     def run_and_generate(self, extra=None, seed_count=1, model_count=1):
-        project = {"data-paths": [self.dir("seed")]}
+        project = {
+            "data-paths": [self.dir("seed")],
+            'macro-paths': [self.dir('macros')]
+        }
         if extra:
             project.update(extra)
         self.use_default_project(project)
@@ -528,14 +531,110 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'columns': {},
                 },
+                'test.test.not_null_model_id': {
+                    'alias': 'not_null_model_id',
+                    'column_name': 'id',
+                    'columns': {},
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'fqn': ['test', 'schema_test', 'not_null_model_id'],
+                    'name': 'not_null_model_id',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/not_null_model_id.sql'),
+                    'raw_sql': "{{ test_not_null(model=ref('model'), column_name='id') }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.not_null_model_id'
+                },
+                'test.test.test_nothing_model_': {
+                    'alias': 'test_nothing_model_',
+                    'columns': {},
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'fqn': ['test', 'schema_test', 'test_nothing_model_'],
+                    'name': 'test_nothing_model_',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/test_nothing_model_.sql'),
+                    'raw_sql': "{{ test_test_nothing(model=ref('model'), ) }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.test_nothing_model_'
+                },
+                'test.test.unique_model_id': {
+                    'alias': 'unique_model_id',
+                    'column_name': 'id',
+                    'columns': {},
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'fqn': ['test', 'schema_test', 'unique_model_id'],
+                    'name': 'unique_model_id',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/unique_model_id.sql'),
+                    'raw_sql': "{{ test_unique(model=ref('model'), column_name='id') }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.unique_model_id'
+                },
             },
             'parent_map': {
                 'model.test.model': ['seed.test.seed'],
                 'seed.test.seed': [],
+                'test.test.not_null_model_id': ['model.test.model'],
+                'test.test.test_nothing_model_': ['model.test.model'],
+                'test.test.unique_model_id': ['model.test.model'],
             },
             'child_map': {
-                'model.test.model': [],
+                'model.test.model': [
+                    'test.test.unique_model_id',
+                    'test.test.not_null_model_id',
+                    'test.test.test_nothing_model_',
+                ],
                 'seed.test.seed': ['model.test.model'],
+                'test.test.not_null_model_id': [],
+                'test.test.test_nothing_model_': [],
+                'test.test.unique_model_id': [],
             },
             'docs': {},
             'metadata': {

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -1414,7 +1414,8 @@ class ParserTest(unittest.TestCase):
                 tags=['schema'],
                 raw_sql=accepted_values_sql,
                 description='',
-                columns={}
+                columns={},
+                column_name='id'
             ),
             ParsedNode(
                 alias='not_null_model_one_id',
@@ -1434,7 +1435,8 @@ class ParserTest(unittest.TestCase):
                 tags=['schema'],
                 raw_sql=not_null_sql,
                 description='',
-                columns={}
+                columns={},
+                column_name='id'
             ),
             ParsedNode(
                 alias='relationships_model_one_id__id__ref_model_two_',
@@ -1455,7 +1457,8 @@ class ParserTest(unittest.TestCase):
                 tags=['schema'],
                 raw_sql=relationships_sql,
                 description='',
-                columns={}
+                columns={},
+                column_name='id'
             ),
             ParsedNode(
                 alias='some_test_model_one_value',
@@ -1495,10 +1498,12 @@ class ParserTest(unittest.TestCase):
                 tags=['schema'],
                 raw_sql=unique_sql,
                 description='',
-                columns={}
+                columns={},
+                column_name='id'
             ),
         ]
-        self.assertEqual(tests, expected_tests)
+        for test, expected in zip(tests, expected_tests):
+            self.assertEqual(test, expected)
 
         expected_patches = [
             ParsedNodePatch(name='model_one',
@@ -1512,7 +1517,8 @@ class ParserTest(unittest.TestCase):
                 docrefs=[],
             ),
         ]
-        self.assertEqual(patches, expected_patches)
+        for patch, expected in zip(patches, expected_patches):
+            self.assertEqual(patch, expected)
 
     def test__simple_data_test(self):
         tests = [{


### PR DESCRIPTION
When a test involves a column, include the column name in the test's manifest representation.

When a test does not involve a column or the node is not a test, there will be no `column_name` field in the manifest at all.