### PR TITLE
Fix out of order execution on model select (#1354)

### DIFF
--- a/core/dbt/linker.py
+++ b/core/dbt/linker.py
@@ -174,33 +174,18 @@ class GraphQueue(object):
         self.inner.join()
 
 
-def _remove_node_from_graph(graph, node):
-    # find all our direct parents in the graph, and all our direct
-    # children. note: do not use the _iter forms here, we need actual lists
-    # as we'll be mutating the graph again
-    parents = graph.predecessors(node)
-    children = graph.successors(node)
-    # remove the actual node
-    graph.remove_node(node)
-    # now redraw the edges, so that if A -> B -> C and B is to be
-    # removed, we will now have A -> C
-    for parent in parents:
-        for child in children:
-            graph.add_edge(parent, child)
-
-
 def _subset_graph(graph, include_nodes):
     """Create and return a new graph that is a shallow copy of graph but with
     only the nodes in include_nodes. Transitive edges across removed nodes are
     preserved as explicit new edges.
     """
-    new_graph = nx.DiGraph(graph)
+    new_graph = nx.algorithms.transitive_closure(graph)
 
     include_nodes = set(include_nodes)
 
     for node in graph.nodes():
         if node not in include_nodes:
-            _remove_node_from_graph(new_graph, node)
+            new_graph.remove_node(node)
 
     for node in include_nodes:
         if node not in new_graph:

--- a/test/integration/007_graph_selection_tests/models/users_rollup_dependency.sql
+++ b/test/integration/007_graph_selection_tests/models/users_rollup_dependency.sql
@@ -1,0 +1,5 @@
+{{
+	config(materialized='table')
+}}
+
+select * from {{ ref('users_rollup') }}

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -60,7 +60,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
         results = self.run_dbt(['run', '--models', 'tag:base+'])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
 
         created_models = self.get_models_in_schema()
         self.assertFalse('base_users' in created_models)
@@ -89,7 +89,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
         results = self.run_dbt(['run', '--models', 'users+'])
-        self.assertEqual(len(results),  3)
+        self.assertEqual(len(results),  4)
 
         self.assertTablesEqual("seed", "users")
         self.assertTablesEqual("summary_expected", "users_rollup")
@@ -104,7 +104,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
         results = self.run_dbt(['run', '--models', 'users+'])
-        self.assertEqual(len(results),  3)
+        self.assertEqual(len(results),  4)
 
         self.assertManyTablesEqual(
             ["SEED", "USERS"],
@@ -194,7 +194,7 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__childrens_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         results = self.run_dbt(['run', '--models', '@base_users'])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
 
         created_models = self.get_models_in_schema()
         self.assertIn('users_rollup', created_models)
@@ -207,8 +207,8 @@ class TestGraphSelection(DBTIntegrationTest):
     def test__postgres__more_childrens_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         results = self.run_dbt(['run', '--models', '@users'])
-        # base_users, emails, users_rollup, but not users (ephemeral)
-        self.assertEqual(len(results), 3)
+        # base_users, emails, users_rollup, users_rollup_dependency, but not users (ephemeral)
+        self.assertEqual(len(results), 4)
 
         created_models = self.get_models_in_schema()
         self.assertIn('users_rollup', created_models)
@@ -216,3 +216,24 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertIn('emails_alt', created_models)
         self.assertNotIn('subdir', created_models)
         self.assertNotIn('nested_users', created_models)
+
+    @attr(type='snowflake')
+    def test__snowflake__skip_intermediate(self):
+        self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
+        results = self.run_dbt(['run', '--models', '@users'])
+        # base_users, emails, users_rollup, users_rollup_dependency
+        self.assertEqual(len(results), 4)
+
+        # now re-run, skipping users_rollup
+        results = self.run_dbt(['run', '--models', '@users', '--exclude', 'users_rollup'])
+        self.assertEqual(len(results), 3)
+
+        # make sure that users_rollup_dependency and users don't interleave
+        users = [r for r in results if r.node.name == 'users'][0]
+        dep = [r for r in results if r.node.name == 'users_rollup_dependency'][0]
+        user_last_end = users.timing[1]['completed_at']
+        dep_first_start = dep.timing[0]['started_at']
+        self.assertTrue(
+            user_last_end < dep_first_start,
+            'dependency started before its transitive parent ({} > {})'.format(user_last_end, dep_first_start)
+        )

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -26,7 +26,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         self.run_dbt(["deps"])
         results = self.run_dbt(['run', '--exclude', 'never_selected'])
-        self.assertEqual(len(results), 8)
+        self.assertEqual(len(results), 9)
 
         args = FakeArgs()
         args.models = include

--- a/test/integration/007_graph_selection_tests/test_tag_selection.py
+++ b/test/integration/007_graph_selection_tests/test_tag_selection.py
@@ -42,7 +42,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
         results = self.run_dbt(['run', '--models', '+tag:specified_in_project+'])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
 
         models_run = [r.node['name'] for r in results]
         self.assertTrue('users' in models_run)
@@ -69,8 +69,10 @@ class TestGraphSelection(DBTIntegrationTest):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
         results = self.run_dbt(['run', '--models', '@tag:users'])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
 
         models_run = set(r.node['name'] for r in results)
-        self.assertEqual({'users', 'users_rollup', 'emails_alt'}, models_run)
-
+        self.assertEqual(
+            {'users', 'users_rollup', 'emails_alt', 'users_rollup_dependency'},
+            models_run
+        )

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -439,7 +439,7 @@ class DBTIntegrationTest(unittest.TestCase):
             args = ["run"]
 
         if strict:
-            args = ["--single-threaded", "--strict"] + args
+            args = ["--strict"] + args
         args.append('--log-cache-events')
         logger.info("Invoking dbt with {}".format(args))
 


### PR DESCRIPTION
Fixes #1354

When we're removing nodes from the new graph we've constructed for the graph queue, replace all the removed transitive dependencies with explicit ones. The idea here is like this:

Imagine you have a DAG of models that is really boring and linear like: (A -> B -> C -> D)

And you've done `dbt run --model A D`. The old code would see a graph with those two nodes and no dependencies:

1) remove B, graph is now (A,), (C -> D)
2) remove C, graph is now (A,), (D,)

The new code works like this:
1) Take the transitive closure of the graph (A -> (B, C, D), B -> (C, D), C -> D)
2) Remove B, the graph is now (A -> (C, D), C -> D)
3) Remove C, the graph is now (A -> D)

A will now correctly execute before D.


Note that if B or C are early-binding views as in postgres/redshift default, this code will still fail, because the `drop ... cascade` when building A will drop B and C as well, and then D has no existing refs.