### PR TITLE
Attaches matching docs to model names and columns. 

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -173,23 +173,25 @@ def create_macro_capture_env(node):
     return ParserMacroCapture
 
 
+def get_env(node=None, capture_macros=False):
+    args = {
+        'extensions': []
+    }
+
+    if capture_macros:
+        args['undefined'] = create_macro_capture_env(node)
+
+    args['extensions'].append(MaterializationExtension)
+    args['extensions'].append(OperationExtension)
+    args['extensions'].append(DocumentationExtension)
+
+    return MacroFuzzEnvironment(**args)
+
+
 def get_template(string, ctx, node=None, capture_macros=False):
     try:
-        args = {
-            'extensions': []
-        }
-
-        if capture_macros:
-            args['undefined'] = create_macro_capture_env(node)
-
-        args['extensions'].append(MaterializationExtension)
-        args['extensions'].append(OperationExtension)
-        args['extensions'].append(DocumentationExtension)
-
-        env = MacroFuzzEnvironment(**args)
-
+        env = get_env(node, capture_macros)
         return env.from_string(dbt.compat.to_string(string), globals=ctx)
-
     except (jinja2.exceptions.TemplateSyntaxError,
             jinja2.exceptions.UndefinedError) as e:
         e.translated = False


### PR DESCRIPTION
NOTE: the first commit is part of PR #1042. Once that is in, I can rebase/squash.

Without specifying anything in a schema.yml file, we now:
 - Attach docs to models whose doc name matches the model name,
regardless of where they are defined.
 - Attach column docs following the nomenclature `{% docs
<model_name>__<column_name> %}` (that's two underscores)

I would have liked to use a `.` instead of `__` to indicate model columns, but `.` has special jinja meaning.