### PR TITLE
Use SWAP instead of RENAME for table materialisation on Snowflake

### DIFF
--- a/dbt/include/global_project/macros/adapters/snowflake.sql
+++ b/dbt/include/global_project/macros/adapters/snowflake.sql
@@ -11,3 +11,8 @@
     {{ sql }}
   );
 {% endmacro %}
+
+{% macro snowflake__swap_table(old_relation, new_relation) -%}
+  alter table {{ old_relation }} swap with {{ new_relation }}
+  ;
+{% endmacro %}


### PR DESCRIPTION
ALTER TABLE REAME is DDL and commits an open transaction. This creates the opportunity for errors to arise if a connection attempts to access the target table, between the renaming of intermediate table and the target table, and before permissions are granted. Snowflake provides an ALTER TABLE SWAP function to allow atomic table swaps.

- Add snowflake__swap_table macro
- Update Snowflake table materialisation to use swap table