### PR TITLE
Add the default target back in (#1088)

### DIFF
--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -278,7 +278,9 @@ class BigQueryAdapter(PostgresAdapter):
             raise dbt.exceptions.RuntimeException("BigQuery Timeout Exceeded")
 
         elif job.error_result:
-            message = '\n'.join(error['message'].strip() for error in job.errors)
+            message = '\n'.join(
+                error['message'].strip() for error in job.errors
+            )
             raise dbt.exceptions.RuntimeException(message)
 
     def make_date_partitioned_table(self, dataset_name, identifier,

--- a/dbt/config.py
+++ b/dbt/config.py
@@ -606,8 +606,10 @@ class Profile(object):
             # render the target if it was parsed from yaml
             target_name = renderer.render_value(raw_profile['target'])
         else:
-            raise DbtProfileError(
-                "target not specified in profile '{}'".format(profile_name)
+            target_name = 'default'
+            logger.debug(
+                "target not specified in profile '{}', using '{}'"
+                .format(profile_name, target_name)
             )
 
         raw_profile_data = cls._get_profile_data(

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -319,12 +319,14 @@ class TestProfile(BaseConfigTest):
         self.assertIn('postgres', str(exc.exception))
         self.assertIn('default', str(exc.exception))
 
-    def test_target_missing(self):
-        del self.default_profile_data['default']['target']
-        with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
-            self.from_raw_profiles()
-        self.assertIn('target not specified in profile', str(exc.exception))
-        self.assertIn('default', str(exc.exception))
+    def test_missing_target(self):
+        profile = self.default_profile_data['default']
+        del profile['target']
+        profile['outputs']['default'] = profile['outputs']['postgres']
+        profile = self.from_raw_profiles()
+        self.assertEqual(profile.profile_name, 'default')
+        self.assertEqual(profile.target_name, 'default')
+        self.assertEqual(profile.credentials.type, 'postgres')
 
     def test_profile_invalid_project(self):
         with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:


### PR DESCRIPTION
Fixes #1088 by setting a default target instead of raising an exception when there is no target set.

Also fix the pep8 failure.