### PR TITLE
Remove operations [#1117]

### DIFF
--- a/dbt/adapters/postgres/impl.py
+++ b/dbt/adapters/postgres/impl.py
@@ -11,7 +11,7 @@ import agate
 from dbt.logger import GLOBAL_LOGGER as logger
 
 
-GET_RELATIONS_OPERATION_NAME = 'get_relations_data'
+GET_RELATIONS_MACRO_NAME = 'get_relations'
 
 
 class PostgresAdapter(SQLAdapter):
@@ -24,9 +24,9 @@ class PostgresAdapter(SQLAdapter):
     def _link_cached_relations(self, manifest):
         schemas = manifest.get_used_schemas()
         try:
-            table = self.run_operation(manifest, GET_RELATIONS_OPERATION_NAME)
+            table = self.execute_macro(manifest, GET_RELATIONS_MACRO_NAME)
         finally:
-            self.release_connection(GET_RELATIONS_OPERATION_NAME)
+            self.release_connection(GET_RELATIONS_MACRO_NAME)
         table = self._relations_filter_table(table, schemas)
 
         for (refed_schema, refed_name, dep_schema, dep_name) in table:

--- a/dbt/clients/jinja.py
+++ b/dbt/clients/jinja.py
@@ -92,10 +92,7 @@ def macro_generator(node):
             template = template_cache.get_node_template(node)
             module = template.make_module(context, False, context)
 
-            if node['resource_type'] == NodeType.Operation:
-                macro = module.__dict__[dbt.utils.get_dbt_operation_name(name)]
-            else:
-                macro = module.__dict__[dbt.utils.get_dbt_macro_name(name)]
+            macro = module.__dict__[dbt.utils.get_dbt_macro_name(name)]
             module.__dict__.update(context)
 
             try:
@@ -143,28 +140,6 @@ class MaterializationExtension(jinja2.ext.Extension):
             materialization_name, adapter_name)
 
         node.body = parser.parse_statements(('name:endmaterialization',),
-                                            drop_needle=True)
-
-        return node
-
-
-class OperationExtension(jinja2.ext.Extension):
-    tags = ['operation']
-
-    def parse(self, parser):
-        node = jinja2.nodes.Macro(lineno=next(parser.stream).lineno)
-        operation_name = \
-            parser.parse_assign_target(name_only=True).name
-
-        node.args = []
-        node.defaults = []
-
-        while parser.stream.skip_if('comma'):
-            target = parser.parse_assign_target(name_only=True)
-
-        node.name = dbt.utils.get_operation_macro_name(operation_name)
-
-        node.body = parser.parse_statements(('name:endoperation',),
                                             drop_needle=True)
 
         return node
@@ -253,7 +228,6 @@ def get_environment(node=None, capture_macros=False):
         args['undefined'] = create_macro_capture_env(node)
 
     args['extensions'].append(MaterializationExtension)
-    args['extensions'].append(OperationExtension)
     args['extensions'].append(DocumentationExtension)
 
     return MacroFuzzEnvironment(**args)

--- a/dbt/context/common.py
+++ b/dbt/context/common.py
@@ -380,22 +380,6 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "try_or_compiler_error": try_or_compiler_error(model)
     })
 
-    # Operations do not represent database relations, so there should be no
-    # 'this' variable in the context for operations. The Operation branch
-    # below should be removed in a future release. The fake relation below
-    # mirrors the historical implementation, without causing errors around
-    # the missing 'alias' attribute for operations
-    #
-    # https://github.com/fishtown-analytics/dbt/issues/878
-    if model.resource_type == NodeType.Operation:
-        this = db_wrapper.adapter.Relation.create(
-                schema=config.credentials.schema,
-                identifier=model.name
-        )
-    else:
-        this = get_this_relation(db_wrapper, config, model_dict)
-
-    context["this"] = this
     return context
 
 
@@ -418,9 +402,13 @@ def modify_generated_context(context, model, model_dict, config, manifest):
     return context
 
 
-def generate_operation_macro(model, config, manifest, provider):
-    """This is an ugly hack to support the fact that the `docs generate`
-    operation ends up in here, and macros are not nodes.
+def generate_execute_macro(model, config, manifest, provider):
+    """Internally, macros can be executed like nodes, with some restrictions:
+
+     - they don't have have all values available that nodes do:
+        - 'this', 'pre_hooks', 'post_hooks', and 'sql' are missing
+        - 'schema' does not use any 'model' information
+     - they can't be configured with config() directives
     """
     model_dict = model.serialize()
     context = generate_base(model, model_dict, config, manifest,
@@ -434,6 +422,10 @@ def generate_model(model, config, manifest, source_config, provider):
     model_dict = model.to_dict()
     context = generate_base(model, model_dict, config, manifest,
                             source_config, provider)
+    # operations (hooks) don't get a 'this'
+    if model.resource_type != NodeType.Operation:
+        this = get_this_relation(context['adapter'], config, model_dict)
+        context['this'] = this
     # overwrite schema if we have it, and hooks + sql
     context.update({
         'schema': model.get('schema', context['schema']),
@@ -454,7 +446,7 @@ def generate(model, config, manifest, source_config=None, provider=None):
         dbt.context.runtime.generate
     """
     if isinstance(model, ParsedMacro):
-        return generate_operation_macro(model, config, manifest, provider)
+        return generate_execute_macro(model, config, manifest, provider)
     else:
         return generate_model(model, config, manifest, source_config,
                               provider)

