### PR TITLE
Adds DBT compare subcommand for comparing local models with database catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,12 @@ And then to actually run them, you can do `make test-quick`.
 
 If you want to see what exactly is getting run on these commands, look at the `Makefile`. Note that the commands start with an `@` which you can ignore, just makefile magic. If you want to see what the involved `tox` commands are using, look at the corresponding `tox.ini` section - hopefully it's pretty self-explanatory.
 
+To run just one integration test at a time, you can run something like:
+
+```
+docker-compose run test tox -e explicit-py36 -- -x --nocapture -a type="postgres" test/integration/040_compare_test/
+```
+
 ### Running tests in CI
 
 When a contributor to dbt pushes code, GitHub will trigger a series of CI builds on CircleCI and Appveyor (Windows) to test all of dbt's code. The CI builds trigger all the integration tests, not just postgres+python3.6.

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -13,6 +13,7 @@ import dbt.task.compile as compile_task
 import dbt.task.debug as debug_task
 import dbt.task.clean as clean_task
 import dbt.task.deps as deps_task
+import dbt.task.compare as compare_task
 import dbt.task.init as init_task
 import dbt.task.seed as seed_task
 import dbt.task.test as test_task
@@ -439,6 +440,13 @@ def parse_args(args):
         help="Pull the most recent version of the dependencies "
         "listed in packages.yml")
     sub.set_defaults(cls=deps_task.DepsTask, which='deps')
+
+    compare_sub = subs.add_parser(
+        'compare',
+        parents=[base_subparser],
+        help="Compare your project specifications with what's in "
+        "the database.")
+    compare_sub.set_defaults(cls=compare_task.CompareTask, which='compare')
 
     sub = subs.add_parser(
         'archive',

--- a/core/dbt/task/compare.py
+++ b/core/dbt/task/compare.py
@@ -1,0 +1,85 @@
+from __future__ import print_function
+
+from dbt.adapters.factory import get_adapter
+from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.node_types import NodeType
+from dbt.utils import is_enabled as check_is_enabled
+
+import dbt.ui.printer
+from dbt.task.base_task import BaseTask
+
+
+class CompareTask(BaseTask):
+    def _get_manifest(self):
+        compiler = dbt.compilation.Compiler(self.config)
+        compiler.initialize()
+
+        all_projects = compiler.get_all_projects()
+
+        manifest = dbt.loader.GraphLoader.load_all(self.config, all_projects)
+        return manifest
+
+    def run(self):
+
+        # Look up all of the relations in the DB
+        adapter = get_adapter(self.config)
+        manifest = self._get_manifest()
+
+        checked_schemas = manifest.get_used_schemas()
+
+        db_relations = []
+        for schema in checked_schemas:
+            db_relations.extend(adapter.list_relations(schema))
+
+        database_relations = set()
+        database_relations_map = dict()
+        for relation in db_relations:
+            relation_id = (relation.schema.lower(),
+                           relation.identifier.lower())
+            database_relations_map[relation_id] = relation
+            database_relations.add(relation_id)
+
+        logger.info("Comparing local models to the database catalog. "
+                    "Checking schemas:")
+        for schema_name in checked_schemas:
+            logger.info("- {}".format(schema_name))
+
+        # Look up all of the relations dbt knows about
+        model_relations = set()
+        for node in manifest.nodes.values():
+            node = node.to_dict()
+            is_refable = node["resource_type"] in NodeType.refable()
+            is_enabled = check_is_enabled(node)
+            is_ephemeral = node["config"]["materialized"] == "ephemeral"
+            if is_refable and is_enabled and not is_ephemeral:
+                rel = (node["schema"].lower(), node["alias"].lower())
+                model_relations.add(rel)
+
+        problems = database_relations - model_relations
+
+        if len(problems) == 0:
+            logger.info(
+                dbt.ui.printer.green(
+                    "All clear! There are no relations in the checked schemas "
+                    "that are not defined in dbt models."
+                )
+            )
+        else:
+            logger.info(
+                dbt.ui.printer.yellow(
+                    "Warning: The following relations do not match any models "
+                    "found in this project:"
+                )
+            )
+
+        problem_relation_list = []  # Get a list of relations to return
+
+        for relation_id in problems:
+            relation = database_relations_map[relation_id]
+            problem_relation_list.append(relation)
+            logger.info("{} {}".format(relation.type.upper(), relation))
+
+        return problem_relation_list
+
+        def interpret_results(self, results):
+            return len(results) == 0

--- a/core/dbt/task/compare.py
+++ b/core/dbt/task/compare.py
@@ -81,5 +81,5 @@ class CompareTask(BaseTask):
 
         return problem_relation_list
 
-        def interpret_results(self, results):
-            return len(results) == 0
+    def interpret_results(self, results):
+        return len(results) == 0

--- a/test/integration/040_compare_test/models/downstream.sql
+++ b/test/integration/040_compare_test/models/downstream.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='view') }}
+
+SELECT * FROM {{ ref('test_view') }}

