### PR TITLE
add --port parameter to "dbt docs serve" (#955)

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -456,6 +456,12 @@ def parse_args(args):
     seed_sub.set_defaults(cls=seed_task.SeedTask, which='seed')
 
     serve_sub = docs_subs.add_parser('serve', parents=[base_subparser])
+    serve_sub.add_argument(
+        '--port',
+        default=8080,
+        type=int,
+        help='Specify the port number for the docs server.'
+    )
     serve_sub.set_defaults(cls=serve_task.ServeTask,
                            which='serve')
 

--- a/dbt/task/serve.py
+++ b/dbt/task/serve.py
@@ -14,13 +14,15 @@ class ServeTask(RunnableTask):
     def run(self):
         os.chdir(self.project['target-path'])
 
-        port = 8080
+        port = self.args.port
 
         shutil.copyfile(DOCS_INDEX_FILE_PATH, 'index.html')
 
         logger.info("Serving docs at 0.0.0.0:{}".format(port))
         logger.info(
-            "To access from your browser, navigate to http://localhost:8080.")
+            "To access from your browser, navigate to http://localhost:{}."
+            .format(port)
+        )
         logger.info("Press Ctrl+C to exit.\n\n")
 
         httpd = TCPServer(
@@ -29,7 +31,7 @@ class ServeTask(RunnableTask):
         )
 
         try:
-            webbrowser.open_new_tab('http://127.0.0.1:8080')
+            webbrowser.open_new_tab('http://127.0.0.1:{}'.format(port))
         except webbrowser.Error as e:
             pass
 


### PR DESCRIPTION
Adds a `--port` parameter to "dbt docs serve" that defaults to 8080.

FIxes #955.