### PR TITLE
limit exception context scope

### DIFF
--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -336,6 +336,29 @@ def get_this_relation(db_wrapper, config, model):
     return db_wrapper.Relation.create_from_node(config, model)
 
 
+def get_pytz_module_context():
+    context_exports = pytz.__all__
+
+    return {
+        name: getattr(pytz, name) for name in context_exports
+    }
+
+
+def get_datetime_module_context():
+    context_exports = [
+        'date',
+        'datetime',
+        'time',
+        'timedelta',
+        'tzinfo',
+        'timezone'
+    ]
+
+    return {
+        name: getattr(pytz, name) for name in context_exports
+    }
+
+
 def generate_base(model, model_dict, config, manifest, source_config,
                   provider, connection_name):
     """Generate the common aspects of the config dict."""
@@ -377,8 +400,8 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "log": log,
         "model": model_dict,
         "modules": {
-            "pytz": pytz,
-            "datetime": datetime
+            "pytz": get_pytz_module_context(),
+            "datetime": get_datetime_module_context(),
         },
         "post_hooks": post_hooks,
         "pre_hooks": pre_hooks,

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -355,7 +355,7 @@ def get_datetime_module_context():
     ]
 
     return {
-        name: getattr(pytz, name) for name in context_exports
+        name: getattr(datetime, name) for name in context_exports
     }
 
 

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -350,8 +350,7 @@ def get_datetime_module_context():
         'datetime',
         'time',
         'timedelta',
-        'tzinfo',
-        'timezone'
+        'tzinfo'
     ]
 
     return {

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -369,7 +369,7 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "config": provider.Config(model_dict, source_config),
         "database": config.credentials.database,
         "env_var": env_var,
-        "exceptions": dbt.exceptions,
+        "exceptions": dbt.exceptions.CONTEXT_EXPORTS,
         "execute": provider.execute,
         "flags": dbt.flags,
         # TODO: Do we have to leave this in?

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -582,19 +582,23 @@ def raise_not_implemented(msg):
 
 # Update this when a new function should be added to the
 # dbt context's `exceptions` key!
-CONTEXT_EXPORTS = [
-    missing_config,
-    missing_materialization,
-    missing_relation,
-    raise_ambiguous_alias,
-    raise_ambiguous_catalog_match,
-    raise_cache_inconsistent,
-    raise_compiler_error,
-    raise_database_error,
-    raise_dep_not_found,
-    raise_dependency_error,
-    raise_duplicate_patch_name,
-    raise_duplicate_resource_name,
-    raise_invalid_schema_yml_version,
-    relation_wrong_type,
-]
+CONTEXT_EXPORTS = {
+    fn.__name__: fn
+    for fn in
+    [
+        missing_config,
+        missing_materialization,
+        missing_relation,
+        raise_ambiguous_alias,
+        raise_ambiguous_catalog_match,
+        raise_cache_inconsistent,
+        raise_compiler_error,
+        raise_database_error,
+        raise_dep_not_found,
+        raise_dependency_error,
+        raise_duplicate_patch_name,
+        raise_duplicate_resource_name,
+        raise_invalid_schema_yml_version,
+        relation_wrong_type,
+    ]
+}

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -578,3 +578,23 @@ def raise_unrecognized_credentials_type(typename, supported_types):
 
 def raise_not_implemented(msg):
     raise NotImplementedException(msg)
+
+
+# Update this when a new function should be added to the
+# dbt context's `exceptions` key!
+CONTEXT_EXPORTS = [
+    missing_config,
+    missing_materialization,
+    missing_relation,
+    raise_ambiguous_alias,
+    raise_ambiguous_catalog_match,
+    raise_cache_inconsistent,
+    raise_compiler_error,
+    raise_database_error,
+    raise_dep_not_found,
+    raise_dependency_error,
+    raise_duplicate_patch_name,
+    raise_duplicate_resource_name,
+    raise_invalid_schema_yml_version,
+    relation_wrong_type,
+]


### PR DESCRIPTION
This limits the scope of the `exceptions` context in dbt by providing an exports list in dbt.exceptions.