### PR TITLE
Compile on docs generate (#932)

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -355,7 +355,21 @@ def parse_args(args):
     compile_sub = subs.add_parser('compile', parents=[base_subparser])
     compile_sub.set_defaults(cls=compile_task.CompileTask, which='compile')
 
-    for sub in [run_sub, compile_sub]:
+    docs_sub = subs.add_parser('docs', parents=[base_subparser])
+    docs_subs = docs_sub.add_subparsers()
+    # it might look like docs_sub is the correct parents entry, but that
+    # will cause weird errors about 'conflicting option strings'.
+    generate_sub = docs_subs.add_parser('generate', parents=[base_subparser])
+    generate_sub.set_defaults(cls=generate_task.GenerateTask,
+                              which='generate')
+    generate_sub.add_argument(
+        '--no-compile',
+        action='store_false',
+        dest='compile',
+        help='Do not run "dbt compile" as part of docs generation'
+    )
+
+    for sub in [run_sub, compile_sub, generate_sub]:
         sub.add_argument(
             '--models',
             required=False,
@@ -414,14 +428,6 @@ def parse_args(args):
         help='Show a sample of the loaded data in the terminal'
     )
     seed_sub.set_defaults(cls=seed_task.SeedTask, which='seed')
-
-    docs_sub = subs.add_parser('docs', parents=[base_subparser])
-    docs_subs = docs_sub.add_subparsers()
-    # it might look like docs_sub is the correct parents entry, but that
-    # will cause weird errors about 'conflicting option strings'.
-    generate_sub = docs_subs.add_parser('generate', parents=[base_subparser])
-    generate_sub.set_defaults(cls=generate_task.GenerateTask,
-                              which='generate')
 
     serve_sub = docs_subs.add_parser('serve', parents=[base_subparser])
     serve_sub.set_defaults(cls=serve_task.ServeTask,

--- a/dbt/task/generate.py
+++ b/dbt/task/generate.py
@@ -12,6 +12,7 @@ import dbt.compilation
 import dbt.exceptions
 
 from dbt.task.base_task import BaseTask
+from dbt.task.compile import CompileTask
 
 
 CATALOG_FILENAME = 'catalog.json'
@@ -116,7 +117,7 @@ def incorporate_catalog_unique_ids(catalog, manifest):
     return nodes
 
 
-class GenerateTask(BaseTask):
+class GenerateTask(CompileTask):
     def _get_manifest(self):
         compiler = dbt.compilation.Compiler(self.project)
         compiler.initialize()
@@ -127,6 +128,15 @@ class GenerateTask(BaseTask):
         return manifest
 
     def run(self):
+        compile_results = None
+        if self.args.compile:
+            compile_results = super(GenerateTask, self).run()
+            if any(r.errored for r in compile_results):
+                dbt.ui.printer.print_timestamped_line(
+                    'compile failed, cannot generate docs'
+                )
+                return {'compile_results': compile_results}
+
         shutil.copyfile(
             DOCS_INDEX_FILE_PATH,
             os.path.join(self.project['target-path'], 'index.html'))
@@ -155,5 +165,15 @@ class GenerateTask(BaseTask):
         dbt.ui.printer.print_timestamped_line(
             'Catalog written to {}'.format(os.path.abspath(path))
         )
+        # now that we've serialized the data we can add compile_results in to
+        # make interpret_results happy.
+        results['compile_results'] = compile_results
 
         return results
+
+    def interpret_results(self, results):
+        compile_results = results.get('compile_results')
+        if compile_results is None:
+            return True
+
+        return super(GenerateTask, self).interpret_results(compile_results)

--- a/test/integration/029_docs_generate_tests/models/schema.yml
+++ b/test/integration/029_docs_generate_tests/models/schema.yml
@@ -18,4 +18,4 @@ models:
       - name: updated_at
         description: The last time this user's email was updated
     tests:
-      - test.test_nothing
+      - test.nothing

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -562,8 +562,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': ['schema'],
                     'unique_id': 'test.test.not_null_model_id'
                 },
-                'test.test.test_nothing_model_': {
-                    'alias': 'test_nothing_model_',
+                'test.test.nothing_model_': {
+                    'alias': 'nothing_model_',
                     'columns': {},
                     'config': {
                         'column_types': {},
@@ -577,18 +577,18 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'depends_on': {'macros': [], 'nodes': ['model.test.model']},
                     'description': '',
                     'empty': False,
-                    'fqn': ['test', 'schema_test', 'test_nothing_model_'],
-                    'name': 'test_nothing_model_',
+                    'fqn': ['test', 'schema_test', 'nothing_model_'],
+                    'name': 'nothing_model_',
                     'original_file_path': self.dir('models/schema.yml'),
                     'package_name': 'test',
-                    'path': os.path.normpath('schema_test/test_nothing_model_.sql'),
-                    'raw_sql': "{{ test_test_nothing(model=ref('model'), ) }}",
+                    'path': os.path.normpath('schema_test/nothing_model_.sql'),
+                    'raw_sql': "{{ test_nothing(model=ref('model'), ) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': os.getcwd(),
                     'schema': my_schema_name,
                     'tags': ['schema'],
-                    'unique_id': 'test.test.test_nothing_model_'
+                    'unique_id': 'test.test.nothing_model_'
                 },
                 'test.test.unique_model_id': {
                     'alias': 'unique_model_id',
@@ -624,18 +624,18 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.model': ['seed.test.seed'],
                 'seed.test.seed': [],
                 'test.test.not_null_model_id': ['model.test.model'],
-                'test.test.test_nothing_model_': ['model.test.model'],
+                'test.test.nothing_model_': ['model.test.model'],
                 'test.test.unique_model_id': ['model.test.model'],
             },
             'child_map': {
                 'model.test.model': [
                     'test.test.not_null_model_id',
-                    'test.test.test_nothing_model_',
+                    'test.test.nothing_model_',
                     'test.test.unique_model_id',
                 ],
                 'seed.test.seed': ['model.test.model'],
                 'test.test.not_null_model_id': [],
-                'test.test.test_nothing_model_': [],
+                'test.test.nothing_model_': [],
                 'test.test.unique_model_id': [],
             },
             'docs': {},

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -53,8 +53,9 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.use_default_project(project)
 
         self.assertEqual(len(self.run_dbt(["seed"])), seed_count)
-        self.run_start_time = datetime.utcnow()
         self.assertEqual(len(self.run_dbt()), model_count)
+        os.remove(os.path.normpath('target/manifest.json'))
+        os.remove(os.path.normpath('target/run_results.json'))
         self.generate_start_time = datetime.utcnow()
         self.run_dbt(['docs', 'generate'])
 
@@ -1139,8 +1140,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         }
         self.assertBetween(
             manifest['generated_at'],
-            start=self.run_start_time,
-            end=self.generate_start_time
+            start=self.generate_start_time
         )
         self.assertEqual(manifest_without_extras, expected_manifest)
 
@@ -1160,6 +1160,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             compiled_sql = '\n\nselect * from `{}`.`{}`.seed'.format(
                 self._profile['project'], schema
             )
+        status = None
 
         return [
             {
@@ -1216,7 +1217,51 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'skip': False,
                 'status': status,
-            }
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'seed',
+                    'build_path': os.path.normpath(
+                        'target/compiled/test/seed.csv'
+                    ),
+                    'columns': {},
+                    'compiled': True,
+                    'compiled_sql': '-- csv --',
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'seed',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {},
+                    },
+                    'depends_on': {'macros': [], 'nodes': []},
+                    'description': '',
+                    'empty': False,
+                    'extra_ctes': [],
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'seed'],
+                    'injected_sql': '-- csv --',
+                    'name': 'seed',
+                    'original_file_path': self.dir('seed/seed.csv'),
+                    'package_name': 'test',
+                    'path': 'seed.csv',
+                    'raw_sql': '-- csv --',
+                    'refs': [],
+                    'resource_type': 'seed',
+                    'root_path': os.getcwd(),
+                    'schema': schema,
+                    'tags': [],
+                    'unique_id': 'seed.test.seed',
+                    'wrapped_sql': 'None'
+                },
+                'skip': False,
+                'status': None,
+            },
         ]
 
     def expected_postgres_references_run_results(self):
