### PR TITLE
RPC: Error handling improvements

### DIFF
--- a/core/dbt/compat.py
+++ b/core/dbt/compat.py
@@ -2,7 +2,6 @@
 
 import abc
 import codecs
-import json
 import warnings
 import decimal
 
@@ -35,12 +34,12 @@ else:
 if WHICH_PYTHON == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
     from SocketServer import TCPServer
-    from Queue import PriorityQueue
+    from Queue import PriorityQueue, Empty as QueueEmpty
     from thread import get_ident
 else:
     from http.server import SimpleHTTPRequestHandler
     from socketserver import TCPServer
-    from queue import PriorityQueue
+    from queue import PriorityQueue, Empty as QueueEmpty
     from threading import get_ident
 
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -45,7 +45,7 @@ def print_compile_stats(stats):
     stat_line = ", ".join(
         ["{} {}".format(ct, names.get(t)) for t, ct in results.items()])
 
-    logger.info("Found {}".format(stat_line))
+    logger.notice("Found {}".format(stat_line))
 
 
 def _add_prepended_cte(prepended_ctes, new_cte):

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -383,7 +383,7 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "config": provider.Config(model_dict, source_config),
         "database": config.credentials.database,
         "env_var": env_var,
-        "exceptions": dbt.exceptions.CONTEXT_EXPORTS,
+        "exceptions": dbt.exceptions.wrapped_exports(model),
         "execute": provider.execute,
         "flags": dbt.flags,
         # TODO: Do we have to leave this in?

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -4,10 +4,8 @@ import logging
 import logging.handlers
 import os
 import sys
-import warnings
 
 import colorama
-
 
 # Colorama needs some help on windows because we're using logger.info
 # intead of print(). If the Windows env doesn't have a TERM var set,
@@ -16,6 +14,27 @@ import colorama
 # to send escape characters and no log handler injection is needed.
 colorama_stdout = sys.stdout
 colorama_wrap = True
+
+colorama.init(wrap=colorama_wrap)
+
+DEBUG = logging.DEBUG
+NOTICE = 15
+INFO = logging.INFO
+WARNING = logging.WARNING
+ERROR = logging.ERROR
+CRITICAL = logging.CRITICAL
+
+logging.addLevelName(NOTICE, 'NOTICE')
+
+
+class Logger(logging.Logger):
+    def notice(self, msg, *args, **kwargs):
+        if self.isEnabledFor(NOTICE):
+            self._log(NOTICE, msg, args, **kwargs)
+
+
+logging.setLoggerClass(Logger)
+
 
 if sys.platform == 'win32' and not os.environ.get('TERM'):
     colorama_wrap = False
@@ -29,22 +48,22 @@ colorama.init(wrap=colorama_wrap)
 # create a global console logger for dbt
 stdout_handler = logging.StreamHandler(colorama_stdout)
 stdout_handler.setFormatter(logging.Formatter('%(message)s'))
-stdout_handler.setLevel(logging.INFO)
+stdout_handler.setLevel(INFO)
 
 logger = logging.getLogger('dbt')
 logger.addHandler(stdout_handler)
-logger.setLevel(logging.DEBUG)
-logging.getLogger().setLevel(logging.CRITICAL)
+logger.setLevel(DEBUG)
+logging.getLogger().setLevel(CRITICAL)
 
 # Quiet these down in the logs
-logging.getLogger('botocore').setLevel(logging.INFO)
-logging.getLogger('requests').setLevel(logging.INFO)
-logging.getLogger('urllib3').setLevel(logging.INFO)
-logging.getLogger('google').setLevel(logging.INFO)
-logging.getLogger('snowflake.connector').setLevel(logging.INFO)
-logging.getLogger('parsedatetime').setLevel(logging.INFO)
+logging.getLogger('botocore').setLevel(INFO)
+logging.getLogger('requests').setLevel(INFO)
+logging.getLogger('urllib3').setLevel(INFO)
+logging.getLogger('google').setLevel(INFO)
+logging.getLogger('snowflake.connector').setLevel(INFO)
+logging.getLogger('parsedatetime').setLevel(INFO)
 # we never want to seek werkzeug logs
-logging.getLogger('werkzeug').setLevel(logging.CRITICAL)
+logging.getLogger('werkzeug').setLevel(CRITICAL)
 
 # provide this for the cache.
 CACHE_LOGGER = logging.getLogger('dbt.cache')
@@ -87,7 +106,7 @@ def initialize_logger(debug_mode=False, path=None):
 
     if debug_mode:
         stdout_handler.setFormatter(default_formatter())
