### PR TITLE
Updates DocumentParser to look for docs in .sql files

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -173,23 +173,25 @@ def create_macro_capture_env(node):
     return ParserMacroCapture
 
 
+def get_env(node=None, capture_macros=False):
+    args = {
+        'extensions': []
+    }
+
+    if capture_macros:
+        args['undefined'] = create_macro_capture_env(node)
+
+    args['extensions'].append(MaterializationExtension)
+    args['extensions'].append(OperationExtension)
+    args['extensions'].append(DocumentationExtension)
+
+    return MacroFuzzEnvironment(**args)
+
+
 def get_template(string, ctx, node=None, capture_macros=False):
     try:
-        args = {
-            'extensions': []
-        }
-
-        if capture_macros:
-            args['undefined'] = create_macro_capture_env(node)
-
-        args['extensions'].append(MaterializationExtension)
-        args['extensions'].append(OperationExtension)
-        args['extensions'].append(DocumentationExtension)
-
-        env = MacroFuzzEnvironment(**args)
-
+        env = get_env(node, capture_macros)
         return env.from_string(dbt.compat.to_string(string), globals=ctx)
-
     except (jinja2.exceptions.TemplateSyntaxError,
             jinja2.exceptions.UndefinedError) as e:
         e.translated = False


### PR DESCRIPTION
Since the .sql files have macros that aren't available to the docs
parser (e.g., `ref`), we can instead get the AST for the docs macros and
directly read out the contents without rendering them.

This assumes that when people write `docs` blocks, they don't contain to
any other macros or other Jinja tomfoolery. It's hard for me to tell if
that's a reasonable assumption or not. If not, we can be more careful. This 
is just meant to be a jumping-off point. 

Relevant to #979 