### PR TITLE
Fix clustering on multiple columns (BigQuery) (#1013)

### DIFF
--- a/dbt/include/global_project/macros/adapters/bigquery.sql
+++ b/dbt/include/global_project/macros/adapters/bigquery.sql
@@ -13,7 +13,7 @@
 
 {% macro cluster_by(raw_cluster_by) %}
   {%- if raw_cluster_by is not none -%}
-  cluster by (
+  cluster by
   {%- if raw_cluster_by is string -%}
     {% set raw_cluster_by = [raw_cluster_by] %}
   {%- endif -%}
@@ -21,7 +21,6 @@
     {{ cluster }}
     {%- if not loop.last -%},{%- endif -%}
   {%- endfor -%}
-  )
 
   {% endif %}
 

--- a/dbt/include/global_project/macros/adapters/bigquery.sql
+++ b/dbt/include/global_project/macros/adapters/bigquery.sql
@@ -13,7 +13,7 @@
 
 {% macro cluster_by(raw_cluster_by) %}
   {%- if raw_cluster_by is not none -%}
-  cluster by
+  cluster by 
   {%- if raw_cluster_by is string -%}
     {% set raw_cluster_by = [raw_cluster_by] %}
   {%- endif -%}

--- a/dbt/include/global_project/macros/adapters/bigquery.sql
+++ b/dbt/include/global_project/macros/adapters/bigquery.sql
@@ -14,7 +14,7 @@
 {% macro cluster_by(raw_cluster_by) %}
   {%- if raw_cluster_by is not none -%}
   cluster by 
-  {%- if raw_cluster_by is string -%}
+  {% if raw_cluster_by is string -%}
     {% set raw_cluster_by = [raw_cluster_by] %}
   {%- endif -%}
   {%- for cluster in raw_cluster_by -%}

--- a/test/integration/022_bigquery_test/models/multi_clustered_model.sql
+++ b/test/integration/022_bigquery_test/models/multi_clustered_model.sql
@@ -1,0 +1,10 @@
+
+{{
+	config(
+		materialized = "table",
+		partition_by = "updated_at",
+		cluster_by = ["dupe","id"],
+	)
+}}
+
+select * from {{ ref('view_model') }}

--- a/test/integration/022_bigquery_test/test_simple_bigquery_view.py
+++ b/test/integration/022_bigquery_test/test_simple_bigquery_view.py
@@ -32,7 +32,7 @@ class TestSimpleBigQueryRun(TestBaseBigQueryRun):
         self.run_dbt(['seed'])
         self.run_dbt(['seed', '--full-refresh'])
         results = self.run_dbt()
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
 
         # The 'dupe' model should fail, but all others should pass
         test_results = self.run_dbt(['test'], expect_pass=False)
@@ -54,7 +54,7 @@ class TestSimpleBigQueryRun(TestBaseBigQueryRun):
     def test__bigquery_exists_non_destructive(self):
         self.run_dbt(['seed'])
         # first run dbt. this should work
-        self.assertEqual(len(self.run_dbt()), 4)
+        self.assertEqual(len(self.run_dbt()), 5)
         # then run dbt with --non-destructive. The view should still exist.
         self.run_dbt(['run', '--non-destructive'])
         # The 'dupe' model should fail, but all others should pass
@@ -81,9 +81,9 @@ class TestUnderscoreBigQueryRun(TestBaseBigQueryRun):
     def test_bigquery_run_twice(self):
         self.run_dbt(['seed'])
         results = self.run_dbt()
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
         results = self.run_dbt()
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
 
         # The 'dupe' model should fail, but all others should pass
         test_results = self.run_dbt(['test'], expect_pass=False)

--- a/test/integration/029_docs_generate_tests/bq_models/multi_clustered.sql
+++ b/test/integration/029_docs_generate_tests/bq_models/multi_clustered.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized='table',
+        partition_by='updated_at',
+        cluster_by=['first_name','email']
+    )
+}}
+
+select id,first_name,email,ip_address,DATE(updated_at) as updated_at from {{ ref('seed') }}

--- a/test/integration/029_docs_generate_tests/bq_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/bq_models/schema.yml
@@ -27,4 +27,18 @@ models:
         description: The user's IP address
       - name: updated_at
         description: When the user was updated
+  - name: multi_clustered
+    description: "A clustered and partitioned copy of the test model, clustered on multiple columns"
+    columns:
+      - name: id
+        description: The user id
+      - name: first_name
+        description: The user's name
+      - name: email
+        description: The user's email
+      - name: ip_address
+        description: The user's IP address
+      - name: updated_at
+        description: When the user was updated
+
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -485,6 +485,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         table_stats = self._bigquery_stats(True)
         clustering_stats = self._bigquery_stats(True, partition='DAY',
                                                 cluster='first_name')
