### PR TITLE
Update broken profiles.yml link

### DIFF
--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -10,7 +10,7 @@ from dbt.task.base import BaseTask
 
 STARTER_REPO = 'https://github.com/fishtown-analytics/dbt-starter-project.git'
 DOCS_URL = 'https://docs.getdbt.com/docs/configure-your-profile'
-SAMPLE_PROFILES_YML_FILE = 'https://github.com/fishtown-analytics/dbt/blob/master/sample.profiles.yml'  # noqa
+SAMPLE_PROFILES_YML_FILE = 'https://docs.getdbt.com/reference#profile'  # noqa
 
 ON_COMPLETE_MESSAGE = """
 Your new dbt project "{project_name}" was created! If this is your first time


### PR DESCRIPTION
## Issue

Closes https://github.com/fishtown-analytics/dbt/issues/1344

## Solution

This MR: 
* replaces the existing (broken) link to the docs where there is a functional, accurate sample profile. This is a great link to point to because the docs are extremely likely to stay updated as the requirements for the `profiles.yml` file changes (rather than _another thing_ to be maintained).