### PR TITLE
move cache_new_relation call into the materialization caller itself

### DIFF
--- a/dbt/include/global_project/macros/adapters/common.sql
+++ b/dbt/include/global_project/macros/adapters/common.sql
@@ -33,10 +33,6 @@
 {% endmacro %}
 
 {% macro create_table_as(temporary, relation, sql) -%}
-  {%- if not temporary -%}
-    {{ adapter.cache_new_relation(relation) }}
-  {%- endif -%}
-
   {{ adapter_macro('create_table_as', temporary, relation, sql) }}
 {%- endmacro %}
 
@@ -50,8 +46,6 @@
 
 
 {% macro create_view_as(relation, sql) -%}
-  {{ adapter.cache_new_relation(relation) }}
-
   {{ adapter_macro('create_view_as', relation, sql) }}
 {%- endmacro %}
 
@@ -63,8 +57,6 @@
 
 
 {% macro create_archive_table(relation, columns) -%}
-  {{ adapter.cache_new_relation(relation) }}
-
   {{ adapter_macro('create_archive_table', relation, columns) }}
 {%- endmacro %}
 

--- a/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -14,7 +14,6 @@
 {% macro default__create_csv_table(model) %}
   {%- set agate_table = model['agate_table'] -%}
   {%- set column_override = model['config'].get('column_types', {}) -%}
-  {{ adapter.cache_new_relation(this) }}
 
   {% set sql %}
     create table {{ this.render(False) }} (

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -453,6 +453,10 @@ class ModelRunner(CompileRunner):
 
         materialization_macro.generator(context)()
 
+        # we must have built a new model, add it to the cache
+        relation = self.adapter.Relation.create_from_node(self.config, model)
+        self.adapter.cache_new_relation(relation)
+
         result = context['load_result']('main')
 
         return RunModelResult(model, status=result.status)


### PR DESCRIPTION
This fixes a horrible logic error around relation caching where externally-specified materializations did not get added to the cache and caused intermittent downstream issues.