-        stdout_handler.setLevel(logging.DEBUG)
+        stdout_handler.setLevel(DEBUG)
 
     if path is not None:
         make_log_dir_if_missing(path)
@@ -105,14 +124,14 @@ def initialize_logger(debug_mode=False, path=None):
         logdir_handler.addFilter(color_filter)
 
         logdir_handler.setFormatter(default_formatter())
-        logdir_handler.setLevel(logging.DEBUG)
+        logdir_handler.setLevel(DEBUG)
 
         logger.addHandler(logdir_handler)
 
         # Log Python warnings to file
         warning_logger = logging.getLogger('py.warnings')
         warning_logger.addHandler(logdir_handler)
-        warning_logger.setLevel(logging.DEBUG)
+        warning_logger.setLevel(DEBUG)
 
     initialized = True
 
@@ -130,6 +149,25 @@ def log_cache_events(flag):
 GLOBAL_LOGGER = logger
 
 
+class QueueFormatter(logging.Formatter):
+    def format(self, record):
+        record.message = record.getMessage()
+        record.asctime = self.formatTime(record, self.datefmt)
+        formatted = self.formatMessage(record)
+
+        output = {
+            'message': formatted,
+            'timestamp': record.asctime,
+            'levelname': record.levelname,
+            'level': record.levelno,
+        }
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+            output['exc_info'] = record.exc_text
+        return output
+
+
 class QueueLogHandler(logging.Handler):
     def __init__(self, queue):
         super(QueueLogHandler, self).__init__()
@@ -143,6 +181,6 @@ class QueueLogHandler(logging.Handler):
 def add_queue_handler(queue):
     """Add a queue log handler to the global logger."""
     handler = QueueLogHandler(queue)
-    handler.setFormatter(default_formatter())
-    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(QueueFormatter())
+    handler.setLevel(DEBUG)
     GLOBAL_LOGGER.addHandler(handler)

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -48,7 +48,7 @@ colorama.init(wrap=colorama_wrap)
 # create a global console logger for dbt
 stdout_handler = logging.StreamHandler(colorama_stdout)
 stdout_handler.setFormatter(logging.Formatter('%(message)s'))
-stdout_handler.setLevel(INFO)
+stdout_handler.setLevel(NOTICE)
 
 logger = logging.getLogger('dbt')
 logger.addHandler(stdout_handler)

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -150,6 +150,22 @@ GLOBAL_LOGGER = logger
 
 
 class QueueFormatter(logging.Formatter):
+    def formatMessage(self, record):
+        superself = super(QueueFormatter, self)
+        if hasattr(superself, 'formatMessage'):
+            # python 3.x
+            return superself.formatMessage(record)
+
+        # python 2.x, handling weird unicode things
+        try:
+            return self._fmt % record.__dict__
+        except UnicodeDecodeError as e:
+            try:
+                record.name = record.name.decode('utf-8')
+                return self._fmt % record.__dict__
+            except UnicodeDecodeError as e:
+                raise e
+
     def format(self, record):
         record.message = record.getMessage()
         record.asctime = self.formatTime(record, self.datefmt)

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -166,7 +166,7 @@ def track_run(task):
         )
     except (dbt.exceptions.NotImplementedException,
             dbt.exceptions.FailedToConnectException) as e:
-        logger.info('ERROR: {}'.format(e))
+        logger.error('ERROR: {}'.format(e))
         dbt.tracking.track_invocation_end(
             config=task.config, args=task.args, result_type="error"
         )

--- a/core/dbt/parser/util.py
+++ b/core/dbt/parser/util.py
@@ -231,12 +231,15 @@ class ParserUtils(object):
         return manifest
 
     @classmethod
-    def add_new_refs(cls, manifest, current_project, node):
+    def add_new_refs(cls, manifest, current_project, node, macros):
         """Given a new node that is not in the manifest, copy the manifest and
         insert the new node into it as if it were part of regular ref
         processing
         """
         manifest = manifest.deepcopy(config=current_project)
+        # it's ok for macros to silently override a local project macro name
+        manifest.macros.update(macros)
+
         if node.unique_id in manifest.nodes:
             # this should be _impossible_ due to the fact that rpc calls get
             # a unique ID that starts with 'rpc'!

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -53,3 +53,16 @@ def dbt_error(exc, logs=None):
     exc = RPCException(code=exc.CODE, message=exc.MESSAGE, data=exc.data(),
                        logs=logs)
     return exc
