### PR TITLE
fix for invalid timestamps returned by source freshness cmd

### DIFF
--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -261,8 +261,8 @@ class SourceFreshnessResult(NodeSerializable):
     def __init__(self, node, max_loaded_at, snapshotted_at,
                  age, status, thread_id, error=None,
                  timing=None, execution_time=0):
-        max_loaded_at = max_loaded_at.isoformat() + 'Z'
-        snapshotted_at = snapshotted_at.isoformat() + 'Z'
+        max_loaded_at = max_loaded_at.isoformat()
+        snapshotted_at = snapshotted_at.isoformat()
         if timing is None:
             timing = []
         super(SourceFreshnessResult, self).__init__(

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -397,7 +397,8 @@ class FreshnessRunner(BaseRunner):
         freshness = self.adapter.calculate_freshness(
             relation,
             compiled_node.loaded_at_field,
-            manifest=manifest
+            manifest=manifest,
+            connection_name=compiled_node.unique_id
         )
         status = self._calculate_status(
             compiled_node.freshness,

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -112,7 +112,7 @@ class BaseRunnableTask(BaseTask):
 
         This does still go through the callback path for result collection.
         """
-        if self.config.args.single_threaded or True:
+        if self.config.args.single_threaded:
             callback(self.call_runner(*args))
         else:
             pool.apply_async(self.call_runner, args=args, callback=callback)

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -119,7 +119,7 @@ class TestSourceFreshness(BaseSourcesTest):
         self.maxDiff = None
         self._id = 100
         # this is the db initial value
-        self.last_inserted_time = "2016-09-19T14:45:51+00:00Z"
+        self.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
     # test_source.test_table should have a loaded_at field of `updated_at`
     # and a freshness of warn_after: 10 hours, error_after: 18 hours
@@ -144,7 +144,7 @@ class TestSourceFreshness(BaseSourcesTest):
                 'source': self.adapter.quote('source'),
             }
         )
-        self.last_inserted_time = insert_time.strftime("%Y-%m-%dT%H:%M:%S+00:00Z")
+        self.last_inserted_time = insert_time.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
     def _assert_freshness_results(self, path, state):
         self.assertTrue(os.path.exists(path))
@@ -160,7 +160,7 @@ class TestSourceFreshness(BaseSourcesTest):
 
         last_inserted_time = self.last_inserted_time
         if last_inserted_time is None:
-            last_inserted_time = "2016-09-19T14:45:51+00:00Z"
+            last_inserted_time = "2016-09-19T14:45:51+00:00"
 
         self.assertEqual(data['sources'], {
             'source.test.test_source.test_table': {


### PR DESCRIPTION
- don't append `Z` to timestamps (these already have timezone offsets?)
- rm debug code for multithreading
- add a connection name to the `calculate_freshness` command

Of these, the last is maybe the most interesting. If we don't do this, then a DatabaseError in one source (eg. because of an incorrect table identifier) can cause dbt to hang. Is there some more general change to make here? Or should we _always_ pass a connection name to adapter methods?

@beckjake you were in here last - super interested what you think about this!