### PR TITLE
Handle concurrent job ordering via a graph iterator (#813)

### DIFF
--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -20,11 +20,11 @@ else:
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from SocketServer import TCPServer
-    from Queue import PriorityQueue
+    from Queue import PriorityQueue, Queue
 else:
     from http.server import SimpleHTTPRequestHandler
     from socketserver import TCPServer
-    from queue import PriorityQueue
+    from queue import PriorityQueue, Queue
 
 
 def to_unicode(s):

--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -20,9 +20,11 @@ else:
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from SocketServer import TCPServer
+    from Queue import PriorityQueue
 else:
     from http.server import SimpleHTTPRequestHandler
     from socketserver import TCPServer
+    from queue import PriorityQueue
 
 
 def to_unicode(s):

--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -20,11 +20,11 @@ else:
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from SocketServer import TCPServer
-    from Queue import PriorityQueue, Queue
+    from Queue import PriorityQueue
 else:
     from http.server import SimpleHTTPRequestHandler
     from socketserver import TCPServer
-    from queue import PriorityQueue, Queue
+    from queue import PriorityQueue
 
 
 def to_unicode(s):

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -169,17 +169,13 @@ class Compiler(object):
         manifest_path = os.path.join(self.config.target_path, filename)
         write_json(manifest_path, manifest.serialize())
 
-    def write_graph_file(self, linker):
+    def write_graph_file(self, linker, manifest):
         filename = graph_file_name
         graph_path = os.path.join(self.config.target_path, filename)
-        linker.write_graph(graph_path)
+        linker.write_graph(graph_path, manifest)
 
     def link_node(self, linker, node, manifest):
         linker.add_node(node.unique_id)
-
-        linker.update_node_data(
-            node.unique_id,
-            node.to_dict())
 
         for dependency in node.depends_on_nodes:
             if manifest.nodes.get(dependency):
@@ -260,7 +256,7 @@ class Compiler(object):
                 manifest.macros.items()):
             stats[node.resource_type] += 1
 
-        self.write_graph_file(linker)
+        self.write_graph_file(linker, manifest)
         print_compile_stats(stats)
 
         return manifest, linker

--- a/dbt/graph/selector.py
+++ b/dbt/graph/selector.py
@@ -318,9 +318,3 @@ class NodeSelector(object):
             concurrent_dependency_list.append(node_level)
 
         return concurrent_dependency_list
-
-
-class FlatNodeSelector(NodeSelector):
-    def as_node_list(self, selected_nodes):
-        return super(FlatNodeSelector, self).as_node_list(selected_nodes,
-                                                          ephemeral_only=True)

--- a/dbt/graph/selector.py
+++ b/dbt/graph/selector.py
@@ -304,17 +304,3 @@ class NodeSelector(object):
         addins = self.get_ancestor_ephemeral_nodes(selected)
 
         return selected | addins
-
-    def as_node_list(self, selected_nodes, ephemeral_only=False):
-        dependency_list = self.linker.as_dependency_list(
-            selected_nodes,
-            ephemeral_only=ephemeral_only)
-
-        concurrent_dependency_list = []
-        for level in dependency_list:
-            node_level = [
-                ParsedNode(**self.linker.get_node(node)) for node in level
-            ]
-            concurrent_dependency_list.append(node_level)
-
-        return concurrent_dependency_list

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -2,6 +2,7 @@ import networkx as nx
 from collections import defaultdict
 
 import dbt.utils
