### PR TITLE
Fix cte ordering (#924)

### DIFF
--- a/dbt/context/runtime.py
+++ b/dbt/context/runtime.py
@@ -49,7 +49,7 @@ def ref(db_wrapper, model, project_cfg, profile, manifest):
         is_ephemeral = (get_materialization(target_model) == 'ephemeral')
 
         if is_ephemeral:
-            model['extra_ctes'][target_model_id] = None
+            model.set_cte(target_model_id, None)
             return adapter.Relation.create(
                 type=adapter.Relation.CTE,
                 identifier=add_ephemeral_model_prefix(

--- a/test/integration/020_ephemeral_test/models/base/female_only.sql
+++ b/test/integration/020_ephemeral_test/models/base/female_only.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='ephemeral') }}
+
+select * from {{ ref('base_copy') }} where gender = 'Female'

--- a/test/integration/020_ephemeral_test/models/super_dependent.sql
+++ b/test/integration/020_ephemeral_test/models/super_dependent.sql
@@ -1,0 +1,3 @@
+select * from {{ref('female_only')}}
+union all
+select * from {{ref('double_dependent')}} where gender = 'Male'

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -22,10 +22,11 @@ class TestEphemeral(DBTIntegrationTest):
         self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
 
         results = self.run_dbt()
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
 
         self.assertTablesEqual("seed", "dependent")
         self.assertTablesEqual("seed", "double_dependent")
+        self.assertTablesEqual("seed", "super_dependent")
 
     @attr(type='snowflake')
     def test__snowflake(self):
@@ -34,6 +35,8 @@ class TestEphemeral(DBTIntegrationTest):
         self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
 
         results = self.run_dbt()
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
 
-        self.assertManyTablesEqual(["SEED", "dependent", "double_dependent"])
+        self.assertManyTablesEqual(
+            ["SEED", "dependent", "double_dependent", "super_dependent"]
+        )

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1096,7 +1096,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'The test model',
                     'docrefs': [],
                     'empty': False,
-                    'extra_ctes': {},
+                    'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'model'],
                     'injected_sql': compiled_sql,
@@ -1196,9 +1196,9 @@ class TestDocsGenerate(DBTIntegrationTest):
                         }
                     ],
                     'empty': False,
-                    'extra_ctes': {
-                        'model.test.ephemeral_copy': cte_sql,
-                    },
+                    'extra_ctes': [
+                        {'id': 'model.test.ephemeral_copy', 'sql': cte_sql},
+                    ],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'ephemeral_summary'],
                     'injected_sql': ephemeral_injected_sql,
@@ -1280,7 +1280,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                         }
                     ],
                     'empty': False,
-                    'extra_ctes': {},
+                    'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'view_summary'],
                     'injected_sql': view_compiled_sql,

--- a/test/unit/test_compiler.py
+++ b/test/unit/test_compiler.py
@@ -74,9 +74,9 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from {{ref("ephemeral")}}',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict([
-                        ('model.root.ephemeral', None)
-                    ]),
+                    extra_ctes=[
+                        {'id': 'model.root.ephemeral', 'sql': None}
+                    ],
                     injected_sql='',
                     compiled_sql=(
                         'with cte as (select * from something_else) '
@@ -105,7 +105,7 @@ class CompilerTest(unittest.TestCase):
                     compiled=True,
                     compiled_sql='select * from source_table',
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict(),
+                    extra_ctes=[],
                     injected_sql=''
                 ),
             },
@@ -159,7 +159,7 @@ class CompilerTest(unittest.TestCase):
                                 'select * from source_table'),
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict(),
+                    extra_ctes=[],
                     injected_sql='',
                     compiled_sql=('with cte as (select * from something_else) '
                                      'select * from source_table')
@@ -186,7 +186,7 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from source_table',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict(),
+                    extra_ctes=[],
                     injected_sql='',
                     compiled_sql=('select * from source_table')
                 ),
@@ -254,9 +254,9 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from {{ref("ephemeral")}}',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict([
-                        ('model.root.ephemeral', None)
-                    ]),
+                    extra_ctes=[
+                        {'id': 'model.root.ephemeral', 'sql': None}
+                    ],
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral'
                 ),
@@ -282,7 +282,7 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from source_table',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict(),
+                    extra_ctes=[],
                     injected_sql='',
                     compiled_sql='select * from source_table'
                 ),
@@ -344,9 +344,9 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from {{ref("ephemeral")}}',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict([
-                        ('model.root.ephemeral', None)
-                    ]),
+                    extra_ctes=[
+                        {'id': 'model.root.ephemeral', 'sql': None}
+                    ],
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral'
                 ),
@@ -372,9 +372,9 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from {{ref("ephemeral_level_two")}}',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict([
-                        ('model.root.ephemeral_level_two', None)
-                    ]),
+                    extra_ctes=[
+                        {'id': 'model.root.ephemeral_level_two', 'sql': None}
+                    ],
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral_level_two' # noqa
                 ),
@@ -400,7 +400,7 @@ class CompilerTest(unittest.TestCase):
                     raw_sql='select * from source_table',
                     compiled=True,
                     extra_ctes_injected=False,
-                    extra_ctes=OrderedDict(),
+                    extra_ctes=[],
                     injected_sql='',
                     compiled_sql='select * from source_table'
                 ),

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -348,7 +348,7 @@ class MixedManifestTest(unittest.TestCase):
                 compiled_sql='also does not matter',
                 extra_ctes_injected=True,
                 injected_sql=None,
-                extra_ctes={}
+                extra_ctes=[]
             ),
             'model.root.events': CompiledNode(
                 name='events',
@@ -374,7 +374,7 @@ class MixedManifestTest(unittest.TestCase):
                 compiled_sql='also does not matter',
                 extra_ctes_injected=True,
                 injected_sql='and this also does not matter',
-                extra_ctes={}
+                extra_ctes=[]
             ),
             'model.root.dep': ParsedNode(
                 name='dep',


### PR DESCRIPTION
An attempt at fixing CTE ordering by changing storage from an OrderedDict mapping cte ID to its sql into a list of `{'id': ..., 'sql': ...}` dicts. 

Note: this issue is not reproducible on Python 3.6+ due to how the semantics of the `dict` type changed. Python 2.7, or 3.5, will see it.