### PR TITLE
Add ipdb to dev requirements so it shows up in test docker containers

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,3 +6,4 @@ pytz==2017.2
 bumpversion==0.5.3
 coverage==4.2
 tox==2.5.0
+ipdb


### PR DESCRIPTION
Since I end up manually editing my dev_requirements.txt to add this line every time I switch branches as it is, let's just put it in permanently. Getting dependencies into the tests' tox environments is a huge hassle and this makes debugging unit/integration test failures so much more pleasant. I left the version unspecified because we don't actually use this dependency, it's purely about developer quality of life.