### PR TITLE
Fix the hub packaging so that it at least mostly works

### DIFF
--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -185,6 +185,34 @@ GIT_PACKAGE_CONTRACT = {
 }
 
 
+VERSION_SPECIFICATION_CONTRACT = {
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'major': {
+            'type': ['string', 'null'],
+        },
+        'minor': {
+            'type': ['string', 'null'],
+        },
+        'patch': {
+            'type': ['string', 'null'],
+        },
+        'prerelease': {
+            'type': ['string', 'null'],
+        },
+        'build': {
+            'type': ['string', 'null'],
+        },
+        'matcher': {
+            'type': 'string',
+            'enum': ['=', '>=', '<=', '>', '<'],
+        },
+    },
+    'required': ['major', 'minor', 'patch', 'prerelease', 'build', 'matcher'],
+}
+
+
 REGISTRY_PACKAGE_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,
@@ -194,28 +222,18 @@ REGISTRY_PACKAGE_CONTRACT = {
             'description': 'The name of the package',
         },
         'version': {
-            'type': 'string',
+            'type': ['string', 'array'],
+            'item': {
+                'anyOf': [
+                    VERSION_SPECIFICATION_CONTRACT,
+                    'string'
+                ],
+            },
             'description': 'The version of the package',
         },
     },
     'required': ['package'],
 }
-
-
-class Package(APIObject):
-    SCHEMA = NotImplemented
-
-
-class LocalPackage(Package):
-    SCHEMA = LOCAL_PACKAGE_CONTRACT
-
-
-class GitPackage(Package):
-    SCHEMA = GIT_PACKAGE_CONTRACT
-
-
-class RegistryPackage(Package):
-    SCHEMA = REGISTRY_PACKAGE_CONTRACT
 
 
 PACKAGE_FILE_CONTRACT = {
@@ -235,6 +253,31 @@ PACKAGE_FILE_CONTRACT = {
     },
     'required': ['packages'],
 }
+
+
+# the metadata from the registry has extra things that we don't care about.
+REGISTRY_PACKAGE_METADATA_CONTRACT = deep_merge(
+    PACKAGE_FILE_CONTRACT,
+    {
+        'additionalProperties': True,
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'downloads': {
+                'type': 'object',
+                'additionalProperties': True,
+                'properties': {
+                    'tarball': {
+                        'type': 'string',
+                    },
+                },
+                'required': ['tarball']
+            },
+        },
+        'required': PACKAGE_FILE_CONTRACT['required'][:] + ['downloads']
+    }
+)
 
 
 class PackageConfig(APIObject):

--- a/dbt/exceptions.py
+++ b/dbt/exceptions.py
@@ -151,6 +151,8 @@ class DbtProfileError(DbtConfigError):
 class SemverException(Exception):
     def __init__(self, msg=None):
         self.msg = msg
+        if msg is not None:
+            super(SemverException, self).__init__(msg)
 
 
 class VersionsNotCompatibleException(SemverException):

--- a/dbt/semver.py
+++ b/dbt/semver.py
@@ -1,6 +1,8 @@
 import re
 import logging
 
+from dbt.api.object import APIObject
+from dbt.contracts.project import VERSION_SPECIFICATION_CONTRACT
 from dbt.exceptions import VersionsNotCompatibleException
 import dbt.utils
 
@@ -158,13 +160,14 @@ class VersionRange(dbt.utils.AttrDict):
         return to_return
 
 
-class VersionSpecifier(dbt.utils.AttrDict):
+class VersionSpecifier(APIObject):
+    SCHEMA = VERSION_SPECIFICATION_CONTRACT
 
     def __init__(self, *args, **kwargs):
-        super(VersionSpecifier, self).__init__(*args, **kwargs)
-
-        if self.matcher is None:
-            self.matcher = Matchers.EXACT
+        kwargs = dict(*args, **kwargs)
+        if kwargs.get('matcher') is None:
+            kwargs['matcher'] = Matchers.EXACT
+        super(VersionSpecifier, self).__init__(**kwargs)
 
     def to_version_string(self, skip_matcher=False):
         prerelease = ''
@@ -289,9 +292,15 @@ class VersionSpecifier(dbt.utils.AttrDict):
 
 
 class UnboundedVersionSpecifier(VersionSpecifier):
-
     def __init__(self, *args, **kwargs):
-        super(dbt.utils.AttrDict, self).__init__(*args, **kwargs)
+        super(UnboundedVersionSpecifier, self).__init__(
+            matcher='=',
+            major=None,
+            minor=None,
+            patch=None,
+            prerelease=None,
+            build=None
+        )
 
     def __str__(self):
         return "*"

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -17,7 +17,8 @@ from dbt.semver import VersionSpecifier, UnboundedVersionSpecifier
 from dbt.utils import AttrDict
 from dbt.api.object import APIObject
 from dbt.contracts.project import LOCAL_PACKAGE_CONTRACT, \
