### PR TITLE
Fix validation issues (#1078)

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -208,6 +208,32 @@ class Project(object):
         self.seeds = seeds
         self.packages = packages
 
+    @staticmethod
+    def _preprocess(project_dict):
+        """Pre-process certain special keys to convert them from None values
+        into empty containers.
+        """
+        handlers = {
+            ('archive',): list,
+            ('on-run-start',): list,
+            ('on-run-end',): list,
+        }
+        for k in ('models', 'seeds'):
+            handlers[(k,)] = dict
+            handlers[(k, 'vars')] = dict
+            handlers[(k, 'pre-hook')] = list
+            handlers[(k, 'post-hook')] = list
+        handlers[('seeds', 'column_types')] = dict
+
+        def converter(value, keypath):
+            if value is None and keypath in handlers:
+                handler = handlers[keypath]
+                return handler()
+            else:
+                return value
+
+        return dbt.utils.deep_map(converter, project_dict)
+
     @classmethod
     def from_project_config(cls, project_dict, packages_dict=None):
         """Create a project from its project and package configuration, as read
@@ -220,6 +246,7 @@ class Project(object):
             the packages file exists and is invalid.
         :returns Project: The project, with defaults populated.
         """
+        project_dict = cls._preprocess(project_dict)
         # just for validation.
         try:
             ProjectContract(**project_dict)
@@ -250,6 +277,7 @@ class Project(object):
         modules_path = project_dict.get('modules-path', 'dbt_modules')
         # in the default case we'll populate this once we know the adapter type
         quoting = project_dict.get('quoting', {})
+
         models = project_dict.get('models', {})
         on_run_start = project_dict.get('on-run-start', [])
         on_run_end = project_dict.get('on-run-end', [])

--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -176,7 +176,8 @@ GIT_PACKAGE_CONTRACT = {
             ),
         },
         'revision': {
-            'type': 'string',
+            'type': ['string', 'array'],
+            'item': 'string',
             'description': 'The git revision to use, if it is not tip',
         },
     },

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -103,6 +103,10 @@ class CompilationException(RuntimeException):
         return 'Compilation'
 
 
+class RecursionException(RuntimeException):
+    pass
+
+
 class ValidationException(RuntimeException):
     pass
 

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -221,6 +221,16 @@ def invoke_dbt(parsed):
         logger.info("Encountered an error while reading the project:")
         logger.info(dbt.compat.to_string(e))
 
+        dbt.tracking.track_invalid_invocation(
+            config=cfg,
+            args=parsed,
+            result_type=e.result_type)
+
+        return None
+    except DbtProfileError as e:
+        logger.info("Encountered an error while reading profiles:")
+        logger.info("  ERROR {}".format(str(e)))
+
         all_profiles = read_profiles(parsed.profiles_dir).keys()
 
         if len(all_profiles) > 0:
@@ -232,16 +242,6 @@ def invoke_dbt(parsed):
                         "profiles.yml file")
 
         logger.info(PROFILES_HELP_MESSAGE)
