### PR TITLE
Support ephemeral nodes (#1368)

### DIFF
--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -482,19 +482,17 @@ REMOTE_COMPILE_RESULT_CONTRACT = {
 class RemoteCompileResult(APIObject):
     SCHEMA = REMOTE_COMPILE_RESULT_CONTRACT
 
-    def __init__(self, raw_sql, compiled_sql, timing=None, **kwargs):
+    def __init__(self, raw_sql, compiled_sql, node, timing=None, **kwargs):
         if timing is None:
             timing = []
+        # this should not show up in the serialized output.
+        self.node = node
         super(RemoteCompileResult, self).__init__(
             raw_sql=raw_sql,
             compiled_sql=compiled_sql,
             timing=timing,
             **kwargs
         )
-
-    @property
-    def node(self):
-        return None
 
     @property
     def error(self):
@@ -525,12 +523,13 @@ REMOTE_RUN_RESULT_CONTRACT = deep_merge(REMOTE_COMPILE_RESULT_CONTRACT, {
 class RemoteRunResult(RemoteCompileResult):
     SCHEMA = REMOTE_RUN_RESULT_CONTRACT
 
-    def __init__(self, raw_sql, compiled_sql, timing=None, table=None):
+    def __init__(self, raw_sql, compiled_sql, node, timing=None, table=None):
         if table is None:
             table = []
         super(RemoteRunResult, self).__init__(
             raw_sql=raw_sql,
             compiled_sql=compiled_sql,
             timing=timing,
-            table=table
+            table=table,
+            node=node
         )

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -545,7 +545,8 @@ class RPCCompileRunner(CompileRunner):
     def execute(self, compiled_node, manifest):
         return RemoteCompileResult(
             raw_sql=compiled_node.raw_sql,
-            compiled_sql=compiled_node.injected_sql
+            compiled_sql=compiled_node.injected_sql,
+            node=compiled_node
         )
 
     def error_result(self, node, error, start_time, timing_info):
@@ -561,6 +562,7 @@ class RPCCompileRunner(CompileRunner):
         return RemoteCompileResult(
             raw_sql=result.raw_sql,
             compiled_sql=result.compiled_sql,
+            node=result.node,
             timing=timing
         )
 
@@ -571,6 +573,7 @@ class RPCExecuteRunner(RPCCompileRunner):
         return RemoteRunResult(
             raw_sql=result.raw_sql,
             compiled_sql=result.compiled_sql,
+            node=result.node,
             table=result.table,
             timing=timing
         )
@@ -586,5 +589,6 @@ class RPCExecuteRunner(RPCCompileRunner):
         return RemoteRunResult(
             raw_sql=compiled_node.raw_sql,
             compiled_sql=compiled_node.injected_sql,
+            node=compiled_node,
             table=table
         )

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -133,7 +133,7 @@ class RPCServerTask(ConfiguredTask):
         self.dispatcher = Dispatcher()
         tasks = tasks or [RemoteCompileTask, RemoteRunTask]
         for cls in tasks:
-            self.register(cls(args, config))
+            self.register(cls(args, config, self.manifest))
 
     def register(self, task):
         self.dispatcher.add_method(RequestTaskHandler.factory(task),

--- a/test/integration/042_sources_test/models/ephemeral_model.sql
+++ b/test/integration/042_sources_test/models/ephemeral_model.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='ephemeral') }}
+
+select 1 as id


### PR DESCRIPTION
﻿Fixes #1368 

Pass along the manifest we compiled instead of loading a new one, so ephemeral nodes now get compiled properly.

As part of debugging, I split up request handling and attached nodes to the results (they don't get serialized), which I'd like to keep.