+from dbt.compat import PriorityQueue
 
 
 GRAPH_SERIALIZE_BLACKLIST = [
@@ -14,6 +15,94 @@ def from_file(graph_file):
     linker.read_graph(graph_file)
 
     return linker
+
+
+class GraphQueue(object):
+    """A fancy queue that is backed by the dependency graph.
+    Note: this will mutate input!
+    """
+    def __init__(self, graph):
+        self.graph = graph
+        # the initial size of the graph, as the PriorityQueue class picks the
+        # lowest value but we want the highest. We need this so we don't have
+        # to re-score all queue entries every time we remove something from
+        # the graph
+        self._initial_size = len(graph)
+        # store the queue as a priority queue.
+        self.inner = PriorityQueue()
+        # things that have been popped off the queue but not finished
+        self.in_progress = set()
+        # things that are in the queue
+        self.queued = set()
+        self.mutex = threading.Lock()
+        # store the number of descendants for each node.
+        self._descendants = self._calculate_descendants()
+
+    def _is_ephemeral(self, node):
+        materialization = dbt.utils.get_materialization(self.node.node[node])
+        return materialization == 'ephemeral'
+
+    def _include_in_count(self, node):
+        """TODO: I'm pretty sure this is really inefficient."""
+        if not dbt.utils.is_blocking_dependency(self.node.node[node]):
+            return False
+        if self._is_ephemeral(node):
+            return False
+        return True
+
+    def _calculate_descendants(self):
+        """We could do this in one pass over the graph instead of
+        len(self.graph) passes but this is easy. For large graphs this may hurt
+        performance.
+        """
+        descendants = {}
+        for node in self.graph.nodes():
+            count = len(
+                d for d in nx.descendants(self.graph, node)
+                if self._include_in_count(d)
+            )
+            descendants[node] = count
+        return descendants
+
+    def get(self):
+        """Get a node off the inner priority queue. If a node is ephemeral,
+        mark it done immediately and get again. This blocks!
+        """
+        task_id = self.inner.get()
+
+    def empty(self):
+        """The graph queue is 'empty' if it all remaining nodes are in progress
+        """
+        return (len(self.graph) - len(self.in_progress)) == 0
+
+    def _find_new_additions(self):
+        """Find any nodes in the graph that need to be added to the internal
+        queue.
+        """
+        for node, in_degree in self.graph.in_degree_iter():
+            if node not in (self.in_progress | self.queued) and in_degree == 0:
+                # lower score = more descendants = higher priority
+                score = self._initial_size - self._descendants[node]
+                self.inner.put((score, node))
+                self.queued.add(node)
+
+    def mark_done(self, task_id):
+        with self.mutex:
+            self.in_progress.remove(task_id)
+            self.graph.remove_node(task_id)
+            self._find_new_additions()
+            self.queue.task_done()
+
+    def _mark_in_progress(self, task_id):
+        self.queued.remove(task_id)
+        self.in_progress.add(task_id)
+
+    def get(self):
+        with self.mutex:
+            value = self.inner.get()
+
+    def join(self):
+        self.queue.join()
 
 
 class Linker(object):
@@ -44,6 +133,36 @@ class Linker(object):
             return " --> ".join(cycle_nodes)
 
         return None
+
+    def as_graph_queue(self, limit_to=None, ephemeral_only=False):
+        """Returns a queue over nodes in the graph that tracks progress of
+        dependecies.
+
+        TODO: handle/understand ephemeral_only / is_blocking_dependency
+        """
+        if limit_to is None:
+            graph_nodes = self.graph.nodes()
+        else:
+            graph_nodes = limit_to
+
+        new_graph = nx.DiGraph(self.graph)
+
+        to_remove = []
+        graph_nodes_lookup = set(graph_nodes)
+        for node in new_graph.nodes():
+            if node not in graph_nodes_lookup:
+                to_remove.append(node)
+
+        for node in to_remove:
+            new_graph.remove(node)
+
+        for node in graph_nodes:
+            if node not in new_graph:
+                raise RuntimeError(
+                    "Couldn't find model '{}' -- does it exist or is "
+                    "it disabled?".format(node)
+                )
+        return GraphQueue(new_graph)
 
     def as_dependency_list(self, limit_to=None, ephemeral_only=False):
         """returns a list of list of nodes, eg. [[0,1], [2], [4,5,6]]. Each

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -68,17 +68,6 @@ class RunManager(object):
 
         return self.Runner(self.config, adapter, node, run_count, num_nodes)
 
-    def deserialize_graph(self):
-        logger.info("Loading dependency graph file.")
-
-        base_target_path = self.config.target_path
-        graph_file = os.path.join(
-            base_target_path,
-            dbt.compilation.graph_file_name
-        )
-
-        return dbt.linker.from_file(graph_file)
-
     def call_runner(self, runner):
         if runner.skip:
             return runner.on_skip()

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -3,7 +3,6 @@ import time
 
 from dbt.adapters.factory import get_adapter
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.compat import Queue
 from dbt.contracts.graph.parsed import ParsedNode
 from dbt.contracts.graph.manifest import CompileResultNode
 from dbt.contracts.results import ExecutionResult
@@ -25,68 +24,49 @@ from multiprocessing.dummy import Pool as ThreadPool
 RESULT_FILE_NAME = 'run_results.json'
 
 
-class RunBuilder(object):
-    """Given a node, build a Runner, tracking the number built so far vs the
-    total.
-
-    # TODO: this name completely sucks
-    """
-    def __init__(self, flattened_nodes, Runner, config):
-        self.run_count = 0
-        num_nodes = len([
-            n for n in flattened_nodes
-            if not Runner.is_ephemeral_model(n)
-        ])
-        self.num_nodes = num_nodes
-        self.Runner = Runner
-        self.config = config
-        self.adapter = get_adapter(config)
-        # TODO: do we need to track this?
-        self._created = {}
-
-    def get_runner(self, node):
-        if self.Runner.is_ephemeral_model(node):
-            runner = self.Runner(self.config, self.adapter, node,
-                                 0, 0)
-        else:
-            self.run_count += 1
-            runner = self.Runner(self.config, self.adapter, node,
-                                 self.run_count, self.num_nodes)
-        self._created[node.unique_id] = runner
-        return runner
-
-
 class RunManager(object):
-    def __init__(self, config, query, Runner, flat=False):
+    def __init__(self, config, query, Runner):
         """
         Runner is a type (not instance!) derived from
             dbt.node_runners.BaseRunner
-
-        if flat is set, nodes will be selected using the FlatNodeSelector
         """
         self.config = config
         self.query = query
         self.Runner = Runner
-        self.run_count = 0
-
-        if flat:
-            Selector = dbt.graph.selector.FlatNodeSelector
-        else:
-            Selector = dbt.graph.selector.NodeSelector
 
         manifest, linker = self.compile(self.config)
         self.manifest = manifest
         self.linker = linker
 
-        selector = Selector(linker, manifest)
+        selector = dbt.graph.selector.NodeSelector(linker, manifest)
         selected_nodes = selector.select(query)
-        # TODO: swap this out for run_graph stuff once I verify this refactor
-        self.dependency_list = selector.as_node_list(selected_nodes)
-        # we use this a couple times.
-        self._flattened_nodes = dbt.utils.flatten_nodes(self.dependency_list)
-        self._builder = RunBuilder(self._flattened_nodes, Runner, config)
+        self.job_queue = self.linker.as_graph_queue(manifest, selected_nodes)
+
+        # we use this a couple times. order does not matter.
+        self._flattened_nodes = [
+            self.manifest.nodes[uid] for uid in selected_nodes
+        ]
+
+        self.run_count = 0
+        self.num_nodes = len([
+            n for n in self._flattened_nodes
+            if not Runner.is_ephemeral_model(n)
+        ])
         self.node_results = []
         self._skipped_children = {}
+
+    def get_runner(self, node):
+        adapter = get_adapter(self.config)
+
+        if self.Runner.is_ephemeral_model(node):
+            run_count = 0
+            num_nodes = 0
+        else:
+            self.run_count += 1
+            run_count = self.run_count
+            num_nodes = self.num_nodes
+
+        return self.Runner(self.config, adapter, node, run_count, num_nodes)
 
     def deserialize_graph(self):
         logger.info("Loading dependency graph file.")
@@ -98,11 +78,6 @@ class RunManager(object):
         )
 
         return dbt.linker.from_file(graph_file)
-
-    def get_dependent(self, node_id):
-        dependent_nodes = self.linker.get_dependent_nodes(node_id)
-        for node_id in dependent_nodes:
-            yield node_id
 
     def call_runner(self, runner):
         if runner.skip:
@@ -136,18 +111,17 @@ class RunManager(object):
         else:
             pool.apply_async(self.call_runner, args=args, callback=callback)
 
-    def run_queue(self, pool, job_queue):
-        """Given a pool and a job queue, submit jobs from the queue to the pool
-        and put the results onto the done queue
+    def run_queue(self, pool):
+        """Given a pool, submit jobs from the queue to the pool.
         """
         def callback(result):
             """A callback to handle results."""
             self._handle_result(result)
-            job_queue.task_done()
+            self.job_queue.mark_done(result.node.unique_id)
 
-        while not job_queue.empty():
-            node = job_queue.get()
-            runner = self._builder.get_runner(node)
+        while not self.job_queue.empty():
+            node = self.job_queue.get()
+            runner = self.get_runner(node)
             # we finally know what we're running! Make sure we haven't decided
             # to skip it due to upstream failures
             if runner.node.unique_id in self._skipped_children:
@@ -156,7 +130,7 @@ class RunManager(object):
             args = (runner,)
             self._submit(pool, args, callback)
         # block on completion
-        job_queue.join()
+        self.job_queue.join()
 
         return
 
@@ -191,39 +165,32 @@ class RunManager(object):
         schemas = list(self.Runner.get_model_schemas(self.manifest))
 
         pool = ThreadPool(num_threads)
-        for node_list in self.dependency_list:
-            job_queue = Queue()
-            # TODO when this is a GraphQueue, we'll never have to do the .put
-            for node in node_list:
-                job_queue.put(node)
+        try:
+            self.run_queue(pool)
 
-            try:
-                # the job queue is exhausted after run_queue exits
-                self.run_queue(pool, job_queue)
+        except KeyboardInterrupt:
+            pool.close()
+            pool.terminate()
 
-            except KeyboardInterrupt:
-                pool.close()
-                pool.terminate()
+            adapter = get_adapter(self.config)
 
-                adapter = get_adapter(self.config)
+            if not adapter.is_cancelable():
+                msg = ("The {} adapter does not support query "
+                       "cancellation. Some queries may still be "
+                       "running!".format(adapter.type()))
 
-                if not adapter.is_cancelable():
-                    msg = ("The {} adapter does not support query "
-                           "cancellation. Some queries may still be "
-                           "running!".format(adapter.type()))
-
-                    yellow = dbt.ui.printer.COLOR_FG_YELLOW
-                    dbt.ui.printer.print_timestamped_line(msg, yellow)
-                    raise
-
-                for conn_name in adapter.cancel_open_connections():
-                    dbt.ui.printer.print_cancel_line(conn_name)
-
-                dbt.ui.printer.print_run_end_messages(self.node_results,
-                                                      early_exit=True)
-
-                pool.join()
+                yellow = dbt.ui.printer.COLOR_FG_YELLOW
+                dbt.ui.printer.print_timestamped_line(msg, yellow)
                 raise
+
+            for conn_name in adapter.cancel_open_connections():
+                dbt.ui.printer.print_cancel_line(conn_name)
+
+            dbt.ui.printer.print_run_end_messages(self.node_results,
+                                                  early_exit=True)
+
+            pool.join()
+            raise
 
         pool.close()
         pool.join()

--- a/dbt/task/archive.py
+++ b/dbt/task/archive.py
@@ -17,8 +17,7 @@ class ArchiveTask(RunnableTask):
             'resource_types': [NodeType.Archive]
         }
 
