### PR TITLE
Render more config fields (#960)

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -114,23 +114,6 @@ class ConfigRenderer(object):
 
         return False
 
-    @staticmethod
-    def _is_port_path(keypath):
-        return len(keypath) == 2 and keypath[-1] == 'port'
-
-    @staticmethod
-    def _convert_port(value, keypath):
-
-        if len(keypath) != 4:
-            return value
-
-        if keypath[-1] == 'port' and keypath[1] == 'outputs':
-            try:
-                return int(value)
-            except ValueError:
-                pass  # let the validator or connection handle this
-        return value
-
     def _render_project_entry(self, value, keypath):
         """Render an entry, in case it's jinja. This is meant to be passed to
         dbt.utils.deep_map.

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -229,6 +229,10 @@ class Var(object):
         elif isinstance(model, ParsedNode):
             local_vars = model.config.get('vars', {})
             self.model_name = model.name
+        elif model is None:
+            # during config parsing we have no model and no local vars
+            self.model_name = '<Configuration>'
+            local_vars = {}
         else:
             # still used for wrapping
             self.model_name = model.nice_name

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -209,7 +209,7 @@ def invoke_dbt(parsed):
     try:
         if parsed.which == 'deps':
             # deps doesn't need a profile, so don't require one.
-            cfg = Project.from_current_directory()
+            cfg = Project.from_current_directory(getattr(parsed, 'vars', '{}'))
         elif parsed.which != 'debug':
             # for debug, we will attempt to load the various configurations as
             # part of the task, so just leave cfg=None.

--- a/dbt/task/debug.py
+++ b/dbt/task/debug.py
@@ -3,6 +3,7 @@ import pprint
 from dbt.logger import GLOBAL_LOGGER as logger
 import dbt.clients.system
 import dbt.config
+import dbt.utils
 
 from dbt.task.base_task import BaseTask
 
@@ -27,15 +28,18 @@ class DebugTask(BaseTask):
         # if we got here, a 'dbt_project.yml' does exist, but we have not tried
         # to parse it.
         project_profile = None
+        cli_vars = dbt.utils.parse_cli_vars(getattr(self.args, 'vars', '{}'))
+
         try:
-            project = dbt.config.Project.from_current_directory()
+            project = dbt.config.Project.from_current_directory(cli_vars)
             project_profile = project.profile_name
         except dbt.config.DbtConfigError as exc:
             project = 'ERROR loading project: {!s}'.format(exc)
 
         # log the profile we decided on as well, if it's available.
         try:
-            profile = dbt.config.Profile.from_args(self.args, project_profile)
+            profile = dbt.config.Profile.from_args(self.args, project_profile,
+                                                   cli_vars)
         except dbt.config.DbtConfigError as exc:
             profile = 'ERROR loading profile: {!s}'.format(exc)
 

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -237,7 +237,7 @@ class GitPackage(Package):
 
     def _fetch_metadata(self, project):
         path = self._checkout(project)
-        return project.from_project_root(path)
+        return project.from_project_root(path, {})
 
     def install(self, project):
         dest_path = self.get_installation_path(project)
@@ -273,7 +273,7 @@ class LocalPackage(Package):
             self.local,
             project.project_root)
 
-        return project.from_project_root(project_file_path)
+        return project.from_project_root(project_file_path, {})
 
     def install(self, project):
         src_path = dbt.clients.system.resolve_path_from_base(

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 from decimal import Decimal
-import os
-import hashlib
-import itertools
-import json
+
 import collections
 import copy
 import functools
+import hashlib
+import itertools
+import json
+import numbers
+import os
 
 import dbt.exceptions
 import dbt.flags
@@ -261,6 +263,53 @@ def deep_merge_item(destination, key, value):
             destination[key] = value
     else:
         destination[key] = value
+
+
+def deep_map(func, value, keypath=(), memo=None, _notfound=object()):
+    """map the function func() onto each non-container value in 'value'
+    recursively, returning a new value. As long as func does not manipulate
+    value, then deep_map will also not manipulate it.
+
+    value should be a value returned by `yaml.safe_load` or `json.load` - the
+    only expected types are list, dict, native python number, str, NoneType,
+    and bool.
+
+    func() will be called on numbers, strings, Nones, and booleans. Its first
+    parameter will be the value, and the second will be its keypath, an
+    iterable over the __getitem__ keys needed to get to it.
+    """
+    # TODO: if we could guarantee no cycles, we would not need to memoize
+    if memo is None:
+        memo = {}
+
+    value_id = id(value)
+    cached = memo.get(value_id, _notfound)
+    if cached is not _notfound:
+        return cached
+
+    atomic_types = (int, float, basestring, type(None), bool)
+
+    if isinstance(value, list):
+        ret = [
+            deep_map(func, v, (keypath + (idx,)), memo)
+            for idx, v in enumerate(value)
+        ]
+    elif isinstance(value, dict):
+        ret = {
+            k: deep_map(func, v, (keypath + (k,)), memo)
+            for k, v in value.items()
+        }
+    elif isinstance(value, atomic_types):
+        ret = func(value, keypath)
+    else:
+        ok_types = (list, dict) + atomic_types
+        # TODO(jeb): real error
+        raise TypeError(
+            'in deep_map, expected one of {!r}, got {!r}'
+            .format(ok_types, type(value))
+        )
+    memo[value_id] = ret
+    return ret
 
 
 class AttrDict(dict):

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -302,8 +302,7 @@ def deep_map(func, value, keypath=(), memo=None, _notfound=object()):
         ret = func(value, keypath)
     else:
         ok_types = (list, dict) + atomic_types
-        # TODO(jeb): real error
-        raise TypeError(
+        raise dbt.exceptions.DbtConfigError(
             'in deep_map, expected one of {!r}, got {!r}'
             .format(ok_types, type(value))
         )

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -129,6 +129,15 @@ class BaseConfigTest(unittest.TestCase):
                         'pass': "{{ env_var('env_value_pass') }}",
                         'dbname': "{{ env_var('env_value_dbname') }}",
                         'schema': "{{ env_var('env_value_schema') }}",
+                    },
+                    'cli-and-env-vars': {
+                        'type': "{{ env_var('env_value_type') }}",
+                        'host': "{{ var('cli_value_host') }}",
+                        'port': "{{ env_var('env_value_port') }}",
+                        'user': "{{ env_var('env_value_user') }}",
+                        'pass': "{{ env_var('env_value_pass') }}",
+                        'dbname': "{{ env_var('env_value_dbname') }}",
+                        'schema': "{{ env_var('env_value_schema') }}",
                     }
                 },
                 'target': 'postgres',
@@ -158,6 +167,7 @@ class BaseConfigTest(unittest.TestCase):
             'env_value_pass': 'env-postgres-pass',
             'env_value_dbname': 'env-postgres-dbname',
             'env_value_schema': 'env-postgres-schema',
+            'env_value_project': 'blah',
         }
 
 
@@ -466,6 +476,28 @@ class TestProfileFile(BaseFileTest):
 
         self.assertIn("not of type 'integer'", str(exc.exception))
 
+    def test_cli_and_env_vars(self):
+        self.args.target = 'cli-and-env-vars'
+        self.args.vars = '{"cli_value_host": "cli-postgres-host"}'
+        with mock.patch.dict(os.environ, self.env_override):
+            profile = self.from_args(cli_vars=None)
+            from_raw = self.from_raw_profile_info(
+                target_override='cli-and-env-vars',
+                cli_vars={'cli_value_host': 'cli-postgres-host'},
+            )
+
+        self.assertEqual(profile.profile_name, 'default')
+        self.assertEqual(profile.target_name, 'cli-and-env-vars')
+        self.assertEqual(profile.threads, 1)
+        self.assertTrue(profile.send_anonymous_usage_stats)
+        self.assertTrue(profile.use_colors)
+        self.assertEqual(profile.credentials.type, 'postgres')
+        self.assertEqual(profile.credentials.host, 'cli-postgres-host')
+        self.assertEqual(profile.credentials.port, 6543)
+        self.assertEqual(profile.credentials.user, 'env-postgres-user')
+        self.assertEqual(profile.credentials.password, 'env-postgres-pass')
+        self.assertEqual(profile, from_raw)
+
     def test_no_profile(self):
         with self.assertRaises(dbt.config.DbtProjectError) as exc:
             profile = self.from_args(project_profile_name=None)
@@ -711,11 +743,35 @@ class TestProjectFile(BaseFileTest):
             self.default_project_data
         )
         self.assertEqual(project, from_config)
+        self.assertEqual(project.version, "0.0.1")
+        self.assertEqual(project.project_name, 'my_test_project')
 
     def test_with_invalid_package(self):
         self.write_packages({'invalid': ['not a package of any kind']})
         with self.assertRaises(dbt.config.DbtProjectError) as exc:
             dbt.config.Project.from_project_root(self.project_dir, {})
+
+
+class TestVariableProjectFile(BaseFileTest):
+    def setUp(self):
+        super(TestVariableProjectFile, self).setUp()
+        self.default_project_data['version'] = "{{ var('cli_version') }}"
+        self.default_project_data['name'] = "{{ env_var('env_value_project') }}"
+        self.write_project(self.default_project_data)
+        # and after the fact, add the project root
+        self.default_project_data['project-root'] = self.project_dir
+
+    def test_cli_and_env_vars(self):
+        cli_vars = '{"cli_version": "0.1.2"}'
+        with mock.patch.dict(os.environ, self.env_override):
+            project = dbt.config.Project.from_project_root(
+                self.project_dir,
+                cli_vars
+            )
+
+        self.assertEqual(project.version, "0.1.2")
+        self.assertEqual(project.project_name, 'blah')
+
 
 
 class TestRuntimeConfig(BaseConfigTest):
@@ -806,3 +862,55 @@ class TestRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.archive, [])
         self.assertEqual(config.seeds, {})
         self.assertEqual(config.packages, PackageConfig(packages=[]))
+
+
+class TestVariableRuntimeConfigFiles(BaseFileTest):
+    def setUp(self):
+        super(TestVariableRuntimeConfigFiles, self).setUp()
+        self.default_project_data.update({
+            'version': "{{ var('cli_version') }}",
+            'name': "{{ env_var('env_value_project') }}",
+            'on-run-end': [
+                "{{ env_var('env_value_project') }}",
+            ],
+            'models': {
+                'foo': {
+                    'post-hook': "{{ env_var('env_value_target') }}",
+                },
+                'bar': {
+                    # just gibberish, make sure it gets interpreted
+                    'materialized': "{{ env_var('env_value_project') }}",
+                }
+            },
+            'seeds': {
+                'foo': {
+                    'post-hook': "{{ env_var('env_value_target') }}",
+                },
+                'bar': {
+                    # just gibberish, make sure it gets interpreted
+                    'materialized': "{{ env_var('env_value_project') }}",
+                }
+            },
+        })
+        self.write_project(self.default_project_data)
+        self.write_profile(self.default_profile_data)
+        # and after the fact, add the project root
+        self.default_project_data['project-root'] = self.project_dir
+
+    def test_cli_and_env_vars(self):
+        self.args.target = 'cli-and-env-vars'
+        self.args.vars = '{"cli_value_host": "cli-postgres-host", "cli_version": "0.1.2"}'
+        with mock.patch.dict(os.environ, self.env_override), temp_cd(self.project_dir):
+            config = dbt.config.RuntimeConfig.from_args(self.args)
+
+        self.assertEqual(config.version, "0.1.2")
+        self.assertEqual(config.project_name, 'blah')
+        self.assertEqual(config.credentials.host, 'cli-postgres-host')
+        self.assertEqual(config.credentials.user, 'env-postgres-user')
+        # make sure hooks are not interpreted
+        self.assertEqual(config.on_run_end, ["{{ env_var('env_value_project') }}"])
+        self.assertEqual(config.models['foo']['post-hook'], "{{ env_var('env_value_target') }}")
+        self.assertEqual(config.models['bar']['materialized'], 'blah')
+        self.assertEqual(config.seeds['foo']['post-hook'], "{{ env_var('env_value_target') }}")
+        self.assertEqual(config.seeds['bar']['materialized'], 'blah')
+

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -693,7 +693,7 @@ class TestProject(BaseConfigTest):
 
     def test_no_project(self):
         with self.assertRaises(dbt.config.DbtProjectError) as exc:
-            dbt.config.Project.from_project_root(self.project_dir)
+            dbt.config.Project.from_project_root(self.project_dir, {})
 
         self.assertIn('no dbt_project.yml', str(exc.exception))
 
@@ -706,7 +706,7 @@ class TestProjectFile(BaseFileTest):
         self.default_project_data['project-root'] = self.project_dir
 
     def test_from_project_root(self):
-        project = dbt.config.Project.from_project_root(self.project_dir)
+        project = dbt.config.Project.from_project_root(self.project_dir, {})
         from_config = dbt.config.Project.from_project_config(
             self.default_project_data
         )
@@ -715,7 +715,7 @@ class TestProjectFile(BaseFileTest):
     def test_with_invalid_package(self):
         self.write_packages({'invalid': ['not a package of any kind']})
         with self.assertRaises(dbt.config.DbtProjectError) as exc:
-            dbt.config.Project.from_project_root(self.project_dir)
+            dbt.config.Project.from_project_root(self.project_dir, {})
 
 
 class TestRuntimeConfig(BaseConfigTest):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -43,7 +43,6 @@ class TestMerge(unittest.TestCase):
                     case['description'], actual, case['expected']))
 
 
-
 class TestDeepMap(unittest.TestCase):
     def setUp(self):
         self.input_value = {
@@ -125,6 +124,4 @@ class TestDeepMap(unittest.TestCase):
 
         actual = dbt.utils.deep_map(self.special_keypath, expected)
         self.assertEquals(actual, expected)
-
-
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -41,3 +41,90 @@ class TestMerge(unittest.TestCase):
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
+
+
+
+class TestDeepMap(unittest.TestCase):
+    def setUp(self):
+        self.input_value = {
+            'foo': {
+                'bar': 'hello',
+                'baz': [1, 90.5, '990', '89.9'],
+            },
+            'nested': [
+                {
+                    'test': '90',
+                    'other_test': None,
+                },
+                {
+                    'test': 400,
+                    'other_test': 4.7e9,
+                },
+            ],
+        }
+
+    @staticmethod
+    def intify_all(value, _):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return -1
+
+    def test__simple_cases(self):
+        expected = {
+            'foo': {
+                'bar': -1,
+                'baz': [1, 90, 990, -1],
+            },
+            'nested': [
+                {
+                    'test': 90,
+                    'other_test': -1,
+                },
+                {
+                    'test': 400,
+                    'other_test': 4700000000,
+                },
+            ],
+        }
+        actual = dbt.utils.deep_map(self.intify_all, self.input_value)
+        self.assertEquals(actual, expected)
+
+        actual = dbt.utils.deep_map(self.intify_all, expected)
+        self.assertEquals(actual, expected)
+
+
+    @staticmethod
+    def special_keypath(value, keypath):
+
+        if tuple(keypath) == ('foo', 'baz', 1):
+            return 'hello'
+        else:
+            return value
+
+    def test__keypath(self):
+        expected = {
+            'foo': {
+                'bar': 'hello',
+                # the only change from input is the second entry here
+                'baz': [1, 'hello', '990', '89.9'],
+            },
+            'nested': [
+                {
+                    'test': '90',
+                    'other_test': None,
+                },
+                {
+                    'test': 400,
+                    'other_test': 4.7e9,
+                },
+            ],
+        }
+        actual = dbt.utils.deep_map(self.special_keypath, self.input_value)
+        self.assertEquals(actual, expected)
+
+        actual = dbt.utils.deep_map(self.special_keypath, expected)
+        self.assertEquals(actual, expected)
+
+
+

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 
+import dbt.exceptions
 import dbt.utils
 
 
@@ -124,4 +125,17 @@ class TestDeepMap(unittest.TestCase):
 
         actual = dbt.utils.deep_map(self.special_keypath, expected)
         self.assertEquals(actual, expected)
+
+    def test__noop(self):
+        actual = dbt.utils.deep_map(lambda x, _: x, self.input_value)
+        self.assertEquals(actual, self.input_value)
+
+    def test_trivial(self):
+        cases = [[], {}, 1, 'abc', None, True]
+        for case in cases:
+            result = dbt.utils.deep_map(lambda x, _: x, case)
+            self.assertEquals(result, case)
+
+        with self.assertRaises(dbt.exceptions.DbtConfigError):
+            dbt.utils.deep_map(lambda x, _: x, {'foo': object()})
 

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -8,13 +8,14 @@ def config_from_parts_or_dicts(project, profile, packages=None, cli_vars='{}'):
     from dbt.config import Project, Profile, RuntimeConfig
     from dbt.utils import parse_cli_vars
     from copy import deepcopy
+    if not isinstance(cli_vars, dict):
+        cli_vars = parse_cli_vars(cli_vars)
     if not isinstance(project, Project):
         project = Project.from_project_config(deepcopy(project), packages)
     if not isinstance(profile, Profile):
         profile = Profile.from_raw_profile_info(deepcopy(profile),
-                                                project.profile_name)
-    if not isinstance(cli_vars, dict):
-        cli_vars = parse_cli_vars(cli_vars)
+                                                project.profile_name,
+                                                cli_vars)
 
     return RuntimeConfig.from_parts(
         project=project,


### PR DESCRIPTION
Implement #960. Almost all fields in project/profile configs are now rendered.

Unrendered fields are 'on-run-end'/'on-run-start' in the root of a project config, and 'post-hook'/'pre-hook' under 'models' and 'seeds' in a project config.

Profile fields are rendered in a two-stage process (target, then targeted profile), to allow users to require nonexistent environment/cli variables on non-loaded targets without error.

The big config-side change, beyond the obvious rendering stuff, is having to pass the cli variables around to the various classmethod constructors so they can build a renderer.