### PR TITLE
Add support for Snowflake SSO authentication

### DIFF
--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -76,17 +76,18 @@ class SnowflakeAdapter(PostgresAdapter):
 
         try:
             credentials = connection.credentials
+            # Pull all of the optional authentication args for the connector, let connector handle the actual arg validation 
+            auth_args = { auth_key:credentials[auth_key] for auth_key in ['user', 'password', 'authenticator'] if auth_key in credentials}
             handle = snowflake.connector.connect(
                 account=credentials.account,
-                user=credentials.user,
-                password=credentials.password,
                 database=credentials.database,
                 schema=credentials.schema,
                 warehouse=credentials.warehouse,
                 role=credentials.get('role', None),
                 autocommit=False,
                 client_session_keep_alive=credentials.get(
-                    'client_session_keep_alive', False)
+                    'client_session_keep_alive', False),
+                **auth_args
             )
 
             connection.handle = handle

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -76,8 +76,11 @@ class SnowflakeAdapter(PostgresAdapter):
 
         try:
             credentials = connection.credentials
-            # Pull all of the optional authentication args for the connector, let connector handle the actual arg validation 
-            auth_args = { auth_key:credentials[auth_key] for auth_key in ['user', 'password', 'authenticator'] if auth_key in credentials}
+            # Pull all of the optional authentication args for the connector,
+            # let connector handle the actual arg validation
+            auth_args = {auth_key: credentials[auth_key]
+                         for auth_key in ['user', 'password', 'authenticator']
+                         if auth_key in credentials}
             handle = snowflake.connector.connect(
                 account=credentials.account,
                 database=credentials.database,

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -89,6 +89,12 @@ SNOWFLAKE_CREDENTIALS_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,
     'properties': {
+         'method': {
+            'enum': ['database', 'oauth', 'oauth_externalbrowser'],
+            'description': (
+                'database: use user/pass creds; oauth use oauth user/pass creds; oauth_externalbrowser no pass required'
+            ),
+        },
         'account': {
             'type': 'string',
         },
@@ -97,6 +103,9 @@ SNOWFLAKE_CREDENTIALS_CONTRACT = {
         },
         'password': {
             'type': 'string',
+        },
+        'authenticator': {
+            'type': 'string'
         },
         'database': {
             'type': 'string',
@@ -114,7 +123,7 @@ SNOWFLAKE_CREDENTIALS_CONTRACT = {
             'type': 'boolean',
         }
     },
-    'required': ['account', 'user', 'password', 'database', 'schema'],
+    'required': ['account', 'user', 'database', 'schema'],
 }
 
 BIGQUERY_CREDENTIALS_CONTRACT = {

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -89,12 +89,6 @@ SNOWFLAKE_CREDENTIALS_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,
     'properties': {
-         'method': {
-            'enum': ['database', 'oauth', 'oauth_externalbrowser'],
-            'description': (
-                'database: use user/pass creds; oauth use oauth user/pass creds; oauth_externalbrowser no pass required'
-            ),
-        },
         'account': {
             'type': 'string',
         },
@@ -105,7 +99,8 @@ SNOWFLAKE_CREDENTIALS_CONTRACT = {
             'type': 'string',
         },
         'authenticator': {
-            'type': 'string'
+            'type': 'string',
+            'description': "Either 'externalbrowser', or a valid Okta url"
         },
         'database': {
             'type': 'string',

--- a/sample.profiles.yml
+++ b/sample.profiles.yml
@@ -37,13 +37,43 @@ config:
 #
 #   [profile-name]:
 #     outputs:
-#       [target-name]:
+#       # 1. Use snowflake user/pass
+#       [target-name-1]:
 #         type: snowflake
 #         threads: [1 - 8]
 #         account: [url prefix for your snowflake connection]
 #
 #         user: [user]
 #         password: [password]
+#         role: [optional, the snowflake role you want to use]
+#
+#         database: [db name]
+#         warehouse: [warehouse]
+#         schema: [schema name]
+#
+#       # 2. Use Okta user/pass
+#       [target-name-2]:
+#         type: snowflake
+#         threads: [1 - 8]
+#         account: [url prefix for your snowflake connection]
+#           
+#         authenticator: 'https://<okta_accout_name>.okta.com/'
+#         user: [okta_user]
+#         password: [okta_password]
+#         role: [optional, the snowflake role you want to use]
+#
+#         database: [db name]
+#         warehouse: [warehouse]
+#         schema: [schema name]
+#
+#       # 3. Use externalbrowser, no password required
+#       [target-name-3]:
+#         type: snowflake
+#         threads: [1 - 8]
+#         account: [url prefix for your snowflake connection]
+#           
+#         authenticator: 'externalbrowser'
+#         user: [sso_user]
 #         role: [optional, the snowflake role you want to use]
 #
 #         database: [db name]

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -21,7 +21,6 @@ class TestSnowflakeAdapter(unittest.TestCase):
                     'type': 'snowflake',
                     'account': 'test_account',
                     'user': 'test_user',
-                    'password': 'test_password',
                     'database': 'test_databse',
                     'warehouse': 'test_warehouse',
                     'schema': 'public',
@@ -100,8 +99,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
             mock.call(
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_databse',
-                password='test_password', role=None, schema='public',
-                user='test_user', warehouse='test_warehouse')
+                role=None, schema='public', user='test_user', 
+                warehouse='test_warehouse')
         ])
 
     def test_client_session_keep_alive_true(self):
@@ -113,7 +112,49 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
-                client_session_keep_alive=True, database='test_databse',
+                client_session_keep_alive=True, database='test_databse', 
+                role=None, schema='public', user='test_user', 
+                warehouse='test_warehouse')
+        ])
+
+
+    def test_user_pass_authentication(self):
+        self.config.credentials = self.config.credentials.incorporate(
+            password='test_password')
+        self.adapter = SnowflakeAdapter(self.config)
+        self.adapter.get_connection(name='new_connection_with_new_config')
+
+        self.snowflake.assert_has_calls([
+            mock.call(
+                account='test_account', autocommit=False,
+                client_session_keep_alive=False, database='test_databse',
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse')
+        ])
+
+    def test_authenticator_user_pass_authentication(self):
+        self.config.credentials = self.config.credentials.incorporate(
+            password='test_password', authenticator='test_sso_url')
+        self.adapter = SnowflakeAdapter(self.config)
+        self.adapter.get_connection(name='new_connection_with_new_config')
+
+        self.snowflake.assert_has_calls([
+            mock.call(
+                account='test_account', autocommit=False,
+                client_session_keep_alive=False, database='test_databse',
+                password='test_password', role=None, schema='public',
+                user='test_user', warehouse='test_warehouse',
+                authenticator='test_sso_url')
+        ])
+    def test_authenticator_externalbrowser_authentication(self):
+        self.config.credentials = self.config.credentials.incorporate(authenticator='externalbrowser')
+        self.adapter = SnowflakeAdapter(self.config)
+        self.adapter.get_connection(name='new_connection_with_new_config')
+
+        self.snowflake.assert_has_calls([
+            mock.call(
+                account='test_account', autocommit=False,
+                client_session_keep_alive=False, database='test_databse',
+                role=None, schema='public', user='test_user', 
+                warehouse='test_warehouse', authenticator='externalbrowser')
         ])

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -11,6 +11,7 @@ from snowflake import connector as snowflake_connector
 
 from .utils import config_from_parts_or_dicts
 
+
 class TestSnowflakeAdapter(unittest.TestCase):
     def setUp(self):
         flags.STRICT_MODE = False
@@ -41,10 +42,12 @@ class TestSnowflakeAdapter(unittest.TestCase):
         }
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
 
