### PR TITLE
single-threaded mode

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -322,6 +322,17 @@ def parse_args(args):
         help='''Run schema validations at runtime. This will surface
         bugs in dbt, but may incur a performance penalty.''')
 
+    # if set, run dbt in single-threaded mode: thread count is ignored, and
+    # calls go through `map` instead of the thread pool. This is useful for
+    # getting performance information about aspects of dbt that normally run in
+    # a thread, as the profiler ignores child threads. Users should really
+    # never use this.
+    p.add_argument(
+        '--single-threaded',
+        action='store_true',
+        help=argparse.SUPPRESS,
+    )
+
     subs = p.add_subparsers(title="Available sub-commands")
 
     base_subparser = argparse.ArgumentParser(add_help=False)

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -94,6 +94,18 @@ class RunManager(object):
                 runners.append(node_runners[unique_id])
         return runners
 
+    def map_run(self, pool, args):
+        """If the caller has passed the magic 'single-threaded' flag, use map()
+        instead of the pool.imap_unordered. The single-threaded flag is
+        intended for gathering more useful performance information about what
+        happens beneath `call_runner`, since python's default profiling tools
+        ignore child threads.
+        """
+        if self.config.args.single_threaded:
+            return map(self.call_runner, args)
+        else:
+            return pool.imap_unordered(self.call_runner, args)
+
     def execute_nodes(self, linker, Runner, manifest, node_dependency_list):
         adapter = get_adapter(self.config)
 
@@ -121,7 +133,7 @@ class RunManager(object):
                 })
 
             try:
-                for result in pool.imap_unordered(self.call_runner, args_list):
+                for result in self.map_run(pool, args_list):
                     is_ephemeral = Runner.is_ephemeral_model(result.node)
                     if not is_ephemeral:
                         node_results.append(result)

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -35,11 +35,13 @@ class FakeArgs(object):
         self.full_refresh = False
         self.models = None
         self.exclude = None
+        self.single_threaded = False
 
 
 class TestArgs(object):
     def __init__(self, kwargs):
         self.which = 'run'
+        self.single_threaded = False
         self.__dict__.update(kwargs)
 
 


### PR DESCRIPTION
This PR is against the `profiler` branch (which I brought up to date with `dev/grace-kelly`), not an actual dev branch. This adds a single-threaded mode that bypasses the thread pool for execution so we can get data about the dbt stuff that runs in threads via the `-r` flag. Obviously this totally ruins wall-clock performance, but the profiler output is still useful.

The threads parameter is still accepted in single-threaded mode, the pool is still set up, etc - they're just ignored. The idea is to keep the difference in control flow between single-threaded/regular as minimal as possible (nothing worse than having a performance trace enabling flag that messes with performance!)

I didn't write tests for this because it seemed unnecessary - it's not a big deal if this regresses since this flag is hidden and nobody should really be using it. Obviously I'd prefer to never regress, but it's a trade-off and we have so many tests already, and proper concurrency tests are hard!

I of course did run it locally with/without the flag and it behaves as it should.