### PR TITLE
Support transient tables on Snowflake

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -110,7 +110,9 @@ class BaseAdapter(object):
     # This should be an implementation of BaseConnectionManager
     ConnectionManager = None
 
-    AdapterSpecificConfigs = set()
+    # A set of clobber config fields accepted by this adapter
+    # for use in materializations
+    AdapterSpecificConfigs = frozenset()
 
     def __init__(self, config):
         self.config = config

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -110,6 +110,8 @@ class BaseAdapter(object):
     # This should be an implementation of BaseConnectionManager
     ConnectionManager = None
 
+    AdapterSpecificConfigs = set()
+
     def __init__(self, config):
         self.config = config
         self.cache = RelationsCache()

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -20,7 +20,7 @@ from dbt.version import get_installed_version
 from dbt.ui import printer
 from dbt.utils import deep_map
 from dbt.utils import parse_cli_vars
-from dbt.utils import DBTConfigKeys
+from dbt.parser.source_config import SourceConfig
 
 from dbt.contracts.project import Project as ProjectContract
 from dbt.contracts.project import PackageConfig
@@ -83,7 +83,7 @@ def _get_config_paths(config, path=(), paths=None):
 
     for key, value in config.items():
         if isinstance(value, dict):
-            if key in DBTConfigKeys:
+            if key in SourceConfig.ConfigKeys:
                 if path not in paths:
                     paths.add(path)
             else:

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -20,27 +20,6 @@ from dbt.node_types import NodeType
 from dbt.clients import yaml_helper
 
 
-DBTConfigKeys = [
-    'alias',
-    'schema',
-    'enabled',
-    'materialized',
-    'dist',
-    'sort',
-    'sql_where',
-    'unique_key',
-    'sort_type',
-    'pre-hook',
-    'post-hook',
-    'vars',
-    'column_types',
-    'bind',
-    'quoting',
-    'tags',
-    'database',
-]
-
-
 class ExitCodes(object):
     Success = 0
     ModelError = 1

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -51,6 +51,8 @@ class BigQueryAdapter(BaseAdapter):
     Column = dbt.schema.BigQueryColumn
     ConnectionManager = BigQueryConnectionManager
 
+    AdapterSpecificConfigs = frozenset({"cluster_by", "partition_by"})
+
     ###
     # Implementations of abstract methods
     ###

--- a/plugins/redshift/dbt/adapters/redshift/impl.py
+++ b/plugins/redshift/dbt/adapters/redshift/impl.py
@@ -7,7 +7,7 @@ import dbt.exceptions
 class RedshiftAdapter(PostgresAdapter):
     ConnectionManager = RedshiftConnectionManager
 
-    AdapterSpecificConfigs = {"sort_type", "dist", "sort", "bind"}
+    AdapterSpecificConfigs = frozenset({"sort_type", "dist", "sort", "bind"})
 
     @classmethod
     def date_function(cls):

--- a/plugins/redshift/dbt/adapters/redshift/impl.py
+++ b/plugins/redshift/dbt/adapters/redshift/impl.py
@@ -7,6 +7,8 @@ import dbt.exceptions
 class RedshiftAdapter(PostgresAdapter):
     ConnectionManager = RedshiftConnectionManager
 
+    AdapterSpecificConfigs = {"sort_type", "dist", "sort", "bind"}
+
     @classmethod
     def date_function(cls):
         return 'getdate()'

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -14,6 +14,8 @@ class SnowflakeAdapter(SQLAdapter):
     Relation = SnowflakeRelation
     ConnectionManager = SnowflakeConnectionManager
 
+    AdapterSpecificConfigs = {"transient"}
+
     @classmethod
     def date_function(cls):
         return 'CURRENT_TIMESTAMP()'

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -14,7 +14,7 @@ class SnowflakeAdapter(SQLAdapter):
     Relation = SnowflakeRelation
     ConnectionManager = SnowflakeConnectionManager
 
-    AdapterSpecificConfigs = {"transient"}
+    AdapterSpecificConfigs = frozenset({"transient"})
 
     @classmethod
     def date_function(cls):

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -3,7 +3,16 @@
     use schema {{ adapter.quote_as_configured(schema, 'schema') }};
   {% endif %}
 
-  {{ default__create_table_as(temporary, relation, sql) }}
+  {%- set transient = config.get('transient', default=true) -%}
+
+  create {% if temporary -%}
+    temporary
+  {%- elif transient -%}
+    transient
+  {%- endif %} table {{ relation.include(database=(not temporary), schema=(not temporary)) }}
+  as (
+    {{ sql }}
+  );
 {% endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -34,7 +34,7 @@ class BaseParserTest(unittest.TestCase):
             'quoting': {},
             'outputs': {
                 'test': {
-                    'type': 'postgres',
+                    'type': 'redshift',
                     'host': 'localhost',
                     'schema': 'analytics',
                     'user': 'test',


### PR DESCRIPTION
Closes #946 

This PR adds support for transient tables on Snowflake using the `transient` config. Example usage:
```
# dbt_project.yml

models:
  transient: true
```

By default, models will be created as "transient". If users wish, they can override the setting to be `false`, which will cause these tables to participate in Snowflake's Time Travel mechanism.

In addition to adding the transient config, I also ripped adapter-specific configs out of the SourceConfig class. These configs are now supplied by adapters. I think this is probably a good idea, but I'm unsure how sound my implementation is. Super open to tweaking things to make this fit nicely into the adapter plugin architecture :) 