### PR TITLE
cache the macro manifest

### DIFF
--- a/dbt/loader.py
+++ b/dbt/loader.py
@@ -21,7 +21,6 @@ class GraphLoader(object):
         self.disabled = []
         self.macro_manifest = None
 
-        # make a manifest with just the macros to get the context
     def _load_macro_nodes(self, resource_type):
         for project_name, project in self.all_projects.items():
             self.macros.update(MacroParser.load_and_parse(
@@ -33,6 +32,7 @@ class GraphLoader(object):
                 resource_type=resource_type,
             ))
 
+        # make a manifest with just the macros to get the context
         self.macro_manifest = Manifest(macros=self.macros, nodes={}, docs={},
                                        generated_at=timestring(), disabled=[])
 

--- a/dbt/parser/archives.py
+++ b/dbt/parser/archives.py
@@ -38,7 +38,8 @@ class ArchiveParser(BaseParser):
         return archives
 
     @classmethod
-    def load_and_parse(cls, root_project, all_projects, macros=None):
+    def load_and_parse(cls, root_project, all_projects, macros=None,
+                       macro_manifest=None):
         """Load and parse archives in a list of projects. Returns a dict
            that maps unique ids onto ParsedNodes"""
 
@@ -67,6 +68,7 @@ class ArchiveParser(BaseParser):
                 all_projects.get(archive.get('package_name')),
                 all_projects,
                 macros=macros,
+                macro_manifest=macro_manifest,
                 archive_config=archive_config)
 
         return to_return

--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -11,7 +11,6 @@ import dbt.context.parser
 from dbt.utils import coalesce
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.contracts.graph.parsed import ParsedNode
-from dbt.contracts.graph.manifest import Manifest
 
 
 class BaseParser(object):
