### PR TITLE
Trim schema whitespace (#1074)

### DIFF
--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -121,7 +121,7 @@ class BaseParser(object):
         schema_override = config.config.get('schema')
         get_schema = context.get('generate_schema_name',
                                  lambda x: default_schema)
-        parsed_node.schema = get_schema(schema_override)
+        parsed_node.schema = get_schema(schema_override).strip()
         parsed_node.alias = config.config.get('alias', default_alias)
 
         # Set tags on node provided in config blocks

--- a/test/integration/024_custom_schema_test/macros/schema.sql
+++ b/test/integration/024_custom_schema_test/macros/schema.sql
@@ -1,6 +1,6 @@
 
-{% macro generate_schema_name(schema_name) -%}
+{% macro generate_schema_name(schema_name) %}
 
     {{ schema_name }}_{{ target.schema }}_macro
 
-{%- endmacro %}
+{% endmacro %}


### PR DESCRIPTION
Fixes #1074 by calling `strip()` on the result of `get_schema()` during parsing.