### PR TITLE
Fix hooks in configs not running (#984)

### DIFF
--- a/dbt/hooks.py
+++ b/dbt/hooks.py
@@ -32,7 +32,7 @@ def get_hook_dict(hook, index):
 
 
 def get_hooks(model, hook_key):
-    hooks = model.get('config', {}).get(hook_key, [])
+    hooks = model.config.get(hook_key, [])
 
     if not isinstance(hooks, (list, tuple)):
         hooks = [hooks]

--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -134,7 +134,7 @@ class BaseParser(object):
         parsed_node.config = config_dict
 
         for hook_type in dbt.hooks.ModelHookType.Both:
-            parsed_node.config[hook_type] = dbt.hooks.get_hooks(node,
+            parsed_node.config[hook_type] = dbt.hooks.get_hooks(parsed_node,
                                                                 hook_type)
 
         parsed_node.validate()

--- a/test/integration/014_hook_tests/configured-models/hooks.sql
+++ b/test/integration/014_hook_tests/configured-models/hooks.sql
@@ -1,0 +1,63 @@
+
+{{
+    config({
+        "pre-hook": "\
+            insert into {{this.schema}}.on_model_hook (\
+                \"state\",\
+                \"target.dbname\",\
+                \"target.host\",\
+                \"target.name\",\
+                \"target.schema\",\
+                \"target.type\",\
+                \"target.user\",\
+                \"target.pass\",\
+                \"target.port\",\
+                \"target.threads\",\
+                \"run_started_at\",\
+                \"invocation_id\"\
+            ) VALUES (\
+                'start',\
+                '{{ target.dbname }}',\
+                '{{ target.host }}',\
+                '{{ target.name }}',\
+                '{{ target.schema }}',\
+                '{{ target.type }}',\
+                '{{ target.user }}',\
+                '{{ target.pass }}',\
+                {{ target.port }},\
+                {{ target.threads }},\
+                '{{ run_started_at }}',\
+                '{{ invocation_id }}'\
+        )",
+        "post-hook": "\
+            insert into {{this.schema}}.on_model_hook (\
+                \"state\",\
+                \"target.dbname\",\
+                \"target.host\",\
+                \"target.name\",\
+                \"target.schema\",\
+                \"target.type\",\
+                \"target.user\",\
+                \"target.pass\",\
+                \"target.port\",\
+                \"target.threads\",\
+                \"run_started_at\",\
+                \"invocation_id\"\
+            ) VALUES (\
+                'end',\
+                '{{ target.dbname }}',\
+                '{{ target.host }}',\
+                '{{ target.name }}',\
+                '{{ target.schema }}',\
+                '{{ target.type }}',\
+                '{{ target.user }}',\
+                '{{ target.pass }}',\
+                {{ target.port }},\
+                {{ target.threads }},\
+                '{{ run_started_at }}',\
+                '{{ invocation_id }}'\
+            )"
+    })
+}}
+
+select 3 as id


### PR DESCRIPTION
Hooks were not getting attached to parsed nodes during the parsing stage of compilation, because the not-fully-built `node` dict was getting passed into `hooks.get_hooks`.

Instead, pass the parsed node in, and change `hooks.get_hooks` to expect a `ParsedNode`.

I also added tests for this behavior, of course.