### PR TITLE
Fix for alter table ... rename statements on Snowflake

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -36,6 +36,7 @@ def print_compile_stats(stats):
         NodeType.Macro: 'macros',
         NodeType.Operation: 'operations',
         NodeType.Seed: 'seed files',
+        NodeType.Source: 'sources',
     }
 
     results = {k: 0 for k in names.keys()}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -81,3 +81,10 @@
 {% macro snowflake__current_timestamp() -%}
   convert_timezone('UTC', current_timestamp())
 {%- endmacro %}
+
+
+{% macro snowflake__rename_relation(from_relation, to_relation) -%}
+  {% call statement('rename_relation') -%}
+    alter table {{ from_relation }} rename to {{ to_relation }}
+  {%- endcall %}
+{% endmacro %}

--- a/test/integration/024_custom_schema_test/models/view_3.sql
+++ b/test/integration/024_custom_schema_test/models/view_3.sql
@@ -1,5 +1,5 @@
 
-{{ config(schema='test') }}
+{{ config(schema='test', materialized='table') }}
 
 
 with v1 as (

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -1,5 +1,5 @@
 from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestCustomSchema(DBTIntegrationTest):
@@ -83,6 +83,42 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
         self.assertTablesEqual("seed","view_1", schema, v1_schema)
         self.assertTablesEqual("seed","view_2", schema, v2_schema)
         self.assertTablesEqual("agg","view_3", schema, xf_schema)
+
+
+class TestCustomProjectSchemaWithPrefixSnowflake(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "custom_schema_024"
+
+    @property
+    def models(self):
+        return "test/integration/024_custom_schema_test/models"
+
+    @property
+    def project_config(self):
+        return {
+            "models": {
+                "schema": "dbt_test"
+            }
+        }
+
+    @use_profile('snowflake')
+    def test__snowflake__custom_schema_with_prefix(self):
+        self.use_default_project()
+        self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
+
+        results = self.run_dbt()
+        self.assertEqual(len(results), 3)
+
+        schema = self.unique_schema().upper()
+        v1_schema = "{}_DBT_TEST".format(schema)
+        v2_schema = "{}_CUSTOM".format(schema)
+        xf_schema = "{}_TEST".format(schema)
+
+        self.assertTablesEqual("SEED","VIEW_1", schema, v1_schema)
+        self.assertTablesEqual("SEED","VIEW_2", schema, v2_schema)
+        self.assertTablesEqual("AGG","VIEW_3", schema, xf_schema)
 
 
 class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -125,7 +125,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
         self.mock_execute.assert_has_calls([
             mock.call(
-                'alter table "test_database"."test_schema".table_a rename to table_b',
+                'alter table "test_database"."test_schema".table_a rename to "test_database"."test_schema".table_b',
                 None
             )
         ])


### PR DESCRIPTION
- fixes #1316
- fixes #1313

On Snowflake, `alter ... rename` statements must include the destination database/schema. Before this change, dbt was just issuing a query like:
```
alter table analytics.prod_ecommerce.orders__dbt_tmp to orders
```

which resulted in the table being renamed to:
```
analytics.prod.orders
```

where `prod` is the schema specified in the active target. Note that this bug only affects models built into custom schemas.

Additionally, added a line of code to correctly render source counts in info level logs during compilation.