### PR TITLE
Add relation name to the exception in case of archive failure

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -380,9 +380,10 @@ def missing_config(model, name):
 
 
 def missing_relation(relation, model=None):
-    raise_compiler_error(
-        "Relation {} not found!".format(relation),
-        model)
+    base_msg = ('The relation `{relation}` was not found!\n'
+                'Check that the relation exists, and that your user'
+                ' has permissions to select from this relation.')
+    raise_compiler_error(base_msg.format(relation=relation), model)
 
 
 def relation_wrong_type(relation, expected_type, model=None):

--- a/core/dbt/include/global_project/macros/materializations/archive/archive.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/archive.sql
@@ -152,7 +152,8 @@
       identifier=target_table) -%}
 
   {%- if source_relation is none -%}
-    {{ exceptions.missing_relation(source_relation) }}
+    {%- set source_relation_name = [source_schema, source_table]|join(".") -%}
+    {{ exceptions.missing_relation(source_relation_name)}}
   {%- endif -%}
 
   {%- if target_relation is none -%}


### PR DESCRIPTION
Fixes #1066

Sample output 

```
Compilation Error in archive users_archived (dbt_project.yml)
  The relation`production_data.users` was not found!
  Check that the relation exists and that your user has permissions to select from this relation.

  > in macro materialization_archive_default (macros/materializations/archive/archive.sql)
  > called by archive users_archived (dbt_project.yml)
```