### PR TITLE
make tracking use the profile directory, and suppress errors (#1180)

### DIFF
--- a/dbt/config.py
+++ b/dbt/config.py
@@ -86,22 +86,6 @@ def read_profiles(profiles_dir=None):
     return profiles
 
 
-def read_config(profiles_dir):
-    profile = read_profile(profiles_dir)
-    if profile is None:
-        return {}
-    else:
-        return profile.get('config', {})
-
-
-def send_anonymous_usage_stats(config):
-    return config.get('send_anonymous_usage_stats', True)
-
-
-def colorize_output(config):
-    return config.get('use_colors', True)
-
-
 class ConfigRenderer(object):
     """A renderer provides configuration rendering for a given set of cli
     variables and a render type.

--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -284,6 +284,20 @@ class PackageConfig(APIObject):
     SCHEMA = PACKAGE_FILE_CONTRACT
 
 
+USER_CONFIG_CONTRACT = {
+    'type': 'object',
+    'additionalProperties': True,
+    'properties': {
+        'send_anonymous_usage_stats': {
+            'type': 'boolean',
+        },
+        'use_colors': {
+            'type': 'boolean',
+        },
+    },
+}
+
+
 PROFILE_INFO_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,
@@ -294,12 +308,7 @@ PROFILE_INFO_CONTRACT = {
         'target_name': {
             'type': 'string',
         },
-        'send_anonymous_usage_stats': {
-            'type': 'boolean',
-        },
-        'use_colors': {
-            'type': 'boolean',
-        },
+        'config': USER_CONFIG_CONTRACT,
         'threads': {
             'type': 'number',
         },
@@ -313,8 +322,7 @@ PROFILE_INFO_CONTRACT = {
         },
     },
     'required': [
-        'profile_name', 'target_name', 'send_anonymous_usage_stats',
-        'use_colors', 'threads', 'credentials'
+        'profile_name', 'target_name', 'config', 'threads', 'credentials'
     ],
 }
 

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -28,9 +28,9 @@ import dbt.deprecations
 import dbt.profiler
 
 from dbt.utils import ExitCodes
-from dbt.config import Project, Profile, RuntimeConfig, PROFILES_DIR, \
+from dbt.config import Project, UserConfig, RuntimeConfig, PROFILES_DIR, \
     read_profiles
-from dbt.exceptions import DbtProfileError, DbtProfileError, RuntimeException
+from dbt.exceptions import DbtProjectError, DbtProfileError, RuntimeException
 
 
 PROFILES_HELP_MESSAGE = """
@@ -118,16 +118,16 @@ def initialize_config_values(parsed):
     easy.
     """
     try:
-        profile = Profile.from_args(parsed)
+        cfg = UserConfig.from_directory(parsed.profiles_dir)
     except RuntimeException:
-        profile = None
+        cfg = UserConfig.from_dict(None)
 
-    if profile is None or profile.send_anonymous_usage_stats:
+    if cfg.send_anonymous_usage_stats:
         dbt.tracking.initialize_tracking(parsed.profiles_dir)
     else:
         dbt.tracking.do_not_track()
 
-    if profile is None or profile.use_colors:
+    if cfg.use_colors:
         dbt.ui.printer.use_colors()
 
 

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -42,6 +42,7 @@ class TestArgs(object):
     def __init__(self, kwargs):
         self.which = 'run'
         self.single_threaded = False
+        self.profiles_dir = DBT_CONFIG_DIR
         self.__dict__.update(kwargs)
 
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -209,8 +209,8 @@ class TestProfile(BaseConfigTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'postgres')
         self.assertEqual(profile.threads, 7)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertTrue(isinstance(profile.credentials, PostgresCredentials))
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'postgres-db-hostname')
@@ -228,8 +228,8 @@ class TestProfile(BaseConfigTest):
         profile = self.from_raw_profiles()
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'postgres')
-        self.assertFalse(profile.send_anonymous_usage_stats)
-        self.assertFalse(profile.use_colors)
+        self.assertFalse(profile.config.send_anonymous_usage_stats)
+        self.assertFalse(profile.config.use_colors)
 
     def test_partial_config_override(self):
         self.default_profile_data['config'] = {
@@ -238,8 +238,8 @@ class TestProfile(BaseConfigTest):
         profile = self.from_raw_profiles()
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'postgres')
-        self.assertFalse(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertFalse(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
 
     def test_missing_type(self):
         del self.default_profile_data['default']['outputs']['postgres']['type']
@@ -364,8 +364,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'postgres')
         self.assertEqual(profile.threads, 7)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertTrue(isinstance(profile.credentials, PostgresCredentials))
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'postgres-db-hostname')
@@ -389,8 +389,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'other')
         self.assertEqual(profile.target_name, 'other-postgres')
         self.assertEqual(profile.threads, 3)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertTrue(isinstance(profile.credentials, PostgresCredentials))
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'other-postgres-db-hostname')
@@ -411,8 +411,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'redshift')
         self.assertEqual(profile.threads, 1)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertTrue(isinstance(profile.credentials, RedshiftCredentials))
         self.assertEqual(profile.credentials.type, 'redshift')
         self.assertEqual(profile.credentials.host, 'redshift-db-hostname')
@@ -434,8 +434,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'with-vars')
         self.assertEqual(profile.threads, 1)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'env-postgres-host')
         self.assertEqual(profile.credentials.port, 6543)
@@ -456,8 +456,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'with-vars')
         self.assertEqual(profile.threads, 1)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'env-postgres-host')
         self.assertEqual(profile.credentials.port, 6543)
@@ -487,8 +487,8 @@ class TestProfileFile(BaseFileTest):
         self.assertEqual(profile.profile_name, 'default')
         self.assertEqual(profile.target_name, 'cli-and-env-vars')
         self.assertEqual(profile.threads, 1)
-        self.assertTrue(profile.send_anonymous_usage_stats)
-        self.assertTrue(profile.use_colors)
+        self.assertTrue(profile.config.send_anonymous_usage_stats)
+        self.assertTrue(profile.config.use_colors)
         self.assertEqual(profile.credentials.type, 'postgres')
         self.assertEqual(profile.credentials.host, 'cli-postgres-host')
         self.assertEqual(profile.credentials.port, 6543)
@@ -978,7 +978,7 @@ class TestRuntimeConfig(BaseConfigTest):
         project = self.get_project()
         profile = self.get_profile()
         # invalid - must be boolean
-        profile.use_colors = None
+        profile.config.use_colors = None
         with self.assertRaises(dbt.exceptions.DbtProjectError):
             dbt.config.RuntimeConfig.from_parts(project, profile, {})
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -62,60 +62,6 @@ model_fqns = frozenset((
 ))
 
 
-class ConfigTest(unittest.TestCase):
-    def setUp(self):
-        self.base_dir = tempfile.mkdtemp()
-        self.profiles_path = os.path.join(self.base_dir, 'profiles.yml')
-
-    def set_up_empty_config(self):
-        with open(self.profiles_path, 'w') as f:
-            f.write(yaml.dump({}))
-
-    def set_up_config_options(self, **kwargs):
-        config = {
-            'config': kwargs
-        }
-
-        with open(self.profiles_path, 'w') as f:
-            f.write(yaml.dump(config))
-
-    def tearDown(self):
-        try:
-            shutil.rmtree(self.base_dir)
-        except:
-            pass
-
-    def test__implicit_opt_in(self):
-        self.set_up_empty_config()
-        config = dbt.config.read_config(self.base_dir)
-        self.assertTrue(dbt.config.send_anonymous_usage_stats(config))
-
-    def test__explicit_opt_out(self):
-        self.set_up_config_options(send_anonymous_usage_stats=False)
-        config = dbt.config.read_config(self.base_dir)
-        self.assertFalse(dbt.config.send_anonymous_usage_stats(config))
-
-    def test__explicit_opt_in(self):
-        self.set_up_config_options(send_anonymous_usage_stats=True)
-        config = dbt.config.read_config(self.base_dir)
-        self.assertTrue(dbt.config.send_anonymous_usage_stats(config))
-
-    def test__implicit_colors(self):
-        self.set_up_empty_config()
-        config = dbt.config.read_config(self.base_dir)
-        self.assertTrue(dbt.config.colorize_output(config))
-
-    def test__explicit_opt_out(self):
-        self.set_up_config_options(use_colors=False)
-        config = dbt.config.read_config(self.base_dir)
-        self.assertFalse(dbt.config.colorize_output(config))
-
-    def test__explicit_opt_in(self):
-        self.set_up_config_options(use_colors=True)
-        config = dbt.config.read_config(self.base_dir)
-        self.assertTrue(dbt.config.colorize_output(config))
-
-
 class Args(object):
     def __init__(self, profiles_dir=None, threads=None, profile=None, cli_vars=None):
         self.profile = profile

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -1,0 +1,108 @@
+import os
+import tempfile
+import unittest
+
+import mock
+import yaml
+
+from dbt import main
+import dbt.tracking
+import dbt.ui.printer
+
+
+class FakeArgs(object):
+    def __init__(self, profiles_dir):
+        self.profiles_dir = profiles_dir
+        self.profile = 'test'
+
+
+@mock.patch('dbt.ui.printer.use_colors')
+@mock.patch('dbt.tracking.do_not_track')
+@mock.patch('dbt.tracking.initialize_tracking')
+class TestInitializeConfig(unittest.TestCase):
+    def setUp(self):
+        self.base_dir = tempfile.mkdtemp()
+        self.profiles_path = os.path.join(self.base_dir, 'profiles.yml')
+        self.args = FakeArgs(self.base_dir)
+
+    def _base_config(self):
+        return {
+            'test': {
+                'outputs': {
+                    'default': {
+                        'type': 'postgres',
+                        'host': 'test',
+                        'port': 5555,
+                        'user': 'db_user',
+                        'pass': 'db_pass',
+                        'dbname': 'dbname',
+                        'schema': 'schema',
+                        },
+                },
+                'target': 'default',
+            }
+        }
+
+    def set_up_empty_config(self):
+        with open(self.profiles_path, 'w') as f:
+            f.write(yaml.dump(self._base_config()))
+
+    def set_up_config_options(self, **kwargs):
+        config = self._base_config()
+        config.update(config=kwargs)
+
+        with open(self.profiles_path, 'w') as f:
+            f.write(yaml.dump(config))
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.base_dir)
+        except:
+            pass
+
+    def test__implicit_missing(self, initialize_tracking, do_not_track, use_colors):
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_called_once_with(self.base_dir)
+        do_not_track.assert_not_called()
+        use_colors.assert_called_once_with()
+
+    def test__implicit_opt_in_colors(self, initialize_tracking, do_not_track, use_colors):
+        self.set_up_empty_config()
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_called_once_with(self.base_dir)
+        do_not_track.assert_not_called()
+        use_colors.assert_called_once_with()
+
+    def test__explicit_opt_out(self, initialize_tracking, do_not_track, use_colors):
+        self.set_up_config_options(send_anonymous_usage_stats=False)
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_not_called()
+        do_not_track.assert_called_once_with()
+        use_colors.assert_called_once_with()
+
+    def test__explicit_opt_in(self, initialize_tracking, do_not_track, use_colors):
+        self.set_up_config_options(send_anonymous_usage_stats=True)
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_called_once_with(self.base_dir)
+        do_not_track.assert_not_called()
+        use_colors.assert_called_once_with()
+
+    def test__explicit_no_colors(self, initialize_tracking, do_not_track, use_colors):
+        self.set_up_config_options(use_colors=False)
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_called_once_with(self.base_dir)
+        do_not_track.assert_not_called()
+        use_colors.assert_not_called()
+
+    def test__explicit_opt_in(self, initialize_tracking, do_not_track, use_colors):
+        self.set_up_config_options(use_colors=True)
+        main.initialize_config_values(self.args)
+
+        initialize_tracking.assert_called_once_with(self.base_dir)
+        do_not_track.assert_not_called()
+        use_colors.assert_called_once_with()


### PR DESCRIPTION
Fixes #1180 

I wanted to make the tracking code use the profile we were going to end up loading later, but our initialization is pretty complicated with various subcommands needing profile/project/both/neither getting those initialized at various times, to the point where it would have been a very large change.

We do need to consider someday about how we want to handle this global state around tracking. I think it should be tied into the Profile object somehow, but that's a lot of refactoring to do, and I want this to get into grace-kelly.