### PR TITLE
upgrade to minimal-snowplow-tracker 0.0.2

### DIFF
--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -1,7 +1,7 @@
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt import version as dbt_version
 from snowplow_tracker import Subject, Tracker, Emitter, logger as sp_logger
-from snowplow_tracker import SelfDescribingJson, disable_contracts
+from snowplow_tracker import SelfDescribingJson
 from datetime import datetime
 
 import pytz
@@ -12,7 +12,6 @@ import os
 
 import dbt.clients.system
 
-disable_contracts()
 sp_logger.setLevel(100)
 
 COLLECTOR_URL = "fishtownanalytics.sinter-collect.com"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'psycopg2>=2.7.5,<2.8',
         'sqlparse==0.2.3',
         'networkx==1.11',
-        'minimal-snowplow-tracker==0.0.1',
+        'minimal-snowplow-tracker==0.0.2',
         'snowflake-connector-python>=1.4.9',
         'requests>=2.18.0,<3',
         'colorama==0.3.9',


### PR DESCRIPTION
this rips out contracts, and speeds up dbt's startup time by about 200ms (12%) on my machine.

test: ran `time dbt --version` five times on this and dev

dev:
 - min: 1.702s
 - median: 1.728s
 - max: 1.829s

this branch:
 - min: 1.506s
 - median: 1.516s
 - max: 1.625s