--- a/test/integration/040_compare_test/test_compare.py
+++ b/test/integration/040_compare_test/test_compare.py
@@ -37,7 +37,6 @@ class TestCompare(DBTIntegrationTest):
                 self.unique_schema()
                 )
         created_models = [rel.table.lower() for rel in relations]
-
         return created_models
 
     def compare_switch_to_ephemeral(self):
@@ -65,7 +64,7 @@ class TestCompare(DBTIntegrationTest):
         self.assertTrue("test_view" in created_models)
         self.assertTrue("downstream" in created_models)
         # Assert dbt compare fails
-        results = self.run_dbt(["compare"])
+        results = self.run_dbt(["compare"], expect_pass=False)
         self.assertTrue(len(results) == 1)
 
     @use_profile("postgres")

--- a/test/integration/040_compare_test/test_compare.py
+++ b/test/integration/040_compare_test/test_compare.py
@@ -1,0 +1,85 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+import os
+
+
+class TestCompare(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "config_040"
+
+    def unique_schema(self):
+        return super(TestCompare, self).unique_schema()
+
+    @staticmethod
+    def dir(path):
+        return "test/integration/040_compare_test/" + path.lstrip("/")
+
+    def tearDown(self):
+        os.remove(self.dir("models/test_view.sql"))
+
+    @property
+    def models(self):
+        return self.dir("models")
+
+    def create_test_model(self, materialization):
+        model = """
+            {{{{ config(materialized='{mat}') }}}}
+            SELECT 1 AS colname
+            """.format(
+            mat=materialization
+        )
+
+        with open(self.dir("models/test_view.sql"), "w") as f:
+            f.write(model)
+
+    def get_created_models(self):
+        relations = self.adapter.list_relations_without_caching(
+                self.unique_schema()
+                )
+        created_models = [rel.table.lower() for rel in relations]
+
+        return created_models
+
+    def compare_switch_to_ephemeral(self):
+
+        # Run dbt with test_view as a view
+        self.create_test_model("view")
+        self.run_dbt(["run"])
+
+        # Assert the view exists in the database
+        created_models = self.get_created_models()
+
+        self.assertTrue("test_view" in created_models)
+        self.assertTrue("downstream" in created_models)
+
+        # Assert dbt compare passes
+        results = self.run_dbt(["compare"])
+
+        self.assertTrue(len(results) == 0)
+
+        # Run dbt with test_view as ephemeral
+        self.create_test_model("ephemeral")
+        self.run_dbt(["run"])
+        # Assert the view still exists in the database
+        created_models = self.get_created_models()
+        self.assertTrue("test_view" in created_models)
+        self.assertTrue("downstream" in created_models)
+        # Assert dbt compare fails
+        results = self.run_dbt(["compare"])
+        self.assertTrue(len(results) == 1)
+
+    @use_profile("postgres")
+    def test__postgres__compare(self):
+        self.compare_switch_to_ephemeral()
+
+    @use_profile("redshift")
+    def test__redshift__compare(self):
+        self.compare_switch_to_ephemeral()
+
+    @use_profile("snowflake")
+    def test__snowflake__compare(self):
+        self.compare_switch_to_ephemeral()
+
+    @use_profile("bigquery")
+    def test__bigquery__compare(self):
+        self.compare_switch_to_ephemeral()


### PR DESCRIPTION
Addresses https://github.com/fishtown-analytics/dbt/issues/1135

Here's an example:

``` 
$ dbt compare

Running with dbt=0.13.0-a1
Comparing local models to the database catalog. Checking schemas:
- dev_example
- dev_downstream
Warning: The following relations do not match any models found in this project:
TABLE "dev_example"."b"
VIEW "dev_downstream"."d"
```