### PR TITLE
Fix/0.13.0 tweaks

### DIFF
--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -3,6 +3,7 @@ import six
 import requests
 from dbt.exceptions import RegistryException
 from dbt.utils import memoized
+from dbt.logger import GLOBAL_LOGGER as logger
 import os
 
 if os.getenv('DBT_PACKAGE_HUB_URL'):
@@ -32,7 +33,9 @@ def _wrap_exceptions(fn):
 @_wrap_exceptions
 def _get(path, registry_base_url=None):
     url = _get_url(path, registry_base_url)
+    logger.debug('Making package registry request: GET {}'.format(url))
     resp = requests.get(url)
+    logger.debug('Response from registry: GET {} {}'.format(url, resp.status_code))
     resp.raise_for_status()
     return resp.json()
 

--- a/core/dbt/clients/registry.py
+++ b/core/dbt/clients/registry.py
@@ -35,7 +35,8 @@ def _get(path, registry_base_url=None):
     url = _get_url(path, registry_base_url)
     logger.debug('Making package registry request: GET {}'.format(url))
     resp = requests.get(url)
-    logger.debug('Response from registry: GET {} {}'.format(url, resp.status_code))
+    logger.debug('Response from registry: GET {} {}'.format(url,
+                                                            resp.status_code))
     resp.raise_for_status()
     return resp.json()
 

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -298,9 +298,9 @@ class ModelRunner(CompileRunner):
                                         self.num_nodes)
 
     def print_result_line(self, result):
-        schema_name = self.node.schema
+        description = self.describe_node()
         dbt.ui.printer.print_model_result_line(result,
-                                               schema_name,
+                                               description,
                                                self.node_index,
                                                self.num_nodes)
 

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -147,8 +147,6 @@ def print_test_result_line(result, schema_name, index, total):
 
 
 def print_model_result_line(result, description, index, total):
-    model = result.node
-
     info, status = get_printable_result(result, 'created', 'creating')
 
     print_fancy_output_line(

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -146,17 +146,13 @@ def print_test_result_line(result, schema_name, index, total):
         result.execution_time)
 
 
-def print_model_result_line(result, schema_name, index, total):
+def print_model_result_line(result, description, index, total):
     model = result.node
 
     info, status = get_printable_result(result, 'created', 'creating')
 
     print_fancy_output_line(
-        "{info} {model_type} model {schema}.{relation}".format(
-            info=info,
-            model_type=get_materialization(model),
-            schema=schema_name,
-            relation=model.get('alias')),
+        "{info} {description}".format(info=info, description=description),
         status,
         index,
         total,


### PR DESCRIPTION
Minor tweaks for 0.13.0 that came up during alpha testing:

1. show db name in model result output (it was already shown in the `RUN` start line)
2. add debug logging for registry requests (fixes #1287)