### PR TITLE
Feature/namespace projects

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -213,7 +213,7 @@ class Project(object):
                  source_paths, macro_paths, data_paths, test_paths,
                  analysis_paths, docs_paths, target_path, clean_targets,
                  log_path, modules_path, quoting, models, on_run_start,
-                 on_run_end, archive, seeds, packages):
+                 on_run_end, archive, seeds, namespace, packages):
         self.project_name = project_name
         self.version = version
         self.project_root = project_root
@@ -234,6 +234,7 @@ class Project(object):
         self.on_run_end = on_run_end
         self.archive = archive
         self.seeds = seeds
+        self.namespace = namespace
         self.packages = packages
 
     @staticmethod
@@ -318,6 +319,7 @@ class Project(object):
         on_run_end = project_dict.get('on-run-end', [])
         archive = project_dict.get('archive', [])
         seeds = project_dict.get('seeds', {})
+        namespace = project_dict.get('namespace')
 
         packages = package_config_from_data(packages_dict)
 
@@ -342,6 +344,7 @@ class Project(object):
             on_run_end=on_run_end,
             archive=archive,
             seeds=seeds,
+            namespace=namespace,
             packages=packages
         )
         # sanity check - this means an internal issue
@@ -387,6 +390,7 @@ class Project(object):
             'on-run-end': self.on_run_end,
             'archive': self.archive,
             'seeds': self.seeds,
+            'namespace': self.namespace,
         })
         if with_packages:
             result.update(self.packages.serialize())
@@ -797,7 +801,7 @@ class RuntimeConfig(Project, Profile):
                  macro_paths, data_paths, test_paths, analysis_paths,
                  docs_paths, target_path, clean_targets, log_path,
                  modules_path, quoting, models, on_run_start, on_run_end,
-                 archive, seeds, profile_name, target_name,
+                 archive, seeds, namespace, profile_name, target_name,
                  send_anonymous_usage_stats, use_colors, threads, credentials,
                  packages, args):
         # 'vars'
@@ -826,6 +830,7 @@ class RuntimeConfig(Project, Profile):
             on_run_end=on_run_end,
             archive=archive,
             seeds=seeds,
+            namespace=namespace,
             packages=packages,
         )
         # 'profile'
@@ -874,6 +879,7 @@ class RuntimeConfig(Project, Profile):
             on_run_end=project.on_run_end,
             archive=project.archive,
             seeds=project.seeds,
+            namespace=project.namespace,
             packages=project.packages,
             profile_name=profile.profile_name,
             target_name=profile.target_name,

--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -143,6 +143,10 @@ PROJECT_CONTRACT = {
             'type': 'object',
             'additionalProperties': True,
         },
+        'namespace': {
+            'type': ['string', 'null'],
+            'description': 'The namespace to give this project.',
+        }
     },
     'required': ['name', 'version'],
 }

--- a/dbt/include/global_project/dbt_project.yml
+++ b/dbt/include/global_project/dbt_project.yml
@@ -4,3 +4,4 @@ version: 1.0
 
 docs-paths: ['docs']
 macro-paths: ["macros"]
+namespace: dbt

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -22,6 +22,8 @@ class GraphLoader(object):
 
     def _load_macro_nodes(self, resource_type):
         for project_name, project in self.all_projects.items():
