### PR TITLE
fix for deps that depend on other local deps

### DIFF
--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -257,7 +257,7 @@ class LocalPackage(Package):
         return self.local
 
     def incorporate(self, _):
-        return LocalPackage(self.local)
+        return LocalPackage(local=self.local)
 
     def source_type(self):
         return 'local'

--- a/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
@@ -1,0 +1,18 @@
+
+name: 'local_dep'
+version: '1.0'
+
+profile: 'default'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"] 
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+

--- a/test/integration/006_simple_dependency_test/local_dependency/models/model_to_import.sql
+++ b/test/integration/006_simple_dependency_test/local_dependency/models/model_to_import.sql
@@ -1,0 +1,3 @@
+
+
+select 1 as id

--- a/test/integration/006_simple_dependency_test/local_models/my_model.sql
+++ b/test/integration/006_simple_dependency_test/local_models/my_model.sql
@@ -1,0 +1,2 @@
+
+select * from {{ ref('model_to_import') }}

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -1,0 +1,29 @@
+from nose.plugins.attrib import attr
+from test.integration.base import DBTIntegrationTest
+
+class TestSimpleDependency(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "local_dependency_006"
+
+    @property
+    def models(self):
+        return "test/integration/006_simple_dependency_test/local_models"
+
+    @property
+    def packages_config(self):
+        return {
+            "packages": [
+                {
+                    'local': 'test/integration/006_simple_dependency_test/local_dependency'
+                }
+            ]
+        }
+
+    @attr(type='postgres')
+    def test_local_dependency(self):
+        self.run_dbt(["deps"])
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results),  2)
+


### PR DESCRIPTION
dbt currently fails if a dep depends on a different local dep. I kind of found myself with a stacktrace by accident, as this is a pretty strange situation to find yourself in.

I added a simple test for a local package, since i don't think we currently have one of those. We should add another test to test the error case fixed by this PR though.

This originally failed with:
```
2018-11-13 21:43:24,828 (MainThread): __init__() takes 1 positional argument but 2 were given
2018-11-13 21:43:24,835 (MainThread): Traceback (most recent call last):
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 76, in main
    results, succeeded = handle_and_check(args)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 126, in handle_and_check
    task, res = run_from_args(parsed)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 181, in run_from_args
    results = run_from_task(task, cfg, parsed)
  File "/Users/drew/fishtown/dbt/dbt/main.py", line 189, in run_from_task
    result = task.run()
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 438, in run
    final_deps.incorporate(package)
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 334, in incorporate
    self[package.name] = self[package.name].incorporate(package)
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 261, in incorporate
    return LocalPackage(self.local)
  File "/Users/drew/fishtown/dbt/dbt/task/deps.py", line 31, in __init__
    super(Package, self).__init__(*args, **kwargs)
TypeError: __init__() takes 1 positional argument but 2 were given
```