### PR TITLE
Add 'location' to google bigquery profile (#969)

### DIFF
--- a/dbt/adapters/bigquery/impl.py
+++ b/dbt/adapters/bigquery/impl.py
@@ -142,8 +142,9 @@ class BigQueryAdapter(PostgresAdapter):
     def get_bigquery_client(cls, profile_credentials):
         project_name = profile_credentials.project
         creds = cls.get_bigquery_credentials(profile_credentials)
-
-        return google.cloud.bigquery.Client(project_name, creds)
+        location = getattr(profile_credentials, 'location', None)
+        return google.cloud.bigquery.Client(project_name, creds,
+                                            location=location)
 
     @classmethod
     def open_connection(cls, connection):

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -139,6 +139,9 @@ BIGQUERY_CREDENTIALS_CONTRACT = {
         'timeout_seconds': {
             'type': 'integer',
         },
+        'location': {
+            'type': 'string',
+        },
     },
     'required': ['method', 'project', 'schema'],
 }

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -35,6 +35,14 @@ class TestBigQueryAdapter(unittest.TestCase):
                     'keyfile': '/tmp/dummy-service-account.json',
                     'threads': 1,
                 },
+                'loc': {
+                    'type': 'bigquery',
+                    'method': 'oauth',
+                    'project': 'dbt-unit-000000',
+                    'schema': 'dummy_schema',
+                    'threads': 1,
+                    'location': 'Luna Station',
+                },
             },
             'target': 'oauth',
         }
@@ -43,15 +51,17 @@ class TestBigQueryAdapter(unittest.TestCase):
             'name': 'X',
             'version': '0.1',
             'project-root': '/tmp/dbt/does-not-exist',
+            'profile': 'default',
         }
 
-    def get_adapter(self, profile):
+    def get_adapter(self, target):
         project = self.project_cfg.copy()
-        project['profile'] = profile
+        profile = self.raw_profile.copy()
+        profile['target'] = target
 
         config = config_from_parts_or_dicts(
             project=project,
-            profile=self.raw_profile,
+            profile=profile,
         )
         return BigQueryAdapter(config)
 
@@ -68,7 +78,6 @@ class TestBigQueryAdapter(unittest.TestCase):
 
         except BaseException as e:
             raise
-            self.fail('validation failed with unknown exception: {}'.format(str(e)))
 
         mock_open_connection.assert_called_once()
 
@@ -84,9 +93,20 @@ class TestBigQueryAdapter(unittest.TestCase):
 
         except BaseException as e:
             raise
-            self.fail('validation failed with unknown exception: {}'.format(str(e)))
 
         mock_open_connection.assert_called_once()
+
+    @patch('dbt.adapters.bigquery.impl.google.auth.default')
+    @patch('dbt.adapters.bigquery.impl.google.cloud.bigquery')
+    def test_location_value(self, mock_bq, mock_auth_default):
+        creds = MagicMock()
+        mock_auth_default.return_value = (creds, MagicMock())
+        adapter = self.get_adapter('loc')
+
+        adapter.acquire_connection('dummy')
+        mock_client = mock_bq.Client
+        mock_client.assert_called_once_with('dbt-unit-000000', creds,
+                                            location='Luna Station')
 
 
 class TestBigQueryRelation(unittest.TestCase):


### PR DESCRIPTION
Add a `location` field to bigquery's profile and pass it along to the underlying google library. Fixes #969 