### PR TITLE
On ephemeral compile errors that lead to skips, generate real errors (#1037)

### DIFF
--- a/dbt/ui/printer.py
+++ b/dbt/ui/printer.py
@@ -220,8 +220,9 @@ def print_run_status_line(results):
     logger.info(stats_line.format(**stats))
 
 
-def print_run_result_error(result):
-    logger.info("")
+def print_run_result_error(result, newline=True):
+    if newline:
+        logger.info("")
 
     if result.failed:
         logger.info(yellow("Failure in {} {} ({})").format(
@@ -243,6 +244,14 @@ def print_run_result_error(result):
                 first = False
             else:
                 logger.info(line)
+
+
+def print_skip_caused_by_error(model, schema, relation, index, num_models,
+                               result):
+    msg = ('SKIP relation {}.{} due to ephemeral model error'
+           .format(schema, relation))
+    print_fancy_output_line(msg, red('ERROR SKIP'), index, num_models)
+    print_run_result_error(result, newline=False)
 
 
 def print_end_of_run_summary(num_errors, early_exit=False):

--- a/test/integration/020_ephemeral_test/ephemeral-errors/base/base.sql
+++ b/test/integration/020_ephemeral_test/ephemeral-errors/base/base.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='ephemeral') }}
+
+select * from {{ this.schema }}.seed

--- a/test/integration/020_ephemeral_test/ephemeral-errors/base/base_copy.sql
+++ b/test/integration/020_ephemeral_test/ephemeral-errors/base/base_copy.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='ephemeral') }}
+
+{{ adapter.invalid_method() }}
+
+select * from {{ ref('base') }}

--- a/test/integration/020_ephemeral_test/ephemeral-errors/dependent.sql
+++ b/test/integration/020_ephemeral_test/ephemeral-errors/dependent.sql
@@ -1,0 +1,2 @@
+-- base copy is an error
+select * from {{ref('base_copy')}} where gender = 'Male'

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -32,3 +32,20 @@ class TestEphemeral(DBTIntegrationTest):
         self.assertManyTablesEqual(
             ["SEED", "DEPENDENT", "DOUBLE_DEPENDENT", "SUPER_DEPENDENT"]
         )
+
+class TestEphemeralErrorHandling(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "ephemeral_020"
+
+    @property
+    def models(self):
+        return "test/integration/020_ephemeral_test/ephemeral-errors"
+
+    @attr(type='postgres')
+    def test__postgres_upstream_error(self):
+        self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
+
+        results = self.run_dbt(expect_pass=False)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].errored)


### PR DESCRIPTION
When an ephemeral model fails and downstream models are skipped, explicitly mark those skipped downstream models as being skipped due to an error, and alter their reporting accordingly, including dbt's exit code.

Old output:
```
> dbt run
echo $?Found 3 models, 0 tests, 0 archives, 0 analyses, 90 macros, 1 operations, 1 seed files

11:29:21 | Concurrency: 2 threads (target='default')
11:29:21 |
11:29:21 | 1 of 2 START view model dbt_postgres.moby_dick_base.................. [RUN]
11:29:21 | 1 of 2 OK created view model dbt_postgres.moby_dick_base............. [CREATE VIEW in 0.04s]
11:29:21 | 2 of 2 SKIP relation dbt_postgres.word_count......................... [SKIP]
11:29:21 |
11:29:21 | Finished running 2 view models in 0.11s.

Completed successfully

Done. PASS=1 ERROR=0 SKIP=1 TOTAL=2
> echo $?
0
```

New output:
```
> dbt run
Found 3 models, 0 tests, 0 archives, 0 analyses, 90 macros, 1 operations, 1 seed files

10:32:18 | Concurrency: 2 threads (target='default')
10:32:18 |
10:32:18 | 1 of 2 START view model dbt_postgres.moby_dick_base.................. [RUN]
10:32:18 | 1 of 2 OK created view model dbt_postgres.moby_dick_base............. [CREATE VIEW in 0.04s]
10:32:19 | 2 of 2 SKIP relation dbt_postgres.word_count due to ephemeral model error [ERROR SKIP]
Compilation Error in model ephemeral_word_count (models/ephemeral_word_count.sql)
  'dbt.context.common.DatabaseWrapper object' has no attribute 'invalid_method'
10:32:19 |
10:32:19 | Finished running 2 view models in 0.11s.

Completed with 1 errors:

Compilation Error in referenced ephemeral model dbt_postgres.ephemeral_word_count

Done. PASS=1 ERROR=1 SKIP=0 TOTAL=2
> echo $?
1
````
