### PR TITLE
package dbt version compatibility (#581)

### DIFF
--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -24,7 +24,7 @@ ARCHIVE_CONFIG_CONTRACT = {
         'target_schema': {'type': 'string'},
         'tables': {
             'type': 'array',
-            'item': ARCHIVE_TABLE_CONFIG_CONTRACT,
+            'items': ARCHIVE_TABLE_CONFIG_CONTRACT,
         }
     },
     'required': ['source_schema', 'target_schema', 'tables'],
@@ -140,6 +140,11 @@ PROJECT_CONTRACT = {
             'type': 'object',
             'additionalProperties': True,
         },
+        # we validate the regex separately, using the pattern in dbt.semver
+        'require-dbt-version': {
+            'type': ['string', 'array'],
+            'items': {'type': 'string'},
+        },
     },
     'required': ['name', 'version'],
 }
@@ -174,7 +179,7 @@ GIT_PACKAGE_CONTRACT = {
         },
         'revision': {
             'type': ['string', 'array'],
-            'item': 'string',
+            'items': {'type': 'string'},
             'description': 'The git revision to use, if it is not tip',
         },
     },
@@ -220,10 +225,10 @@ REGISTRY_PACKAGE_CONTRACT = {
         },
         'version': {
             'type': ['string', 'array'],
-            'item': {
+            'items': {
                 'anyOf': [
                     VERSION_SPECIFICATION_CONTRACT,
-                    'string'
+                    {'type': 'string'}
                 ],
             },
             'description': 'The version of the package',

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -530,6 +530,14 @@ def parse_args(args):
             If specified, DBT will drop incremental models and
             fully-recalculate the incremental table from the model definition.
             """)
+        sub.add_argument(
+            '--no-version-check',
+            dest='version_check',
+            action='store_false',
+            help="""
+            If set, skip ensuring dbt's version matches the one specified in
+            the dbt_project.yml file ('require-dbt-version')
+            """)
 
     seed_sub = subs.add_parser(
         'seed',

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -152,7 +152,8 @@ class RegistryPackage(Package):
     def incorporate(self, other):
         return RegistryPackage(
             package=self.package,
-            version=self.version + other.version
+            version=[x.to_version_string() for x in
+                     self.version + other.version]
         )
 
     def _check_in_index(self):

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -209,11 +209,10 @@ def dependencies_for_path(config, module_path):
         try:
             yield config.new_project(full_obj)
         except dbt.exceptions.DbtProjectError as e:
-            logger.info(
-                "Error reading dependency project at {}".format(
-                    full_obj)
+            raise dbt.exceptions.DbtProjectError(
+                'Failed to read package at {}: {}'
+                .format(full_obj, e)
             )
-            logger.info(str(e))
 
 
 def dependency_projects(config):

--- a/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/local_dependency/dbt_project.yml
@@ -5,10 +5,12 @@ version: '1.0'
 profile: 'default'
 
 source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
+
+require-dbt-version: '>=0.1.0'
 
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -1,5 +1,10 @@
 from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest
+import mock
+
+import dbt.semver
+import dbt.config
+import dbt.exceptions
 
 class TestSimpleDependency(DBTIntegrationTest):
 
@@ -41,7 +46,6 @@ class TestSimpleDependency(DBTIntegrationTest):
         )
 
 
-
 class TestSimpleDependencyWithSchema(TestSimpleDependency):
     @property
     def project_config(self):
@@ -57,3 +61,20 @@ class TestSimpleDependencyWithSchema(TestSimpleDependency):
 
     def configured_schema(self):
         return 'configured_{}_macro'.format(self.unique_schema())
+
+    @attr(type='postgres')
+    @mock.patch('dbt.config.get_installed_version')
+    def test_postgres_local_dependency_out_of_date(self, mock_get):
+        mock_get.return_value = dbt.semver.VersionSpecifier.from_version_string('0.0.1')
+        self.run_dbt(['deps'])
+        with self.assertRaises(dbt.exceptions.DbtProjectError) as e:
+            self.run_dbt(['run'])
+            self.assertIn('--no-version-check', str(e.exception))
+
+    @attr(type='postgres')
+    @mock.patch('dbt.config.get_installed_version')
+    def test_postgres_local_dependency_out_of_date_no_check(self, mock_get):
+        mock_get.return_value = dbt.semver.VersionSpecifier.from_version_string('0.0.1')
+        self.run_dbt(['deps'])
+        results = self.run_dbt(['run', '--no-version-check'])
+        self.assertEqual(len(results), 3)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -14,6 +14,7 @@ import dbt.exceptions
 from dbt.adapters.postgres import PostgresCredentials
 from dbt.adapters.redshift import RedshiftCredentials
 from dbt.contracts.project import PackageConfig
+from dbt.semver import VersionSpecifier
 
 
 @contextmanager
@@ -64,7 +65,8 @@ model_fqns = frozenset((
 
 
 class Args(object):
-    def __init__(self, profiles_dir=None, threads=None, profile=None, cli_vars=None):
+    def __init__(self, profiles_dir=None, threads=None, profile=None,
+                 cli_vars=None, version_check=None):
         self.profile = profile
         if threads is not None:
             self.threads = threads
@@ -72,6 +74,8 @@ class Args(object):
             self.profiles_dir = profiles_dir
         if cli_vars is not None:
             self.vars = cli_vars
+        if version_check is not None:
+            self.version_check = version_check
 
 
 class BaseConfigTest(unittest.TestCase):
@@ -143,7 +147,8 @@ class BaseConfigTest(unittest.TestCase):
                 'target': 'other-postgres',
             }
         }
-        self.args = Args(profiles_dir=self.profiles_dir, cli_vars='{}')
+        self.args = Args(profiles_dir=self.profiles_dir, cli_vars='{}',
+                         version_check=True)
         self.env_override = {
             'env_value_type': 'postgres',
             'env_value_host': 'env-postgres-host',
@@ -534,6 +539,8 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.on_run_end, [])
         self.assertEqual(project.archive, [])
         self.assertEqual(project.seeds, {})
+        self.assertEqual(project.dbt_version,
+                         [VersionSpecifier.from_version_string('>=0.0.0')])
         self.assertEqual(project.packages, PackageConfig(packages=[]))
         # just make sure str() doesn't crash anything, that's always
         # embarrassing
@@ -617,7 +624,7 @@ class TestProject(BaseConfigTest):
                     'tables': [
                         {
                             'source_table': 'my_table',
-                            'target_Table': 'my_table_archived',
+                            'target_table': 'my_table_archived',
                             'updated_at': 'updated_at_field',
                             'unique_key': 'table_id',
                         },
@@ -631,6 +638,7 @@ class TestProject(BaseConfigTest):
                     'post-hook': 'grant select on {{ this }} to bi_user',
                 },
             },
+            'require-dbt-version': '>=0.1.0',
         })
         packages = {
             'packages': [
@@ -689,7 +697,7 @@ class TestProject(BaseConfigTest):
             'tables': [
                 {
                     'source_table': 'my_table',
-                    'target_Table': 'my_table_archived',
+                    'target_table': 'my_table_archived',
                     'updated_at': 'updated_at_field',
                     'unique_key': 'table_id',
                 },
@@ -702,6 +710,8 @@ class TestProject(BaseConfigTest):
                 'post-hook': 'grant select on {{ this }} to bi_user',
             },
         })
+        self.assertEqual(project.dbt_version,
+                         [VersionSpecifier.from_version_string('>=0.1.0')])
         self.assertEqual(project.packages, PackageConfig(packages=[
             {
                 'local': 'foo',
@@ -743,6 +753,16 @@ class TestProject(BaseConfigTest):
             dbt.config.Project.from_project_root(self.project_dir, {})
 
         self.assertIn('no dbt_project.yml', str(exc.exception))
+
+    def test_invalid_version(self):
+        self.default_project_data['require-dbt-version'] = 'hello!'
+        with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:
+            dbt.config.Project.from_project_config(self.default_project_data)
+
+    def test_unsupported_version(self):
+        self.default_project_data['require-dbt-version'] = '>99999.0.0'
+        # allowed, because the RuntimeConfig checks, not the Project itself
+        dbt.config.Project.from_project_config(self.default_project_data)
 
     def test__no_unused_resource_config_paths(self):
         self.default_project_data.update({
@@ -885,7 +905,6 @@ class TestProjectWithConfigs(BaseConfigTest):
         self.assertEqual(len(unused), 0)
 
 
-
 class TestProjectFile(BaseFileTest):
     def setUp(self):
         super(TestProjectFile, self).setUp()
@@ -946,10 +965,21 @@ class TestRuntimeConfig(BaseConfigTest):
             self.default_profile_data, self.default_project_data['profile'], {}
         )
 
+    def from_parts(self, exc=None):
+        project = self.get_project()
+        profile = self.get_profile()
+        if exc is None:
+            return dbt.config.RuntimeConfig.from_parts(project, profile, self.args)
+
+        with self.assertRaises(exc) as raised:
+            err = raised
+            dbt.config.RuntimeConfig.from_parts(project, profile, self.args)
+        return err
+
     def test_from_parts(self):
         project = self.get_project()
         profile = self.get_profile()
-        config = dbt.config.RuntimeConfig.from_parts(project, profile, {})
+        config = dbt.config.RuntimeConfig.from_parts(project, profile, self.args)
 
         self.assertEqual(config.cli_vars, {})
         self.assertEqual(config.to_profile_info(), profile.to_profile_info())
@@ -981,6 +1011,44 @@ class TestRuntimeConfig(BaseConfigTest):
         profile.config.use_colors = None
         with self.assertRaises(dbt.exceptions.DbtProjectError):
             dbt.config.RuntimeConfig.from_parts(project, profile, {})
+
+    def test_supported_version(self):
+        self.default_project_data['require-dbt-version'] = '>0.0.0'
+        conf = self.from_parts()
+        self.assertEqual(set(x.to_version_string() for x in conf.dbt_version), {'>0.0.0'})
+
+    def test_unsupported_version(self):
+        self.default_project_data['require-dbt-version'] = '>99999.0.0'
+        raised = self.from_parts(dbt.exceptions.DbtProjectError)
+        self.assertIn('This version of dbt is not supported', str(raised.exception))
+
+    def test_unsupported_version_no_check(self):
+        self.default_project_data['require-dbt-version'] = '>99999.0.0'
+        self.args.version_check = False
+        conf = self.from_parts()
+        self.assertEqual(set(x.to_version_string() for x in conf.dbt_version), {'>99999.0.0'})
+
+    def test_supported_version_range(self):
+        self.default_project_data['require-dbt-version'] = ['>0.0.0', '<=99999.0.0']
+        conf = self.from_parts()
+        self.assertEqual(set(x.to_version_string() for x in conf.dbt_version), {'>0.0.0', '<=99999.0.0'})
+
+    def test_unsupported_version_range(self):
+        self.default_project_data['require-dbt-version'] = ['>0.0.0', '<=0.0.1']
+        raised = self.from_parts(dbt.exceptions.DbtProjectError)
+        self.assertIn('This version of dbt is not supported', str(raised.exception))
+
+    def test_unsupported_version_range_no_check(self):
+        self.default_project_data['require-dbt-version'] = ['>0.0.0', '<=0.0.1']
+        self.args.version_check = False
+        conf = self.from_parts()
+        self.assertEqual(set(x.to_version_string() for x in conf.dbt_version), {'>0.0.0', '<=0.0.1'})
+
+    def test_impossible_version_range(self):
+        self.default_project_data['require-dbt-version'] = ['>99999.0.0', '<=0.0.1']
+        raised = self.from_parts(dbt.exceptions.DbtProjectError)
+        self.assertIn('The package version requirement can never be satisfied', str(raised.exception))
+
 
 
 class TestRuntimeConfigFiles(BaseFileTest):


### PR DESCRIPTION
Fixes #581

Implements the `require-dbt-version` config item described there. I switched underscores for hyphens to be consistent with the other config items.

The `--no-version-check` flag is only implemented for `compile`, `run`, and `docs generate`. Other commands will never do version checks at all if they end up loading RuntimeConfigs (maybe they should).

Failures in loading packages in the modules directory cause dbt to fail, even if they aren't used. This is kind of a breaking change, as dbt previously logged those errors, ignored the packages, and continued.