### PR TITLE
let the empty string mean null (#993)

### DIFF
--- a/dbt/clients/agate_helper.py
+++ b/dbt/clients/agate_helper.py
@@ -4,12 +4,12 @@ import agate
 DEFAULT_TYPE_TESTER = agate.TypeTester(types=[
     agate.data_types.Boolean(true_values=('true',),
                              false_values=('false',),
-                             null_values=('null',)),
-    agate.data_types.Number(null_values=('null',)),
-    agate.data_types.TimeDelta(null_values=('null',)),
-    agate.data_types.Date(null_values=('null',)),
-    agate.data_types.DateTime(null_values=('null',)),
-    agate.data_types.Text(null_values=('null',))
+                             null_values=('null', '')),
+    agate.data_types.Number(null_values=('null', '')),
+    agate.data_types.TimeDelta(null_values=('null', '')),
+    agate.data_types.Date(null_values=('null', '')),
+    agate.data_types.DateTime(null_values=('null', '')),
+    agate.data_types.Text(null_values=('null', ''))
 ])
 
 

--- a/test/integration/005_simple_seed_test/data/seed_actual.csv
+++ b/test/integration/005_simple_seed_test/data/seed_actual.csv
@@ -497,5 +497,5 @@ id,first_name,email,ip_address,birthday
 496,Brenda,bparkerdr@skype.com,63.232.216.86,1974-05-18 05:58:29
 497,Tammy,tmurphyds@constantcontact.com,56.56.37.112,2014-08-05 18:22:25
 498,Larry,lhayesdt@wordpress.com,162.146.13.46,1997-02-26 14:01:53
-499,Evelyn,ethomasdu@hhs.gov,6.241.88.250,2007-09-14 13:03:34
+499,,ethomasdu@hhs.gov,6.241.88.250,2007-09-14 13:03:34
 500,Paula,pshawdv@networksolutions.com,123.27.47.249,2003-10-30 21:19:20

--- a/test/integration/005_simple_seed_test/seed.sql
+++ b/test/integration/005_simple_seed_test/seed.sql
@@ -508,5 +508,5 @@ VALUES
     (496,'Brenda','bparkerdr@skype.com','63.232.216.86','1974-05-18 05:58:29'),
     (497,'Tammy','tmurphyds@constantcontact.com','56.56.37.112','2014-08-05 18:22:25'),
     (498,'Larry','lhayesdt@wordpress.com','162.146.13.46','1997-02-26 14:01:53'),
-    (499,'Evelyn','ethomasdu@hhs.gov','6.241.88.250','2007-09-14 13:03:34'),
+    (499,NULL,'ethomasdu@hhs.gov','6.241.88.250','2007-09-14 13:03:34'),
     (500,'Paula','pshawdv@networksolutions.com','123.27.47.249','2003-10-30 21:19:20');


### PR DESCRIPTION
When dbt encounters the empty string in a csv, treat it as `NULL` instead of `''`.

Fixes #993 