### PR TITLE
get the default schema name generator from the root package [#801]

### DIFF
--- a/dbt/parser/archives.py
+++ b/dbt/parser/archives.py
@@ -1,12 +1,12 @@
 
 from dbt.contracts.graph.unparsed import UnparsedNode
 from dbt.node_types import NodeType
-from dbt.parser.base import BaseParser
+from dbt.parser.base import MacrosKnownParser
 
 import os
 
 
-class ArchiveParser(BaseParser):
+class ArchiveParser(MacrosKnownParser):
     @classmethod
     def parse_archives_from_project(cls, config):
         archives = []
@@ -37,17 +37,15 @@ class ArchiveParser(BaseParser):
 
         return archives
 
-    @classmethod
-    def load_and_parse(cls, root_project, all_projects, macros=None,
-                       macro_manifest=None):
+    def load_and_parse(self):
         """Load and parse archives in a list of projects. Returns a dict
            that maps unique ids onto ParsedNodes"""
 
         archives = []
         to_return = {}
 
-        for name, project in all_projects.items():
-            archives = archives + cls.parse_archives_from_project(project)
+        for name, project in self.all_projects.items():
+            archives = archives + self.parse_archives_from_project(project)
 
         # We're going to have a similar issue with parsed nodes, if we want to
         # make parse_node return those.
@@ -57,18 +55,14 @@ class ArchiveParser(BaseParser):
             # argument.
             archive_config = a.pop('config')
             archive = UnparsedNode(**a)
-            node_path = cls.get_path(archive.get('resource_type'),
-                                     archive.get('package_name'),
-                                     archive.get('name'))
+            node_path = self.get_path(archive.resource_type,
+                                      archive.package_name,
+                                      archive.name)
 
-            to_return[node_path] = cls.parse_node(
+            to_return[node_path] = self.parse_node(
                 archive,
                 node_path,
-                root_project,
-                all_projects.get(archive.get('package_name')),
-                all_projects,
-                macros=macros,
-                macro_manifest=macro_manifest,
+                self.all_projects.get(archive.package_name),
                 archive_config=archive_config)
 
         return to_return

--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -12,12 +12,20 @@ from dbt.utils import coalesce
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.contracts.graph.parsed import ParsedNode
 from dbt.parser.source_config import SourceConfig
+from dbt.node_types import NodeType
 
 
 class BaseParser(object):
+    def __init__(self, root_project_config, all_projects):
+        self.root_project_config = root_project_config
+        self.all_projects = all_projects
 
-    @classmethod
-    def load_and_parse(cls, *args, **kwargs):
+    @property
+    def default_schema(self):
+        return getattr(self.root_project_config.credentials, 'schema',
+                       'public')
+
+    def load_and_parse(self, *args, **kwargs):
         raise dbt.exceptions.NotImplementedException("Not implemented")
 
     @classmethod
@@ -37,12 +45,60 @@ class BaseParser(object):
 
         return fqn
 
-    @classmethod
-    def parse_node(cls, node, node_path, root_project_config,
-                   package_project_config, all_projects,
-                   tags=None, fqn_extra=None, fqn=None, macros=None,
-                   agate_table=None, archive_config=None, column_name=None,
-                   macro_manifest=None):
+
+class MacrosKnownParser(BaseParser):
+    def __init__(self, root_project_config, all_projects, macro_manifest):
+        super(MacrosKnownParser, self).__init__(
+            root_project_config=root_project_config,
+            all_projects=all_projects
+        )
+        self.macro_manifest = macro_manifest
+        self._get_schema_func = None
+
+    def get_schema_func(self):
+        """The get_schema function is set by a few different things:
+            - if there is a 'generate_schema_name' macro in the root project,
+                it will be used.
+            - if that does not exist but there is a 'generate_schema_name'
+                macro in the 'dbt' internal project, that will be used
+            - if neither of those exist (unit tests?), a function that returns
+                the 'default schema' as set in the root project's 'credentials'
+                is used
+
+        """
+        if self._get_schema_func is not None:
+            return self._get_schema_func
+
+        get_schema_macro = self.macro_manifest.find_macro_by_name(
+            'generate_schema_name',
+            self.root_project_config.project_name
+        )
+        if get_schema_macro is None:
+            get_schema_macro = self.macro_manifest.find_macro_by_name(
+                'generate_schema_name',
+                dbt.include.GLOBAL_PROJECT_NAME
+            )
+        if get_schema_macro is None:
+            def get_schema(_):
+                return self.default_schema
+        else:
+            # use the macro itself as the 'parsed node' to pass into
+            # parser.generate() to get a context.
+            macro_node = get_schema_macro.incorporate(
+                resource_type=NodeType.Operation
+            )
+            root_context = dbt.context.parser.generate(
+                macro_node, self.root_project_config,
+                self.macro_manifest, self.root_project_config
+            )
+            get_schema = get_schema_macro.generator(root_context)
+
+        self._get_schema_func = get_schema
+        return self._get_schema_func
+
+    def parse_node(self, node, node_path, package_project_config, tags=None,
+                   fqn_extra=None, fqn=None, agate_table=None,
+                   archive_config=None, column_name=None):
         """Parse a node, given an UnparsedNode and any other required information.
 
         agate_table should be set if the node came from a seed file.
@@ -58,7 +114,6 @@ class BaseParser(object):
             node['agate_table'] = agate_table
         tags = coalesce(tags, [])
         fqn_extra = coalesce(fqn_extra, [])
-        macros = coalesce(macros, {})
 
         node.update({
             'refs': [],
@@ -69,11 +124,11 @@ class BaseParser(object):
         })
 
         if fqn is None:
-            fqn = cls.get_fqn(node.get('path'), package_project_config,
-                              fqn_extra)
+            fqn = self.get_fqn(node.get('path'), package_project_config,
+                               fqn_extra)
 
         config = SourceConfig(
-            root_project_config,
+            self.root_project_config,
             package_project_config,
             fqn,
             node['resource_type'])
@@ -94,9 +149,7 @@ class BaseParser(object):
         node['config'] = config_dict
 
         # Set this temporarily so get_rendered() has access to a schema & alias
-        default_schema = getattr(root_project_config.credentials, 'schema',
-                                 'public')
-        node['schema'] = default_schema
+        node['schema'] = self.default_schema
         default_alias = node.get('name')
         node['alias'] = default_alias
 
@@ -105,8 +158,11 @@ class BaseParser(object):
             node['column_name'] = column_name
 
         parsed_node = ParsedNode(**node)
-        context = dbt.context.parser.generate(parsed_node, root_project_config,
-                                              macro_manifest, config)
+        context = dbt.context.parser.generate(
+            parsed_node,
+            self.root_project_config,
+            self.macro_manifest,
+            config)
 
         dbt.clients.jinja.get_rendered(
             parsed_node.raw_sql, context, parsed_node.to_shallow_dict(),
@@ -121,20 +177,8 @@ class BaseParser(object):
         # Special macro defined in the global project. Use the root project's
         # definition, not the current package
         schema_override = config.config.get('schema')
-        get_schema_macro = macro_manifest.find_macro_by_name(
-            'generate_schema_name',
-            root_project_config.project_name
-        )
-        if get_schema_macro is None:
-            get_schema_macro = macro_manifest.find_macro_by_name(
-                'generate_schema_name',
-                dbt.include.GLOBAL_PROJECT_NAME
-            )
-        if get_schema_macro is None:
-            def get_schema(_):
-                return default_schema
-        else:
-            get_schema = get_schema_macro.generator(context)
+        get_schema = self.get_schema_func()
+
         parsed_node.schema = get_schema(schema_override)
         parsed_node.alias = config.config.get('alias', default_alias)
 

--- a/dbt/parser/base_sql.py
+++ b/dbt/parser/base_sql.py
@@ -8,18 +8,16 @@ import dbt.utils
 import dbt.flags
 
 from dbt.contracts.graph.unparsed import UnparsedNode
-from dbt.parser.base import BaseParser
+from dbt.parser.base import MacrosKnownParser
 
 
-class BaseSqlParser(BaseParser):
+class BaseSqlParser(MacrosKnownParser):
     @classmethod
     def get_compiled_path(cls, name, relative_path):
         raise dbt.exceptions.NotImplementedException("Not implemented")
 
-    @classmethod
-    def load_and_parse(cls, package_name, root_project, all_projects, root_dir,
-                       relative_dirs, resource_type, tags=None, macros=None,
-                       macro_manifest=None):
+    def load_and_parse(self, package_name, root_dir, relative_dirs,
+                       resource_type, tags=None):
         """Load and parse models in a list of directories. Returns a dict
            that maps unique ids onto ParsedNodes"""
 
@@ -28,11 +26,8 @@ class BaseSqlParser(BaseParser):
         if tags is None:
             tags = []
 
-        if macros is None:
-            macros = {}
-
         if dbt.flags.STRICT_MODE:
-            dbt.contracts.project.ProjectList(**all_projects)
+            dbt.contracts.project.ProjectList(**self.all_projects)
 
         file_matches = dbt.clients.system.find_matching(
             root_dir,
@@ -48,7 +43,8 @@ class BaseSqlParser(BaseParser):
             parts = dbt.utils.split_path(file_match.get('relative_path', ''))
             name, _ = os.path.splitext(parts[-1])
 
-            path = cls.get_compiled_path(name, file_match.get('relative_path'))
+            path = self.get_compiled_path(name,
+                                          file_match.get('relative_path'))
 
             original_file_path = os.path.join(
                 file_match.get('searched_path'),
@@ -64,38 +60,26 @@ class BaseSqlParser(BaseParser):
                 'raw_sql': file_contents
             })
 
-        return cls.parse_sql_nodes(result, root_project, all_projects, tags,
-                                   macros, macro_manifest)
+        return self.parse_sql_nodes(result, tags)
 
-    @classmethod
-    def parse_sql_nodes(cls, nodes, root_project, projects,
-                        tags=None, macros=None, macro_manifest=None):
+    def parse_sql_nodes(self, nodes, tags=None):
 
         if tags is None:
             tags = []
-
-        if macros is None:
-            macros = {}
 
         to_return = {}
         disabled = []
 
         for n in nodes:
             node = UnparsedNode(**n)
-            package_name = node.get('package_name')
+            package_name = node.package_name
 
-            node_path = cls.get_path(node.get('resource_type'),
-                                     package_name,
-                                     node.get('name'))
+            node_path = self.get_path(node.resource_type,
+                                      package_name,
+                                      node.name)
 
-            node_parsed = cls.parse_node(node,
-                                         node_path,
-                                         root_project,
-                                         projects.get(package_name),
-                                         projects,
-                                         tags=tags,
-                                         macros=macros,
-                                         macro_manifest=macro_manifest)
+            project = self.all_projects.get(package_name)
+            node_parsed = self.parse_node(node, node_path, project, tags=tags)
 
             # Ignore disabled nodes
             if not node_parsed['config']['enabled']:

--- a/dbt/parser/hooks.py
+++ b/dbt/parser/hooks.py
@@ -26,25 +26,17 @@ class HookParser(BaseSqlParser):
 
         return hooks
 
-    @classmethod
-    def get_hooks(cls, all_projects, hook_type):
+    def get_hooks(self, hook_type):
         project_hooks = collections.defaultdict(list)
 
-        for project_name, project in all_projects.items():
-            hooks = cls.get_hooks_from_project(project, hook_type)
+        for project_name, project in self.all_projects.items():
+            hooks = self.get_hooks_from_project(project, hook_type)
             project_hooks[project_name].extend(hooks)
 
         return project_hooks
 
-    @classmethod
-    def load_and_parse_run_hook_type(cls, root_project, all_projects,
-                                     hook_type, macros=None,
-                                     macro_manifest=None):
-
-        if dbt.flags.STRICT_MODE:
-            dbt.contracts.project.ProjectList(**all_projects)
-
-        project_hooks = cls.get_hooks(all_projects, hook_type)
+    def load_and_parse_run_hook_type(self, hook_type):
+        project_hooks = self.get_hooks(hook_type)
 
         result = []
         for project_name, hooks in project_hooks.items():
@@ -64,25 +56,17 @@ class HookParser(BaseSqlParser):
                 })
 
         tags = [hook_type]
-        hooks, _ = cls.parse_sql_nodes(result, root_project, all_projects,
-                                       tags=tags, macros=macros,
-                                       macro_manifest=macro_manifest)
+        hooks, _ = self.parse_sql_nodes(result, tags=tags)
         return hooks
 
-    @classmethod
-    def load_and_parse(cls, root_project, all_projects, macros=None,
-                       macro_manifest=None):
-        if macros is None:
-            macros = {}
+    def load_and_parse(self):
+        if dbt.flags.STRICT_MODE:
+            dbt.contracts.project.ProjectList(**self.all_projects)
 
         hook_nodes = {}
         for hook_type in RunHookType.Both:
-            project_hooks = cls.load_and_parse_run_hook_type(
-                root_project,
-                all_projects,
+            project_hooks = self.load_and_parse_run_hook_type(
                 hook_type,
-                macros=macros,
-                macro_manifest=macro_manifest
             )
             hook_nodes.update(project_hooks)
 

--- a/dbt/parser/macros.py
+++ b/dbt/parser/macros.py
@@ -18,8 +18,7 @@ from dbt.contracts.graph.parsed import ParsedMacro
 
 
 class MacroParser(BaseParser):
-    @classmethod
-    def parse_macro_file(cls, macro_file_path, macro_file_contents, root_path,
+    def parse_macro_file(self, macro_file_path, macro_file_contents, root_path,
                          package_name, resource_type, tags=None, context=None):
 
         logger.debug("Parsing {}".format(macro_file_path))
@@ -61,7 +60,7 @@ class MacroParser(BaseParser):
             if node_type != resource_type:
                 continue
 
-            unique_id = cls.get_path(resource_type, package_name, name)
+            unique_id = self.get_path(resource_type, package_name, name)
 
             merged = dbt.utils.deep_merge(
                 base_node.serialize(),
@@ -79,16 +78,15 @@ class MacroParser(BaseParser):
 
         return to_return
 
-    @classmethod
-    def load_and_parse(cls, package_name, root_project, all_projects, root_dir,
-                       relative_dirs, resource_type, tags=None):
+    def load_and_parse(self, package_name, root_dir, relative_dirs,
+                       resource_type, tags=None):
         extension = "[!.#~]*.sql"
 
         if tags is None:
             tags = []
 
         if dbt.flags.STRICT_MODE:
-            dbt.contracts.project.ProjectList(**all_projects)
+            dbt.contracts.project.ProjectList(**self.all_projects)
 
         file_matches = dbt.clients.system.find_matching(
             root_dir,
@@ -107,7 +105,7 @@ class MacroParser(BaseParser):
             )
 
             result.update(
-                cls.parse_macro_file(
+                self.parse_macro_file(
                     original_file_path,
                     file_contents,
                     root_dir,

--- a/dbt/parser/schemas.py
+++ b/dbt/parser/schemas.py
@@ -16,7 +16,7 @@ from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.utils import get_pseudo_test_path
 from dbt.contracts.graph.unparsed import UnparsedNode, UnparsedNodeUpdate
 from dbt.contracts.graph.parsed import ParsedNodePatch
-from dbt.parser.base import BaseParser
+from dbt.parser.base import MacrosKnownParser
 
 
 def get_nice_schema_test_name(test_type, test_name, args):
@@ -89,7 +89,7 @@ def build_test_raw_sql(test_namespace, model_name, test_type, test_args):
     return raw_sql
 
 
-class SchemaParser(BaseParser):
+class SchemaParser(MacrosKnownParser):
     """This is the original schema parser but with everything in one huge CF of
     a method so I can refactor it more nicely.
     """
@@ -176,17 +176,15 @@ class SchemaParser(BaseParser):
             raw_sql=raw_sql
         )
 
-    @classmethod
-    def build_parsed_node(cls, unparsed, model_name, test_namespace, test_type,
-                          root_project, all_projects, macros, macro_manifest,
-                          column_name):
+    def build_parsed_node(self, unparsed, model_name, test_namespace,
+                          test_type, column_name):
         """Given an UnparsedNode with a node type of Test and some extra
         information, build a ParsedNode representing the test.
         """
 
         test_path = os.path.basename(unparsed.original_file_path)
 
-        source_package = all_projects.get(unparsed.package_name)
+        source_package = self.all_projects.get(unparsed.package_name)
         if source_package is None:
             desc = '"{}" test on model "{}"'.format(test_type,
                                                     model_name)
@@ -195,47 +193,40 @@ class SchemaParser(BaseParser):
         # supply our own fqn which overrides the hashed version from the path
         full_path = get_pseudo_test_path(unparsed.name, test_path,
                                          'schema_test')
-        fqn_override = cls.get_fqn(full_path, source_package)
+        fqn_override = self.get_fqn(full_path, source_package)
 
-        node_path = cls.get_path(NodeType.Test, unparsed.package_name,
-                                 unparsed.name)
+        node_path = self.get_path(NodeType.Test, unparsed.package_name,
+                                  unparsed.name)
 
-        return cls.parse_node(unparsed,
-                              node_path,
-                              root_project,
-                              source_package,
-                              all_projects,
-                              tags=['schema'],
-                              fqn_extra=None,
-                              fqn=fqn_override,
-                              macros=macros,
-                              column_name=column_name,
-                              macro_manifest=macro_manifest)
+        return self.parse_node(unparsed,
+                               node_path,
+                               source_package,
+                               tags=['schema'],
+                               fqn_extra=None,
+                               fqn=fqn_override,
+                               column_name=column_name)
 
-    @classmethod
-    def build_node(cls, model_name, package_name, test_type, test_args,
-                   root_dir, original_file_path, root_project, all_projects,
-                   macros, macro_manifest, column_name=None):
+    def build_node(self, model_name, package_name, test_type, test_args,
+                   root_dir, original_file_path, column_name=None):
         """From the various components that are common to both v1 and v2 schema,
         build a ParsedNode representing a test case.
         """
         original_test_type = test_type
-        test_namespace, test_type, package_name = cls.calculate_namespace(
+        test_namespace, test_type, package_name = self.calculate_namespace(
             test_type, package_name
         )
 
-        test_namespace, test_type, package_name = cls.calculate_namespace(
+        test_namespace, test_type, package_name = self.calculate_namespace(
             test_type, package_name
         )
 
-        unparsed = cls.build_unparsed_node(model_name, package_name, test_type,
-                                           test_args, test_namespace, root_dir,
-                                           original_file_path)
+        unparsed = self.build_unparsed_node(model_name, package_name,
+                                            test_type, test_args,
+                                            test_namespace, root_dir,
+                                            original_file_path)
 
-        parsed = cls.build_parsed_node(unparsed, model_name, test_namespace,
-                                       original_test_type, root_project,
-                                       all_projects, macros, macro_manifest,
-                                       column_name)
+        parsed = self.build_parsed_node(unparsed, model_name, test_namespace,
+                                        original_test_type, column_name)
         return parsed
 
     @classmethod
@@ -273,10 +264,8 @@ class SchemaParser(BaseParser):
 
             yield original_file_path, test_yml
 
-    @classmethod
-    def parse_v1_test_yml(cls, original_file_path, test_yml, package_name,
-                          root_project, all_projects, root_dir, macros=None,
-                          macro_manifest=None):
+    def parse_v1_test_yml(self, original_file_path, test_yml, package_name,
+                          root_dir):
         """Parse v1 yml contents, yielding parsed nodes.
 
         A v1 yml file is laid out like this ('variables' written
@@ -327,19 +316,15 @@ class SchemaParser(BaseParser):
                     continue
 
                 for config in configs:
-                    test_args = cls._build_v1_test_args(config)
-                    to_add = cls.build_node(
+                    test_args = self._build_v1_test_args(config)
+                    to_add = self.build_node(
                         model_name, package_name, test_type, test_args,
-                        root_dir, original_file_path,
-                        root_project, all_projects, macros,
-                        macro_manifest)
+                        root_dir, original_file_path)
                     if to_add is not None:
                         yield to_add
 
-    @classmethod
-    def parse_v2_yml(cls, original_file_path, test_yml, package_name,
-                     root_project, all_projects, root_dir, macros,
-                     macro_manifest):
+    def parse_v2_yml(self, original_file_path, test_yml, package_name,
+                     root_dir):
         """Parse v2 yml contents, yielding both parsed nodes and node patches.
 
         A v2 yml file is laid out like this ('variables' written
@@ -390,16 +375,13 @@ class SchemaParser(BaseParser):
                 dbt.utils.compiler_warning(model.get('name'), msg)
                 continue
 
-            iterator = cls.parse_model(model, package_name, root_dir,
-                                       original_file_path, root_project,
-                                       all_projects, macros, macro_manifest)
+            iterator = self.parse_model(model, package_name, root_dir,
+                                        original_file_path)
 
             for node_type, node in iterator:
                 yield node_type, node
 
-    @classmethod
-    def parse_model(cls, model, package_name, root_dir, path, root_project,
-                    all_projects, macros, macro_manifest):
+    def parse_model(self, model, package_name, root_dir, path):
         """Given an UnparsedNodeUpdate, return column info about the model
 
             - column info (name and maybe description) as a dict
@@ -422,23 +404,21 @@ class SchemaParser(BaseParser):
             }
             dbt.clients.jinja.get_rendered(description, context)
             for test in column.get('tests', []):
-                test_type, test_args = cls._build_v2_test_args(
+                test_type, test_args = self._build_v2_test_args(
                     test, column_name
                 )
-                node = cls.build_node(
+                node = self.build_node(
                     model_name, package_name, test_type, test_args, root_dir,
-                    path, root_project, all_projects, macros, macro_manifest,
-                    column_name
+                    path, column_name
                 )
                 yield 'test', node
 
         for test in model.get('tests', []):
             # table tests don't inject any extra values, model name is
             # available via `model.name`
-            test_type, test_args = cls._build_v2_test_args(test, None)
-            node = cls.build_node(model_name, package_name, test_type,
-                                  test_args, root_dir, path, root_project,
-                                  all_projects, macros, macro_manifest)
+            test_type, test_args = self._build_v2_test_args(test, None)
+            node = self.build_node(model_name, package_name, test_type,
+                                   test_args, root_dir, path)
             yield 'test', node
 
         context = {'doc': dbt.context.parser.docs(model, docrefs)}
@@ -454,34 +434,28 @@ class SchemaParser(BaseParser):
         )
         yield 'patch', patch
 
-    @classmethod
-    def load_and_parse(cls, package_name, root_project, all_projects, root_dir,
-                       relative_dirs, macros=None, macro_manifest=None):
+    def load_and_parse(self, package_name, root_dir, relative_dirs):
         if dbt.flags.STRICT_MODE:
-            dbt.contracts.project.ProjectList(**all_projects)
+            dbt.contracts.project.ProjectList(**self.all_projects)
         new_tests = {}  # test unique ID -> ParsedNode
         node_patches = {}  # model name -> dict
 
-        iterator = cls.find_schema_yml(package_name, root_dir, relative_dirs)
+        iterator = self.find_schema_yml(package_name, root_dir, relative_dirs)
 
         for original_file_path, test_yml in iterator:
             version = test_yml.get('version', 1)
             # the version will not be an int if it's a v1 model that has a
             # model named 'version'.
             if version == 1 or not isinstance(version, int):
-                cls.check_v2_missing_version(original_file_path, test_yml)
+                self.check_v2_missing_version(original_file_path, test_yml)
                 new_tests.update(
                     (t.get('unique_id'), t)
-                    for t in cls.parse_v1_test_yml(
-                        original_file_path, test_yml, package_name,
-                        root_project, all_projects, root_dir, macros,
-                        macro_manifest)
+                    for t in self.parse_v1_test_yml(
+                        original_file_path, test_yml, package_name, root_dir)
                 )
             elif version == 2:
-                v2_results = cls.parse_v2_yml(
-                        original_file_path, test_yml, package_name,
-                        root_project, all_projects, root_dir, macros,
-                        macro_manifest)
+                v2_results = self.parse_v2_yml(
+                        original_file_path, test_yml, package_name, root_dir)
                 for result_type, node in v2_results:
                     if result_type == 'patch':
                         node_patches[node.name] = node

--- a/test/integration/006_simple_dependency_test/local_dependency/macros/generate_schema_name.sql
+++ b/test/integration/006_simple_dependency_test/local_dependency/macros/generate_schema_name.sql
@@ -1,0 +1,4 @@
+{# This should be ignored as it's in a subpackage #}
+{% macro generate_schema_name(custom_schema_name=none) -%}
+  invalid_schema_name
+{%- endmacro %}

--- a/test/integration/006_simple_dependency_test/local_models/my_configured_model.sql
+++ b/test/integration/006_simple_dependency_test/local_models/my_configured_model.sql
@@ -1,0 +1,4 @@
+{{
+    config(schema='configured')
+}}
+select * from {{ ref('model_to_import') }}

--- a/test/integration/006_simple_dependency_test/schema_override_macros/schema.sql
+++ b/test/integration/006_simple_dependency_test/schema_override_macros/schema.sql
@@ -1,0 +1,6 @@
+
+{% macro generate_schema_name(schema_name) -%}
+
+    {{ schema_name }}_{{ target.schema }}_macro
+
+{%- endmacro %}

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -21,16 +21,24 @@ class TestSimpleDependency(DBTIntegrationTest):
             ]
         }
 
-    def expected_schema(self):
+    def base_schema(self):
         return self.unique_schema()
+
+    def configured_schema(self):
+        return self.unique_schema() + '_configured'
 
     @attr(type='postgres')
     def test_postgres_local_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
-        self.assertEqual(len(results),  2)
-        self.assertTrue(all(r.node.schema == self.expected_schema()
-                            for r in results))
+        self.assertEqual(len(results),  3)
+        self.assertEqual({r.node.schema for r in results},
+                         {self.base_schema(), self.configured_schema()})
+        self.assertEqual(
+            len([r.node for r in results
+                 if r.node.schema == self.base_schema()]),
+            2
+        )
 
 
 
@@ -44,5 +52,8 @@ class TestSimpleDependencyWithSchema(TestSimpleDependency):
             }
         }
 
