### PR TITLE
Bigquery: smarter delete_dataset

### DIFF
--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -447,13 +447,6 @@ class BigQueryAdapter(PostgresAdapter):
             with self.exception_handler('create dataset', model_name):
                 client.create_dataset(dataset)
 
-    def drop_tables_in_schema(self, dataset):
-        conn = self.get_connection()
-        client = conn.handle
-
-        for table in client.list_tables(dataset):
-            client.delete_table(table.reference)
-
     def drop_schema(self, schema, model_name=None):
         logger.debug('Dropping schema "%s".', schema)
 
@@ -465,8 +458,7 @@ class BigQueryAdapter(PostgresAdapter):
 
         dataset = self.get_dataset(schema, model_name)
         with self.exception_handler('drop dataset', model_name):
-            self.drop_tables_in_schema(dataset)
-            client.delete_dataset(dataset)
+            client.delete_dataset(dataset, delete_contents=True)
 
     def get_existing_schemas(self, model_name=None):
         conn = self.get_connection(model_name)


### PR DESCRIPTION
We already have integration tests that test this. I proved it works by removing the `drop_tables_in_schema` call and running the tests. `tearDown` failed on the first test. Then, I added the `delete_contents` flag and it worked again.