### PR TITLE
Add newline around SQL in incremental materialization to guard against line comments.

### DIFF
--- a/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -60,7 +60,9 @@
 
        {% set tmp_table_sql -%}
          {# We are using a subselect instead of a CTE here to allow PostgreSQL to use indexes. -#}
-         select * from ({{ sql }}) as dbt_incr_sbq
+         select * from (
+           {{ sql }}
+         ) as dbt_incr_sbq
          where ({{ sql_where }})
            or ({{ sql_where }}) is null
        {%- endset %}


### PR DESCRIPTION
Prevents syntax errors when the last line of a model is a line comment.