### PR TITLE
Fix error with validation code (#956)

### DIFF
--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -236,10 +236,9 @@ class Var(object):
         raw = self.local_vars[var_name]
         if raw is None:
             pretty_vars = self.pretty_dict(self.local_vars)
-            model_name = dbt.utils.get_model_name_or_none(self.model)
             dbt.exceptions.raise_compiler_error(
                 self.NoneVarError.format(
-                    var_name, model_name, pretty_vars
+                    var_name, self.model_name, pretty_vars
                 ),
                 self.model
             )

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -1,0 +1,53 @@
+import mock
+import unittest
+
+from dbt.contracts.graph.parsed import ParsedNode
+from dbt.context.common import Var
+import dbt.exceptions
+
+class TestVar(unittest.TestCase):
+    def setUp(self):
+        self.model = ParsedNode(
+            alias='model_one',
+            name='model_one',
+            schema='analytics',
+            resource_type='model',
+            unique_id='model.root.model_one',
+            fqn=['root', 'model_one'],
+            empty=False,
+            package_name='root',
+            original_file_path='model_one.sql',
+            root_path='/usr/src/app',
+            refs=[],
+            depends_on={
+                'nodes': [],
+                'macros': []
+            },
+            config={
+                'enabled': True,
+                'materialized': 'view',
+                'post-hook': [],
+                'pre-hook': [],
+                'vars': {},
+                'quoting': {},
+                'column_types': {},
+            },
+            tags=[],
+            path='model_one.sql',
+            raw_sql='',
+            description='',
+            columns={}
+        )
+        self.context = mock.MagicMock()
+
+    def test_var_not_none_is_none(self):
+        var = Var(self.model, self.context, overrides={'foo': None})
+        var.assert_var_defined('foo', None)
+        with self.assertRaises(dbt.exceptions.CompilationException):
+            var.assert_var_not_none('foo')
+
+    def test_var_defined_is_missing(self):
+        var = Var(self.model, self.context, overrides={})
+        var.assert_var_defined('foo', 'bar')
+        with self.assertRaises(dbt.exceptions.CompilationException):
+            var.assert_var_defined('foo', None)


### PR DESCRIPTION
We already set the model's name properly inside the class's `__init__`, so we don't need to figure it out again, we can just use that.