-        runner = RunManager(self.config, query, ArchiveRunner, flat=True)
-        results = runner.run()
+        results = RunManager(self.config, query, ArchiveRunner).run()
 
         dbt.ui.printer.print_run_end_messages(results)
 

--- a/dbt/task/archive.py
+++ b/dbt/task/archive.py
@@ -10,7 +10,6 @@ import dbt.ui.printer
 
 class ArchiveTask(RunnableTask):
     def run(self):
-        runner = RunManager(self.config)
 
         query = {
             'include': ['*'],
@@ -18,7 +17,8 @@ class ArchiveTask(RunnableTask):
             'resource_types': [NodeType.Archive]
         }
 
-        results = runner.run_flat(query, ArchiveRunner)
+        runner = RunManager(self.config, query, ArchiveRunner, flat=True)
+        results = runner.run()
 
         dbt.ui.printer.print_run_end_messages(results)
 

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -11,7 +11,6 @@ from dbt.task.base_task import RunnableTask
 
 class CompileTask(RunnableTask):
     def run(self):
-        runner = RunManager(self.config)
 
         query = {
             "include": self.args.models,
@@ -19,8 +18,8 @@ class CompileTask(RunnableTask):
             "resource_types": NodeType.executable(),
             "tags": [],
         }
-
-        results = runner.run(query, CompileRunner)
+        runner = RunManager(self.config, query, CompileRunner)
+        results = runner.run()
 
         dbt.ui.printer.print_timestamped_line('Done.')
 

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -18,8 +18,7 @@ class CompileTask(RunnableTask):
             "resource_types": NodeType.executable(),
             "tags": [],
         }