-    GIT_PACKAGE_CONTRACT, REGISTRY_PACKAGE_CONTRACT
+    GIT_PACKAGE_CONTRACT, REGISTRY_PACKAGE_CONTRACT, \
+    REGISTRY_PACKAGE_METADATA_CONTRACT, PackageConfig
 
 from dbt.task.base_task import BaseTask
 
@@ -85,7 +86,7 @@ class Package(APIObject):
 
     def get_project_name(self, project):
         metadata = self.fetch_metadata(project)
-        return metadata.project_name
+        return metadata.name
 
     def get_installation_path(self, project):
         dest_dirname = self.get_project_name(project)
@@ -130,7 +131,10 @@ class RegistryPackage(Package):
         return "version {}".format(self.version_name())
 
     def incorporate(self, other):
-        return RegistryPackage(self.package, self.version + other.version)
+        return RegistryPackage(
+            package=self.package,
+            version=self.version + other.version
+        )
 
     def _check_in_index(self):
         index = registry.index_cached()
@@ -158,9 +162,8 @@ class RegistryPackage(Package):
 
     def _fetch_metadata(self, project):
         version_string = self.version_name()
-        # TODO(jeb): this needs to actually return a RuntimeConfig, instead of
-        # parsed json from a URL
-        return registry.package_version(self.package, version_string)
+        dct = registry.package_version(self.package, version_string)
+        return RegistryPackageMetadata(**dct)
 
     def install(self, project):
         version_string = self.version_name()
@@ -170,11 +173,22 @@ class RegistryPackage(Package):
         tar_path = os.path.realpath(os.path.join(DOWNLOADS_PATH, tar_name))
         dbt.clients.system.make_directory(os.path.dirname(tar_path))
 
-        download_url = metadata.get('downloads').get('tarball')
+        download_url = metadata['downloads']['tarball']
         dbt.clients.system.download(download_url, tar_path)
         deps_path = project.modules_path
         package_name = self.get_project_name(project)
         dbt.clients.system.untar_package(tar_path, deps_path, package_name)
+
+
+# the metadata is a package config with extra attributes we don't care about.
+class RegistryPackageMetadata(PackageConfig):
+    SCHEMA = REGISTRY_PACKAGE_METADATA_CONTRACT
+
+
+class ProjectPackageMetadata(object):
+    def __init__(self, project):
+        self.name = project.project_name
+        self.packages = project.packages.packages
 
 
 class GitPackage(Package):
@@ -237,7 +251,8 @@ class GitPackage(Package):
 
     def _fetch_metadata(self, project):
         path = self._checkout(project)
-        return project.from_project_root(path, {})
+        loaded = project.from_project_root(path, {})
+        return ProjectPackageMetadata(loaded)
 
     def install(self, project):
         dest_path = self.get_installation_path(project)
@@ -273,7 +288,8 @@ class LocalPackage(Package):
             self.local,
             project.project_root)
 