+
+
+class QueueMessageType(object):
+    Error = 'error'
+    Result = 'result'
+    Log = 'log'
+
+    @classmethod
+    def terminating(cls):
+        return [
+            cls.Error,
+            cls.Result
+        ]

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -1,0 +1,55 @@
+from jsonrpc.exceptions import JSONRPCDispatchException, JSONRPCInvalidParams
+
+import dbt.exceptions
+
+
+class RPCException(JSONRPCDispatchException):
+    def __init__(self, code=None, message=None, data=None, logs=None):
+        if code is None:
+            code = -32000
+        if message is None:
+            message = 'Server error'
+        if data is None:
+            data = {}
+
+        super(RPCException, self).__init__(code=code, message=message,
+                                           data=data)
+        self.logs = logs
+
+    @property
+    def logs(self):
+        return self.error.data.get('logs')
+
+    @logs.setter
+    def logs(self, value):
+        if value is None:
+            return
+        self.error.data['logs'] = value
+
+    @classmethod
+    def from_error(cls, err):
+        return cls(err.code, err.message, err.data, err.data.get('logs'))
+
+
+def invalid_params(err, logs):
+    return RPCException(
+        code=JSONRPCInvalidParams.code,
+        message=JSONRPCInvalidParams.MESSAGE,
+        data={'logs': logs}
+    )
+
+
+def server_error(err, logs=None):
+    exc = dbt.exceptions.Exception(str(err))
+    return dbt_error(exc, logs)
+
+
+def timeout_error(timeout_value, logs=None):
+    exc = dbt.exceptions.RPCTimeoutException(timeout_value)
+    return dbt_error(exc, logs)
+
+
+def dbt_error(exc, logs=None):
+    exc = RPCException(code=exc.CODE, message=exc.MESSAGE, data=exc.data(),
+                       logs=logs)
+    return exc

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -31,11 +31,11 @@ class RPCException(JSONRPCDispatchException):
         return cls(err.code, err.message, err.data, err.data.get('logs'))
 
 
-def invalid_params(err, logs):
+def invalid_params(data):
     return RPCException(
-        code=JSONRPCInvalidParams.code,
+        code=JSONRPCInvalidParams.CODE,
         message=JSONRPCInvalidParams.MESSAGE,
-        data={'logs': logs}
+        data=data
     )
 
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -7,7 +7,7 @@ from dbt.config import RuntimeConfig, Project
 from dbt.config.profile import read_profile, PROFILES_DIR
 from dbt import tracking
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.utils import to_string
+from dbt.compat import to_string
 import dbt.exceptions
 
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -52,16 +52,16 @@ class BaseTask(object):
         try:
             config = cls.ConfigType.from_args(args)
         except dbt.exceptions.DbtProjectError as exc:
-            logger.info("Encountered an error while reading the project:")
-            logger.info(to_string(exc))
+            logger.error("Encountered an error while reading the project:")
+            logger.error("  ERROR: {}".format(str(exc)))
 
             tracking.track_invalid_invocation(
                 args=args,
                 result_type=exc.result_type)
             raise dbt.exceptions.RuntimeException('Could not run dbt')
         except dbt.exceptions.DbtProfileError as exc:
-            logger.info("Encountered an error while reading profiles:")
-            logger.info("  ERROR {}".format(str(exc)))
+            logger.error("Encountered an error while reading profiles:")
+            logger.error("  ERROR {}".format(str(exc)))
 
             all_profiles = read_profiles(args.profiles_dir).keys()
 

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -36,7 +36,7 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
     METHOD_NAME = 'compile'
 
     def __init__(self, args, config):
