### PR TITLE
Postgresql dependency query speedup

### DIFF
--- a/dbt/include/global_project/macros/relations/postgres_relations.sql
+++ b/dbt/include/global_project/macros/relations/postgres_relations.sql
@@ -4,7 +4,7 @@
     -- in pg_depend, objid is the dependent, refobjid is the referenced object
     -- "a pg_depend entry indicates that the referenced object cannot be dropped without also dropping the dependent object."
     -- #}
-    with relation as (
+with relation as (
         select
             pg_rewrite.ev_class as class,
             pg_rewrite.oid as id
@@ -31,21 +31,29 @@
         from pg_namespace
         where nspname != 'information_schema' and nspname not like 'pg_%'
     ),
-    relationships as (
+    referenced as (
         select
-            referenced_class.name as referenced_name,
-            referenced_class.schema as referenced_schema_id,
-            dependent_class.name as dependent_name,
-            dependent_class.schema as dependent_schema_id,
-            referenced_class.kind as kind
+            relation.id AS id,
+            referenced_class.name ,
+            referenced_class.schema ,
+            referenced_class.kind
         from relation
         join class as referenced_class on relation.class=referenced_class.id
-        join dependency on relation.id=dependency.id
+        where referenced_class.kind in ('r', 'v') 
+    ),
+    relationships as (
+        select
+            referenced.name as referenced_name,
+            referenced.schema as referenced_schema_id,
+            dependent_class.name as dependent_name,
+            dependent_class.schema as dependent_schema_id,
+            referenced.kind as kind
+        from referenced
+        join dependency on referenced.id=dependency.id
         join class as dependent_class on dependency.ref=dependent_class.id
         where
-            referenced_class.kind in ('r', 'v') and
-            (referenced_class.name != dependent_class.name or
-             referenced_class.schema != dependent_class.schema)
+            (referenced.name != dependent_class.name or
+             referenced.schema != dependent_class.schema)
     )
 
     select
@@ -58,6 +66,7 @@
     join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id
     group by referenced_schema, referenced_name, dependent_schema, dependent_name
     order by referenced_schema, referenced_name, dependent_schema, dependent_name;
+
   {%- endcall -%}
 
   {{ return(load_result('relations').table) }}


### PR DESCRIPTION
Closes #1193

split the relationship CTE in order to speed the dependency query on large postgres dbs