### PR TITLE
Fix dbt deps on non-english shells (#1222)

### DIFF
--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -12,7 +12,7 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False):
     if dirname is not None:
         clone_cmd.append(dirname)
 
-    result = run_cmd(cwd, clone_cmd)
+    result = run_cmd(cwd, clone_cmd, env={'LC_ALL': 'C'})
 
     if remove_git_dir:
         rmdir(os.path.join(dirname, '.git'))
@@ -21,7 +21,7 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False):
 
 
 def list_tags(cwd):
-    out, err = run_cmd(cwd, ['git', 'tag', '--list'])
+    out, err = run_cmd(cwd, ['git', 'tag', '--list'], env={'LC_ALL': 'C'})
     tags = out.decode('utf-8').strip().split("\n")
     return tags
 
@@ -40,7 +40,8 @@ def _checkout(cwd, repo, branch):
     else:
         spec = 'origin/{}'.format(branch)
 
-    out, err = run_cmd(cwd, ['git', 'reset', '--hard', spec])
+    out, err = run_cmd(cwd, ['git', 'reset', '--hard', spec],
+                       env={'LC_ALL': 'C'})
     return out, err
 
 
@@ -55,13 +56,13 @@ def checkout(cwd, repo, branch=None):
 
 
 def get_current_sha(cwd):
-    out, err = run_cmd(cwd, ['git', 'rev-parse', 'HEAD'])
+    out, err = run_cmd(cwd, ['git', 'rev-parse', 'HEAD'], env={'LC_ALL': 'C'})
 
     return out.decode('utf-8')
 
 
 def remove_remote(cwd):
-    return run_cmd(cwd, ['git', 'remote', 'rm', 'origin'])
+    return run_cmd(cwd, ['git', 'remote', 'rm', 'origin'], env={'LC_ALL': 'C'})
 
 
 def clone_and_checkout(repo, cwd, dirname=None, remove_git_dir=False,

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -268,7 +268,7 @@ def _interpret_oserror(exc, cwd, cmd):
     )
 
 
-def run_cmd(cwd, cmd):
+def run_cmd(cwd, cmd, env=None):
     logger.debug('Executing "{}"'.format(' '.join(cmd)))
     if len(cmd) == 0:
         raise dbt.exceptions.CommandError(cwd, cmd)
@@ -278,7 +278,8 @@ def run_cmd(cwd, cmd):
             cmd,
             cwd=cwd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            env=env)
 
         out, err = proc.communicate()
     except OSError as exc:

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -273,13 +273,20 @@ def run_cmd(cwd, cmd, env=None):
     if len(cmd) == 0:
         raise dbt.exceptions.CommandError(cwd, cmd)
 
+    # the env argument replaces the environment entirely, which has exciting
+    # consequences on Windows! Do an update instead.
+    full_env = env
+    if env is not None:
+        full_env = os.environ.copy()
+        full_env.update(env)
+
     try:
         proc = subprocess.Popen(
             cmd,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=env)
+            env=full_env)
 
         out, err = proc.communicate()
     except OSError as exc:

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -236,7 +236,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
-                client_session_keep_alive=False, database='test_databse',
+                client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', private_key='test_key')
         ])


### PR DESCRIPTION
Fixes #1222 

- Adds an `env` parameter to `dbt.clients.system.run_cmd`
- Git commands that parse stderr/stdout now pass `env={'LC_ALL': 'C'}` to `run_cmd`

I went for a more surgical approach instead of making everything use that environment variable, but I think that would be valid as well.

The obvious integration test case (set `LC_ALL=es_ES` in `setUp` and run the existing deps test) passes even without this change so I have not included it, but I have manually verified it and it does behave properly now.