-    def expected_schema(self):
+    def base_schema(self):
         return 'dbt_test_{}_macro'.format(self.unique_schema())
+
+    def configured_schema(self):
+        return 'configured_{}_macro'.format(self.unique_schema())

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -21,9 +21,28 @@ class TestSimpleDependency(DBTIntegrationTest):
             ]
         }
 
+    def expected_schema(self):
+        return self.unique_schema()
+
     @attr(type='postgres')
-    def test_local_dependency(self):
+    def test_postgres_local_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
         self.assertEqual(len(results),  2)
+        self.assertTrue(all(r.node.schema == self.expected_schema()
+                            for r in results))
 
+
+
+class TestSimpleDependencyWithSchema(TestSimpleDependency):
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['test/integration/006_simple_dependency_test/schema_override_macros'],
+            'models': {
+                'schema': 'dbt_test',
+            }
+        }
+
+    def expected_schema(self):
+        return 'dbt_test_{}_macro'.format(self.unique_schema())

--- a/test/unit/test_docs_blocks.py
+++ b/test/unit/test_docs_blocks.py
@@ -124,9 +124,8 @@ class DocumentationParserTest(unittest.TestCase):
             'root': self.root_project_config,
             'some_package': self.subdir_project_config
         }
-        parsed = list(docs.DocumentationParser.parse(
-            all_projects, self.root_project_config, docfile
-        ))
+        parser = docs.DocumentationParser(self.root_project_config, all_projects)
+        parsed = list(parser.parse(docfile))
         parsed.sort(key=lambda x: x.name)
 
         self.assertEqual(len(parsed), 2)

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -69,6 +69,11 @@ class BaseParserTest(unittest.TestCase):
             project=snowplow_project, profile=profile_data
         )
 