@@ -1322,7 +1367,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'wrapped_sql': 'None',
                 },
                 'skip': False,
-                'status': 'SELECT 1',
+                'status': None,
             },
             {
                 'error': None,
@@ -1403,7 +1448,51 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'wrapped_sql': 'None',
                 },
                 'skip': False,
-                'status': 'CREATE VIEW',
+                'status': None,
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'seed',
+                    'build_path': os.path.normpath(
+                        'target/compiled/test/seed.csv'
+                    ),
+                    'columns': {},
+                    'compiled': True,
+                    'compiled_sql': '-- csv --',
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'seed',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {},
+                    },
+                    'depends_on': {'macros': [], 'nodes': []},
+                    'description': '',
+                    'empty': False,
+                    'extra_ctes': [],
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'seed'],
+                    'injected_sql': '-- csv --',
+                    'name': 'seed',
+                    'original_file_path': self.dir('seed/seed.csv'),
+                    'package_name': 'test',
+                    'path': 'seed.csv',
+                    'raw_sql': '-- csv --',
+                    'refs': [],
+                    'resource_type': 'seed',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'seed.test.seed',
+                    'wrapped_sql': 'None'
+                },
+                'skip': False,
+                'status': None,
             },
         ]
 
@@ -1415,8 +1504,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.assertIn('elapsed_time', run_result)
         self.assertBetween(
             run_result['generated_at'],
-            start=self.run_start_time,
-            end=self.generate_start_time
+            start=self.generate_start_time
         )
         self.assertGreater(run_result['elapsed_time'], 0)
         self.assertTrue(
@@ -1424,6 +1512,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             "run_result['elapsed_time'] is of type {}, expected float".format(
                 str(type(run_result['elapsed_time'])))
         )