-        runner = RunManager(self.config, query, CompileRunner)
-        results = runner.run()
+        results = RunManager(self.config, query, CompileRunner).run()
 
         dbt.ui.printer.print_timestamped_line('Done.')
 

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -20,8 +20,7 @@ class RunTask(RunnableTask):
             "tags": []
         }
 
-        runner = RunManager(self.config, query, ModelRunner)
-        results = runner.run()
+        results = RunManager(self.config, query, ModelRunner).run()
 
         if results:
             dbt.ui.printer.print_run_end_messages(results)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -12,7 +12,6 @@ from dbt.task.base_task import RunnableTask
 
 class RunTask(RunnableTask):
     def run(self):
-        runner = RunManager(self.config)
 
         query = {
             "include": self.args.models,
@@ -21,7 +20,8 @@ class RunTask(RunnableTask):
             "tags": []
         }
 
-        results = runner.run(query, ModelRunner)
+        runner = RunManager(self.config, query, ModelRunner)
+        results = runner.run()
 
         if results:
             dbt.ui.printer.print_run_end_messages(results)

--- a/dbt/task/seed.py
+++ b/dbt/task/seed.py
@@ -9,13 +9,13 @@ import dbt.ui.printer
 
 class SeedTask(RunnableTask):
     def run(self):