-
-        dbt.tracking.track_invalid_invocation(
-            config=cfg,
-            args=parsed,
-            result_type=e.result_type)
-
-        return None
-    except DbtProfileError as e:
-        logger.info("Encountered an error while reading profiles:")
-        logger.info("  ERROR {}".format(str(e)))
 
         dbt.tracking.track_invalid_invocation(
             config=cfg,

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -265,7 +265,7 @@ def deep_merge_item(destination, key, value):
         destination[key] = value
 
 
-def deep_map(func, value, keypath=(), memo=None, _notfound=object()):
+def deep_map(func, value, keypath=()):
     """map the function func() onto each non-container value in 'value'
     recursively, returning a new value. As long as func does not manipulate
     value, then deep_map will also not manipulate it.
@@ -277,26 +277,19 @@ def deep_map(func, value, keypath=(), memo=None, _notfound=object()):
     func() will be called on numbers, strings, Nones, and booleans. Its first
     parameter will be the value, and the second will be its keypath, an
     iterable over the __getitem__ keys needed to get to it.
+
+    If there are cycles in the value, this will cause an infinite loop.
     """
-    # TODO: if we could guarantee no cycles, we would not need to memoize
-    if memo is None:
-        memo = {}
-
-    value_id = id(value)
-    cached = memo.get(value_id, _notfound)
-    if cached is not _notfound:
-        return cached
-
     atomic_types = (int, float, basestring, type(None), bool)
 
     if isinstance(value, list):
         ret = [
-            deep_map(func, v, (keypath + (idx,)), memo)
+            deep_map(func, v, (keypath + (idx,)))
             for idx, v in enumerate(value)
         ]
     elif isinstance(value, dict):
         ret = {
-            k: deep_map(func, v, (keypath + (k,)), memo)
+            k: deep_map(func, v, (keypath + (k,)))
             for k, v in value.items()
         }
     elif isinstance(value, atomic_types):
@@ -307,7 +300,7 @@ def deep_map(func, value, keypath=(), memo=None, _notfound=object()):
             'in deep_map, expected one of {!r}, got {!r}'
             .format(ok_types, type(value))
         )
-    memo[value_id] = ret
+
     return ret
 
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -265,7 +265,32 @@ def deep_merge_item(destination, key, value):
         destination[key] = value
 
 
-def deep_map(func, value, keypath=()):
+def _deep_map(func, value, keypath):
+    atomic_types = (int, float, basestring, type(None), bool)
+
+    if isinstance(value, list):
+        ret = [
+            _deep_map(func, v, (keypath + (idx,)))
+            for idx, v in enumerate(value)
+        ]
+    elif isinstance(value, dict):
+        ret = {
+            k: _deep_map(func, v, (keypath + (k,)))
+            for k, v in value.items()
+        }
+    elif isinstance(value, atomic_types):
+        ret = func(value, keypath)
+    else:
+        ok_types = (list, dict) + atomic_types
+        raise dbt.exceptions.DbtConfigError(
+            'in _deep_map, expected one of {!r}, got {!r}'
+            .format(ok_types, type(value))
+        )
+
+    return ret
+
+
+def deep_map(func, value):
     """map the function func() onto each non-container value in 'value'
     recursively, returning a new value. As long as func does not manipulate
     value, then deep_map will also not manipulate it.
@@ -278,30 +303,17 @@ def deep_map(func, value, keypath=()):
     parameter will be the value, and the second will be its keypath, an
     iterable over the __getitem__ keys needed to get to it.
 
-    If there are cycles in the value, this will cause an infinite loop.
+    :raises: If there are cycles in the value, raises a
+        dbt.exceptions.RecursionException
     """
-    atomic_types = (int, float, basestring, type(None), bool)
-
-    if isinstance(value, list):
-        ret = [
-            deep_map(func, v, (keypath + (idx,)))
-            for idx, v in enumerate(value)
-        ]
-    elif isinstance(value, dict):
-        ret = {
-            k: deep_map(func, v, (keypath + (k,)))
-            for k, v in value.items()
-        }
-    elif isinstance(value, atomic_types):
-        ret = func(value, keypath)
-    else:
-        ok_types = (list, dict) + atomic_types
-        raise dbt.exceptions.DbtConfigError(
-            'in deep_map, expected one of {!r}, got {!r}'
-            .format(ok_types, type(value))
-        )
-
-    return ret
+    try:
+        return _deep_map(func, value, ())
+    except RuntimeError as exc:
+        if 'maximum recursion depth exceeded' in str(exc):
+            raise dbt.exceptions.RecursionException(
+                'Cycle detected in deep_map'
+            )
+        raise
 
 
 class AttrDict(dict):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -854,6 +854,17 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.models, {'vars': {}, 'pre-hook': [], 'post-hook': []})
         self.assertEqual(project.seeds, {'vars': {}, 'pre-hook': [], 'post-hook': [], 'column_types': {}})
 
