### PR TITLE
Fix/more helpful invalid refs (#1080)

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -185,6 +185,10 @@ class DocumentationExtension(jinja2.ext.Extension):
         return node
 
 
+def _is_dunder_name(name):
+    return name.startswith('__') and name.endswith('__')
+
+
 def create_macro_capture_env(node):
 
     class ParserMacroCapture(jinja2.Undefined):
@@ -220,7 +224,7 @@ def create_macro_capture_env(node):
             )
 
         def __getattr__(self, name):
-            if name == 'name' or name.startswith('__') and name.endswith('__'):
+            if name == 'name' or _is_dunder_name(name):
                 raise AttributeError(
                     "'{}' object has no attribute '{}'"
                     .format(type(self).__name__, name)

--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -206,12 +206,18 @@ def create_macro_capture_env(node):
             path = os.path.join(self.node.get('root_path'),
                                 self.node.get('original_file_path'))
 
-            dbt.exceptions.raise_compiler_error(
+            logger.debug(
                 'A ParserMacroCapture has been deecopy()d, invalid reference '
-                'to {}.{} in node {}.{} (source path: {})'
-                .format(self.package_name, self.name,
-                        self.node.get('package_name'), self.node.get('name'),
+                'to "{}" in node {}.{} (source path: {})'
+                .format(self.name, self.node.get('package_name'),
+                        self.node.get('name'),
                         path))
+
+            dbt.exceptions.raise_compiler_error(
+                'dbt has detected at least one invalid reference in {}.{}. '
+                'Check logs for more information'
+                .format(self.node.get('package_name'), self.node.get('name'))
+            )
 
         def __getattr__(self, name):
             if name == 'name' or name.startswith('__') and name.endswith('__'):


### PR DESCRIPTION
Fixes #1080 - in particular the issue described by @raybuhr

There are some neat things going on here:
 - the issue is that `ParserMacroCapture.__getattr__` accesses `self.name` without ensuring that it is not doing a lookup for `self.name` -> recursion error
 - which can happen if a `ParserMacroCapture` is deepcopied. deepcopy sort of calls __new__(), and populates the created object, bypassing __init__ through a convoluted set of `hasattr` checks that we pass due to the `__getattr__` implementation.
 - which can happen if an undefined value was `ref`'d

The ways you might think would help (raising AttributeError in __getattr__, etc) all end up being pretty unhelpful since jinja does propagation of Undefined values, so you get odd TypeErrors down the line. But implementing a `__deepcopy__` that raises a compiler error works: jinja won't catch it and the error can be pretty precise/helpful. Any time you find yourself calling copy.deepcopy() with an undefined value, things have gone horribly wrong, so I think it's a valid solution.