### PR TITLE
fix dbt seed --show (#1288)

### DIFF
--- a/core/dbt/task/seed.py
+++ b/core/dbt/task/seed.py
@@ -23,11 +23,11 @@ class SeedTask(RunnableTask):
         return results
 
     def show_table(self, result):
-        table = result.node['agate_table']
+        table = result.node.agate_table
         rand_table = table.order_by(lambda x: random.random())
 
-        schema = result.node['schema']
-        alias = result.node['alias']
+        schema = result.node.schema
+        alias = result.node.alias
 
         header = "Random sample of table: {}.{}".format(schema, alias)
         logger.info("")

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -30,8 +30,9 @@ class TestSimpleSeed(DBTIntegrationTest):
         self.assertEqual(len(results),  1)
         self.assertTablesEqual("seed_actual","seed_expected")
 
-        # this should truncate the seed_actual table, then re-insert
-        results = self.run_dbt(["seed"])
+        # this should truncate the seed_actual table, then re-insert.
+        # also, '--show' should not crash dbt!
+        results = self.run_dbt(["seed", '--show'])
         self.assertEqual(len(results),  1)
         self.assertTablesEqual("seed_actual","seed_expected")
 


### PR DESCRIPTION
Fixes #1288

I just hit this locally and lo and behold there's an issue for it. The fix is pretty simple, this just never got touched when nodes became objects and agate_table is a weird/special attribute. I also made sure a test calls seed with `--show`, just to make sure it doesn't crash anymore.