### PR TITLE
Ensure character columns are treated as string types.

### DIFF
--- a/dbt/schema.py
+++ b/dbt/schema.py
@@ -45,7 +45,7 @@ class Column(object):
             return self.dtype
 
     def is_string(self):
-        return self.dtype.lower() in ['text', 'character varying']
+        return self.dtype.lower() in ['text', 'character varying', 'character']
 
     def is_numeric(self):
         return self.dtype.lower() in ['numeric', 'number']

--- a/test/unit/test_schema.py
+++ b/test/unit/test_schema.py
@@ -2,6 +2,17 @@ import unittest
 
 import dbt.schema
 
+class TestStringType(unittest.TestCase):
+
+    def test__character_type(self):
+        col = dbt.schema.Column(
+            'fieldname',
+            'character',
+            char_size=10
+        )
+
+        self.assertEqual(col.data_type, 'character varying(10)')
+
 
 class TestNumericType(unittest.TestCase):
 


### PR DESCRIPTION
Closes #1194

I was playing around with `dbt archive` and hit the following failure:

```
2018-12-18 21:44:14,545 (Thread-1): Postgres error: Value too long for character type
DETAIL:  
  -----------------------------------------------
  error:  Value too long for character type
  code:      8001
  context:   Value too long for type character(1)
  query:     2816593
  location:  funcs_string.hpp:286
  process:   query3_106_2816593 [pid=13606]
  -----------------------------------------------
```

Tracking this down with debug mode, the column `redacted_uuid char(36),` in the original table definition (Redshift) was getting recreated as `"redacted_uuid" character,` in the dbt archive table.

Researching this lead me to `schema.py` where `character` columns are not interpreted as string types, therefore no size character length information is used when generating the create table statement.

To note, the query to generate columns for dbt returns the following info from my redshift table:

|column_name|data_type|character_maximum_length|numeric_size|
|---------------|---------|--||
|redacted_uuiid|character|36||	

I don't know the implications of this change on other databases or functionality but it seems functionally more accurate. Also, I'm fine for the resulting column to be `character varying(size)` as the `character` column is generated from an ETL tool so it's a pain to change, which would have been my first quick fix.

Happy to adjust or change based on feedback - just throwing this up since it seemed like a valuable quick fix.