### PR TITLE
add pre_hook/post_hook aliases to config (#1124)

### DIFF
--- a/dbt/context/parser.py
+++ b/dbt/context/parser.py
@@ -50,11 +50,18 @@ class Config:
         self.model = model
         self.source_config = source_config
 
+    @staticmethod
+    def _transform_kwargs(kwargs):
+        for k in ('pre_hook', 'post_hook'):
+            if k in kwargs:
+                kwargs[k.replace('_', '-')] = kwargs.pop(k)
+        return kwargs
+
     def __call__(self, *args, **kwargs):
         if len(args) == 1 and len(kwargs) == 0:
             opts = args[0]
         elif len(args) == 0 and len(kwargs) > 0:
-            opts = kwargs
+            opts = self._transform_kwargs(kwargs)
         else:
             dbt.exceptions.raise_compiler_error(
                 "Invalid inline model config",

--- a/test/integration/014_hook_tests/kwargs-models/hooks.sql
+++ b/test/integration/014_hook_tests/kwargs-models/hooks.sql
@@ -1,0 +1,63 @@
+
+{{
+    config(
+        pre_hook="\
+            insert into {{this.schema}}.on_model_hook (\
+                \"state\",\
+                \"target.dbname\",\
+                \"target.host\",\
+                \"target.name\",\
+                \"target.schema\",\
+                \"target.type\",\
+                \"target.user\",\
+                \"target.pass\",\
+                \"target.port\",\
+                \"target.threads\",\
+                \"run_started_at\",\
+                \"invocation_id\"\
+            ) VALUES (\
+                'start',\
+                '{{ target.dbname }}',\
+                '{{ target.host }}',\
+                '{{ target.name }}',\
+                '{{ target.schema }}',\
+                '{{ target.type }}',\
+                '{{ target.user }}',\
+                '{{ target.pass }}',\
+                {{ target.port }},\
+                {{ target.threads }},\
+                '{{ run_started_at }}',\
+                '{{ invocation_id }}'\
+        )",
+        post_hook="\
+            insert into {{this.schema}}.on_model_hook (\
+                \"state\",\
+                \"target.dbname\",\
+                \"target.host\",\
+                \"target.name\",\
+                \"target.schema\",\
+                \"target.type\",\
+                \"target.user\",\
+                \"target.pass\",\
+                \"target.port\",\
+                \"target.threads\",\
+                \"run_started_at\",\
+                \"invocation_id\"\
+            ) VALUES (\
+                'end',\
+                '{{ target.dbname }}',\
+                '{{ target.host }}',\
+                '{{ target.name }}',\
+                '{{ target.schema }}',\
+                '{{ target.type }}',\
+                '{{ target.user }}',\
+                '{{ target.pass }}',\
+                {{ target.port }},\
+                {{ target.threads }},\
+                '{{ run_started_at }}',\
+                '{{ invocation_id }}'\
+            )"
+    )
+}}
+
+select 3 as id

--- a/test/integration/014_hook_tests/test_model_hooks.py
+++ b/test/integration/014_hook_tests/test_model_hooks.py
@@ -147,7 +147,7 @@ class TestPrePostModelHooks(BaseTestPrePost):
         return "test/integration/014_hook_tests/models"
 
     @attr(type='postgres')
-    def test_pre_and_post_model_hooks(self):
+    def test_postgres_pre_and_post_model_hooks(self):
         self.run_dbt(['run'])
 
         self.check_hooks('start')
@@ -177,7 +177,7 @@ class TestPrePostModelHooksOnSeeds(DBTIntegrationTest):
         }
 
     @attr(type='postgres')
-    def test_hooks_on_seeds(self):
+    def test_postgres_hooks_on_seeds(self):
         res = self.run_dbt(['seed'])
         self.assertEqual(len(res), 1, 'Expected exactly one item')
         res = self.run_dbt(['test'])
@@ -196,14 +196,14 @@ class TestPrePostModelHooksInConfig(BaseTestPrePost):
         return "test/integration/014_hook_tests/configured-models"
 
     @attr(type='postgres')
-    def test_pre_and_post_model_hooks_model(self):
+    def test_postgres_pre_and_post_model_hooks_model(self):
         self.run_dbt(['run'])
 
         self.check_hooks('start')
         self.check_hooks('end')
 
     @attr(type='postgres')
-    def test_pre_and_post_model_hooks_model_and_project(self):
+    def test_postgres_pre_and_post_model_hooks_model_and_project(self):
         self.use_default_project({
             'models': {
                 'test': {
@@ -229,4 +229,10 @@ class TestPrePostModelHooksInConfig(BaseTestPrePost):
 
         self.check_hooks('start', count=2)
         self.check_hooks('end', count=2)
+
+class TestPrePostModelHooksInConfigKwargs(TestPrePostModelHooksInConfig):
+
+    @property
+    def models(self):
+        return "test/integration/014_hook_tests/kwargs-models"
 


### PR DESCRIPTION
Fixes #1124 by allowing users to use `pre_hook` and `post_hook` in keyword arguments to the config. They are not accepted as dictionary arguments (so `{{ config({"pre_hook": ...}) }}` is not accepted). If a user were to somehow get both `pre-hook` and `pre_hook` into a config's keyword arguments, `pre_hook` would overwrite `pre-hook`.