+        self.all_projects = {
+            'root': self.root_project_config,
+            'snowplow': self.snowplow_project_config
+        }
+
 
 
 class SourceConfigTest(BaseParserTest):
@@ -172,14 +177,14 @@ class ParserTest(BaseParserTest):
             'path': 'model_one.sql',
             'raw_sql': ("select * from events"),
         }]
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
 
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -235,13 +240,13 @@ class ParserTest(BaseParserTest):
             'materialized': 'ephemeral'
         })
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -281,12 +286,15 @@ class ParserTest(BaseParserTest):
             'raw_sql': (" "),
         }]
 
+        del self.all_projects['snowplow']
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -334,13 +342,14 @@ class ParserTest(BaseParserTest):
             'raw_sql': "select * from {{ref('base')}}"
         }]
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.base': ParsedNode(
                     alias='base',
@@ -441,13 +450,14 @@ class ParserTest(BaseParserTest):
                         "select * from e left join s on s.id = e.sid"),
         }]
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.events': ParsedNode(
                     alias='events',
@@ -621,13 +631,14 @@ class ParserTest(BaseParserTest):
                         "select * from e left join s on s.id = e.sid"),
         }]
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.snowplow.events': ParsedNode(
                     alias='events',
@@ -929,13 +940,14 @@ class ParserTest(BaseParserTest):
             'materialized': 'table'
         })
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -1015,13 +1027,14 @@ class ParserTest(BaseParserTest):
             'materialized': 'view'
         })
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.table': ParsedNode(
                     alias='table',
