### PR TITLE
Fix errors on null schema (#980)

### DIFF
--- a/dbt/adapters/default/impl.py
+++ b/dbt/adapters/default/impl.py
@@ -24,6 +24,24 @@ connections_in_use = {}
 connections_available = []
 
 
+def _filter_schemas(manifest):
+    """Return a function that takes a row and decides if the row should be
+    included in the catalog output.
+    """
+    schemas = frozenset({
+        node.schema.lower()
+        for node in manifest.nodes.values()
+    })
+
+    def test(row):
+        # the schema may be present but None
+        table_schema = row.get('table_schema')
+        if table_schema is None:
+            return False
+        return table_schema.lower() in schemas
+    return test
+
+
 class DefaultAdapter(object):
     DEFAULT_QUOTE = True
 
@@ -830,10 +848,5 @@ class DefaultAdapter(object):
         finally:
             cls.release_connection(profile, GET_CATALOG_OPERATION_NAME)
 
-        schemas = list({
-            node.schema.lower()
-            for node in manifest.nodes.values()
-        })
-
-        results = table.where(lambda r: r['table_schema'].lower() in schemas)
+        results = table.where(_filter_schemas(manifest))
         return results


### PR DESCRIPTION
Fixes #980 by filtering null schemas out on the adapter level. We wouldn't allow null schemas in our manifest so we don't have to handle a `node.schema is None` scenario.