### PR TITLE
Fix error skip criteria (#1093)

### DIFF
--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -191,9 +191,10 @@ class BaseRunner(object):
                 )
                 # set an error so dbt will exit with an error code
                 error = (
-                    'Compilation Error in referenced ephemeral model {}.{}'
-                    .format(self.skip_cause.node.schema,
-                            self.skip_cause.node.name)
+                    'Compilation Error in {}, caused by compilation error '
+                    'in referenced ephemeral model {}'
+                    .format(self.skip_cause.node.unique_id,
+                            self.node.unique_id)
                 )
             else:
                 dbt.ui.printer.print_skip_line(

--- a/dbt/node_runners.py
+++ b/dbt/node_runners.py
@@ -193,8 +193,8 @@ class BaseRunner(object):
                 error = (
                     'Compilation Error in {}, caused by compilation error '
                     'in referenced ephemeral model {}'
-                    .format(self.skip_cause.node.unique_id,
-                            self.node.unique_id)
+                    .format(self.node.unique_id,
+                            self.skip_cause.node.unique_id)
                 )
             else:
                 dbt.ui.printer.print_skip_line(


### PR DESCRIPTION
Fixes #1093 

On nodes skipped due to failures, only log `ERROR SKIP` when the skip cause node was ephemeral.