### PR TITLE
allow strings in hook configuration (#1097)

### DIFF
--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -19,8 +19,10 @@ else:
 
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
+    from SocketServer import TCPServer
 else:
     from http.server import SimpleHTTPRequestHandler
+    from socketserver import TCPServer
 
 
 def to_unicode(s):

--- a/dbt/task/serve.py
+++ b/dbt/task/serve.py
@@ -1,10 +1,9 @@
 import shutil
 import os
 import webbrowser
-from socketserver import TCPServer
 
 from dbt.include import DOCS_INDEX_FILE_PATH
-from dbt.compat import SimpleHTTPRequestHandler
+from dbt.compat import SimpleHTTPRequestHandler, TCPServer
 from dbt.logger import GLOBAL_LOGGER as logger
 
 from dbt.task.base_task import RunnableTask

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -767,6 +767,23 @@ class TestProject(BaseConfigTest):
         str(project)
         json.dumps(project.to_project_config())
 
+    def test_string_run_hooks(self):
+        self.default_project_data.update({
+            'on-run-start': '{{ logging.log_run_start_event() }}',
+            'on-run-end': '{{ logging.log_run_end_event() }}',
+        })
+        project = dbt.config.Project.from_project_config(
+            self.default_project_data
+        )
+        self.assertEqual(
+            project.on_run_start,
+            ['{{ logging.log_run_start_event() }}']
+        )
+        self.assertEqual(
+            project.on_run_end,
+            ['{{ logging.log_run_end_event() }}']
+        )
+
     def test_invalid_project_name(self):
         self.default_project_data['name'] = 'invalid-project-name'
         with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:


### PR DESCRIPTION
Fixes #1097
- Modify the config preprocessing step to convert `str` -> `[str]` for hooks, instead of only `None` -> `[]`
- Add a unit test to make sure conversion happens