### PR TITLE
Only create schemas for selected nodes (#1239)

### DIFF
--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -241,4 +241,4 @@ class SQLAdapter(BaseAdapter):
             kwargs={'database': database, 'schema': schema},
             connection_name=model_name
         )
-        return results[0] > 0
+        return results[0][0] > 0

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -200,7 +200,7 @@
 
 
 {% macro check_schema_exists(database, schema) -%}
-  {{ return(adapter_macro('check_schema_exists', database)) }}
+  {{ return(adapter_macro('check_schema_exists', database, schema)) }}
 {% endmacro %}
 
 {% macro default__check_schema_exists(database, schema) -%}

--- a/core/dbt/runner.py
+++ b/core/dbt/runner.py
@@ -171,8 +171,6 @@ class RunManager(object):
         dbt.ui.printer.print_timestamped_line(concurrency_line)
         dbt.ui.printer.print_timestamped_line("")
 
-        schemas = list(self.Runner.get_model_schemas(self.manifest))
-
         pool = ThreadPool(num_threads)
         try:
             self.run_queue(pool)
@@ -303,10 +301,12 @@ class RunManager(object):
         else:
             logger.info("")
 
+        selected_uids = frozenset(n.unique_id for n in self._flattened_nodes)
         try:
             self.Runner.before_hooks(self.config, adapter, self.manifest)
             started = time.time()
-            self.Runner.before_run(self.config, adapter, self.manifest)
+            self.Runner.before_run(self.config, adapter, self.manifest,
+                                   selected_uids)
             res = self.execute_nodes()
             self.Runner.after_run(self.config, adapter, res, self.manifest)
             elapsed = time.time() - started

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -71,7 +71,10 @@
   {% if database -%}
     {{ adapter.verify_database(database) }}
   {%- endif -%}
-  "select distinct nspname from pg_namespace"
+  {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
+    select distinct nspname from pg_namespace
+  {% endcall %}
+  {{ return(load_result('list_schemas').table) }}
 {% endmacro %}
 
 {% macro postgres__check_schema_exists(database, schema) -%}
@@ -81,4 +84,5 @@
   {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) %}
     select count(*) from pg_namespace where nspname = '{{ schema }}'
   {% endcall %}
+  {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -62,7 +62,7 @@
 {% macro snowflake__check_schema_exists(database, schema) -%}
   {% call statement('check_schema_exists', fetch_result=True) -%}
         select count(*)
-        from {{ information_schema_name(database) }}
+        from {{ information_schema_name(database) }}.schemata
         where upper(schema_name) = upper('{{ schema }}')
             and upper(catalog_name) = upper('{{ database }}')
   {%- endcall %}

--- a/test/integration/007_graph_selection_tests/models/never_selected.sql
+++ b/test/integration/007_graph_selection_tests/models/never_selected.sql
@@ -1,0 +1,5 @@
+{{
+	config(schema='_and_then')
+}}
+
+select * from {{ this.schema }}.seed

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -11,6 +11,22 @@ class TestGraphSelection(DBTIntegrationTest):
     def models(self):
         return "test/integration/007_graph_selection_tests/models"
 
+    def assert_correct_schemas(self):
+        exists = self.adapter.check_schema_exists(
+            self.default_database,
+            self.unique_schema(),
+            '__test'
+        )
+        self.assertTrue(exists)
+
+        schema = self.unique_schema()+'_and_then'
+        exists = self.adapter.check_schema_exists(
+            self.default_database,
+            schema,
+            '__test'
+        )
+        self.assertFalse(exists)
+
     @attr(type='postgres')
     def test__postgres__specific_model(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
@@ -23,6 +39,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('users_rollup' in created_models)
         self.assertFalse('base_users' in created_models)
         self.assertFalse('emails' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='postgres')
     def test__postgres__tags(self):
@@ -36,6 +53,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('emails' in created_models)
         self.assertTrue('users' in created_models)
         self.assertTrue('users_rollup' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='postgres')
     def test__postgres__tags_and_children(self):
@@ -49,6 +67,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('emails' in created_models)
         self.assertTrue('users_rollup' in created_models)
         self.assertTrue('users' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='snowflake')
     def test__snowflake__specific_model(self):
@@ -62,7 +81,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('USERS_ROLLUP' in created_models)
         self.assertFalse('BASE_USERS' in created_models)
         self.assertFalse('EMAILS' in created_models)
-
+        self.assert_correct_schemas()
 
     @attr(type='postgres')
     def test__postgres__specific_model_and_children(self):
@@ -76,6 +95,7 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('emails' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_and_children(self):
@@ -105,6 +125,7 @@ class TestGraphSelection(DBTIntegrationTest):
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
         self.assertFalse('emails' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_and_parents(self):
@@ -137,6 +158,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('base_users' in created_models)
         self.assertFalse('users_rollup' in created_models)
         self.assertFalse('emails' in created_models)
+        self.assert_correct_schemas()
 
     @attr(type='snowflake')
     def test__snowflake__specific_model_with_exclusion(self):
@@ -164,3 +186,4 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('emails', created_models)
         self.assertIn('subdir', created_models)
         self.assertIn('nested_users', created_models)
+        self.assert_correct_schemas()

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -25,7 +25,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
     def run_schema_and_assert(self, include, exclude, expected_tests):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         self.run_dbt(["deps"])
-        results = self.run_dbt()
+        results = self.run_dbt(['run', '--exclude', 'never_selected'])
         self.assertEqual(len(results), 7)
 
         args = FakeArgs()

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -236,7 +236,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
-                client_session_keep_alive=False, database='test_databse',
+                client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', private_key='test_key')
         ])


### PR DESCRIPTION
Fixes #1239 

This PR passes along the set of selected UIDs to the `before_run` method of the chosen Runner class, which is then used to filter out the nodes that dbt needs to build schemas for. We still unconditionally create the default schema, for snowflake.

Also I have no idea what was up with `check_schema_exists`, but it's fixed.

For tests, I just modified some of the existing graph selection tests, which seemed sufficient.