### PR TITLE
fix for error-ed out transactions on redshift

### DIFF
--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -640,6 +640,14 @@ def _build_source_snapshot_freshness_subparser(subparsers, base_subparser):
         target/sources.json
         """
     )
+    sub.add_argument(
+        '--threads',
+        type=int,
+        required=False,
+        help="""
+        Specify number of threads to use. Overrides settings in profiles.yml
+        """
+    )
     sub.set_defaults(cls=freshness_task.FreshnessTask,
                      which='snapshot-freshness')
     return sub

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -400,6 +400,7 @@ class FreshnessRunner(BaseRunner):
     def execute(self, compiled_node, manifest):
         relation = self.adapter.Relation.create_from_source(compiled_node)
         # given a Source, calculate its fresnhess.
+        self.adapter.clear_transaction(compiled_node.unique_id)
         freshness = self.adapter.calculate_freshness(
             relation,
             compiled_node.loaded_at_field,


### PR DESCRIPTION
### Problem

On Redshift (and Postgres?) a single invalid freshness query (ie. for an invalid table) would result in a dead transaction. Subsequent queries used the same connection (and transaction?) and so would fail with with the following error:
```
Database Error in source my_table (models/schema.yml)
  relation "public.my_table" does not exist

Database Error in source my_table2 (models/schema.yml)
  current transaction is aborted, commands ignored until end of transaction block

Database Error in source my_table3 (models/schema.yml)
  current transaction is aborted, commands ignored until end of transaction block
```

### Solution
Clear the transaction before running freshness queries

### Questions
Why are different freshness queries using the same transaction/handle? The fix applied in this PR works well (though it is certainly heavy-handed). Is there a better way to accomplish this?


### Changes
- Reset transactions before running freshness queries
- add a `--threads` argument (reasonable)