+        # sort the results so we can make reasonable assertions
+        run_result['results'].sort(key=lambda r: r['node']['unique_id'])
         self.assertEqual(run_result['results'], expected_run_results)
 
     @use_profile('postgres')
@@ -1464,8 +1554,9 @@ class TestDocsGenerate(DBTIntegrationTest):
     def test__bigquery__nested_models(self):
         self.use_default_project({'source-paths': [self.dir('bq_models')]})
 
-        self.run_start_time = datetime.utcnow()
         self.assertEqual(len(self.run_dbt()), 2)
+        os.remove(os.path.normpath('target/manifest.json'))
+        os.remove(os.path.normpath('target/run_results.json'))
         self.generate_start_time = datetime.utcnow()
         self.run_dbt(['docs', 'generate'])
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime, timedelta
 
 from test.integration.base import DBTIntegrationTest, use_profile
+from dbt.compat import basestring
 
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
@@ -12,6 +13,14 @@ class AnyFloat(object):
     """
     def __eq__(self, other):
         return isinstance(other, float)
+
+
+class AnyStringWith(object):
+    def __init__(self, contains):
+        self.contains = contains
+
+    def __eq__(self, other):
+        return isinstance(other, basestring) and self.contains in other
 
 
 class TestDocsGenerate(DBTIntegrationTest):
@@ -617,7 +626,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'root_path': os.getcwd(),
                     'schema': my_schema_name,
                     'tags': ['schema'],
-                    'unique_id': 'test.test.unique_model_id'
+                    'unique_id': 'test.test.unique_model_id',
                 },
             },
             'parent_map': {
@@ -833,7 +842,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'tags': [],
                     'unique_id': 'seed.test.seed'
-                }
+                },
             },
             'docs': {
                 'test.ephemeral_summary': {
@@ -1258,6 +1267,134 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': [],
                     'unique_id': 'seed.test.seed',
                     'wrapped_sql': 'None'
+                },
+                'skip': False,
+                'status': None,
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'not_null_model_id',
+                     'build_path': os.path.normpath('target/compiled/test/schema_test/not_null_model_id.sql'),
+                     'column_name': 'id',
+                     'columns': {},
+                     'compiled': True,
+                     'compiled_sql': AnyStringWith('id is null'),
+                     'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'extra_ctes': [],
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'schema_test', 'not_null_model_id'],
+                    'injected_sql': AnyStringWith('id is null'),
+                    'name': 'not_null_model_id',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/not_null_model_id.sql'),
+                    'raw_sql': "{{ test_not_null(model=ref('model'), column_name='id') }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': schema,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.not_null_model_id',
+                    'wrapped_sql': AnyStringWith('id is null')
+                },
+                'skip': False,
+                'status': None,
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'nothing_model_',
+                    'build_path': os.path.normpath('target/compiled/test/schema_test/nothing_model_.sql'),
+                    'columns': {},
+                    'compiled': True,
+                    'compiled_sql': AnyStringWith('select 0'),
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'extra_ctes': [],
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'schema_test', 'nothing_model_'],
+                    'injected_sql':  AnyStringWith('select 0'),
+                    'name': 'nothing_model_',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/nothing_model_.sql'),
+                    'raw_sql': "{{ test_nothing(model=ref('model'), ) }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': schema,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.nothing_model_',
+                    'wrapped_sql':  AnyStringWith('select 0'),
+                },
+                'skip': False,
+                'status': None
+            },
+            {
+                'error': None,
+                'execution_time': AnyFloat(),
+                'fail': None,
+                'node': {
+                    'alias': 'unique_model_id',
+                    'build_path': os.path.normpath('target/compiled/test/schema_test/unique_model_id.sql'),
+                    'column_name': 'id',
+                    'columns': {},
+                    'compiled': True,
+                    'compiled_sql': AnyStringWith('count(*)'),
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {},
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['model.test.model']},
+                    'description': '',
+                    'empty': False,
+                    'extra_ctes': [],
+                    'extra_ctes_injected': True,
+                    'fqn': ['test', 'schema_test', 'unique_model_id'],
+                    'injected_sql': AnyStringWith('count(*)'),
+                    'name': 'unique_model_id',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'package_name': 'test',
+                    'path': os.path.normpath('schema_test/unique_model_id.sql'),
+                    'raw_sql': "{{ test_unique(model=ref('model'), column_name='id') }}",
+                    'refs': [['model']],
+                    'resource_type': 'test',
+                    'root_path': os.getcwd(),
+                    'schema': schema,
+                    'tags': ['schema'],
+                    'unique_id': 'test.test.unique_model_id',
+                    'wrapped_sql': AnyStringWith('count(*)')
                 },
                 'skip': False,
                 'status': None,


### PR DESCRIPTION
Implicitly run `dbt compile` when running `dbt docs generate`, the re-do.

The issue with the last merge was that one PR added some tests, and this PR causes tests to be represented differently than they used to be, so when the other got merged and then this branch got merged, sadness ensued even though in isolation both were fine.

The change from the previous PR is in the outputs (which are reflected by the test changes). Please treat this as a fresh review to some degree, to make sure you're happy with the new outputs!