### PR TITLE
Prefix temp relations with model name instead of alias (#1321)

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/archive/archive.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/archive.sql
@@ -188,7 +188,7 @@
 
 
   {%- set identifier = model['alias'] -%}
-  {%- set tmp_identifier = identifier + '__dbt_archival_tmp' -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_archival_tmp' -%}
 
   {% set tmp_table_sql -%}
 

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -16,7 +16,7 @@
   {%- set unique_key = config.get('unique_key') -%}
 
   {%- set identifier = model['alias'] -%}
-  {%- set tmp_identifier = identifier + '__dbt_incremental_tmp' -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_incremental_tmp' -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,  type='table') -%}

--- a/core/dbt/include/global_project/macros/materializations/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/table/table.sql
@@ -1,7 +1,7 @@
 {% materialization table, default %}
   {%- set identifier = model['alias'] -%}
-  {%- set tmp_identifier = identifier + '__dbt_tmp' -%}
-  {%- set backup_identifier = identifier + '__dbt_backup' -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}
+  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}

--- a/core/dbt/include/global_project/macros/materializations/view/view.sql
+++ b/core/dbt/include/global_project/macros/materializations/view/view.sql
@@ -1,8 +1,8 @@
 {%- materialization view, default -%}
 
   {%- set identifier = model['alias'] -%}
-  {%- set tmp_identifier = identifier + '__dbt_tmp' -%}
-  {%- set backup_identifier = identifier + '__dbt_backup' -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}
+  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
@@ -1,7 +1,7 @@
 {% materialization table, adapter='snowflake' %}
   {%- set identifier = model['alias'] -%}
-  {%- set tmp_identifier = identifier + '__dbt_tmp' -%}
-  {%- set backup_identifier = identifier + '__dbt_backup' -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}
+  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}


### PR DESCRIPTION
Fixes #1321 

Change everywhere we make a temp relation named like `{???}_dbt_`, to use `name` instead of `alias`. This should avoid collisions when multiple models with the same aliases in different schemas are building at the same time, because model names are required to be unique.

I'm struggling to come up with a good way to reliably test this, but existing tests didn't appear to break.