### PR TITLE
Fix refs in vars in projects being rendered (#1047)

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -99,7 +99,7 @@ class ConfigRenderer(object):
         self.context['var'] = Var(None, self.context, cli_vars)
 
     @staticmethod
-    def _is_hook_path(keypath):
+    def _is_hook_or_model_vars_path(keypath):
         if not keypath:
             return False
 
@@ -107,9 +107,13 @@ class ConfigRenderer(object):
         # run hooks
         if first in {'on-run-start', 'on-run-end'}:
             return True
-        # model hooks
+        # models have two things to avoid
         if first in {'seeds', 'models'}:
+            # model-level hooks
             if 'pre-hook' in keypath or 'post-hook' in keypath:
+                return True
+            # model-level 'vars' declarations
+            if 'vars' in keypath:
                 return True
 
         return False
@@ -126,8 +130,9 @@ class ConfigRenderer(object):
         :param key str: The key to convert on.
         :return Any: The rendered entry.
         """
-        # hooks should be treated as raw sql, they'll get rendered later
-        if self._is_hook_path(keypath):
+        # hooks should be treated as raw sql, they'll get rendered later.
+        # Same goes for 'vars' declarations inside 'models'/'seeds'.
+        if self._is_hook_or_model_vars_path(keypath):
             return value
 
         return self.render_value(value)

--- a/test/integration/003_simple_reference_test/models/view_using_ref.sql
+++ b/test/integration/003_simple_reference_test/models/view_using_ref.sql
@@ -1,0 +1,9 @@
+{{
+  config(
+    materialized = "view"
+  )
+}}
+
+select gender, count(*) as ct from {{ var('var_ref') }}
+group by gender
+order by gender asc

--- a/test/integration/003_simple_reference_test/test_simple_reference.py
+++ b/test/integration/003_simple_reference_test/test_simple_reference.py
@@ -9,6 +9,16 @@ class TestSimpleReference(DBTIntegrationTest):
     def models(self):
         return "test/integration/003_simple_reference_test/models"
 
+    @property
+    def project_config(self):
+        return {
+            'models': {
+                'vars': {
+                    'var_ref': '{{ ref("view_copy") }}',
+                }
+            }
+        }
+
     @use_profile('postgres')
     def test__postgres__simple_reference(self):
         self.use_default_project()
@@ -17,7 +27,7 @@ class TestSimpleReference(DBTIntegrationTest):
 
         results = self.run_dbt()
         # ephemeral_copy doesn't show up in results
-        self.assertEqual(len(results),  7)
+        self.assertEqual(len(results),  8)
 
         # Copies should match
         self.assertTablesEqual("seed","incremental_copy")
@@ -29,11 +39,12 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected","materialized_summary")
         self.assertTablesEqual("summary_expected","view_summary")
         self.assertTablesEqual("summary_expected","ephemeral_summary")
+        self.assertTablesEqual("summary_expected","view_using_ref")
 
         self.run_sql_file("test/integration/003_simple_reference_test/update.sql")
 
         results = self.run_dbt()
-        self.assertEqual(len(results),  7)
+        self.assertEqual(len(results),  8)
 
         # Copies should match
         self.assertTablesEqual("seed","incremental_copy")
@@ -45,6 +56,7 @@ class TestSimpleReference(DBTIntegrationTest):
         self.assertTablesEqual("summary_expected","materialized_summary")
         self.assertTablesEqual("summary_expected","view_summary")
         self.assertTablesEqual("summary_expected","ephemeral_summary")
+        self.assertTablesEqual("summary_expected","view_using_ref")
 
     @use_profile('snowflake')
     def test__snowflake__simple_reference(self):
@@ -52,7 +64,7 @@ class TestSimpleReference(DBTIntegrationTest):
         self.run_sql_file("test/integration/003_simple_reference_test/seed.sql")
 
         results = self.run_dbt()
-        self.assertEqual(len(results),  7)
+        self.assertEqual(len(results),  8)
 
         # Copies should match
         self.assertManyTablesEqual(
@@ -64,7 +76,7 @@ class TestSimpleReference(DBTIntegrationTest):
             "test/integration/003_simple_reference_test/update.sql")
 
         results = self.run_dbt()
-        self.assertEqual(len(results),  7)
+        self.assertEqual(len(results),  8)
 
         self.assertManyTablesEqual(
             ["SEED", "INCREMENTAL_COPY", "MATERIALIZED_COPY", "VIEW_COPY"],


### PR DESCRIPTION
In #1035 I added logic that uses jinja to render all fields with a context containing vars/env_vars. This was a mistake, since apparently you can ref() models in there, and rendering will always fail if you do that.

I also added a test that reproduces the issue.

An alternative to consider: should _nothing_ under models/seeds get rendered until execution time?