--- a/dbt/contracts/graph/manifest.py
+++ b/dbt/contracts/graph/manifest.py
@@ -256,13 +256,6 @@ class Manifest(APIObject):
                 return doc
         return None
 
-    def find_operation_by_name(self, name, package):
-        """Find a macro in the graph by its name and package name, or None for
-        any package.
-        """
-        return self._find_by_name(name, package, 'macros',
-                                  [NodeType.Operation])
-
     def find_macro_by_name(self, name, package):
         """Find a macro in the graph by its name and package name, or None for
         any package.

--- a/dbt/contracts/graph/parsed.py
+++ b/dbt/contracts/graph/parsed.py
@@ -405,7 +405,6 @@ PARSED_MACRO_CONTRACT = deep_merge(
             'resource_type': {
                 'enum': [
                     NodeType.Macro,
-                    NodeType.Operation,
                 ],
             },
             'unique_id': {

--- a/dbt/contracts/graph/unparsed.py
+++ b/dbt/contracts/graph/unparsed.py
@@ -62,9 +62,6 @@ UNPARSED_NODE_CONTRACT = deep_merge(
                     NodeType.Model,
                     NodeType.Test,
                     NodeType.Analysis,
-                    # Note: Hooks fail if you remove this, even though it's
-                    # also allowed in ParsedMacro, which seems wrong.
-                    # Maybe need to move hook operations into macros?
                     NodeType.Operation,
                     NodeType.Seed,
                     # we need this if parse_node is going to handle archives.

--- a/dbt/include/global_project/macros/operations/catalog/get_catalog.sql
+++ b/dbt/include/global_project/macros/operations/catalog/get_catalog.sql
@@ -1,4 +1,0 @@
-{% operation get_catalog_data %}
-    {% set catalog = dbt.get_catalog() %}
-    {{ return(catalog) }}
-{% endoperation %}

--- a/dbt/include/global_project/macros/operations/relations/get_relations.sql
+++ b/dbt/include/global_project/macros/operations/relations/get_relations.sql
@@ -1,4 +1,0 @@
-{% operation get_relations_data %}
-    {% set relations = dbt.get_relations() %}
-    {{ return(relations) }}
-{% endoperation %}

--- a/dbt/parser/base.py
+++ b/dbt/parser/base.py
@@ -82,13 +82,8 @@ class MacrosKnownParser(BaseParser):
             def get_schema(_):
                 return self.default_schema
         else:
-            # use the macro itself as the 'parsed node' to pass into
-            # parser.generate() to get a context.
-            macro_node = get_schema_macro.incorporate(
-                resource_type=NodeType.Operation
-            )
             root_context = dbt.context.parser.generate(
-                macro_node, self.root_project_config,
+                get_schema_macro, self.root_project_config,
                 self.macro_manifest, self.root_project_config
             )
             get_schema = get_schema_macro.generator(root_context)

--- a/dbt/parser/macros.py
+++ b/dbt/parser/macros.py
@@ -53,10 +53,6 @@ class MacroParser(BaseParser):
                 node_type = NodeType.Macro
                 name = macro_name.replace(dbt.utils.MACRO_PREFIX, '')
 
-            elif macro_name.startswith(dbt.utils.OPERATION_PREFIX):
-                node_type = NodeType.Operation
-                name = macro_name.replace(dbt.utils.OPERATION_PREFIX, '')
-
             if node_type != resource_type:
                 continue
 

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -151,16 +151,11 @@ def find_in_list_by_name(haystack, target_name, target_package, nodetype):
 
 
 MACRO_PREFIX = 'dbt_macro__'
-OPERATION_PREFIX = 'dbt_operation__'
 DOCS_PREFIX = 'dbt_docs__'
 
 
 def get_dbt_macro_name(name):
     return '{}{}'.format(MACRO_PREFIX, name)
-
-
-def get_dbt_operation_name(name):
-    return '{}{}'.format(OPERATION_PREFIX, name)
 
 
 def get_dbt_docs_name(name):
@@ -178,13 +173,6 @@ def get_materialization_macro_name(materialization_name, adapter_type=None,
         return get_dbt_macro_name(name)
     else:
         return name
-
-
-def get_operation_macro_name(operation_name, with_prefix=True):
-    if with_prefix:
-        return get_dbt_operation_name(operation_name)
-    else:
-        return operation_name
 
 
 def get_docs_macro_name(docs_name, with_prefix=True):

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -133,8 +133,8 @@ class TestPostgresAdapter(unittest.TestCase):
             port=5432,
             connect_timeout=10)
 
-    @mock.patch.object(PostgresAdapter, 'run_operation')
-    def test_get_catalog_various_schemas(self, mock_run):
+    @mock.patch.object(PostgresAdapter, 'execute_macro')
+    def test_get_catalog_various_schemas(self, mock_execute):
         column_names = ['table_schema', 'table_name']
         rows = [
             ('foo', 'bar'),
@@ -143,8 +143,8 @@ class TestPostgresAdapter(unittest.TestCase):
             ('quux', 'bar'),
             ('skip', 'bar')
         ]
-        mock_run.return_value = agate.Table(rows=rows,
-                                            column_names=column_names)
+        mock_execute.return_value = agate.Table(rows=rows,
+                                                column_names=column_names)
 
         mock_manifest = mock.MagicMock()
         mock_manifest.get_used_schemas.return_value = {'foo', 'quux'}


### PR DESCRIPTION
Fixes #1117 and re-implements #878 since this is planned for 0.13.0 anyway.
Remove operations on the jinja level, and replace them with `execute_macro`. Some context generation stuff had to be updated, but nothing of substance.