### PR TITLE
Allows the profile directory to be set with an environment var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ target/
 *.sublime-*
 
 .python-version
+
+# Vim
+*.sw*

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -1,4 +1,5 @@
 import os.path
+import os
 from copy import deepcopy
 import hashlib
 import pprint
@@ -23,6 +24,10 @@ DEFAULT_SEND_ANONYMOUS_USAGE_STATS = True
 DEFAULT_USE_COLORS = True
 DEFAULT_PROFILES_DIR = os.path.join(os.path.expanduser('~'), '.dbt')
 
+if os.environ.get('DBT_PROFILES_DIR') is not None:
+    PROFILES_DIR = os.environ.get('DBT_PROFILES_DIR')
+else:
+    PROFILES_DIR = DEFAULT_PROFILES_DIR
 
 INVALID_PROFILE_MESSAGE = """
 dbt encountered an error while trying to read your profiles.yml file.
@@ -41,7 +46,7 @@ Here, [profile name] should be replaced with a profile name
 defined in your profiles.yml file. You can find profiles.yml here:
 
 {profiles_file}/profiles.yml
-""".format(profiles_file=DEFAULT_PROFILES_DIR)
+""".format(profiles_file=PROFILES_DIR)
 
 
 def read_profile(profiles_dir):
@@ -62,7 +67,7 @@ def read_profile(profiles_dir):
 def read_profiles(profiles_dir=None):
     """This is only used in main, for some error handling"""
     if profiles_dir is None:
-        profiles_dir = DEFAULT_PROFILES_DIR
+        profiles_dir = PROFILES_DIR
 
     raw_profiles = read_profile(profiles_dir)
 
@@ -624,7 +629,7 @@ class Profile(object):
 
         threads_override = getattr(args, 'threads', None)
         # TODO(jeb): is it even possible for this to not be set?
-        profiles_dir = getattr(args, 'profiles_dir', DEFAULT_PROFILES_DIR)
+        profiles_dir = getattr(args, 'profiles_dir', PROFILES_DIR)
         target_override = getattr(args, 'target', None)
         raw_profiles = read_profile(profiles_dir)
         profile_name = cls._pick_profile_name(args.profile,

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -23,11 +23,7 @@ DEFAULT_THREADS = 1
 DEFAULT_SEND_ANONYMOUS_USAGE_STATS = True
 DEFAULT_USE_COLORS = True
 DEFAULT_PROFILES_DIR = os.path.join(os.path.expanduser('~'), '.dbt')
-
-if os.environ.get('DBT_PROFILES_DIR') is not None:
-    PROFILES_DIR = os.environ.get('DBT_PROFILES_DIR')
-else:
-    PROFILES_DIR = DEFAULT_PROFILES_DIR
+PROFILES_DIR = os.path.expanduser(os.environ.get('DBT_PROFILES_DIR', DEFAULT_PROFILES_DIR))
 
 INVALID_PROFILE_MESSAGE = """
 dbt encountered an error while trying to read your profiles.yml file.

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -23,7 +23,9 @@ DEFAULT_THREADS = 1
 DEFAULT_SEND_ANONYMOUS_USAGE_STATS = True
 DEFAULT_USE_COLORS = True
 DEFAULT_PROFILES_DIR = os.path.join(os.path.expanduser('~'), '.dbt')
-PROFILES_DIR = os.path.expanduser(os.environ.get('DBT_PROFILES_DIR', DEFAULT_PROFILES_DIR))
+PROFILES_DIR = os.path.expanduser(
+        os.environ.get('DBT_PROFILES_DIR', DEFAULT_PROFILES_DIR)
+        )
 
 INVALID_PROFILE_MESSAGE = """
 dbt encountered an error while trying to read your profiles.yml file.

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -27,7 +27,7 @@ import dbt.deprecations
 
 from dbt.utils import ExitCodes
 from dbt.config import Project, RuntimeConfig, DbtProjectError, \
-    DbtProfileError, DEFAULT_PROFILES_DIR, read_config, \
+    DbtProfileError, PROFILES_DIR, read_config, \
     send_anonymous_usage_stats, colorize_output, read_profiles
 from dbt.exceptions import DbtProfileError, DbtProfileError, RuntimeException
 
@@ -298,11 +298,11 @@ def parse_args(args):
 
     base_subparser.add_argument(
         '--profiles-dir',
-        default=DEFAULT_PROFILES_DIR,
+        default=PROFILES_DIR,
         type=str,
         help="""
         Which directory to look in for the profiles.yml file. Default = {}
-        """.format(DEFAULT_PROFILES_DIR)
+        """.format(PROFILES_DIR)
     )
 
     base_subparser.add_argument(

--- a/dbt/task/debug.py
+++ b/dbt/task/debug.py
@@ -16,7 +16,7 @@ PROFILE_DIR_MESSAGE = """To view your profiles.yml file, run:
 class DebugTask(BaseTask):
     def path_info(self):
         open_cmd = dbt.clients.system.open_dir_cmd()
-        profiles_dir = dbt.config.DEFAULT_PROFILES_DIR
+        profiles_dir = dbt.config.PROFILES_DIR
 
         message = PROFILE_DIR_MESSAGE.format(
             open_cmd=open_cmd,

--- a/dbt/task/init.py
+++ b/dbt/task/init.py
@@ -91,7 +91,7 @@ class InitTask(BaseTask):
     def run(self):
         project_dir = self.args.project_name
 
-        profiles_dir = dbt.config.DEFAULT_PROFILES_DIR
+        profiles_dir = dbt.config.PROFILES_DIR
         profiles_file = os.path.join(profiles_dir, 'profiles.yml')
 
         self.create_profiles_dir(profiles_dir)


### PR DESCRIPTION
Passing the CLI flag (as in `dbt run --profiles-dir ~/path/to/profile`)
should still work. Similarly, if no DBT_PROFILES_DIR environment
variable is set, DBT will look for profiles in the default location.