### PR TITLE
use pypi for the latest version instead of git [#1122]

### DIFF
--- a/dbt/version.py
+++ b/dbt/version.py
@@ -14,17 +14,9 @@ def get_latest_version():
     resp = requests.get(PYPI_VERSION_URL)
     try:
         data = resp.json()
-    except json.JSONDecodeError:
-        raise dbt.exceptions.RuntimeError(
-            'Got invalid data from pypi while querying versions: not json'
-        )
-
-    try:
         version_string = data['info']['version']
-    except KeyError:
-        raise dbt.exceptions.RuntimeError(
-            'Got invalid data from pypi while querying versions: bad data'
-        )
+    except (json.JSONDecodeError, KeyError):
+        return None
 
     return dbt.semver.VersionSpecifier.from_version_string(version_string)
 
@@ -49,7 +41,7 @@ def get_version_information():
     if latest is None:
         return ("{}The latest version of dbt could not be determined!\n"
                 "Make sure that the following URL is accessible:\n{}"
-                .format(version_msg, REMOTE_VERSION_FILE))
+                .format(version_msg, PYPI_VERSION_URL))
 
     if installed == latest:
         return "{}Up to date!".format(version_msg)

--- a/dbt/version.py
+++ b/dbt/version.py
@@ -11,11 +11,11 @@ PYPI_VERSION_URL = 'https://pypi.org/pypi/dbt/json'
 
 
 def get_latest_version():
-    resp = requests.get(PYPI_VERSION_URL)
     try:
+        resp = requests.get(PYPI_VERSION_URL)
         data = resp.json()
         version_string = data['info']['version']
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, requests.RequestException):
         return None
 
     return dbt.semver.VersionSpecifier.from_version_string(version_string)

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -9,19 +9,9 @@ import sys
 class VersionTest(unittest.TestCase):
 
     @patch("dbt.version.__version__", "0.10.0")
-    def test_versions_equal(self):
-
-        dbt.version.get_remote_version_file_contents = MagicMock(
-            return_value="""
-                [bumpversion]
-                current_version = 0.10.0
-                commit = True
-                tag = True
-
-                [bumpversion:file:setup.py]
-
-                [bumpversion:file:dbt/version.py]
-            """)
+    @patch('dbt.version.requests.get')
+    def test_versions_equal(self, mock_get):
+        mock_get.return_value.json.return_value = {'info': {'version': '0.10.0'}}
 
         latest_version = dbt.version.get_latest_version()
         installed_version = dbt.version.get_installed_version()
@@ -37,18 +27,9 @@ class VersionTest(unittest.TestCase):
                                   expected_version_information)
 
     @patch("dbt.version.__version__", "0.10.2-a1")
-    def test_installed_version_greater(self):
-        dbt.version.get_remote_version_file_contents = MagicMock(
-            return_value="""
-                [bumpversion]
-                current_version = 0.10.1
-                commit = True
-                tag = True
-
-                [bumpversion:file:setup.py]
-
-                [bumpversion:file:dbt/version.py]
-            """)
+    @patch('dbt.version.requests.get')
+    def test_installed_version_greater(self, mock_get):
+        mock_get.return_value.json.return_value = {'info': {'version': '0.10.1'}}
 
         latest_version = dbt.version.get_latest_version()
         installed_version = dbt.version.get_installed_version()
@@ -63,18 +44,9 @@ class VersionTest(unittest.TestCase):
                                   expected_version_information)
 
     @patch("dbt.version.__version__", "0.9.5")
-    def test_installed_version_lower(self):
-        dbt.version.get_remote_version_file_contents = MagicMock(
-            return_value="""
-                [bumpversion]
-                current_version = 0.10.0
-                commit = True
-                tag = True
-
-                [bumpversion:file:setup.py]
-
-                [bumpversion:file:dbt/version.py]
-            """)
+    @patch('dbt.version.requests.get')
+    def test_installed_version_lower(self, mock_get):
+        mock_get.return_value.json.return_value = {'info': {'version': '0.10.0'}}
 
         latest_version = dbt.version.get_latest_version()
         installed_version = dbt.version.get_installed_version()
@@ -92,20 +64,10 @@ class VersionTest(unittest.TestCase):
 
     # suppress having version info printed to the screen during tests.
     @patch('sys.stderr')
-    def test_dbt_version_flag(self, stderr):
-        dbt.version.get_remote_version_file_contents = MagicMock(
-            return_value="""
-                [bumpversion]
-                current_version = 0.10.1
-                commit = True
-                tag = True
-
-                [bumpversion:file:setup.py]
-
-                [bumpversion:file:dbt/version.py]
-            """)
+    @patch('dbt.version.requests.get')
+    def test_dbt_version_flag(self, mock_get, stderr):
+        mock_get.return_value.json.return_value = {'info': {'version': '0.10.1'}}
 
         with self.assertRaises(SystemExit) as exc:
             dbt.main.handle_and_check(['--version'])
         self.assertEqual(exc.exception.code, 0)
-


### PR DESCRIPTION
Fixes #1122 
Query the pypi api for latest version info instead of using github. This assumes that pypi behaves the way we think it does (using the latest non-prerelease version in the `info` field). I used `requests` since it's in requirements.txt anyway and is a lot more pleasant to use for things like this.