### PR TITLE
do not try to remove remote after dbt init

### DIFF
--- a/dbt/task/init.py
+++ b/dbt/task/init.py
@@ -64,7 +64,6 @@ class InitTask(BaseTask):
         dbt.clients.git.clone(
             STARTER_REPO, '.', project_name,
             remove_git_dir=True)
-        dbt.clients.git.remove_remote(project_name)
 
     def create_profiles_dir(self, profiles_dir):
         if not os.path.exists(profiles_dir):

--- a/test/integration/040_init_test/test_init.py
+++ b/test/integration/040_init_test/test_init.py
@@ -11,7 +11,7 @@ class TestInit(DBTIntegrationTest):
         if os.path.exists(project_name):
             shutil.rmtree(project_name)
 
-        DBTIntegrationTest.tearDown(self)
+        super(TestInit, self).tearDown()
 
     def get_project_name(self):
         return "my_project_{}".format(self.unique_schema())
@@ -25,7 +25,7 @@ class TestInit(DBTIntegrationTest):
         return "test/integration/040_init_test/models"
 
     @use_profile('postgres')
-    def test_init_task(self):
+    def test_postgres_init_task(self):
         project_name = self.get_project_name()
         self.run_dbt(['init', project_name])
 
@@ -33,5 +33,9 @@ class TestInit(DBTIntegrationTest):
         project_file = os.path.join(project_name, 'dbt_project.yml')
         project_file_exists = os.path.exists(project_file)
 
+        git_dir = os.path.join(project_name, '.git')
+        git_dir_exists = os.path.exists(git_dir)
+
         self.assertTrue(dir_exists)
         self.assertTrue(project_file_exists)
+        self.assertFalse(git_dir_exists)

--- a/test/integration/040_init_test/test_init.py
+++ b/test/integration/040_init_test/test_init.py
@@ -1,0 +1,37 @@
+
+from test.integration.base import DBTIntegrationTest, use_profile
+import os
+import shutil
+
+
+class TestInit(DBTIntegrationTest):
+    def tearDown(self):
+        project_name = self.get_project_name()
+
+        if os.path.exists(project_name):
+            shutil.rmtree(project_name)
+
+        DBTIntegrationTest.tearDown(self)
+
+    def get_project_name(self):
+        return "my_project_{}".format(self.unique_schema())
+
+    @property
+    def schema(self):
+        return "init_040"
+
+    @property
+    def models(self):
+        return "test/integration/040_init_test/models"
+
+    @use_profile('postgres')
+    def test_init_task(self):
+        project_name = self.get_project_name()
+        self.run_dbt(['init', project_name])
+
+        dir_exists = os.path.exists(project_name)
+        project_file = os.path.join(project_name, 'dbt_project.yml')
+        project_file_exists = os.path.exists(project_file)
+
+        self.assertTrue(dir_exists)
+        self.assertTrue(project_file_exists)


### PR DESCRIPTION
Fixes #1209 by removing a call to delete the remote from the cloned repo. The entire .git dir is deleted right before this, so the command previously could not succeed