@@ -41,7 +40,8 @@ class BaseParser(object):
     def parse_node(cls, node, node_path, root_project_config,
                    package_project_config, all_projects,
                    tags=None, fqn_extra=None, fqn=None, macros=None,
-                   agate_table=None, archive_config=None, column_name=None):
+                   agate_table=None, archive_config=None, column_name=None,
+                   macro_manifest=None):
         """Parse a node, given an UnparsedNode and any other required information.
 
         agate_table should be set if the node came from a seed file.
@@ -103,13 +103,9 @@ class BaseParser(object):
         if column_name is not None:
             node['column_name'] = column_name
 
-        # make a manifest with just the macros to get the context
-        manifest = Manifest(macros=macros, nodes={}, docs={},
-                            generated_at=dbt.utils.timestring(), disabled=[])
-
         parsed_node = ParsedNode(**node)
         context = dbt.context.parser.generate(parsed_node, root_project_config,
-                                              manifest, config)
+                                              macro_manifest, config)
 
         dbt.clients.jinja.get_rendered(
             parsed_node.raw_sql, context, parsed_node.to_shallow_dict(),

--- a/dbt/parser/base_sql.py
+++ b/dbt/parser/base_sql.py
@@ -18,7 +18,8 @@ class BaseSqlParser(BaseParser):
 
     @classmethod
     def load_and_parse(cls, package_name, root_project, all_projects, root_dir,
-                       relative_dirs, resource_type, tags=None, macros=None):
+                       relative_dirs, resource_type, tags=None, macros=None,
+                       macro_manifest=None):
         """Load and parse models in a list of directories. Returns a dict
            that maps unique ids onto ParsedNodes"""
 
@@ -64,11 +65,11 @@ class BaseSqlParser(BaseParser):
             })
 
         return cls.parse_sql_nodes(result, root_project, all_projects, tags,
-                                   macros)
+                                   macros, macro_manifest)
 
     @classmethod
     def parse_sql_nodes(cls, nodes, root_project, projects,
-                        tags=None, macros=None):
+                        tags=None, macros=None, macro_manifest=None):
 
         if tags is None:
             tags = []
@@ -93,7 +94,8 @@ class BaseSqlParser(BaseParser):
                                          projects.get(package_name),
                                          projects,
                                          tags=tags,
-                                         macros=macros)
+                                         macros=macros,
+                                         macro_manifest=macro_manifest)
 
             # Ignore disabled nodes
             if not node_parsed['config']['enabled']:

--- a/dbt/parser/hooks.py
+++ b/dbt/parser/hooks.py
@@ -38,7 +38,8 @@ class HookParser(BaseSqlParser):
 
     @classmethod
     def load_and_parse_run_hook_type(cls, root_project, all_projects,
-                                     hook_type, macros=None):
+                                     hook_type, macros=None,
+                                     macro_manifest=None):
 
         if dbt.flags.STRICT_MODE:
             dbt.contracts.project.ProjectList(**all_projects)
@@ -64,11 +65,13 @@ class HookParser(BaseSqlParser):
 
         tags = [hook_type]
         hooks, _ = cls.parse_sql_nodes(result, root_project, all_projects,
-                                       tags=tags, macros=macros)
+                                       tags=tags, macros=macros,
+                                       macro_manifest=macro_manifest)
         return hooks
 
     @classmethod
-    def load_and_parse(cls, root_project, all_projects, macros=None):
+    def load_and_parse(cls, root_project, all_projects, macros=None,
+                       macro_manifest=None):
         if macros is None:
             macros = {}
 
@@ -78,7 +81,8 @@ class HookParser(BaseSqlParser):
                 root_project,
                 all_projects,
                 hook_type,
-                macros=macros
+                macros=macros,
+                macro_manifest=macro_manifest
             )
             hook_nodes.update(project_hooks)
 

--- a/dbt/parser/seeds.py
+++ b/dbt/parser/seeds.py
@@ -46,7 +46,8 @@ class SeedParser(BaseParser):
 
     @classmethod
     def load_and_parse(cls, package_name, root_project, all_projects, root_dir,
-                       relative_dirs, tags=None, macros=None):
+                       relative_dirs, tags=None, macros=None,
+                       macro_manifest=None):
         """Load and parse seed files in a list of directories. Returns a dict
            that maps unique ids onto ParsedNodes"""
 
@@ -70,7 +71,8 @@ class SeedParser(BaseParser):
             parsed = cls.parse_node(node, node_path, root_project,
                                     all_projects.get(package_name),
                                     all_projects, tags=tags, macros=macros,
-                                    agate_table=agate_table)
+                                    agate_table=agate_table,
+                                    macro_manifest=macro_manifest)
             result[node_path] = parsed
 
         return result

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -73,6 +73,9 @@ class ParserTest(unittest.TestCase):
             project=snowplow_project, profile=profile_data
         )
 
+        self.macro_manifest = Manifest(macros={}, nodes={}, docs={},
+                                       generated_at=timestring(), disabled=[])
+
         self.model_config = {
             'enabled': True,
             'materialized': 'view',
@@ -111,7 +114,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -172,7 +176,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -216,7 +221,8 @@ class ParserTest(unittest.TestCase):
             ModelParser.parse_sql_nodes(
                 models,
                 self.root_project_config,
-                {'root': self.root_project_config}),
+                {'root': self.root_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -269,7 +275,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.base': ParsedNode(
                     alias='base',
@@ -375,7 +382,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.events': ParsedNode(
                     alias='events',
@@ -554,7 +562,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.snowplow.events': ParsedNode(
                     alias='events',
@@ -861,7 +870,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -946,7 +956,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.table': ParsedNode(
                     alias='table',
@@ -1145,7 +1156,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.table': ParsedNode(
                     alias='table',
@@ -1263,7 +1275,8 @@ class ParserTest(unittest.TestCase):
                 'root': self.root_project_config,
                 'snowplow': self.snowplow_project_config
             },
-            root_dir=get_os_path('/usr/src/app')
+            root_dir=get_os_path('/usr/src/app'),
+            macro_manifest=self.macro_manifest
         ))
         results.sort(key=lambda n: n.name)
 
@@ -1393,7 +1406,8 @@ class ParserTest(unittest.TestCase):
                 'snowplow': self.snowplow_project_config
             },
             root_dir=get_os_path('/usr/src/app'),
-            macros=None
+            macros=None,
+            macro_manifest=self.macro_manifest
         ))
 
         # split this into tests and patches, assert there's nothing else
@@ -1594,7 +1608,8 @@ class ParserTest(unittest.TestCase):
                 tests,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'test.root.no_events': ParsedNode(
                     alias='no_events',
@@ -1711,7 +1726,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -1756,7 +1772,8 @@ class ParserTest(unittest.TestCase):
                 models,
                 self.root_project_config,
                 {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config}),
+                 'snowplow': self.snowplow_project_config},
+                macro_manifest=self.macro_manifest),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt/issues/1098

I had played around with this a while back to inform how much of a speedup we'd get in parsing. This change really makes the parsing step fly! I took a pretty heavy-handed approach here, so I'm very open to feedback/suggestions on ways to do this better.

For our internal analytics project, this brings the "time to stdout" down from 11.1s to 6.8s. That's not a rigorous analysis, but I'm sure it will be welcomed by many.