### PR TITLE
fix: Widen botocore/boto3 requirements (#1234)

### DIFF
--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -25,8 +25,8 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'dbt-postgres=={}'.format(package_version),
-        'boto3>=1.6.23,<1.8.0',
-        'botocore>=1.9.23,<1.11.0',
+        'boto3>=1.6.23,<1.10.0',
+        'botocore>=1.9.23,<1.13.0',
         'psycopg2>=2.7.5,<2.8',
     ]
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -25,8 +25,6 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'snowflake-connector-python>=1.4.9',
-        'boto3>=1.6.23,<1.8.0',
-        'botocore>=1.9.23,<1.11.0',
+        'snowflake-connector-python>=1.6.12',
     ]
 )


### PR DESCRIPTION
Fixes #1234 

In the snowflake adapter, increase the minimum snowflake-connector-python to 1.6.12, that was the most recent boto3/botocore requirements change.

Then in the redshift plugin, set the boto3/botocore maximum versions to match the snowflake plugin's dependencies' upper bound. Currently, that includes the most recent versions of boto3/botocore.