### PR TITLE
build on all dev branches, build on any branch named starting with "pr/"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,11 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- master
+  branches:
+    include:
+    - master
+    - dev/*
+    - pr/*
 
 jobs:
 - job: UnitTest


### PR DESCRIPTION
This changes the azure pipelines CI process a bit. Instead of only running on changes to `master`, it will now run on any changes to:
 - `master`
 - any branch that starts with `dev/`
 - any branch that starts with `pr/`

The latter should help with contributor PR testing, though it's kind of hacky: Basically, do all the things you'd do to trigger circleci builds, except make sure you've named your branch starting with "pr/".

I don't think this is the most elegant solution possible, and we'll want to prune our branches, but it's something.