+        multi_clustering_stats = self._bigquery_stats(True, partition='DAY',
+                                                cluster='first_name,email')
         nesting_columns = {
             'field_1': {
                 "name": "field_1",
@@ -540,7 +542,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'type': 'table'
                 },
-                'stats': clustering_stats,
+                'stats': multi_clustering_stats,
                 'columns': self._clustered_bigquery_columns('DATE'),
             },
             'seed.test.seed': {
@@ -1198,6 +1200,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         nested_view_sql_path = self.dir('bq_models/nested_view.sql')
         nested_table_sql_path = self.dir('bq_models/nested_table.sql')
         clustered_sql_path = self.dir('bq_models/clustered.sql')
+        multi_clustered_sql_path = self.dir('bq_models/multi_clustered.sql')
         my_schema_name = self.unique_schema()
         return {
             'nodes': {
@@ -1426,12 +1429,14 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'child_map': {
                 'model.test.clustered': [],
+                'model.test.multi_clustered': [],
                 'model.test.nested_table': ['model.test.nested_view'],
                 'model.test.nested_view': [],
-                'seed.test.seed': ['model.test.clustered']
+                'seed.test.seed': ['model.test.clustered','model.test.multi_clustered']
             },
             'parent_map': {
                 'model.test.clustered': ['seed.test.seed'],
+                'model.test.multi_clustered': ['seed.test.seed'],
                 'seed.test.seed': [],
                 'model.test.nested_table': [],
                 'model.test.nested_view': ['model.test.nested_table'],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -531,6 +531,18 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'stats': clustering_stats,
                 'columns': self._clustered_bigquery_columns('DATE'),
             },
+            'model.test.multi_clustered': {
+                'unique_id': 'model.test.multi_clustered',
+                'metadata': {
+                    'comment': None,
+                    'name': 'multi_clustered',
+                    'owner': None,
+                    'schema': my_schema_name,
+                    'type': 'table'
+                },
+                'stats': clustering_stats,
+                'columns': self._clustered_bigquery_columns('DATE'),
+            },
             'seed.test.seed': {
                 'unique_id': 'seed.test.seed',
                 'metadata': {
@@ -1239,6 +1251,59 @@ class TestDocsGenerate(DBTIntegrationTest):
                         },
                     },
                     'description': 'A clustered and partitioned copy of the test model',
+                    'patch_path': self.dir('bq_models/schema.yml'),
+                    'docrefs': [],
+                },
+                'model.test.multi_clustered': {
+                    'alias': 'multi_clustered',
+                    'config': {
+                        'cluster_by': ['first_name','email'],
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'table',
+                        'partition_by': 'updated_at',
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'vars': {}
+                    },
+                    'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
+                    'empty': False,
+                    'fqn': ['test', 'multi_clustered'],
+                    'name': 'multi_clustered',
+                    'original_file_path': multi_clustered_sql_path,
+                    'package_name': 'test',
+                    'path': 'multi_clustered.sql',
+                    'raw_sql': _read_file(multi_clustered_sql_path).rstrip('\n'),
+                    'refs': [['seed']],
+                    'resource_type': 'model',
+                    'root_path': os.getcwd(),
+                    'schema': my_schema_name,
+                    'tags': [],
+                    'unique_id': 'model.test.multi_clustered',
+                    'columns': {
+                        'email': {
+                            'description': "The user's email",
+                            'name': 'email'
+                        },
+                        'first_name': {
+                            'description': "The user's name",
+                            'name': 'first_name'
+                        },
+                        'id': {
+                            'description': 'The user id',
+                            'name': 'id'
+                        },
+                        'ip_address': {
+                            'description': "The user's IP address",
+                            'name': 'ip_address'
+                        },
+                        'updated_at': {
+                            'description': 'When the user was updated',
+                            'name': 'updated_at'
+                        },
+                    },
+                    'description': 'A clustered and partitioned copy of the test model, clustered on multiple columns',
                     'patch_path': self.dir('bq_models/schema.yml'),
                     'docrefs': [],
                 },

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2140,7 +2140,7 @@ class TestDocsGenerate(DBTIntegrationTest):
     def test__bigquery__complex_models(self):
         self.run_and_generate(
             extra={'source-paths': [self.dir('bq_models')]},
-            model_count=3
+            model_count=4
         )
 
         self.verify_catalog(self.expected_bigquery_complex_catalog())


### PR DESCRIPTION
Fixes #1013, proposed addendum to #978 

From the [BQ docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#clustering_column_list):
> clustering_column_list is a comma-separated list that determines how to cluster the table. The clustering column list can contain a list of up to four clustering columns.

When clustering by a single column, BQ will accept either `cluster by colname` or `cluster by (colname)`. When clustering by multiple columns, however, `cluster by col_a, col_b` works fine, whereas `cluster by (col_a, col_b)` raises the following error:
```
CLUSTER BY expression must be groupable, but type is STRUCT at [4:14]
```