### PR TITLE
Add source selector support (#1256)

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -172,7 +172,6 @@ class Compiler(object):
                 linker.dependency(
                     node.unique_id,
                     (manifest.nodes.get(dependency).unique_id))
-
             else:
                 dbt.exceptions.dependency_not_found(node, dependency)
 

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -176,17 +176,23 @@ class NodeSelector(object):
 
     def get_nodes_by_source(self, graph, source_full_name):
         """yields nodes from graph are the specified source."""
-        if source_full_name.count('.') != 1:
+        parts = source_full_name.split('.')
+        if len(parts) == 1:
+            target_source, target_table = parts[0], None
+        elif len(parts) == 2:
+            target_source, target_table = parts
+        else:  # len(parts) > 2 or len(parts) == 0
             msg = (
                 'Invalid source selector value "{}". Sources must be of the '
-                'form `${{source_name}}.${{target_name}}`'
+                'form `${{source_name}}` or '
+                '`${{source_name}}.${{target_name}}`'
             ).format(source_full_name)
             raise dbt.exceptions.RuntimeException(msg)
 
-        target = tuple(source_full_name.split('.'))
-
         for node, real_node in self.source_nodes(graph):
-            if (real_node.source_name, real_node.name) == target:
+            if real_node.source_name != target_source:
+                continue
+            if target_table is None or target_table == real_node.name:
                 yield node
 
     def get_nodes_from_spec(self, graph, spec):

--- a/test/integration/042_sources_test/models/multi_source_model.sql
+++ b/test/integration/042_sources_test/models/multi_source_model.sql
@@ -1,0 +1,2 @@
+select * from {{ source('test_source', 'other_test_table')}}
+	join {{ source('other_source', 'test_table')}} using (id)

--- a/test/integration/042_sources_test/models/nonsource_descendant.sql
+++ b/test/integration/042_sources_test/models/nonsource_descendant.sql
@@ -1,0 +1,1 @@
+select * from {{ schema }}.source

--- a/test/integration/042_sources_test/models/schema.yml
+++ b/test/integration/042_sources_test/models/schema.yml
@@ -37,3 +37,9 @@ sources:
               column_name: favorite_color
               to: ref('descendant_model')
               field: favorite_color
+      - name: other_test_table
+        sql_table_name: "{{ var('test_run_schema') }}.other_table"
+  - name: other_source
+    tables:
+      - name: test_table
+        sql_table_name: "{{ var('test_run_schema') }}.other_source_table"

--- a/test/integration/042_sources_test/source.sql
+++ b/test/integration/042_sources_test/source.sql
@@ -111,3 +111,43 @@ VALUES
     ('green', 98,'Gloria','gwalker2p@usa.gov','156.140.7.128','1997-10-04 07:58:58'),
     ('green', 99,'Paul','pjohnson2q@umn.edu','183.59.198.197','1991-11-14 12:33:55'),
     ('green', 100,'Frank','fgreene2r@blogspot.com','150.143.68.121','2010-06-12 23:55:39');
+
+create table {schema}.other_table (
+    id INTEGER,
+    first_name VARCHAR(11)
+);
+
+
+INSERT INTO {schema}.other_table
+    (id, first_name)
+VALUES
+    (1, 'Larry'),
+    (2, 'Curly'),
+    (3, 'Moe');
+
+create table {schema}.other_source_table (
+    id INTEGER,
+    color VARCHAR(10)
+);
+
+
+INSERT INTO {schema}.other_source_table
+    (id, color)
+VALUES
+    (1, 'blue'),
+    (2, 'red'),
+    (3, 'green');
+
+
+create table {schema}.expected_multi_source(
+    id INTEGER,
+    first_name VARCHAR(11),
+    color VARCHAR(10)
+);
+
+INSERT INTO {schema}.expected_multi_source
+    (id, first_name, color)
+VALUES
+    (1, 'Larry', 'blue'),
+    (2, 'Curly', 'red'),
+    (3, 'Moe', 'green');

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -1,6 +1,7 @@
 from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest, use_profile
 import os
+import dbt.exceptions
 
 class TestSources(DBTIntegrationTest):
     @property
@@ -11,21 +12,61 @@ class TestSources(DBTIntegrationTest):
     def models(self):
         return "test/integration/042_sources_test/models"
 
-    @use_profile('postgres')
-    def test_basic_source_def(self):
+    def setUp(self):
+        super(TestSources, self).setUp()
         os.environ['DBT_TEST_SCHEMA_NAME_VARIABLE'] = 'test_run_schema'
         self.run_sql_file('test/integration/042_sources_test/source.sql',
                           kwargs={'schema':self.unique_schema()})
-        self.run_dbt([
-            'run',
-            '--vars',
-            '{{test_run_schema: {}}}'.format(self.unique_schema())
-        ])
+
+    def tearDown(self):
+        del os.environ['DBT_TEST_SCHEMA_NAME_VARIABLE']
+        super(TestSources, self).tearDown()
+
+    def run_dbt_with_vars(self, cmd, *args, **kwargs):
+        cmd.extend(['--vars',
+                    '{{test_run_schema: {}}}'.format(self.unique_schema())])
+        return self.run_dbt(cmd, *args, **kwargs)
+
+    @use_profile('postgres')
+    def test_basic_source_def(self):
+        results = self.run_dbt_with_vars(['run'])
+        self.assertEqual(len(results), 2)
         self.assertTablesEqual('source', 'descendant_model')
-        results = self.run_dbt([
+        self.assertTablesEqual('descendant_model', 'nonsource_descendant')
+        results = self.run_dbt_with_vars(['test'])
+        self.assertEqual(len(results), 4)
+
+    @use_profile('postgres')
+    def test_source_selector(self):
+        # only one of our models explicitly depends upon a source
+        results = self.run_dbt_with_vars([
+            'run',
+            '--models',
+            'source:test_source.test_table+'
+        ])
+        self.assertEqual(len(results), 1)
+        self.assertTablesEqual('source', 'descendant_model')
+        results = self.run_dbt_with_vars([
             'test',
-            '--vars',
-            '{{test_run_schema: {}}}'.format(self.unique_schema())
+            '--models',
+            'source:test_source.test_table+'
         ])
         self.assertEqual(len(results), 4)
-        del os.environ['DBT_TEST_SCHEMA_NAME_VARIABLE']
+
+    @use_profile('postgres')
+    def test_empty_source_def(self):
+        # sources themselves can never be selected, so nothing should be run
+        results = self.run_dbt_with_vars([
+            'run',
+            '--models',
+            'source:test_source.test_table'
+        ])
+        self.assertEqual(len(results), 0)
+
+    @use_profile('postgres')
+    def test_invalid_source_def(self):
+        with self.assertRaises(dbt.exceptions.RuntimeException) as exc:
+            self.run_dbt_with_vars([
+                'run', '--models', 'source:test_source+'
+            ])
+            self.assertIn('Invalid source selector value', str(exc))


### PR DESCRIPTION
Fix #1256 

Implements `source:...` syntax support in the selector. You must provide both a source name and a source table name, like `source:snowplow.events` (not just `source:snowplow+`.)

Sources end up in the linker's graph (they were technically already there), but are filtered out by the node selector just before they get returned.