+            if project.namespace is not None:
+                project_name = project.namespace
             self.macros.update(MacroParser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,
@@ -34,6 +36,8 @@ class GraphLoader(object):
     def _load_sql_nodes(self, parser, resource_type, relative_dirs_attr,
                         **kwargs):
         for project_name, project in self.all_projects.items():
+            if project.namespace is not None:
+                project_name = project.namespace
             nodes, disabled = parser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,

--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -20,10 +20,14 @@ class GraphLoader(object):
         self.patches = {}
         self.disabled = []
 
-    def _load_macro_nodes(self, resource_type):
+    def get_projects(self):
         for project_name, project in self.all_projects.items():
             if project.namespace is not None:
                 project_name = project.namespace
+            yield project_name, project
+
+    def _load_macro_nodes(self, resource_type):
+        for project_name, project in self.get_projects():
             self.macros.update(MacroParser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,
@@ -35,9 +39,7 @@ class GraphLoader(object):
 
     def _load_sql_nodes(self, parser, resource_type, relative_dirs_attr,
                         **kwargs):
-        for project_name, project in self.all_projects.items():
-            if project.namespace is not None:
-                project_name = project.namespace
+        for project_name, project in self.get_projects():
             nodes, disabled = parser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,
@@ -56,7 +58,7 @@ class GraphLoader(object):
         self._load_macro_nodes(NodeType.Operation)
 
     def _load_seeds(self):
-        for project_name, project in self.all_projects.items():
+        for project_name, project in self.get_projects():
             self.nodes.update(SeedParser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,
@@ -83,7 +85,7 @@ class GraphLoader(object):
         self._load_seeds()
 
     def _load_docs(self):
-        for project_name, project in self.all_projects.items():
+        for project_name, project in self.get_projects():
             self.docs.update(DocumentationParser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,
@@ -93,7 +95,7 @@ class GraphLoader(object):
             ))
 
     def _load_schema_tests(self):
-        for project_name, project in self.all_projects.items():
+        for project_name, project in self.get_projects():
             tests, patches = SchemaParser.load_and_parse(
                 package_name=project_name,
                 root_project=self.root_project,

--- a/test/integration/006_simple_dependency_test/dependent/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/dependent/dbt_project.yml
@@ -1,0 +1,2 @@
+name: dependent
+version: 1.0.0

--- a/test/integration/006_simple_dependency_test/dependent/macros/m.sql
+++ b/test/integration/006_simple_dependency_test/dependent/macros/m.sql
@@ -1,0 +1,3 @@
+{% macro do_it() %}
+{{ dependent.really_do_it() }}
+{% endmacro %}

--- a/test/integration/006_simple_dependency_test/namespaced_macros/x.sql
+++ b/test/integration/006_simple_dependency_test/namespaced_macros/x.sql
@@ -1,0 +1,3 @@
+{% macro really_do_it() %}
+select 100 as id
+{% endmacro %}

--- a/test/integration/006_simple_dependency_test/namespaced_models/primary.sql
+++ b/test/integration/006_simple_dependency_test/namespaced_models/primary.sql
@@ -1,0 +1,1 @@
+{{ dependent.do_it() }}

--- a/test/integration/006_simple_dependency_test/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency.py
@@ -122,3 +122,33 @@ class TestSimpleDependencyBranch(DBTIntegrationTest):
         models = self.get_models_in_schema()
 
         self.assertFalse('empty' in models.keys())
+
+class TestNamespacedDependency(DBTIntegrationTest):
+    @property
+    def models(self):
+        return "test/integration/006_simple_dependency_test/namespaced_models"
+
+    @property
+    def schema(self):
+        return "simple_dependency_006"
+
+    @property
+    def project_config(self):
+        return {
+            'namespace': 'dependent',
+            'macro-paths': ['test/integration/006_simple_dependency_test/namespaced_macros'],
+        }
+
+    @property
+    def packages_config(self):
+        return {
+            'packages': [
+                {'local': 'test/integration/006_simple_dependency_test/dependent'},
+            ],
+        }
+
+    @attr(type='postgres')
+    def test_postgres_whatever(self):
+        self.run_dbt(['deps'])
+        results = self.run_dbt(['run'])
+        self.assertEqual(len(results), 1)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -587,6 +587,7 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.on_run_end, [])
         self.assertEqual(project.archive, [])
         self.assertEqual(project.seeds, {})
+        self.assertEqual(project.namespace, None)
         self.assertEqual(project.packages, PackageConfig(packages=[]))
         # just make sure str() doesn't crash anything, that's always
         # embarrassing
@@ -684,6 +685,7 @@ class TestProject(BaseConfigTest):
                     'post-hook': 'grant select on {{ this }} to bi_user',
                 },
             },
+            'namespace': 'my-test-namespace',
         })
         packages = {
             'packages': [
@@ -755,6 +757,7 @@ class TestProject(BaseConfigTest):
                 'post-hook': 'grant select on {{ this }} to bi_user',
             },
         })
+        self.assertEqual(project.namespace, 'my-test-namespace')
         self.assertEqual(project.packages, PackageConfig(packages=[
             {
                 'local': 'foo',

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -95,6 +95,19 @@ class ParserTest(unittest.TestCase):
             'tags': [],
         }
 
+        not_snowplow_namespace_project = {
+            'name': 'not_snowplow',
+            'version': '0.1',
+            'profile': 'test',
+            'project-root': os.path.abspath('./dbt_modules/not_snowplow'),
+            'namespace': 'snowplow',
+        }
+
+        self.not_snowplow_project_config = config_from_parts_or_dicts(
+            project=not_snowplow_namespace_project,
+            profile=profile_data
+        )
+
     def test__single_model(self):
         models = [{
             'name': 'model_one',


### PR DESCRIPTION
Create the concept of 'namespace projects', where a project can inject itself into another project's namespace. This will be useful for adapters as plugins.

project_a/dbt_project.yml:
```
name: foo
namespace: foo
version: 1.0.0

profile: talk
```

project_a/macros/other_thing.sql
```
{% macro do_other_thing() %}
select 2 as id
{% endmacro %}
```

project_a/packages.yml
```
packages:
  - local: ../project_b
```

project_a/models/one.sql
```
{{ foo.do_thing() }}
```

project_b/dbt_project.yml
```
name: bar
namespace: foo
version: 1.0.0
```

project_b/macros/thing.sql
```
{% macro do_thing() %}
{{ foo.do_other_thing() }}
{% endmacro %}
```


After running `dbt deps && dbt compile` in `project_a`:
project_a/target/compiled/foo/one.sql
```
select 2 as id
```

So both projects can see each other and see themselves as being in the same namespace.