### PR TITLE
fix analysis to only compile sql once like model nodes [#1152]

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -132,7 +132,7 @@ class Compiler(object):
 
         injected_node, _ = prepend_ctes(compiled_node, manifest)
 
-        should_wrap = {NodeType.Test, NodeType.Analysis, NodeType.Operation}
+        should_wrap = {NodeType.Test, NodeType.Operation}
         if injected_node.resource_type in should_wrap:
             # data tests get wrapped in count(*)
             # TODO : move this somewhere more reasonable

--- a/test/integration/019_analysis_tests/analysis/raw_stuff.sql
+++ b/test/integration/019_analysis_tests/analysis/raw_stuff.sql
@@ -1,0 +1,3 @@
+{% raw %}
+{% invalid jinja stuff %}
+{% endraw %}


### PR DESCRIPTION
Fixes #1152 
Due to dbt's parsing structure, the existing analysis code compiles its contents twice, which is why `raw` blocks aren't accepted. I've changed the compiler to treat Analysis nodes more like Models during compilation, instead of like seeds and tests. Based on what I found, custom tests probably don't respect `raw` blocks in their jinja and that's probably harder to fix.

It's possible that I don't understand analysis nodes very well and so my fix is just totally wrong... there isn't much of an existing test suite around them.

This fix may also break existing code since it only renders the output once instead of twice, and people may have written analyses with this behavior in mind. 