@@ -1215,13 +1228,14 @@ class ParserTest(BaseParserTest):
             'sort': ['timestamp', 'id']
         })
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.table': ParsedNode(
                     alias='table',
@@ -1330,17 +1344,17 @@ class ParserTest(BaseParserTest):
             'relationships: [{from: id, to: ref(\'model_two\'), field: id}]' # noqa
             '}}}'
         )
-        results = list(SchemaParser.parse_v1_test_yml(
+
+        parser = SchemaParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+        results = list(parser.parse_v1_test_yml(
             original_file_path='test_one.yml',
             test_yml=test_yml,
             package_name='root',
-            root_project=self.root_project_config,
-            all_projects={
-                'root': self.root_project_config,
-                'snowplow': self.snowplow_project_config
-            },
-            root_dir=get_os_path('/usr/src/app'),
-            macro_manifest=self.macro_manifest
+            root_dir=get_os_path('/usr/src/app')
         ))
         results.sort(key=lambda n: n.name)
 
@@ -1460,18 +1474,16 @@ class ParserTest(BaseParserTest):
             '{relationships: {from: id, to: ref(\'model_two\')}}]'
             '}], tests: [some_test: { key: value }]}]}'
         )
-        results = list(SchemaParser.parse_v2_yml(
+        parser = SchemaParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+        results = list(parser.parse_v2_yml(
             original_file_path='test_one.yml',
             test_yml=test_yml,
             package_name='root',
-            root_project=self.root_project_config,
-            all_projects={
-                'root': self.root_project_config,
-                'snowplow': self.snowplow_project_config
-            },
-            root_dir=get_os_path('/usr/src/app'),
-            macros=None,
-            macro_manifest=self.macro_manifest
+            root_dir=get_os_path('/usr/src/app')
         ))
 
         # split this into tests and patches, assert there's nothing else
@@ -1629,9 +1641,10 @@ class ParserTest(BaseParserTest):
         all_projects = {}
         root_dir = '/some/path'
         relative_dirs = ['a', 'b']
+        parser = dbt.parser.schemas.SchemaParser(root_project, all_projects, None)
         with self.assertRaises(dbt.exceptions.CompilationException) as cm:
-            dbt.parser.schemas.SchemaParser.load_and_parse(
-                'test', root_project, all_projects, root_dir, relative_dirs
+            parser.load_and_parse(
+                'test', root_dir, relative_dirs
             )
             self.assertIn('https://docs.getdbt.com/v0.11/docs/schemayml-files',
                           str(cm.exception))
@@ -1652,8 +1665,9 @@ class ParserTest(BaseParserTest):
         all_projects = {}
         root_dir = '/some/path'
         relative_dirs = ['a', 'b']
-        dbt.parser.schemas.SchemaParser.load_and_parse(
-            'test', root_project, all_projects, root_dir, relative_dirs
+        parser = dbt.parser.schemas.SchemaParser(root_project, all_projects, None)
+        parser.load_and_parse(
+            'test', root_dir, relative_dirs
         )
 
     def test__simple_data_test(self):
@@ -1667,13 +1681,14 @@ class ParserTest(BaseParserTest):
             'raw_sql': "select * from {{ref('base')}}"
         }]
 
+        parser = DataTestParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            DataTestParser.parse_sql_nodes(
-                tests,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(tests),
             ({
                 'test.root.no_events': ParsedNode(
                     alias='no_events',
@@ -1708,8 +1723,8 @@ class ParserTest(BaseParserTest):
   {{a}} + {{b}}
 {% endmacro %}
 """
-
-        result = MacroParser.parse_macro_file(
+        parser = MacroParser(None, None)
+        result = parser.parse_macro_file(
             macro_file_path='simple_macro.sql',
             macro_file_contents=macro_file_contents,
             root_path=get_os_path('/usr/src/app'),
@@ -1745,8 +1760,8 @@ class ParserTest(BaseParserTest):
   {{a}} + {{b}}
 {% endmacro %}
 """
-
-        result = MacroParser.parse_macro_file(
+        parser = MacroParser(None, None)
+        result = parser.parse_macro_file(
             macro_file_path='simple_macro.sql',
             macro_file_contents=macro_file_contents,
             root_path=get_os_path('/usr/src/app'),
@@ -1785,13 +1800,14 @@ class ParserTest(BaseParserTest):
             'raw_sql': ("select *, {{package.simple(1, 2)}} from events"),
         }]
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',
@@ -1831,13 +1847,14 @@ class ParserTest(BaseParserTest):
             'raw_sql': ("select *, {{ simple(1, 2) }} from events"),
         }]
 
+        parser = ModelParser(
+            self.root_project_config,
+            self.all_projects,
+            self.macro_manifest
+        )
+
         self.assertEqual(
-            ModelParser.parse_sql_nodes(
-                models,
-                self.root_project_config,
-                {'root': self.root_project_config,
-                 'snowplow': self.snowplow_project_config},
-                macro_manifest=self.macro_manifest),
+            parser.parse_sql_nodes(models),
             ({
                 'model.root.model_one': ParsedNode(
                     alias='model_one',


### PR DESCRIPTION
Fixes #801 by always using the root package to look up the schema name generator. Adds tests. This required quite a bit of refactoring to get the data we wanted!