### PR TITLE
fix for optional adapter configs with aliases

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -54,6 +54,7 @@ class Credentials(APIObject):
             serialized.update({
                 new_name: serialized[canonical_name]
                 for new_name, canonical_name in self.ALIASES.items()
+                if canonical_name in serialized
             })
         return serialized
 


### PR DESCRIPTION
This PR will only re-alias configs if they are present in the user-supplied configuration. I found this because my IAM auth target failed, since passwords aren't required for IAM auth.

dbt failed with:
```
KeyError: 'password'
```