### PR TITLE
Handle undefined variables in jinja better (#935)

### DIFF
--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -222,6 +222,11 @@ def create_macro_capture_env(node):
                 .format(self.node.get('package_name'), self.node.get('name'))
             )
 
+        def __getitem__(self, name):
+            # Propagate the undefined value if a caller accesses this as if it
+            # were a dictionary
+            return self
+
         def __getattr__(self, name):
             if name == 'name' or _is_dunder_name(name):
                 raise AttributeError(

--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -195,9 +195,8 @@ def create_macro_capture_env(node):
         """
         This class sets up the parser to capture macros.
         """
-        def __init__(self, hint=None, obj=None, name=None,
-                     exc=None):
-            super(jinja2.Undefined, self).__init__()
+        def __init__(self, hint=None, obj=None, name=None, exc=None):
+            super(ParserMacroCapture, self).__init__(hint=hint, name=name)
             self.node = node
             self.name = name
             self.package_name = node.get('package_name')

--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -210,16 +210,15 @@ def create_macro_capture_env(node):
                                 self.node.get('original_file_path'))
 
             logger.debug(
-                'A ParserMacroCapture has been deecopy()d, invalid reference '
-                'to "{}" in node {}.{} (source path: {})'
+                'dbt encountered an undefined variable, "{}" in node {}.{} '
+                '(source path: {})'
                 .format(self.name, self.node.get('package_name'),
-                        self.node.get('name'),
-                        path))
+                        self.node.get('name'), path))
 
+            # match jinja's message
             dbt.exceptions.raise_compiler_error(
-                'dbt has detected at least one invalid reference in {}.{}. '
-                'Check logs for more information'
-                .format(self.node.get('package_name'), self.node.get('name'))
+                "{!r} is undefined".format(self.name),
+                node=self.node
             )
 
         def __getitem__(self, name):


### PR DESCRIPTION
Fixes #935 (I think!)
There were some issues with `ParsedMacroCapture` and its inheritance from `jinja2.Undefined` that were causing issues.
In particular, `ParsedMacroCapture`'s `super()` call was calling `object.__init__` as it had the wrong class as its first argument. This meant that the underlying machinery for `jinja2.Undefined` wasn't getting set up. Once that was fixed, I added in the `hint` and `name` parameters so we can get nice messages

The file in question:
```
select * from {{ ref(thing+'a') }}
```

Old (snipped the stacktrace for brevity):
```
Encountered an error:
exceptions must derive from BaseException
Traceback (most recent call last):
  ...
  File "dbt-0b0c26f75515b90cb4d064c0", line 1, in top-level template code
    from __future__ import division, generator_stop
TypeError: exceptions must derive from BaseException
```

New:
```
Encountered an error:
Compilation Error in model x (models/x.sql)
  'thing' is undefined
```

Another kind of bad file:
```
{{ config(something=TRUE) }}
select 1 as id
```

Old: Same bad stuff

New:
```
Encountered an error:
Compilation Error in model x (models/x.sql)
  'TRUE' is undefined
```