### PR TITLE
RPC: macros

### DIFF
--- a/core/dbt/parser/util.py
+++ b/core/dbt/parser/util.py
@@ -231,12 +231,15 @@ class ParserUtils(object):
         return manifest
 
     @classmethod
-    def add_new_refs(cls, manifest, current_project, node):
+    def add_new_refs(cls, manifest, current_project, node, macros):
         """Given a new node that is not in the manifest, copy the manifest and
         insert the new node into it as if it were part of regular ref
         processing
         """
         manifest = manifest.deepcopy(config=current_project)
+        # it's ok for macros to silently override a local project macro name
+        manifest.macros.update(macros)
+
         if node.unique_id in manifest.nodes:
             # this should be _impossible_ due to the fact that rpc calls get
             # a unique ID that starts with 'rpc'!

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -31,11 +31,11 @@ class RPCException(JSONRPCDispatchException):
         return cls(err.code, err.message, err.data, err.data.get('logs'))
 
 
-def invalid_params(err, logs):
+def invalid_params(data):
     return RPCException(
-        code=JSONRPCInvalidParams.code,
+        code=JSONRPCInvalidParams.CODE,
         message=JSONRPCInvalidParams.MESSAGE,
-        data={'logs': logs}
+        data=data
     )
 
 

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -6,6 +6,7 @@ from dbt.loader import load_all_projects, GraphLoader
 from dbt.node_runners import CompileRunner, RPCCompileRunner
 from dbt.node_types import NodeType
 from dbt.parser.analysis import RPCCallParser
+from dbt.parser.macros import MacroParser
 from dbt.parser.util import ParserUtils
 import dbt.ui.printer
 
@@ -37,7 +38,6 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
 
     def __init__(self, args, config):
         super(RemoteCompileTask, self).__init__(args, config)
-        self.parser = None
         self._base_manifest = GraphLoader.load_all(
             config,
             internal_manifest=get_adapter(config).check_internal_manifest()
@@ -56,15 +56,28 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
         self._skipped_children = {}
         self._raise_next_tick = None
 
-    def handle_request(self, name, sql):
-        self.parser = RPCCallParser(
+    def handle_request(self, name, sql, macros=None):
+        request_path = os.path.join(self.config.target_path, 'rpc', name)
+        all_projects = load_all_projects(self.config)
+        macro_overrides = {}
+        if macros is not None:
+            macros = self.decode_sql(macros)
+            macro_parser = MacroParser(self.config, all_projects)
+            macro_overrides.update(macro_parser.parse_macro_file(
+                macro_file_path='from remote system',
+                macro_file_contents=macros,
+                root_path=request_path,
+                package_name=self.config.project_name,
+                resource_type=NodeType.Macro
+            ))
+
+        rpc_parser = RPCCallParser(
             self.config,
-            all_projects=load_all_projects(self.config),
+            all_projects=all_projects,
             macro_manifest=self._base_manifest
         )
 
         sql = self.decode_sql(sql)
-        request_path = os.path.join(self.config.target_path, 'rpc', name)
         node_dict = {
             'name': name,
             'root_path': request_path,
@@ -74,13 +87,16 @@ class RemoteCompileTask(CompileTask, RemoteCallable):
             'package_name': self.config.project_name,
             'raw_sql': sql,
         }
-        unique_id, node = self.parser.parse_sql_node(node_dict)
+
+        unique_id, node = rpc_parser.parse_sql_node(node_dict)
 
         self.manifest = ParserUtils.add_new_refs(
             manifest=self._base_manifest,
             current_project=self.config,
-            node=node
+            node=node,
+            macros=macro_overrides
         )
+
         # don't write our new, weird manifest!
         self.linker = compile_manifest(self.config, self.manifest, write=False)
         selected_uids = [node.unique_id]

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -369,8 +369,6 @@ class RemoteCallable(object):
     @staticmethod
     def raise_invalid_base64(sql):
         raise rpc.invalid_params(
-            code=JSONRPCInvalidParams.CODE,
-            message=JSONRPCInvalidParams.MESSAGE,
             data={
                 'message': 'invalid base64-encoded sql input',
                 'sql': str(sql),

--- a/test/integration/042_sources_test/macros/macro.sql
+++ b/test/integration/042_sources_test/macros/macro.sql
@@ -1,0 +1,7 @@
+{% macro override_me() -%}
+	exceptions.raise_compiler_error('this is a bad macro')
+{%- endmacro %}
+
+{% macro happy_little_macro() -%}
+	{{ override_me() }}
+{%- endmacro %}


### PR DESCRIPTION
Fixes #1308 

Add an optional "macros" parameter to rpc calls (compile and run). The parameter name is "macros" and the data should be base64-encoded text that when decoded, represents a coherent macro sql file. You can specify as many macros as you would like, and passed macros override those in the current project for the current API call.