-        return project.from_project_root(project_file_path, {})
+        loaded = project.from_project_root(project_file_path, {})
+        return ProjectPackageMetadata(loaded)
 
     def install(self, project):
         src_path = dbt.clients.system.resolve_path_from_base(
@@ -437,7 +453,7 @@ class DepsTask(BaseTask):
                 final_deps.incorporate(package)
                 final_deps[name].resolve_version()
                 target_config = final_deps[name].fetch_metadata(self.config)
-                sub_deps.incorporate_from_yaml(target_config.packages.packages)
+                sub_deps.incorporate_from_yaml(target_config.packages)
             pending_deps = sub_deps
 
         self._check_for_duplicate_project_names(final_deps)

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -1,8 +1,9 @@
 import unittest
+import mock
 
 import dbt.exceptions
-from dbt.task.deps import GitPackage, LocalPackage
-
+from dbt.task.deps import GitPackage, LocalPackage, RegistryPackage
+from dbt.semver import VersionSpecifier
 
 class TestLocalPackage(unittest.TestCase):
     def test_init(self):
@@ -33,7 +34,7 @@ class TestGitPackage(unittest.TestCase):
         c.resolve_version()
         self.assertEqual(c.version, ['0.0.1'])
 
-    def test_resovle_fail(self):
+    def test_resolve_fail(self):
         a = GitPackage(git='http://example.com', revision='0.0.1')
         b = GitPackage(git='http://example.com', revision='0.0.2')
         c = a.incorporate(b)
@@ -41,3 +42,164 @@ class TestGitPackage(unittest.TestCase):
         self.assertEqual(c.version, ['0.0.1', '0.0.2'])
         with self.assertRaises(dbt.exceptions.DependencyException):
             c.resolve_version()
+
+
+class TestHubPackage(unittest.TestCase):
+    def setUp(self):
+        self.patcher = mock.patch('dbt.task.deps.registry')
+        self.registry = self.patcher.start()
+        self.index_cached = self.registry.index_cached
+        self.get_available_versions = self.registry.get_available_versions
+        self.package_version = self.registry.package_version
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_init(self):
+        a = RegistryPackage(package='fishtown-analytics-test/a',
+                            version='0.1.2')
+        self.assertEqual(a.package, 'fishtown-analytics-test/a')
+        self.assertEqual(
+            a.version,
+            [VersionSpecifier(
+                build=None,
+                major='0',
+                matcher='=',
+                minor='1',
+                patch='2',
+                prerelease=None
+            )]
+        )
+        self.assertEqual(a.source_type(), 'hub')
+
+    def test_invalid(self):
+        with self.assertRaises(dbt.exceptions.ValidationException):
+            RegistryPackage(package='namespace/name', key='invalid')
+
+    def test_resolve_ok(self):
+        self.index_cached.return_value = [
+            'fishtown-analytics-test/a',
+        ]
+        self.get_available_versions.return_value = [
+            '0.1.2', '0.1.3'
+        ]
+        self.package_version.return_value = {
+            'id': 'fishtown-analytics-test/a/0.1.2',
+            'name': 'a',
+            'version': '0.1.2',
+            'packages': [],
+            '_source': {
+                'blahblah': 'asdfas',
+            },
+            'downloads': {
+                'tarball': 'https://example.com/invalid-url!',
+                'extra': 'field',
+            },
+            'newfield': ['another', 'value'],
+        }
+
+        a = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.2'
+        )
+        b = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.2'
+        )
+        c = a.incorporate(b)
+        self.assertEqual(
+            c.version,
+            [
+                VersionSpecifier({
+                    'build': None,
+                    'major': '0',
+                    'matcher': '=',
+                    'minor': '1',
+                    'patch': '2',
+                    'prerelease': None,
+                }),
+                VersionSpecifier({
+                    'build': None,
+                    'major': '0',
+                    'matcher': '=',
+                    'minor': '1',
+                    'patch': '2',
+                    'prerelease': None,
+                })
+            ]
+        )
+        c.resolve_version()
+        self.assertEqual(c.package, 'fishtown-analytics-test/a')
+        self.assertEqual(
+            c.version,
+            [VersionSpecifier({
+                'build': None,
+                'major': '0',
+                'matcher': '=',
+                'minor': '1',
+                'patch': '2',
+                'prerelease': None,
+            })]
+        )
+        self.assertEqual(c.source_type(), 'hub')
+
+    def test_resolve_missing_package(self):
+        self.index_cached.return_value = [
+            'fishtown-analytics-test/b',
+        ]
+        a = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.2'
+        )
+        with self.assertRaises(dbt.exceptions.DependencyException) as e:
+            exc = e
+            a.resolve_version()
+
+        msg = 'Package fishtown-analytics-test/a was not found in the package index'
+        self.assertEqual(msg, str(exc.exception))
+
+    def test_resolve_missing_version(self):
+        self.index_cached.return_value = [
+            'fishtown-analytics-test/a',
+        ]
+        self.get_available_versions.return_value = [
+            '0.1.3', '0.1.4'
+        ]
+        a = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.2'
+        )
+        with self.assertRaises(dbt.exceptions.DependencyException) as e:
+            exc = e
+            a.resolve_version()
+        msg = (
+            "Could not find a matching version for package "
+            "fishtown-analytics-test/a\n  Requested range: =0.1.2, =0.1.2\n  "
+            "Available versions: ['0.1.3', '0.1.4']"
+        )
+        self.assertEqual(msg, str(exc.exception))
+
+    def test_resolve_conflict(self):
+        self.index_cached.return_value = [
+            'fishtown-analytics-test/a',
+        ]
+        self.get_available_versions.return_value = [
+            '0.1.2', '0.1.3'
+        ]
+        a = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.2'
+        )
+        b = RegistryPackage(
+            package='fishtown-analytics-test/a',
+            version='0.1.3'
+        )
+        c = a.incorporate(b)
+        with self.assertRaises(dbt.exceptions.DependencyException) as e:
+            exc = e
+            c.resolve_version()
+        msg = (
+            "Version error for package fishtown-analytics-test/a: Could not "
+            "find a satisfactory version from options: ['=0.1.2', '=0.1.3']"
+        )
+        self.assertEqual(msg, str(exc.exception))


### PR DESCRIPTION
I broke this pretty badly before when I was working on the contracts. 

- Fixed `dbt deps` with hub packages, before it just crashed and now it actually resolves metadata
- Added minimal json schema validation to make sure that the fields `dbt deps` accesses are at least required
- Added some unit tests
- Fixed some more issues uncovered by the tests regarding `incorporate`.

I haven't tested dependencies of dependencies, that seemed hard without writing an integration test.