### PR TITLE
set upper bound on boto3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ google-cloud-bigquery>=1.0.0,<2
 requests>=2.18.0,<3
 agate>=1.6,<2
 jsonschema==2.6.0
-boto3>=1.6.23
+boto3>=1.6.23,<1.8.0

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
         'google-cloud-bigquery>=1.0.0,<2',
         'agate>=1.6,<2',
         'jsonschema==2.6.0',
-        'boto3>=1.6.23'
+        'boto3>=1.6.23,<1.8.0'
     ]
 )


### PR DESCRIPTION
fixes #959 

This PR sets an upper bound for dbt's boto3 requirement to resolve incompatibility issues with `snowflake-connector-python`.

Before this change:

**installation**
```
$ pip install -e .
....
boto3 1.8.3 has requirement botocore<1.12.0,>=1.11.3, but you'll have botocore 1.10.84 which is incompatible.
snowflake-connector-python 1.6.7 has requirement boto3<1.8.0,>=1.4.4, but you'll have boto3 1.8.3 which is incompatible.
....
```

**running dbt**
```
$ dbt --version
Traceback (most recent call last):
  File "/Users/drew/fishtown/dbt/env/bin/dbt", line 4, in <module>
    __import__('pkg_resources').require('dbt==0.11.0a1')
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3105, in <module>
    @_call_aside
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3089, in _call_aside
    f(*args, **kwargs)
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3118, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 580, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 593, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/Users/drew/fishtown/dbt/env/lib/python2.7/site-packages/pkg_resources/__init__.py", line 781, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'botocore<1.12.0,>=1.11.3' distribution was not found and is required by boto3
```

No warnings or errors exist after this change was made.