-        super(CompileTask, self).__init__(args, config)
+        super(RemoteCompileTask, self).__init__(args, config)
         self.parser = None
         self._base_manifest = GraphLoader.load_all(
             config,

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -6,6 +6,7 @@ from dbt.loader import load_all_projects, GraphLoader
 from dbt.node_runners import CompileRunner, RPCCompileRunner
 from dbt.node_types import NodeType
 from dbt.parser.analysis import RPCCallParser
+from dbt.parser.macros import MacroParser
 from dbt.parser.util import ParserUtils
 import dbt.ui.printer
 
@@ -37,7 +38,6 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
 
     def __init__(self, args, config):
         super(RemoteCompileTask, self).__init__(args, config)
-        self.parser = None
         self._base_manifest = GraphLoader.load_all(
             config,
             internal_manifest=get_adapter(config).check_internal_manifest()
@@ -56,15 +56,28 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
         self._skipped_children = {}
         self._raise_next_tick = None
 
-    def handle_request(self, name, sql):
-        self.parser = RPCCallParser(
+    def handle_request(self, name, sql, macros=None):
+        request_path = os.path.join(self.config.target_path, 'rpc', name)
+        all_projects = load_all_projects(self.config)
+        macro_overrides = {}
+        if macros is not None:
+            macros = self.decode_sql(macros)
+            macro_parser = MacroParser(self.config, all_projects)
+            macro_overrides.update(macro_parser.parse_macro_file(
+                macro_file_path='from remote system',
+                macro_file_contents=macros,
+                root_path=request_path,
+                package_name=self.config.project_name,
+                resource_type=NodeType.Macro
+            ))
+
+        rpc_parser = RPCCallParser(
             self.config,
-            all_projects=load_all_projects(self.config),
+            all_projects=all_projects,
             macro_manifest=self._base_manifest
         )
 
         sql = self.decode_sql(sql)
-        request_path = os.path.join(self.config.target_path, 'rpc', name)
         node_dict = {
             'name': name,
             'root_path': request_path,
@@ -74,13 +87,16 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
             'package_name': self.config.project_name,
             'raw_sql': sql,
         }
-        unique_id, node = self.parser.parse_sql_node(node_dict)
+
+        unique_id, node = rpc_parser.parse_sql_node(node_dict)
 
         self.manifest = ParserUtils.add_new_refs(
             manifest=self._base_manifest,
             current_project=self.config,
-            node=node
+            node=node,
+            macros=macro_overrides
         )
+
         # don't write our new, weird manifest!
         self.linker = compile_manifest(self.config, self.manifest, write=False)
         selected_uids = [node.unique_id]

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -1,16 +1,126 @@
 import json
-import os
+import multiprocessing
+import time
 
 from jsonrpc import Dispatcher, JSONRPCResponseManager
 
 from werkzeug.wrappers import Request, Response
 from werkzeug.serving import run_simple
 
-from dbt.logger import RPC_LOGGER as logger
+from dbt.logger import RPC_LOGGER as logger, add_queue_handler
 from dbt.task.base import ConfiguredTask
 from dbt.task.compile import CompileTask, RemoteCompileTask
 from dbt.task.run import RemoteRunTask
 from dbt.utils import JSONEncoder
+from dbt.compat import QueueEmpty
+import dbt.exceptions
+from dbt import rpc
+
+
+class RequestTaskHandler(object):
+    def __init__(self, task):
+        self.task = task
+        self.queue = None
+        self.process = None
+        self.started = None
+        self.timeout = None
+        self.logs = []
+
+    def _next_timeout(self):
+        if self.timeout is None:
+            return None
+        end = self.started + self.timeout
+        timeout = end - time.time()
+        if timeout < 0:
+            raise dbt.exceptions.RPCTimeoutException(self.timeout)
+        return timeout
+
+    def _wait_for_results(self):
+        """Wait for results off the queue. If there is a timeout set, and it is
+        exceeded, raise an RPCTimeoutException.
+        """
+        while True:
+            get_timeout = self._next_timeout()
+            try:
+                msgtype, value = self.queue.get(timeout=get_timeout)
+            except QueueEmpty:
+                raise dbt.exceptions.RPCTimeoutException(self.timeout)
+
+            if msgtype == 'log':
+                self.logs.append(value)
+            else:
+                return msgtype, value
+
+    def _join_process(self):
+        try:
+            msgtype, result = self._wait_for_results()
+        except dbt.exceptions.RPCTimeoutException as exc:
+            self.process.terminate()
+            raise rpc.timeout_error(self.timeout)
+        except dbt.exceptions.Exception as exc:
+            raise rpc.dbt_error(exc)
+        except Exception as exc:
+            raise rpc.server_error(exc)
+        finally:
+            self.process.join()
+
+        self.process = None
+        self.queue = None
+
+        if msgtype == 'error':
+            raise rpc.RPCException.from_error(result)
+
+        return result
+
+    def get_result(self):
+        try:
+            result = self._join_process()
+        except rpc.RPCException as exc:
+            exc.logs = self.logs
+            raise
+
+        result['logs'] = self.logs
+        return result
+
+    def task_bootstrap(self, kwargs):
+        # the first thing we do in a new process: start logging
+        add_queue_handler(self.queue)
+
+        error = None
+        result = None
+        try:
+            result = self.task.handle_request(**kwargs)
+        except rpc.RPCException as exc:
+            error = exc
+        except dbt.exceptions.Exception as exc:
+            logger.debug('dbt runtime exception', exc_info=True)
+            error = rpc.dbt_error(exc)
+        except Exception as exc:
+            logger.debug('uncaught python exception', exc_info=True)
+            error = rpc.server_error(exc)
+
+        # put whatever result we got onto the queue as well.
+        if error is not None:
+            self.queue.put(['error', error.error])
+        else:
+            self.queue.put(['result', result])
+
+    def handle(self, kwargs):
+        self.started = time.time()
+        self.timeout = kwargs.pop('timeout', None)
+        self.queue = multiprocessing.Queue()
+        self.process = multiprocessing.Process(
+            target=self.task_bootstrap,
+            args=(kwargs,)
+        )
+        self.process.start()
+        return self.get_result()
+
+    @classmethod
+    def factory(cls, task):
+        def handler(**kwargs):
+            return cls(task).handle(kwargs)
+        return handler
 
 
 class RPCServerTask(ConfiguredTask):
@@ -25,7 +135,7 @@ class RPCServerTask(ConfiguredTask):
             self.register(cls(args, config))
 
     def register(self, task):
-        self.dispatcher.add_method(task.safe_handle_request,
+        self.dispatcher.add_method(RequestTaskHandler.factory(task),
                                    name=task.METHOD_NAME)
 
     @property
@@ -60,10 +170,7 @@ class RPCServerTask(ConfiguredTask):
     def handle_request(self, request):
         msg = 'Received request ({0}) from {0.remote_addr}, data={0.data}'
         logger.info(msg.format(request))
-        # request_data is the request as a parsedjson object
-        response = JSONRPCResponseManager.handle(
-            request.data, self.dispatcher
-        )
+        response = JSONRPCResponseManager.handle(request.data, self.dispatcher)
         json_data = json.dumps(response.data, cls=JSONEncoder)
         response = Response(json_data, mimetype='application/json')
         # this looks and feels dumb, but our json encoder converts decimals and

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -369,8 +369,6 @@ class RemoteCallable(object):
     @staticmethod
     def raise_invalid_base64(sql):
         raise rpc.invalid_params(
-            code=JSONRPCInvalidParams.CODE,
-            message=JSONRPCInvalidParams.MESSAGE,
             data={
                 'message': 'invalid base64-encoded sql input',
                 'sql': str(sql),

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -273,8 +273,8 @@ class GraphRunnableTask(ManifestTask):
         self._runtime_initialize()
 
         if len(self._flattened_nodes) == 0:
-            logger.info("WARNING: Nothing to do. Try checking your model "
-                        "configs and model specification args")
+            logger.warning("WARNING: Nothing to do. Try checking your model "
+                           "configs and model specification args")
             return []
         else:
             logger.info("")

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -1,18 +1,14 @@
-from datetime import datetime
-from decimal import Decimal
-
 import collections
 import copy
+import datetime
 import functools
 import hashlib
 import itertools
 import json
-import numbers
 import os
 
 import dbt.exceptions
 
-from dbt.include.global_project import PACKAGES
 from dbt.compat import basestring, DECIMALS
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
@@ -442,7 +438,7 @@ def add_ephemeral_model_prefix(s):
 def timestring():
     """Get the current datetime as an RFC 3339-compliant string"""
     # isoformat doesn't include the mandatory trailing 'Z' for UTC.
-    return datetime.utcnow().isoformat() + 'Z'
+    return datetime.datetime.utcnow().isoformat() + 'Z'
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -453,8 +449,9 @@ class JSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, DECIMALS):
             return float(obj)
-        if isinstance(obj, datetime):
+        if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return obj.isoformat()
+
         return super(JSONEncoder, self).default(obj)
 
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -146,7 +146,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             "diststyle": {
               "id": "diststyle",
               "label": "Dist Style",
-              "value": "EVEN",
+              "value": AnyStringWith(None),
               "description": "Distribution style or distribution key column, if key distribution is defined.",
               "include": True
             },

--- a/test/integration/042_sources_test/macros/macro.sql
+++ b/test/integration/042_sources_test/macros/macro.sql
@@ -1,0 +1,7 @@
+{% macro override_me() -%}
+	exceptions.raise_compiler_error('this is a bad macro')
+{%- endmacro %}
+
+{% macro happy_little_macro() -%}
+	{{ override_me() }}
+{%- endmacro %}


### PR DESCRIPTION
Fixes #1309 
Fixes #1310 

All dbt errors now have proper error codes/messages
The raised message at runtime ends up in result.error.data.message
The raised message type at runtime ends up in result.error.data.typename
result.error.message is a plaintext name for result.error.code
dbt.exceptions.Exception.data() becomes result.error.data
Include logs in the RPC responses - for errors under `response.error.data.logs` and for results under `response.result.logs`. The results are enqueued back to the main process, so even timeouts get logs.

I refactored safe_run by just chunking everything up as part of this, as I wanted to override particular parts of the error handling chain (mostly to keep raising errors farther and father up the stack of `safe_*`)
