### PR TITLE
0.13.0 fixes around database quoting and rendering

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -18,6 +18,7 @@ from dbt.loader import GraphLoader
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.schema import Column
 from dbt.utils import filter_null_values, translate_aliases
+from dbt.node_types import NodeType
 
 from dbt.adapters.base.meta import AdapterMeta, available, available_raw, \
     available_deprecated

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -229,7 +229,14 @@ class BaseAdapter(object):
         if not dbt.flags.USE_CACHE:
             return
 
-        schemas = manifest.get_used_schemas()
+        # We only really need to cache relations for resources that
+        # dbt will try to build. Even the executable() list is probably
+        # more expansive than necessary. Really, we just want to avoid
+        # caching Sources here, as there could be _many_ different schemas
+        # in the list, and dbt largely doesn't need to know if those sources
+        # exist or not.
+        resource_types = NodeType.executable()
+        schemas = manifest.get_used_schemas(resource_types)
 
         relations = []
         # add all relations

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -405,7 +405,7 @@ class Manifest(APIObject):
         return frozenset({
             (node.database, node.schema)
             for node in self.nodes.values()
-            if resource_types and node.resource_type in resource_types
+            if not resource_types or node.resource_type in resource_types
         })
 
     def get_used_databases(self):

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -4,7 +4,7 @@ from dbt.contracts.graph.parsed import PARSED_NODE_CONTRACT, \
     PARSED_MACRO_CONTRACT, PARSED_DOCUMENTATION_CONTRACT, \
     PARSED_SOURCE_DEFINITION_CONTRACT
 from dbt.contracts.graph.compiled import COMPILED_NODE_CONTRACT, CompiledNode
-from dbt.exceptions import ValidationException
+from dbt.exceptions import ValidationException, raise_duplicate_resource_name
 from dbt.node_types import NodeType
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt import tracking
@@ -401,10 +401,11 @@ class Manifest(APIObject):
             type(self).__name__, name)
         )
 
-    def get_used_schemas(self):
+    def get_used_schemas(self, resource_types=None):
         return frozenset({
             (node.database, node.schema)
             for node in self.nodes.values()
+            if resource_types and node.resource_type in resource_types
         })
 
     def get_used_databases(self):

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -286,11 +286,17 @@ class CompileRunner(BaseRunner):
 
 
 class ModelRunner(CompileRunner):
+    def get_node_representation(self):
+        if self.config.credentials.database == self.node.database:
+            template = "{0.schema}.{0.alias}"
+        else:
+            template = "{0.database}.{0.schema}.{0.alias}"
+
+        return template.format(self.node)
+
     def describe_node(self):
-        materialization = dbt.utils.get_materialization(self.node)
-        return "{0} model {1.database}.{1.schema}.{1.alias}".format(
-            materialization, self.node
-        )
+        return "{} model {}".format(self.node.get_materialization(),
+                                    self.get_node_representation())
 
     def print_start_line(self):
         description = self.describe_node()
@@ -477,7 +483,7 @@ class ArchiveRunner(ModelRunner):
 
 class SeedRunner(ModelRunner):
     def describe_node(self):
-        return "seed file {0.database}.{0.schema}.{0.alias}".format(self.node)
+        return "seed file {}".format(self.get_node_representation())
 
     def before_execute(self):
         description = self.describe_node()

--- a/plugins/snowflake/dbt/adapters/snowflake/relation.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/relation.py
@@ -9,7 +9,7 @@ class SnowflakeRelation(BaseRelation):
         },
         'quote_character': '"',
         'quote_policy': {
-            'database': True,
+            'database': False,
             'schema': False,
             'identifier': False,
         },

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -69,7 +69,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
 
         self.mock_execute.assert_has_calls([
-            mock.call('drop schema if exists "test_database"."test_schema" cascade', None)
+            mock.call('drop schema if exists test_database."test_schema" cascade', None)
         ])
 
     def test_quoting_on_drop(self):
@@ -84,7 +84,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
         self.mock_execute.assert_has_calls([
             mock.call(
-                'drop table if exists "test_database"."test_schema".test_table cascade',
+                'drop table if exists test_database."test_schema".test_table cascade',
                 None
             )
         ])
@@ -100,7 +100,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.adapter.truncate_relation(relation)
 
         self.mock_execute.assert_has_calls([
-            mock.call('truncate table "test_database"."test_schema".test_table', None)
+            mock.call('truncate table test_database."test_schema".test_table', None)
         ])
 
     def test_quoting_on_rename(self):
@@ -125,7 +125,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
         self.mock_execute.assert_has_calls([
             mock.call(
-                'alter table "test_database"."test_schema".table_a rename to "test_database"."test_schema".table_b',
+                'alter table test_database."test_schema".table_a rename to test_database."test_schema".table_b',
                 None
             )
         ])


### PR DESCRIPTION
- do not quote snowflake database identifiers by default (preserves <=0.12.2 behavior)
- do not find relations in source schemas in list_relations (strictly to speed up parsing -- is the mechanism shown here an acceptable way to accomplish this?)
- do not render database names in stdout if a custom database is not specified (aesthetics)

I took some liberties here to round out the rest of the feedback around the 0.13.0 prerelease, but happy to discuss or revisit any of these!