### PR TITLE
call compile when generating docs (#932)

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -355,7 +355,21 @@ def parse_args(args):
     compile_sub = subs.add_parser('compile', parents=[base_subparser])
     compile_sub.set_defaults(cls=compile_task.CompileTask, which='compile')
 
-    for sub in [run_sub, compile_sub]:
+    docs_sub = subs.add_parser('docs', parents=[base_subparser])
+    docs_subs = docs_sub.add_subparsers()
+    # it might look like docs_sub is the correct parents entry, but that
+    # will cause weird errors about 'conflicting option strings'.
+    generate_sub = docs_subs.add_parser('generate', parents=[base_subparser])
+    generate_sub.set_defaults(cls=generate_task.GenerateTask,
+                              which='generate')
+    generate_sub.add_argument(
+        '--no-compile',
+        action='store_false',
+        dest='compile',
+        help='Do not run "dbt compile" as part of docs generation'
+    )
+
+    for sub in [run_sub, compile_sub, generate_sub]:
         sub.add_argument(
             '--models',
             required=False,
@@ -414,14 +428,6 @@ def parse_args(args):
         help='Show a sample of the loaded data in the terminal'
     )
     seed_sub.set_defaults(cls=seed_task.SeedTask, which='seed')
-
-    docs_sub = subs.add_parser('docs', parents=[base_subparser])
-    docs_subs = docs_sub.add_subparsers()
-    # it might look like docs_sub is the correct parents entry, but that
-    # will cause weird errors about 'conflicting option strings'.
-    generate_sub = docs_subs.add_parser('generate', parents=[base_subparser])
-    generate_sub.set_defaults(cls=generate_task.GenerateTask,
-                              which='generate')
 
     serve_sub = docs_subs.add_parser('serve', parents=[base_subparser])
     serve_sub.set_defaults(cls=serve_task.ServeTask,

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -135,7 +135,7 @@ class GenerateTask(CompileTask):
                 dbt.ui.printer.print_timestamped_line(
                     'compile failed, cannot generate docs'
                 )
-                return
+                return {'compile_results': compile_results}
 
         shutil.copyfile(
             DOCS_INDEX_FILE_PATH,


### PR DESCRIPTION
When we're doing `dbt docs generate`, implicitly call `dbt compile` unless the user provides the `--no-compile` flag.