### PR TITLE
Feature/operations actually

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -744,9 +744,16 @@ class BaseAdapter(object):
 
         macro = manifest.find_macro_by_name(macro_name, project)
         if macro is None:
+            if project is None:
+                package_name = 'any package'
+            else:
+                package_name = 'the "{}" package'.format(project)
+
+            # The import of dbt.context.runtime below shadows 'dbt'
+            import dbt.exceptions
             raise dbt.exceptions.RuntimeException(
-                'Could not find macro with name {} in project {}'
-                .format(macro_name, project)
+                'dbt could not find a macro with the name "{}" in {}'
+                .format(macro_name, package_name)
             )
 
         # This causes a reference cycle, as dbt.context.runtime.generate()

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -20,6 +20,7 @@ import dbt.task.archive as archive_task
 import dbt.task.generate as generate_task
 import dbt.task.serve as serve_task
 import dbt.task.freshness as freshness_task
+import dbt.task.run_operation as run_operation_task
 from dbt.adapters.factory import reset_adapters
 
 import dbt.tracking
@@ -722,6 +723,33 @@ def parse_args(args):
     _build_docs_serve_subparser(docs_subs, base_subparser)
     _build_test_subparser(subs, base_subparser)
     _build_source_snapshot_freshness_subparser(source_subs, base_subparser)
+
+    sub = subs.add_parser(
+        'run-operation',
+        parents=[base_subparser],
+        help="""
+            (beta) Run the named macro with any supplied arguments. This
+            subcommand is unstable and subject to change in a future release
+            of dbt. Please use it with caution"""
+    )
+    sub.add_argument(
+        '--macro',
+        required=True,
+        help="""
+            Specify the macro to invoke. dbt will call this macro with the
+            supplied arguments and then exit"""
+    )
+    sub.add_argument(
+        '--args',
+        type=str,
+        default='{}',
+        help="""
+            Supply arguments to the macro. This dictionary will be mapped
+            to the keyword arguments defined in the selected macro. This
+            argument should be a YAML string, eg. '{my_variable: my_value}'"""
+    )
+    sub.set_defaults(cls=run_operation_task.RunOperationTask,
+                     which='run-operation')
 
     if len(args) == 0:
         p.print_help()

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -1,0 +1,40 @@
+from dbt.logger import GLOBAL_LOGGER as logger
+
+from dbt.task.base_task import BaseTask
+from dbt.adapters.factory import get_adapter
+from dbt.loader import GraphLoader
+
+import dbt
+import dbt.utils
+import dbt.exceptions
+
+
+class RunOperationTask(BaseTask):
+    def _get_macro_parts(self):
+        macro_name = self.args.macro
+        if '.' in macro_name:
+            package_name, macro_name = macro_name.split(".", 1)
+        else:
+            package_name = None
+
+        return package_name, macro_name
+
+    def _get_kwargs(self):
+        return dbt.utils.parse_cli_vars(self.args.args)
+
+    def run(self):
+        manifest = GraphLoader.load_all(self.config)
+        adapter = get_adapter(self.config)
+
+        package_name, macro_name = self._get_macro_parts()
+        macro_kwargs = self._get_kwargs()
+
+        res = adapter.execute_macro(
+            macro_name,
+            project=package_name,
+            kwargs=macro_kwargs,
+            manifest=manifest,
+            connection_name="macro_{}".format(macro_name)
+        )
+
+        return res


### PR DESCRIPTION
Fixes #582, at least initially. This is a feature that we need to deploy and play around with to understand better, but it's difficult to use it for production workloads if it's not in a production release of dbt! 

I suspect this functionality may change in meaningful ways, and I therefore suggest that:
1. we discourse the use of the task for folks who aren't interested in bleeding-edge dbt features
2. we do not document or promote this feature until (at least) the next release of dbt

I tried hiding the subtask from the argparse help menu, but i think `argparse.SUPPRESS` only works for flags (and not subtasks).

Once this is merged and we've had some time to experiment with it, we should queue up a subsequent issue to round out any rough edges and add some tasks.

Potential use cases:
- vacuum/analyze on redshift
- auto-compression for big tables on redshift
- periodic unloads from redshift
- copy into snowflake from s3
- swap schemas (eg. for blue/green deployments)
- really any out-of-band SQL that should be templated + versioned is suitable here

Really compellingly, we can supply entrypoint macros in packages, so the [redshift](https://github.com/fishtown-analytics/redshift) package could contain macros that make it dead simple to do some really complex perf tuning!