### PR TITLE
(fixes #1119) Ignore dependencies into dbt schemas from external schemas

### DIFF
--- a/dbt/adapters/postgres/impl.py
+++ b/dbt/adapters/postgres/impl.py
@@ -160,7 +160,7 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
                                              identifier=dep_name)
 
             # don't record in cache if this relation isn't in a relevant schema
-            if refed_schema in schemas:
+            if refed_schema.lower() in schemas:
                 self.cache.add_link(dependent, referenced)
 
     def _list_relations(self, schema, model_name=None):

--- a/dbt/adapters/postgres/impl.py
+++ b/dbt/adapters/postgres/impl.py
@@ -158,7 +158,10 @@ class PostgresAdapter(dbt.adapters.default.DefaultAdapter):
                                               identifier=refed_name)
             dependent = self.Relation.create(schema=dep_schema,
                                              identifier=dep_name)
-            self.cache.add_link(dependent, referenced)
+
+            # don't record in cache if this relation isn't in a relevant schema
+            if refed_schema in schemas:
+                self.cache.add_link(dependent, referenced)
 
     def _list_relations(self, schema, model_name=None):
         sql = """

--- a/test/integration/037_external_reference_test/standalone_models/my_model.sql
+++ b/test/integration/037_external_reference_test/standalone_models/my_model.sql
@@ -1,0 +1,2 @@
+
+select 1 as id


### PR DESCRIPTION
fixes #1119 by checking the schema name of the downstream relation. If it is not in the list of schemas that dbt cares about, it is discarded.