-        runner = RunManager(self.config)
         query = {
             "include": ["*"],
             "exclude": [],
             "resource_types": [NodeType.Seed],
         }
-        results = runner.run_flat(query, SeedRunner)
+        runner = RunManager(self.config, query, SeedRunner, flat=True)
+        results = runner.run()
 
         if self.args.show:
             self.show_tables(results)

--- a/dbt/task/seed.py
+++ b/dbt/task/seed.py
@@ -14,8 +14,7 @@ class SeedTask(RunnableTask):
             "exclude": [],
             "resource_types": [NodeType.Seed],
         }
-        runner = RunManager(self.config, query, SeedRunner, flat=True)
-        results = runner.run()
+        results = RunManager(self.config, query, SeedRunner).run()
 
         if self.args.show:
             self.show_tables(results)

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -40,8 +40,7 @@ class TestTask(RunnableTask):
             raise RuntimeError("unexpected")
 
         query['tags'] = tags
-        runner = RunManager(self.config, query, TestRunner, flat=True)
-        results = runner.run()
+        results = RunManager(self.config, query, TestRunner).run()
 
         dbt.ui.printer.print_run_end_messages(results)
 

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -18,7 +18,6 @@ class TestTask(RunnableTask):
            d) accepted value
     """
     def run(self):
-        runner = RunManager(self.config)
 
         include = self.args.models
         exclude = self.args.exclude
@@ -41,7 +40,8 @@ class TestTask(RunnableTask):
             raise RuntimeError("unexpected")
 
         query['tags'] = tags
-        results = runner.run_flat(query, TestRunner)
+        runner = RunManager(self.config, query, TestRunner, flat=True)
+        results = runner.run()
 
         dbt.ui.printer.print_run_end_messages(results)
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -338,10 +338,6 @@ def to_string(s):
         return s
 
 
-def is_blocking_dependency(node):
-    return (is_type(node, NodeType.Model))
-
-
 def get_materialization(node):
     return node.get('config', {}).get('materialized')
 

--- a/test/unit/test_linker.py
+++ b/test/unit/test_linker.py
@@ -3,7 +3,7 @@ import unittest
 
 import dbt.utils
 
-from dbt.compilation import Linker
+from dbt import linker
 try:
     from queue import Empty
 except KeyError:
@@ -18,13 +18,13 @@ def _mock_manifest(nodes):
 class LinkerTest(unittest.TestCase):
 
     def setUp(self):
-        self.real_is_blocking_dependency = dbt.utils.is_blocking_dependency
-        self.linker = Linker()
-
-        dbt.utils.is_blocking_dependency = mock.MagicMock(return_value=True)
+        self.patcher = mock.patch.object(linker, 'is_blocking_dependency')
+        self.is_blocking_dependency = self.patcher.start()
+        self.is_blocking_dependency.return_value = True
+        self.linker = linker.Linker()
 
     def tearDown(self):
-        dbt.utils.is_blocking_dependency = self.real_is_blocking_dependency
+        self.patcher.stop()
 
     def test_linker_add_node(self):
         expected_nodes = ['A', 'B', 'C']

--- a/test/unit/test_linker.py
+++ b/test/unit/test_linker.py
@@ -4,7 +4,16 @@ import unittest
 import dbt.utils
 
 from dbt.compilation import Linker
+try:
+    from queue import Empty
+except KeyError:
+    from Queue import Empty
 
+
+def _mock_manifest(nodes):
+    return mock.MagicMock(nodes={
+        n: mock.MagicMock(unique_id=n) for n in nodes
+    })
 
 class LinkerTest(unittest.TestCase):
 
@@ -28,15 +37,43 @@ class LinkerTest(unittest.TestCase):
 
         self.assertEqual(len(actual_nodes), len(expected_nodes))
 
+    def assert_would_join(self, queue):
+        """test join() without timeout risk"""
+        self.assertEqual(queue.inner.unfinished_tasks, 0)
+
     def test_linker_add_dependency(self):
         actual_deps = [('A', 'B'), ('A', 'C'), ('B', 'C')]
 
         for (l, r) in actual_deps:
             self.linker.dependency(l, r)
 
-        expected_dep_list = [['C'], ['B'], ['A']]
-        actual_dep_list = self.linker.as_dependency_list()
-        self.assertEqual(expected_dep_list, actual_dep_list)
+        manifest = _mock_manifest('ABC')
+        queue = self.linker.as_graph_queue(manifest)
+
+        got = queue.get(block=False)
+        self.assertEqual(got.unique_id, 'C')
+        with self.assertRaises(Empty):
+            queue.get(block=False)
+        self.assertFalse(queue.empty())
+        queue.mark_done('C')
+        self.assertFalse(queue.empty())
+
+        got = queue.get(block=False)
+        self.assertEqual(got.unique_id, 'B')
+        with self.assertRaises(Empty):
+            queue.get(block=False)
+        self.assertFalse(queue.empty())
+        queue.mark_done('B')
+        self.assertFalse(queue.empty())
+
+        got = queue.get(block=False)
+        self.assertEqual(got.unique_id, 'A')
+        with self.assertRaises(Empty):
+            queue.get(block=False)
+        self.assertTrue(queue.empty())
+        queue.mark_done('A')
+        self.assert_would_join(queue)
+        self.assertTrue(queue.empty())
 
     def test_linker_add_disjoint_dependencies(self):
         actual_deps = [('A', 'B')]
@@ -46,18 +83,32 @@ class LinkerTest(unittest.TestCase):
             self.linker.dependency(l, r)
         self.linker.add_node(additional_node)
 
-        # has to be one of these two
-        possible = [
-                [['Z', 'B'], ['A']],
-                [['B', 'Z'], ['A']],
-        ]
 
-        actual = self.linker.as_dependency_list()
+        manifest = _mock_manifest('ABZ')
+        queue = self.linker.as_graph_queue(manifest)
 
-        for expected in possible:
-            if expected == actual:
-                return
-        self.assertTrue(False, actual)
+        # the first one we get must be B, it has the longest dep chain
+        first = queue.get(block=False)
+        self.assertEqual(first.unique_id, 'B')
+        self.assertFalse(queue.empty())
+        queue.mark_done('B')
+        self.assertFalse(queue.empty())
+
+        second = queue.get(block=False)
+        self.assertIn(second.unique_id, {'A', 'Z'})
+        self.assertFalse(queue.empty())
+        queue.mark_done(second.unique_id)
+        self.assertFalse(queue.empty())
+
+        third = queue.get(block=False)
+        self.assertIn(third.unique_id, {'A', 'Z'})
+        with self.assertRaises(Empty):
+            queue.get(block=False)
+        self.assertNotEqual(second.unique_id, third.unique_id)
+        self.assertTrue(queue.empty())
+        queue.mark_done(third.unique_id)
+        self.assert_would_join(queue)
+        self.assertTrue(queue.empty())
 
     def test_linker_dependencies_limited_to_some_nodes(self):
         actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'D')]
@@ -65,13 +116,30 @@ class LinkerTest(unittest.TestCase):
         for (l, r) in actual_deps:
             self.linker.dependency(l, r)
 
-        actual_limit = self.linker.as_dependency_list(['B'])
-        expected_limit = [['B']]
-        self.assertEqual(expected_limit, actual_limit)
+        queue = self.linker.as_graph_queue(_mock_manifest('ABCD'), ['B'])
+        got = queue.get(block=False)
+        self.assertEqual(got.unique_id, 'B')
+        self.assertTrue(queue.empty())
+        queue.mark_done('B')
+        self.assert_would_join(queue)
 
-        actual_limit_2 = self.linker.as_dependency_list(['A', 'B'])
-        expected_limit_2 = [['B'], ['A']]
-        self.assertEqual(expected_limit_2, actual_limit_2)
+        queue_2 = self.linker.as_graph_queue(_mock_manifest('ABCD'), ['A', 'B'])
+        got = queue_2.get(block=False)
+        self.assertEqual(got.unique_id, 'B')
+        self.assertFalse(queue_2.empty())
+        with self.assertRaises(Empty):
+            queue_2.get(block=False)
+        queue_2.mark_done('B')
+        self.assertFalse(queue_2.empty())
+
+        got = queue_2.get(block=False)
+        self.assertEqual(got.unique_id, 'A')
+        self.assertTrue(queue_2.empty())
+        with self.assertRaises(Empty):
+            queue_2.get(block=False)
+        self.assertTrue(queue_2.empty())
+        queue_2.mark_done('A')
+        self.assert_would_join(queue_2)
 
     def test_linker_bad_limit_throws_runtime_error(self):
         actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'D')]
@@ -79,8 +147,8 @@ class LinkerTest(unittest.TestCase):
         for (l, r) in actual_deps:
             self.linker.dependency(l, r)
 
-        self.assertRaises(RuntimeError,
-                          self.linker.as_dependency_list, ['ZZZ'])
+        with self.assertRaises(RuntimeError):
+            self.linker.as_graph_queue(_mock_manifest('ABCD'), ['ZZZ'])
 
     def test__find_cycles__cycles(self):
         actual_deps = [('A', 'B'), ('B', 'C'), ('C', 'A')]


### PR DESCRIPTION
Fixes #813 by replacing the node selector `as_node_list` with `as_graph_iterator` and do graph operations using it. The current metric is that nodes whose dependencies have finished are placed onto a priority queue, prioritized by the number of dependencies they have in the graph as a whole, instead of creating runlevels and only operating on the pool before them.

This required quite a bit of restructuring in the RunManager, as it needs to feed completeness information back into the queue. A source of confidence in that refactor is commit e7b1a09, which accomplishes a lot of this with (postgres, at least) integration tests still passing. Other intermediates that I never committed also passed tests during the process of writing acddb3b, so I have pretty high confidence in the new structure.

Worker threads block when there are no nodes left to process.
