### PR TITLE
Re-order Agate type inference ordering

### DIFF
--- a/dbt/clients/agate_helper.py
+++ b/dbt/clients/agate_helper.py
@@ -2,13 +2,13 @@
 import agate
 
 DEFAULT_TYPE_TESTER = agate.TypeTester(types=[
-    agate.data_types.Boolean(true_values=('true',),
-                             false_values=('false',),
-                             null_values=('null', '')),
     agate.data_types.Number(null_values=('null', '')),
     agate.data_types.TimeDelta(null_values=('null', '')),
     agate.data_types.Date(null_values=('null', '')),
     agate.data_types.DateTime(null_values=('null', '')),
+    agate.data_types.Boolean(true_values=('true',),
+                             false_values=('false',),
+                             null_values=('null', '')),
     agate.data_types.Text(null_values=('null', ''))
 ])
 


### PR DESCRIPTION
By putting Booleans after Numbers, Agate will correctly infer values like "0" and "1" as Numbers. The boolean type is followed only by "Text", so values like "True" and "False" should still be inferred
as booleans appropriately.

Before:
```
09:57:14 | Concurrency: 8 threads (target='dev')
09:57:14 |
09:57:14 | 1 of 1 START test not_null_eph_id.................................... [RUN]
09:57:14 | 1 of 1 FAIL 1 not_null_eph_id........................................ [FAIL True in 0.02s]
```

After
```
09:57:14 | Concurrency: 8 threads (target='dev')
09:57:14 |
09:57:14 | 1 of 1 START test not_null_eph_id.................................... [RUN]
09:57:14 | 1 of 1 FAIL 1 not_null_eph_id........................................ [FAIL 1 in 0.02s]
```