### PR TITLE
handle cdecimal.Decimal during serialization [#1155]

### DIFF
--- a/dbt/compat.py
+++ b/dbt/compat.py
@@ -1,6 +1,14 @@
 import codecs
 import json
 import warnings
+import decimal
+
+try:
+    import cdecimal
+except ImportError:
+    DECIMALS = (decimal.Decimal,)
+else:
+    DECIMALS = (decimal.Decimal, cdecimal.Decimal)
 
 WHICH_PYTHON = None
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -14,7 +14,7 @@ import dbt.exceptions
 import dbt.flags
 
 from dbt.include import GLOBAL_DBT_MODULES_PATH
-from dbt.compat import basestring
+from dbt.compat import basestring, DECIMALS
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
 from dbt.clients import yaml_helper
@@ -476,6 +476,6 @@ class JSONEncoder(json.JSONEncoder):
     converted to floats.
     """
     def default(self, obj):
-        if isinstance(obj, Decimal):
+        if isinstance(obj, DECIMALS):
             return float(obj)
         return super(JSONEncoder, self).default(obj)


### PR DESCRIPTION
Fixes #1155 by adding JSON serialization handling for `cdecimal.Decimal` if `cdecimal` is installed.

Agate uses `cdecimal.Decimal` if it's available, but it doesn't pass `isinstance(x, decimal.Decimal)` checks so it bypasses our JSON serializer's type checks.

In the presence of `cdecimal`, a bunch of tests will fail - this PR does not fix those cases