-        self.handle = mock.MagicMock(spec=snowflake_connector.SnowflakeConnection)
+        self.handle = mock.MagicMock(
+            spec=snowflake_connector.SnowflakeConnection)
         self.cursor = self.handle.cursor.return_value
         self.mock_execute = self.cursor.execute
-        self.patcher = mock.patch('dbt.adapters.snowflake.impl.snowflake.connector.connect')
+        self.patcher = mock.patch(
+            'dbt.adapters.snowflake.impl.snowflake.connector.connect')
         self.snowflake = self.patcher.start()
 
         self.snowflake.return_value = self.handle
@@ -72,7 +75,9 @@ class TestSnowflakeAdapter(unittest.TestCase):
             relation_type='table'
         )
         self.mock_execute.assert_has_calls([
-            mock.call('drop table if exists "test_schema".test_table cascade', None)
+            mock.call(
+                'drop table if exists "test_schema".test_table cascade',
+                None)
         ])
 
     def test_quoting_on_truncate(self):
@@ -91,7 +96,9 @@ class TestSnowflakeAdapter(unittest.TestCase):
             to_name='table_b'
         )
         self.mock_execute.assert_has_calls([
-            mock.call('alter table "test_schema".table_a rename to table_b', None)
+            mock.call(
+                'alter table "test_schema".table_a rename to table_b',
+                None)
         ])
 
     def test_client_session_keep_alive_false_by_default(self):
@@ -99,7 +106,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
             mock.call(
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_databse',
-                role=None, schema='public', user='test_user', 
+                role=None, schema='public', user='test_user',
                 warehouse='test_warehouse')
         ])
 
@@ -112,11 +119,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
-                client_session_keep_alive=True, database='test_databse', 
-                role=None, schema='public', user='test_user', 
+                client_session_keep_alive=True, database='test_databse',
+                role=None, schema='public', user='test_user',
                 warehouse='test_warehouse')
         ])
-
 
     def test_user_pass_authentication(self):
         self.config.credentials = self.config.credentials.incorporate(
@@ -146,8 +152,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 user='test_user', warehouse='test_warehouse',
                 authenticator='test_sso_url')
         ])
+
     def test_authenticator_externalbrowser_authentication(self):
-        self.config.credentials = self.config.credentials.incorporate(authenticator='externalbrowser')
+        self.config.credentials = self.config.credentials.incorporate(
+            authenticator='externalbrowser')
         self.adapter = SnowflakeAdapter(self.config)
         self.adapter.get_connection(name='new_connection_with_new_config')
 
@@ -155,6 +163,6 @@ class TestSnowflakeAdapter(unittest.TestCase):
             mock.call(
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_databse',
-                role=None, schema='public', user='test_user', 
+                role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='externalbrowser')
         ])


### PR DESCRIPTION
Feature request https://github.com/fishtown-analytics/dbt/issues/1172 - adds support for SSO authentication through the Snowflake Python connector, more details in the issue. I updated the Snowflake connection contract to add an 'authenticator' field, then just updated the Snowflake adapter to pass in whatever combo of authentication args was specified to the connector. Validation of the actual args is left up to the connector itself, which gives good error messages when they're invalid.

Unit tests verify everything's getting passed through correctly, and I manually tested that I can authenticate through both the 'externalbrowser' and Okta authenticator. 

I did remove 'password' from the required fields in the Snowflake contract, but the error message returned by Snowflake when you forget it is pretty good:

`ERROR: Database Error`
  `251006: None: Password is empty`