+    def test_cycle(self):
+        models = {}
+        models['models'] = models
+        self.default_project_data.update({
+            'models': models,
+        })
+        with self.assertRaises(dbt.exceptions.DbtProjectError):
+            dbt.config.Project.from_project_config(
+                self.default_project_data
+            )
+
 
 class TestProjectWithConfigs(BaseConfigTest):
     def setUp(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -826,6 +826,34 @@ class TestProject(BaseConfigTest):
         ))}, [])
         mock_logger.info.assert_not_called()
 
+    def test_none_values(self):
+        self.default_project_data.update({
+            'models': None,
+            'seeds': None,
+            'archive': None,
+            'on-run-end': None,
+            'on-run-start': None,
+        })
+        project = dbt.config.Project.from_project_config(
+            self.default_project_data
+        )
+        self.assertEqual(project.models, {})
+        self.assertEqual(project.on_run_start, [])
+        self.assertEqual(project.on_run_end, [])
+        self.assertEqual(project.archive, [])
+        self.assertEqual(project.seeds, {})
+
+    def test_nested_none_values(self):
+        self.default_project_data.update({
+            'models': {'vars': None, 'pre-hook': None, 'post-hook': None},
+            'seeds': {'vars': None, 'pre-hook': None, 'post-hook': None, 'column_types': None},
+        })
+        project = dbt.config.Project.from_project_config(
+            self.default_project_data
+        )
+        self.assertEqual(project.models, {'vars': {}, 'pre-hook': [], 'post-hook': []})
+        self.assertEqual(project.seeds, {'vars': {}, 'pre-hook': [], 'post-hook': [], 'column_types': {}})
+
 
 class TestProjectWithConfigs(BaseConfigTest):
     def setUp(self):

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -1,0 +1,43 @@
+import unittest
+
+import dbt.exceptions
+from dbt.task.deps import GitPackage, LocalPackage
+
+
+class TestLocalPackage(unittest.TestCase):
+    def test_init(self):
+        a = LocalPackage(local='/path/to/package')
+        a.resolve_version()
+        self.assertEqual(a.source_type(), 'local')
+        self.assertEqual(a.local, '/path/to/package')
+
+
+class TestGitPackage(unittest.TestCase):
+    def test_init(self):
+        a = GitPackage(git='http://example.com', revision='0.0.1')
+        self.assertEqual(a.git, 'http://example.com')
+        self.assertEqual(a.revision, '0.0.1')
+        self.assertEqual(a.version, ['0.0.1'])
+        self.assertEqual(a.source_type(), 'git')
+
+    def test_invalid(self):
+        with self.assertRaises(dbt.exceptions.ValidationException):
+            GitPackage(git='http://example.com', version='0.0.1')
+
+    def test_resolve_ok(self):
+        a = GitPackage(git='http://example.com', revision='0.0.1')
+        b = GitPackage(git='http://example.com', revision='0.0.1')
+        c = a.incorporate(b)
+        self.assertEqual(c.git, 'http://example.com')
+        self.assertEqual(c.version, ['0.0.1', '0.0.1'])
+        c.resolve_version()
+        self.assertEqual(c.version, ['0.0.1'])
+
+    def test_resovle_fail(self):
+        a = GitPackage(git='http://example.com', revision='0.0.1')
+        b = GitPackage(git='http://example.com', revision='0.0.2')
+        c = a.incorporate(b)
+        self.assertEqual(c.git, 'http://example.com')
+        self.assertEqual(c.version, ['0.0.1', '0.0.2'])
+        with self.assertRaises(dbt.exceptions.DependencyException):
+            c.resolve_version()


### PR DESCRIPTION
Fixes #1078 by:
 - preprocessing the dictionary as read from yaml, initializing certain None values as collections
 - relaxing the restrictions on GitPackage.revision to support the existing workflow

To make it easier to handle the preprocessing use case, I changed `dbt.utils.deep_map` to remove memoization, so instead of handling cycles dbt will hit the maximum recursion depth. Accordingly, I added handling for that, `deep_map` now can raise a `dbt.exceptions.RecursionException` and all callers handle it accordingly. The only way I can think of to create a cycle is to use anchors/tags in yaml, so hopefully if you've created a cycle you know what you're doing and the cause is obvious!