### PR TITLE
presto notimplemented errors (#1228)

### DIFF
--- a/plugins/presto/dbt/include/presto/macros/materializations/archive.sql
+++ b/plugins/presto/dbt/include/presto/macros/materializations/archive.sql
@@ -1,0 +1,6 @@
+
+{% materialization archive, adapter='presto' -%}
+  {{ exceptions.raise_not_implemented(
+    'archive materialization not implemented for '+adapter.type())
+  }}
+{% endmaterialization %}

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -51,6 +51,20 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         self.assertFalse("empty" in models.keys())
         self.assertFalse("disabled" in models.keys())
 
+    @use_profile("presto")
+    def test__presto__simple_copy(self):
+        self.use_default_project({"data-paths": [self.dir("seed-initial")]})
+
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+        results = self.run_dbt(expect_pass=False)
+        self.assertEqual(len(results),  7)
+        for result in results:
+            if 'incremental' in result.node.name:
+                self.assertIn('not implemented for presto', result.error)
+
+        self.assertManyTablesEqual(["seed", "view_model", "materialized"])
+
     @use_profile("snowflake")
     def test__snowflake__simple_copy(self):
         self.use_default_project({"data-paths": [self.dir("seed-initial")]})

--- a/test/integration/004_simple_archive_test/data/seed.csv
+++ b/test/integration/004_simple_archive_test/data/seed.csv
@@ -1,0 +1,21 @@
+id,first_name,last_name,email,gender,ip_address,updated_at
+1,Judith,Kennedy,jkennedy0@phpbb.com,Female,54.60.24.128,2015-12-24 12:19:28
+2,Arthur,Kelly,akelly1@eepurl.com,Male,62.56.24.215,2015-10-28 16:22:15
+3,Rachel,Moreno,rmoreno2@msu.edu,Female,31.222.249.23,2016-04-05 02:05:30
+4,Ralph,Turner,rturner3@hp.com,Male,157.83.76.114,2016-08-08 00:06:51
+5,Laura,Gonzales,lgonzales4@howstuffworks.com,Female,30.54.105.168,2016-09-01 08:25:38
+6,Katherine,Lopez,klopez5@yahoo.co.jp,Female,169.138.46.89,2016-08-30 18:52:11
+7,Jeremy,Hamilton,jhamilton6@mozilla.org,Male,231.189.13.133,2016-07-17 02:09:46
+8,Heather,Rose,hrose7@goodreads.com,Female,87.165.201.65,2015-12-29 22:03:56
+9,Gregory,Kelly,gkelly8@trellian.com,Male,154.209.99.7,2016-03-24 21:18:16
+10,Rachel,Lopez,rlopez9@themeforest.net,Female,237.165.82.71,2016-08-20 15:44:49
+11,Donna,Welch,dwelcha@shutterfly.com,Female,103.33.110.138,2016-02-27 01:41:48
+12,Russell,Lawrence,rlawrenceb@qq.com,Male,189.115.73.4,2016-06-11 03:07:09
+13,Michelle,Montgomery,mmontgomeryc@scientificamerican.com,Female,243.220.95.82,2016-06-18 16:27:19
+14,Walter,Castillo,wcastillod@pagesperso-orange.fr,Male,71.159.238.196,2016-10-06 01:55:44
+15,Robin,Mills,rmillse@vkontakte.ru,Female,172.190.5.50,2016-10-31 11:41:21
+16,Raymond,Holmes,rholmesf@usgs.gov,Male,148.153.166.95,2016-10-03 08:16:38
+17,Gary,Bishop,gbishopg@plala.or.jp,Male,161.108.182.13,2016-08-29 19:35:20
+18,Anna,Riley,arileyh@nasa.gov,Female,253.31.108.22,2015-12-11 04:34:27
+19,Sarah,Knight,sknighti@foxnews.com,Female,222.220.3.177,2016-09-26 00:49:06
+20,Phyllis,Fox,pfoxj@creativecommons.org,Female,163.191.232.95,2016-08-21 10:35:19

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -896,18 +896,30 @@ class DBTIntegrationTest(unittest.TestCase):
         table_a_result = self.get_relation_columns(relation_a)
         table_b_result = self.get_relation_columns(relation_b)
 
+        text_types = {'text', 'character varying', 'character', 'varchar'}
+
         self.assertEqual(len(table_a_result), len(table_b_result))
         for a_column, b_column in zip(table_a_result, table_b_result):
             a_name, a_type, a_size = a_column
             b_name, b_type, b_size = b_column
-            self.assertEqual(a_name, b_name)
-            self.assertEqual(a_type, b_type)
+            self.assertEqual(a_name, b_name,
+                '{} vs {}: column "{}" != "{}"'.format(
+                    relation_a, relation_b, a_name, b_name
+                ))
+
+            self.assertEqual(a_type, b_type,
+                '{} vs {}: column "{}" has type "{}" != "{}"'.format(
+                    relation_a, relation_b, a_name, a_type, b_type
+                ))
 
             if self.adapter_type == 'presto' and None in (a_size, b_size):
                 # None is compatible with any size
                 continue
 
-            self.assertEqual(a_size, b_size)
+            self.assertEqual(a_size, b_size,
+                '{} vs {}: column "{}" has size "{}" != "{}"'.format(
+                    relation_a, relation_b, a_name, a_size, b_size
+                ))
 
     def assertEquals(self, *args, **kwargs):
         # assertEquals is deprecated. This makes the warnings less chatty


### PR DESCRIPTION
Resolves #1228 

Note: This is against the `feature/presto-adapter` branch (#1245), not `dev/stephen-girard`.

- Make archives on presto print 'not implemented' errors and exit instead of running invalid SQL.
- Add tests that ensure archives/incremental models on presto fail with proper errors.