### PR TITLE
On unexpected errors in safe_run, do not raise (#1223)

### DIFF
--- a/core/dbt/compat.py
+++ b/core/dbt/compat.py
@@ -22,9 +22,11 @@ except NameError:
 if WHICH_PYTHON == 2:
     basestring = basestring
     bigint = long
+    import __builtin__ as builtins
 else:
     basestring = str
     bigint = int
+    import builtins
 
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1,13 +1,13 @@
-from dbt.compat import basestring
+from dbt.compat import basestring, builtins
 from dbt.logger import GLOBAL_LOGGER as logger
 import re
 
 
-class Exception(BaseException):
+class Exception(builtins.Exception):
     pass
 
 
-class MacroReturn(BaseException):
+class MacroReturn(builtins.BaseException):
     """
     Hack of all hacks
     """

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -76,7 +76,6 @@ class BaseRunner(object):
 
         result = RunModelResult(self.node)
         started = time.time()
-        exc_info = (None, None, None)
 
         try:
             # if we fail here, we still have a compiled node to return
@@ -109,9 +108,6 @@ class BaseRunner(object):
             result.status = 'ERROR'
 
         except Exception as e:
-            # set this here instead of finally, as python 2/3 exc_info()
-            # behavior with re-raised exceptions are slightly different
-            exc_info = sys.exc_info()
             prefix = "Unhandled error while executing {filepath}".format(
                         filepath=self.node.build_path)
 
@@ -120,14 +116,11 @@ class BaseRunner(object):
                          error=str(e).strip())
 
             logger.error(error)
-            raise e
+            result.error = dbt.compat.to_string(e)
+            result.status = 'ERROR'
 
         finally:
             exc_str = self._safe_release_connection()
-
-            # if we had an unhandled exception, re-raise it
-            if exc_info and exc_info[1]:
-                six.reraise(*exc_info)
 
             # if releasing failed and the result doesn't have an error yet, set
             # an error


### PR DESCRIPTION
Fixes #1223 

When we hit unexpected errors in safe_run, don't raise them. log at error level, convert them into error results, and return those.
Also, `dbt.exceptions.Exception` now derives from `builtins.Exception` instead of `builtins.BaseException` directly. I left MacroReturn as-is because that seems to be kind of in the spirit of the whole BaseException/Exception split in Python, but that could also quite reasonably change.