### PR TITLE
add handling for v1 schema.yml with a model named "version", and tests (#950)

### DIFF
--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -439,11 +439,11 @@ def raise_duplicate_patch_name(name, patch_1, patch_2):
 
 def raise_incorrect_version(path):
     raise_compiler_error(
-        'The schema file at {} does not contain a version specifier. dbt '
-        'assumes that schema.yml files without version specifiers are version '
-        '1 schemas, but this file looks like a version 2 schema. If this is '
-        'the case, you can fix this error by adding `version: 2` to the top '
-        'of the file.\n\nOtherwise, please consult the documentation for more '
-        'information on schema.yml syntax:\n\n'
+        'The schema file at {} does not contain a valid version specifier. '
+        'dbt assumes that schema.yml files without version specifiers are '
+        'version 1 schemas, but this file looks like a version 2 schema. If '
+        'this is the case, you can fix this error by adding `version: 2` to '
+        'the top of the file.\n\nOtherwise, please consult the documentation '
+        'for more information on schema.yml syntax:\n\n'
         'https://docs.getdbt.com/v0.11/docs/schemayml-files'.format(path)
     )

--- a/dbt/parser/schemas.py
+++ b/dbt/parser/schemas.py
@@ -459,7 +459,9 @@ class SchemaParser(BaseParser):
 
         for original_file_path, test_yml in iterator:
             version = test_yml.get('version', 1)
-            if version == 1:
+            # the version will not be an int if it's a v1 model that has a
+            # model named 'version'.
+            if version == 1 or not isinstance(version, int):
                 cls.check_v2_missing_version(original_file_path, test_yml)
                 new_tests.update(
                     (t.get('unique_id'), t)

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -1544,6 +1544,26 @@ class ParserTest(unittest.TestCase):
             self.assertIn('https://docs.getdbt.com/v0.11/docs/schemayml-files',
                           str(cm.exception))
 
+    @mock.patch.object(SchemaParser, 'build_node')
+    @mock.patch.object(SchemaParser, 'find_schema_yml')
+    @mock.patch.object(dbt.parser.schemas, 'logger')
+    def test__schema_v1_version_model(self, mock_logger, find_schema_yml, build_node):
+        test_yml = yaml.safe_load(
+            '{model_one: {constraints: {not_null: [id],'
+            'unique: [id],'
+            'accepted_values: [{field: id, values: ["a","b"]}],'
+            'relationships: [{from: id, to: ref(\'model_two\'), field: id}]' # noqa
+            '}}, version: {constraints: {not_null: [id]}}}'
+        )
+        find_schema_yml.return_value = [('/some/path/schema.yml', test_yml)]
+        root_project = {}
+        all_projects = {}
+        root_dir = '/some/path'
+        relative_dirs = ['a', 'b']
+        dbt.parser.schemas.SchemaParser.load_and_parse(
+            'test', root_project, all_projects, root_dir, relative_dirs
+        )
+
     def test__simple_data_test(self):
         tests = [{
             'name': 'no_events',


### PR DESCRIPTION
This is a silly issue, and an easy fix. I do something similar in the v1->v2 schema converter.