### PR TITLE
Snowflake default unquoted (#824)

### DIFF
--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -18,6 +18,7 @@ from dbt.utils import filter_null_values
 
 
 class SnowflakeAdapter(PostgresAdapter):
+    DEFAULT_QUOTE = False
 
     Relation = SnowflakeRelation
 

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -129,8 +129,8 @@ class SnowflakeAdapter(PostgresAdapter):
             schema=_schema,
             identifier=name,
             quote_policy={
+                'identifier': True,
                 'schema': True,
-                'identifier': True
             },
             type=relation_type_lookup.get(type))
                 for (name, _schema, type) in results]
@@ -222,11 +222,11 @@ class SnowflakeAdapter(PostgresAdapter):
     @classmethod
     def _make_match_kwargs(cls, project_cfg, schema, identifier):
         if identifier is not None and \
-           project_cfg.get('quoting', {}).get('identifier', True) is False:
+           project_cfg.get('quoting', {}).get('identifier', False) is False:
             identifier = identifier.upper()
 
         if schema is not None and \
-           project_cfg.get('quoting', {}).get('schema', True) is False:
+           project_cfg.get('quoting', {}).get('schema', False) is False:
             schema = schema.upper()
 
         return filter_null_values({'identifier': identifier,

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -9,8 +9,8 @@ class SnowflakeRelation(DefaultRelation):
         'quote_character': '"',
         'quote_policy': {
             'database': True,
-            'schema': True,
-            'identifier': True,
+            'schema': False,
+            'identifier': False,
         },
         'include_policy': {
             'database': False,

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -233,8 +233,6 @@ def invoke_dbt(parsed):
 
             return None
 
-    proj.log_warnings()
-
     flags.NON_DESTRUCTIVE = getattr(proj.args, 'non_destructive', False)
 
     arg_drop_existing = getattr(proj.args, 'drop_existing', False)

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -248,23 +248,6 @@ class Project(object):
         except dbt.exceptions.ValidationException as e:
             raise DbtProjectError(str(e), self)
 
-    def log_warnings(self):
-        target_cfg = self.run_environment()
-        db_type = target_cfg.get('type')
-
-        if db_type == 'snowflake' and self.cfg \
-                                          .get('quoting', {}) \
-                                          .get('identifier') is None:
-            msg = dbt.ui.printer.yellow(
-                'You are using Snowflake, but you did not specify a '
-                'quoting strategy for your identifiers.\nQuoting '
-                'behavior for Snowflake will change in a future release, '
-                'so it is recommended that you define this explicitly.\n\n'
-                'For more information, see: {}\n'
-            )
-
-            logger.warn(msg.format(dbt.links.SnowflakeQuotingDocs))
-
     def hashed_name(self):
         if self.cfg.get("name", None) is None:
             return None

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -56,13 +56,13 @@ class TestSimpleCopy(DBTIntegrationTest):
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
     @use_profile("snowflake")
     def test__snowflake__simple_copy__quoting_on(self):
@@ -180,13 +180,13 @@ class TestSimpleCopyLowercasedSchema(DBTIntegrationTest):
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         self.run_dbt(["seed"])
         self.run_dbt()
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
 
     @use_profile("snowflake")
     def test__snowflake__seed__quoting_switch_schema(self):

--- a/test/integration/002_varchar_widening_test/test_varchar_widening.py
+++ b/test/integration/002_varchar_widening_test/test_varchar_widening.py
@@ -43,11 +43,11 @@ class TestVarcharWidening(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results),  2)
 
-        self.assertManyTablesEqual(["SEED", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "INCREMENTAL", "MATERIALIZED"])
 
         self.run_sql_file("test/integration/002_varchar_widening_test/update.sql")
 
         results = self.run_dbt()
         self.assertEqual(len(results),  2)
 
-        self.assertManyTablesEqual(["SEED", "incremental", "materialized"])
+        self.assertManyTablesEqual(["SEED", "INCREMENTAL", "MATERIALIZED"])

--- a/test/integration/003_simple_reference_test/test_simple_reference.py
+++ b/test/integration/003_simple_reference_test/test_simple_reference.py
@@ -63,8 +63,8 @@ class TestSimpleReference(DBTIntegrationTest):
 
         # Copies should match
         self.assertManyTablesEqual(
-            ["SEED", "incremental_copy", "materialized_copy", "view_copy"],
-            ["SUMMARY_EXPECTED", "incremental_summary", "materialized_summary", "view_summary", "ephemeral_summary"]
+            ["SEED", "INCREMENTAL_COPY", "MATERIALIZED_COPY", "VIEW_COPY"],
+            ["SUMMARY_EXPECTED", "INCREMENTAL_SUMMARY", "MATERIALIZED_SUMMARY", "VIEW_SUMMARY", "EPHEMERAL_SUMMARY"]
         )
 
         self.run_sql_file(
@@ -74,8 +74,8 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertEqual(len(results),  7)
 
         self.assertManyTablesEqual(
-            ["SEED", "incremental_copy", "materialized_copy", "view_copy"],
-            ["SUMMARY_EXPECTED", "incremental_summary", "materialized_summary", "view_summary", "ephemeral_summary"]
+            ["SEED", "INCREMENTAL_COPY", "MATERIALIZED_COPY", "VIEW_COPY"],
+            ["SUMMARY_EXPECTED", "INCREMENTAL_SUMMARY", "MATERIALIZED_SUMMARY", "VIEW_SUMMARY", "EPHEMERAL_SUMMARY"]
         )
 
     @attr(type='postgres')
@@ -150,10 +150,10 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertEqual(len(results),  1)
 
         # Copies should match
-        self.assertTablesEqual("SEED", "materialized_copy")
+        self.assertTablesEqual("SEED", "MATERIALIZED_COPY")
 
         created_models = self.get_models_in_schema()
-        self.assertTrue('materialized_copy' in created_models)
+        self.assertTrue('MATERIALIZED_COPY' in created_models)
 
     @attr(type='snowflake')
     def test__snowflake__simple_reference_with_models_and_children(self):
@@ -171,24 +171,24 @@ class TestSimpleReference(DBTIntegrationTest):
 
         # Copies should match
         self.assertManyTablesEqual(
-            ["SEED", "materialized_copy"],
-            ["SUMMARY_EXPECTED", "materialized_summary", "ephemeral_summary"]
+            ["SEED", "MATERIALIZED_COPY"],
+            ["SUMMARY_EXPECTED", "MATERIALIZED_SUMMARY", "EPHEMERAL_SUMMARY"]
         )
 
         created_models = self.get_models_in_schema()
 
-        self.assertFalse('incremental_copy' in created_models)
-        self.assertFalse('incremental_summary' in created_models)
-        self.assertFalse('view_copy' in created_models)
-        self.assertFalse('view_summary' in created_models)
+        self.assertFalse('INCREMENTAL_COPY' in created_models)
+        self.assertFalse('INCREMENTAL_SUMMARY' in created_models)
+        self.assertFalse('VIEW_COPY' in created_models)
+        self.assertFalse('VIEW_SUMMARY' in created_models)
 
         # make sure this wasn't errantly materialized
-        self.assertFalse('ephemeral_copy' in created_models)
+        self.assertFalse('EPHEMERAL_COPY' in created_models)
 
-        self.assertTrue('materialized_copy' in created_models)
-        self.assertTrue('materialized_summary' in created_models)
-        self.assertEqual(created_models['materialized_copy'], 'table')
-        self.assertEqual(created_models['materialized_summary'], 'table')
+        self.assertTrue('MATERIALIZED_COPY' in created_models)
+        self.assertTrue('MATERIALIZED_SUMMARY' in created_models)
+        self.assertEqual(created_models['MATERIALIZED_COPY'], 'table')
+        self.assertEqual(created_models['MATERIALIZED_SUMMARY'], 'table')
 
-        self.assertTrue('ephemeral_summary' in created_models)
-        self.assertEqual(created_models['ephemeral_summary'], 'table')
+        self.assertTrue('EPHEMERAL_SUMMARY' in created_models)
+        self.assertEqual(created_models['EPHEMERAL_SUMMARY'], 'table')

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -63,7 +63,7 @@ class TestSimpleArchive(DBTIntegrationTest):
         results = self.run_dbt(["archive"])
         self.assertEqual(len(results),  1)
 
-        self.assertTablesEqual("ARCHIVE_EXPECTED", "archive_actual")
+        self.assertTablesEqual("ARCHIVE_EXPECTED", "ARCHIVE_ACTUAL")
 
         self.run_sql_file("test/integration/004_simple_archive_test/invalidate_snowflake.sql")
         self.run_sql_file("test/integration/004_simple_archive_test/update.sql")
@@ -71,7 +71,7 @@ class TestSimpleArchive(DBTIntegrationTest):
         results = self.run_dbt(["archive"])
         self.assertEqual(len(results),  1)
 
-        self.assertTablesEqual("ARCHIVE_EXPECTED", "archive_actual")
+        self.assertTablesEqual("ARCHIVE_EXPECTED", "ARCHIVE_ACTUAL")
 
     @attr(type='redshift')
     def test__redshift__simple_archive(self):

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -35,11 +35,11 @@ class TestGraphSelection(DBTIntegrationTest):
         results = self.run_dbt(['run', '--models', 'users'])
         self.assertEqual(len(results),  1)
 
-        self.assertTablesEqual("SEED", "users")
+        self.assertTablesEqual("SEED", "USERS")
         created_models = self.get_models_in_schema()
-        self.assertFalse('users_rollup' in created_models)
-        self.assertFalse('base_users' in created_models)
-        self.assertFalse('emails' in created_models)
+        self.assertFalse('USERS_ROLLUP' in created_models)
+        self.assertFalse('BASE_USERS' in created_models)
+        self.assertFalse('EMAILS' in created_models)
 
 
     @attr(type='postgres')
@@ -67,12 +67,12 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertEqual(len(results),  2)
 
         self.assertManyTablesEqual(
-            ["SEED", "users"],
-            ["SUMMARY_EXPECTED", "users_rollup"]
+            ["SEED", "USERS"],
+            ["SUMMARY_EXPECTED", "USERS_ROLLUP"]
         )
         created_models = self.get_models_in_schema()
-        self.assertFalse('base_users' in created_models)
-        self.assertFalse('emails' in created_models)
+        self.assertFalse('BASE_USERS' in created_models)
+        self.assertFalse('EMAILS' in created_models)
 
 
     @attr(type='postgres')
@@ -100,13 +100,13 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertEqual(len(results),  2)
 
         self.assertManyTablesEqual(
-            ["SEED", "users"],
-            ["SUMMARY_EXPECTED", "users_rollup"]
+            ["SEED", "USERS"],
+            ["SUMMARY_EXPECTED", "USERS_ROLLUP"]
         )
 
         created_models = self.get_models_in_schema()
-        self.assertFalse('base_users' in created_models)
-        self.assertFalse('emails' in created_models)
+        self.assertFalse('BASE_USERS' in created_models)
+        self.assertFalse('EMAILS' in created_models)
 
 
     @attr(type='postgres')
@@ -137,8 +137,8 @@ class TestGraphSelection(DBTIntegrationTest):
         )
         self.assertEqual(len(results),  1)
 
-        self.assertManyTablesEqual(["SEED", "users"])
+        self.assertManyTablesEqual(["SEED", "USERS"])
         created_models = self.get_models_in_schema()
-        self.assertFalse('base_users' in created_models)
-        self.assertFalse('users_rollup' in created_models)
-        self.assertFalse('emails' in created_models)
+        self.assertFalse('BASE_USERS' in created_models)
+        self.assertFalse('USERS_ROLLUP' in created_models)
+        self.assertFalse('EMAILS' in created_models)

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -38,5 +38,5 @@ class TestEphemeral(DBTIntegrationTest):
         self.assertEqual(len(results), 3)
 
         self.assertManyTablesEqual(
-            ["SEED", "dependent", "double_dependent", "super_dependent"]
+            ["SEED", "DEPENDENT", "DOUBLE_DEPENDENT", "SUPER_DEPENDENT"]
         )

--- a/test/integration/021_concurrency_test/test_concurrency.py
+++ b/test/integration/021_concurrency_test/test_concurrency.py
@@ -52,11 +52,11 @@ class TestConcurrency(DBTIntegrationTest):
         results = self.run_dbt(expect_pass=False)
         self.assertEqual(len(results), 7)
 
-        self.assertManyTablesEqual(["SEED", "view_model", "dep", "table_a", "table_b"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "DEP", "TABLE_A", "TABLE_B"])
 
         self.run_sql_file("test/integration/021_concurrency_test/update.sql")
 
         results = self.run_dbt(expect_pass=False)
         self.assertEqual(len(results), 7)
 
-        self.assertManyTablesEqual(["SEED", "view_model", "dep", "table_a", "table_b"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "DEP", "TABLE_A", "TABLE_B"])

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1154,7 +1154,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         if self.adapter_type == 'snowflake':
             status = 'SUCCESS 1'
-
+            compiled_sql = compiled_sql.replace('"', '')
         if self.adapter_type == 'bigquery':
             status = 'OK'
             compiled_sql = '\n\nselect * from `{}`.`{}`.seed'.format(

--- a/test/integration/030_statement_test/test_statements.py
+++ b/test/integration/030_statement_test/test_statements.py
@@ -30,7 +30,7 @@ class TestStatements(DBTIntegrationTest):
 
     @attr(type="snowflake")
     def test_snowflake_statements(self):
-        self.use_profile("postgres")
+        self.use_profile("snowflake")
         self.use_default_project({"data-paths": [self.dir("seed")]})
 
         results = self.run_dbt(["seed"])

--- a/test/integration/030_statement_test/test_statements.py
+++ b/test/integration/030_statement_test/test_statements.py
@@ -38,7 +38,7 @@ class TestStatements(DBTIntegrationTest):
         results = self.run_dbt()
         self.assertEqual(len(results), 1)
 
-        self.assertManyTablesEqual(["statement_actual", "statement_expected"])
+        self.assertManyTablesEqual(["STATEMENT_ACTUAL", "STATEMENT_EXPECTED"])
 
     @attr(type="bigquery")
     def test_bigquery_statements(self):

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -437,7 +437,16 @@ class DBTIntegrationTest(unittest.TestCase):
                 table_filter=table_filters_s)
 
         columns = self.run_sql(sql, fetch='all')
-        return sorted(columns, key=lambda x: "{}.{}".format(x[0], x[1]))
+        return sorted(map(self.filter_many_columns, columns),
+                      key=lambda x: "{}.{}".format(x[0], x[1]))
+
+    def filter_many_columns(self, column):
+        table_name, column_name, data_type, char_size = column
+        # in snowflake, all varchar widths are created equal
+        if self.adapter_type == 'snowflake':
+            if char_size and char_size < 16777216:
+                char_size = 16777216
+        return (table_name, column_name, data_type, char_size)
 
     def get_table_columns(self, table, schema=None):
         schema = self.unique_schema() if schema is None else schema

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -309,9 +309,8 @@ class DBTIntegrationTest(unittest.TestCase):
         self.adapter.cleanup_connections()
 
     def _create_schema(self):
-
         if self.adapter_type == 'bigquery':
-            self.adapter.create_schema(profile, project, self.unique_schema(), '__test')
+            self.adapter.create_schema(self._profile, self.project, self.unique_schema(), '__test')
         else:
             schema = self.quote_as_configured(self.unique_schema(), 'schema')
             self.run_sql('CREATE SCHEMA {}'.format(schema))

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -298,7 +298,7 @@ class DBTIntegrationTest(unittest.TestCase):
         except:
             os.rename("dbt_modules", "dbt_modules-{}".format(time.time()))
 
-        adapter = get_adapter(self._profile)
+        self.adapter = get_adapter(self._profile)
 
         self._drop_schema()
 
@@ -306,12 +306,12 @@ class DBTIntegrationTest(unittest.TestCase):
         if hasattr(self.handle, 'close'):
             self.handle.close()
 
-        adapter.cleanup_connections()
+        self.adapter.cleanup_connections()
 
     def _create_schema(self):
 
         if self.adapter_type == 'bigquery':
-            adapter.create_schema(profile, project, self.unique_schema(), '__test')
+            self.adapter.create_schema(profile, project, self.unique_schema(), '__test')
         else:
             schema = self.quote_as_configured(self.unique_schema(), 'schema')
             self.run_sql('CREATE SCHEMA {}'.format(schema))
@@ -319,8 +319,8 @@ class DBTIntegrationTest(unittest.TestCase):
 
     def _drop_schema(self):
         if self.adapter_type == 'bigquery':
-            adapter.drop_schema(self._profile, self.project,
-                                self.unique_schema(), '__test')
+            self.adapter.drop_schema(self._profile, self.project,
+                                     self.unique_schema(), '__test')
         else:
             had_existing = False
             try:


### PR DESCRIPTION
This fixes #824. The actual code changes are fairly simple, but this required extensive test changes to the base test class. I'm still not totally confident in them, the integration tests make a lot of quoting-related assumptions, but the tests do seem to pass and the test changes I made to the regular test files seem reasonable. I think this adventure exposed that there are probably some more tests we should add (like a `TestSimpleCopyUppercasedSchema` that forces uppercase schemas and tests non-snowflake dbs), but I think that's a separate PR/issue.