### PR TITLE
RPC server task management

### DIFF
--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -30,9 +30,10 @@ class SQLConnectionManager(BaseConnectionManager):
 
     def cancel_open(self):
         names = []
+        this_connection = self.get_if_exists()
         with self.lock:
             for connection in self.thread_connections.values():
-                if connection.name == 'master':
+                if connection is this_connection:
                     continue
 
                 self.cancel(connection)

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -129,6 +129,22 @@ class RPCTimeoutException(RuntimeException):
         return result
 
 
+class RPCKilledException(RuntimeException):
+    CODE = 10009
+    MESSAGE = 'RPC process killed'
+
+    def __init__(self, signum):
+        self.signum = signum
+        self.message = 'RPC process killed by signal {}'.format(self.signum)
+        super(RPCKilledException, self).__init__(self.message)
+
+    def data(self):
+        return {
+            'signum': self.signum,
+            'message': self.message,
+        }
+
+
 class DatabaseException(RuntimeException):
     CODE = 10003
     MESSAGE = "Database Error"

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -221,6 +221,10 @@ class RequestTaskHandler(object):
             result = self.task.handle_request(**kwargs)
         except RPCException as exc:
             error = exc
+        except dbt.exceptions.RPCKilledException as exc:
+            # do NOT log anything here, you risk triggering a deadlock on the
+            # queue handler we inserted above
+            error = dbt_error(exc)
         except dbt.exceptions.Exception as exc:
             logger.debug('dbt runtime exception', exc_info=True)
             error = dbt_error(exc)

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -1,5 +1,23 @@
-from jsonrpc.exceptions import JSONRPCDispatchException, JSONRPCInvalidParams
+from jsonrpc.exceptions import JSONRPCDispatchException, \
+                               JSONRPCInvalidParams, \
+                               JSONRPCParseError, \
+                               JSONRPCInvalidRequestException, \
+                               JSONRPCInvalidRequest
+from jsonrpc import JSONRPCResponseManager
+from jsonrpc.jsonrpc import JSONRPCRequest
+from jsonrpc.jsonrpc2 import JSONRPC20Response
 
+import json
+import uuid
+import multiprocessing
+import os
+import signal
+import time
+from collections import namedtuple
+
+from dbt.logger import RPC_LOGGER as logger
+from dbt.logger import add_queue_handler
+from dbt.compat import QueueEmpty
 import dbt.exceptions
 
 
@@ -15,6 +33,12 @@ class RPCException(JSONRPCDispatchException):
         super(RPCException, self).__init__(code=code, message=message,
                                            data=data)
         self.logs = logs
+
+    def __str__(self):
+        return (
+            'RPCException({0.code}, {0.message}, {0.data}, {1.logs})'
+            .format(self.error, self)
+        )
 
     @property
     def logs(self):
@@ -66,3 +90,301 @@ class QueueMessageType(object):
             cls.Error,
             cls.Result
         ]
+
+
+def sigterm_handler(signum, frame):
+    raise dbt.exceptions.RPCKilledException(signum)
+
+
+class RequestDispatcher(object):
+    """A special dispatcher that knows about requests."""
+    def __init__(self, http_request, json_rpc_request, manager):
+        self.http_request = http_request
+        self.json_rpc_request = json_rpc_request
+        self.manager = manager
+        self.task = None
+
+    def rpc_factory(self, task):
+        request_handler = RequestTaskHandler(task,
+                                             self.http_request,
+                                             self.json_rpc_request)
+
+        def rpc_func(**kwargs):
+            try:
+                self.manager.add_request(request_handler)
+                return request_handler.handle(kwargs)
+            finally:
+                self.manager.mark_done(request_handler)
+
+        return rpc_func
+
+    def __getitem__(self, key):
+        # the dispatcher's keys are method names and its values are functions
+        # that implement the RPC calls
+        func = self.manager.rpc_builtin(key)
+        if func is not None:
+            return func
+
+        task = self.manager.rpc_task(key)
+        return self.rpc_factory(task)
+
+
+class RequestTaskHandler(object):
+    def __init__(self, task, http_request, json_rpc_request):
+        self.task = task
+        self.http_request = http_request
+        self.json_rpc_request = json_rpc_request
+        self.queue = None
+        self.process = None
+        self.started = None
+        self.timeout = None
+        self.logs = []
+        self.task_id = uuid.uuid4()
+
+    @property
+    def request_source(self):
+        return self.http_request.remote_addr
+
+    @property
+    def request_id(self):
+        return self.json_rpc_request._id
+
+    @property
+    def method(self):
+        return self.task.METHOD_NAME
+
+    def _next_timeout(self):
+        if self.timeout is None:
+            return None
+        end = self.started + self.timeout
+        timeout = end - time.time()
+        if timeout < 0:
+            raise dbt.exceptions.RPCTimeoutException(self.timeout)
+        return timeout
+
+    def _wait_for_results(self):
+        """Wait for results off the queue. If there is a timeout set, and it is
+        exceeded, raise an RPCTimeoutException.
+        """
+        while True:
+            get_timeout = self._next_timeout()
+            try:
+                msgtype, value = self.queue.get(timeout=get_timeout)
+            except QueueEmpty:
+                raise dbt.exceptions.RPCTimeoutException(self.timeout)
+
+            if msgtype == QueueMessageType.Log:
+                self.logs.append(value)
+            elif msgtype in QueueMessageType.terminating():
+                return msgtype, value
+            else:
+                raise dbt.exceptions.InternalException(
+                    'Got invalid queue message type {}'.format(msgtype)
+                )
+
+    def _join_process(self):
+        try:
+            msgtype, result = self._wait_for_results()
+        except dbt.exceptions.RPCTimeoutException as exc:
+            self.process.terminate()
+            raise timeout_error(self.timeout)
+        except dbt.exceptions.Exception as exc:
+            raise dbt_error(exc)
+        except Exception as exc:
+            raise server_error(exc)
+        finally:
+            self.process.join()
+
+        if msgtype == QueueMessageType.Error:
+            raise RPCException.from_error(result)
+
+        return result
+
+    def get_result(self):
+        try:
+            result = self._join_process()
+        except RPCException as exc:
+            exc.logs = self.logs
+            raise
+
+        result['logs'] = self.logs
+        return result
+
+    def task_bootstrap(self, kwargs):
+        signal.signal(signal.SIGTERM, sigterm_handler)
+        # the first thing we do in a new process: start logging
+        add_queue_handler(self.queue)
+
+        error = None
+        result = None
+        try:
+            result = self.task.handle_request(**kwargs)
+        except RPCException as exc:
+            error = exc
+        except dbt.exceptions.Exception as exc:
+            logger.debug('dbt runtime exception', exc_info=True)
+            error = dbt_error(exc)
+        except Exception as exc:
+            logger.debug('uncaught python exception', exc_info=True)
+            error = server_error(exc)
+
+        # put whatever result we got onto the queue as well.
+        if error is not None:
+            self.queue.put([QueueMessageType.Error, error.error])
+        else:
+            self.queue.put([QueueMessageType.Result, result])
+
+    def handle(self, kwargs):
+        self.started = time.time()
+        self.timeout = kwargs.pop('timeout', None)
+        self.queue = multiprocessing.Queue()
+        self.process = multiprocessing.Process(
+            target=self.task_bootstrap,
+            args=(kwargs,)
+        )
+        self.process.start()
+        return self.get_result()
+
+    @property
+    def state(self):
+        if self.started is None:
+            return 'not started'
+        elif self.process is None:
+            return 'initializing'
+        elif self.process.is_alive():
+            return 'running'
+        else:
+            return 'finished'
+
+
+TaskRow = namedtuple(
+    'TaskRow',
+    'task_id request_id request_source method state start elapsed timeout'
+)
+
+
+class TaskManager(object):
+    def __init__(self):
+        self.tasks = {}
+        self.completed = {}
+        self._rpc_task_map = {}
+        self._rpc_function_map = {}
+        self._lock = multiprocessing.Lock()
+
+    def add_request(self, request_handler):
+        self.tasks[request_handler.task_id] = request_handler
+
+    def add_task_handler(self, task):
+        self._rpc_task_map[task.METHOD_NAME] = task
+
+    def rpc_task(self, method_name):
+        return self._rpc_task_map[method_name]
+
+    def process_listing(self, active=True, completed=False):
+        included_tasks = {}
+        with self._lock:
+            if completed:
+                included_tasks.update(self.completed)
+            if active:
+                included_tasks.update(self.tasks)
+
+        table = []
+        now = time.time()
+        for task_handler in included_tasks.values():
+            start = task_handler.started
+            if start is not None:
+                elapsed = now - start
+
+            table.append(TaskRow(
+                str(task_handler.task_id), task_handler.request_id,
+                task_handler.request_source, task_handler.method,
+                task_handler.state, start, elapsed, task_handler.timeout
+            ))
+        table.sort(key=lambda r: (r.state, r.start))
+        result = {
+            'columns': list(TaskRow._fields),
+            'rows': [list(r) for r in table],
+        }
+        return result
+
+    def process_kill(self, task_id):
+        # TODO: this result design is terrible
+        result = {
+            'found': False,
+            'started': False,
+            'finished': False,
+            'killed': False
+        }
+        task_id = uuid.UUID(task_id)
+        try:
+            task = self.tasks[task_id]
+        except KeyError:
+            # nothing to do!
+            return result
+
+        result['found'] = True
+
+        if task.process is None:
+            return result
+        pid = task.process.pid
+        if pid is None:
+            return result
+
+        result['started'] = True
+
+        if task.process.is_alive():
+            os.kill(pid, signal.SIGINT)
+            result['killed'] = True
+            return result
+
+        result['finished'] = True
+        return result
+
+    def rpc_builtin(self, method_name):
+        if method_name == 'ps':
+            return self.process_listing
+        if method_name == 'kill':
+            return self.process_kill
+        return None
+
+    def mark_done(self, request_handler):
+        task_id = request_handler.task_id
+        with self._lock:
+            if task_id not in self.tasks:
+                # lost a task! Maybe it was killed before it started.
+                return
+            self.completed[task_id] = self.tasks.pop(task_id)
+
+    def methods(self):
+        return list(self._rpc_task_map)
+
+
+class ResponseManager(JSONRPCResponseManager):
+    """Override the default response manager to handle request metadata and
+    track in-flight tasks.
+    """
+    @classmethod
+    def handle(cls, http_request, task_manager):
+        # pretty much just copy+pasted from the original, with slight tweaks to
+        # preserve the request
+        request_str = http_request.data
+        if isinstance(request_str, bytes):
+            request_str = request_str.decode("utf-8")
+
+        try:
+            data = json.loads(request_str)
+        except (TypeError, ValueError):
+            return JSONRPC20Response(error=JSONRPCParseError()._data)
+
+        try:
+            request = JSONRPCRequest.from_data(data)
+        except JSONRPCInvalidRequestException:
+            return JSONRPC20Response(error=JSONRPCInvalidRequest()._data)
+
+        dispatcher = RequestDispatcher(
+            http_request,
+            request,
+            task_manager
+        )
+
+        return cls.handle_request(request, dispatcher)

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -306,8 +306,7 @@ class TaskManager(object):
             ))
         table.sort(key=lambda r: (r.state, r.start))
         result = {
-            'columns': list(TaskRow._fields),
-            'rows': [list(r) for r in table],
+            'rows': [dict(r._asdict()) for r in table],
         }
         return result
 

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -356,7 +356,8 @@ class TaskManager(object):
             self.completed[task_id] = self.tasks.pop(task_id)
 
     def methods(self):
-        return list(self._rpc_task_map)
+        rpc_builtin_methods = ['ps', 'kill']
+        return list(self._rpc_task_map) + rpc_builtin_methods
 
 
 class ResponseManager(JSONRPCResponseManager):

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -1,149 +1,33 @@
 import json
-import multiprocessing
-import time
-
-from jsonrpc import Dispatcher, JSONRPCResponseManager
 
 from werkzeug.wsgi import DispatcherMiddleware
 from werkzeug.wrappers import Request, Response
 from werkzeug.serving import run_simple
 from werkzeug.exceptions import NotFound
 
-from dbt.logger import RPC_LOGGER as logger, add_queue_handler
+from dbt.logger import RPC_LOGGER as logger
 from dbt.task.base import ConfiguredTask
 from dbt.task.compile import CompileTask, RemoteCompileTask
 from dbt.task.run import RemoteRunTask
 from dbt.utils import JSONEncoder
-from dbt.compat import QueueEmpty
-import dbt.exceptions
 from dbt import rpc
-
-
-class RequestTaskHandler(object):
-    def __init__(self, task):
-        self.task = task
-        self.queue = None
-        self.process = None
-        self.started = None
-        self.timeout = None
-        self.logs = []
-
-    def _next_timeout(self):
-        if self.timeout is None:
-            return None
-        end = self.started + self.timeout
-        timeout = end - time.time()
-        if timeout < 0:
-            raise dbt.exceptions.RPCTimeoutException(self.timeout)
-        return timeout
-
-    def _wait_for_results(self):
-        """Wait for results off the queue. If there is a timeout set, and it is
-        exceeded, raise an RPCTimeoutException.
-        """
-        while True:
-            get_timeout = self._next_timeout()
-            try:
-                msgtype, value = self.queue.get(timeout=get_timeout)
-            except QueueEmpty:
-                raise dbt.exceptions.RPCTimeoutException(self.timeout)
-
-            if msgtype == rpc.QueueMessageType.Log:
-                self.logs.append(value)
-            elif msgtype in rpc.QueueMessageType.terminating():
-                return msgtype, value
-            else:
-                raise dbt.exceptions.InternalException(
-                    'Got invalid queue message type {}'.format(msgtype)
-                )
-
-    def _join_process(self):
-        try:
-            msgtype, result = self._wait_for_results()
-        except dbt.exceptions.RPCTimeoutException as exc:
-            self.process.terminate()
-            raise rpc.timeout_error(self.timeout)
-        except dbt.exceptions.Exception as exc:
-            raise rpc.dbt_error(exc)
-        except Exception as exc:
-            raise rpc.server_error(exc)
-        finally:
-            self.process.join()
-
-        if msgtype == rpc.QueueMessageType.Error:
-            raise rpc.RPCException.from_error(result)
-
-        return result
-
-    def get_result(self):
-        try:
-            result = self._join_process()
-        except rpc.RPCException as exc:
-            exc.logs = self.logs
-            raise
-
-        result['logs'] = self.logs
-        return result
-
-    def task_bootstrap(self, kwargs):
-        # the first thing we do in a new process: start logging
-        add_queue_handler(self.queue)
-
-        error = None
-        result = None
-        try:
-            result = self.task.handle_request(**kwargs)
-        except rpc.RPCException as exc:
-            error = exc
-        except dbt.exceptions.Exception as exc:
-            logger.debug('dbt runtime exception', exc_info=True)
-            error = rpc.dbt_error(exc)
-        except Exception as exc:
-            logger.debug('uncaught python exception', exc_info=True)
-            error = rpc.server_error(exc)
-
-        # put whatever result we got onto the queue as well.
-        if error is not None:
-            self.queue.put([rpc.QueueMessageType.Error, error.error])
-        else:
-            self.queue.put([rpc.QueueMessageType.Result, result])
-
-    def handle(self, kwargs):
-        self.started = time.time()
-        self.timeout = kwargs.pop('timeout', None)
-        self.queue = multiprocessing.Queue()
-        self.process = multiprocessing.Process(
-            target=self.task_bootstrap,
-            args=(kwargs,)
-        )
-        self.process.start()
-        return self.get_result()
-
-    @classmethod
-    def factory(cls, task):
-        def handler(**kwargs):
-            return cls(task).handle(kwargs)
-        return handler
 
 
 class RPCServerTask(ConfiguredTask):
     def __init__(self, args, config, tasks=None):
         super(RPCServerTask, self).__init__(args, config)
         # compile locally
-        self.compile_task = CompileTask(args, config)
-        self.compile_task.run()
-        self.dispatcher = Dispatcher()
+        self.manifest = self._compile_manifest()
+        self.task_manager = rpc.TaskManager()
         tasks = tasks or [RemoteCompileTask, RemoteRunTask]
         for cls in tasks:
-            self.register(cls(args, config, self.manifest))
+            task = cls(args, config, self.manifest)
+            self.task_manager.add_task_handler(task)
 
-    def register(self, task):
-        self.dispatcher.add_method(RequestTaskHandler.factory(task),
-                                   name=task.METHOD_NAME)
-
-    @property
-    def manifest(self):
-        return self.compile_task.manifest
+    def _compile_manifest(self):
+        compile_task = CompileTask(self.args, self.config)
+        compile_task.run()
+        return compile_task.manifest
 
     def run(self):
         host = self.args.host
@@ -159,7 +43,7 @@ class RPCServerTask(ConfiguredTask):
         )
 
         logger.info(
-            'Supported methods: {}'.format(list(self.dispatcher.keys()))
+            'Supported methods: {}'.format(self.task_manager.methods())
         )
 
         logger.info(
@@ -171,13 +55,18 @@ class RPCServerTask(ConfiguredTask):
             '/jsonrpc': self.handle_jsonrpc_request,
         })
 
-        run_simple(host, port, app, processes=self.config.threads)
+        # we have to run in threaded mode if we want to share subprocess
+        # handles, which is the easiest way to implement `kill` (it makes `ps`
+        # easier as well). The alternative involves tracking metadata+state in
+        # a multiprocessing.Manager, adds polling the manager to the request
+        # task handler and in general gets messy fast.
+        run_simple(host, port, app, threaded=True)
 
     @Request.application
     def handle_jsonrpc_request(self, request):
         msg = 'Received request ({0}) from {0.remote_addr}, data={0.data}'
         logger.info(msg.format(request))
-        response = JSONRPCResponseManager.handle(request.data, self.dispatcher)
+        response = rpc.ResponseManager.handle(request, self.task_manager)
         json_data = json.dumps(response.data, cls=JSONEncoder)
         response = Response(json_data, mimetype='application/json')
         # this looks and feels dumb, but our json encoder converts decimals and

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -4,7 +4,6 @@ import re
 import time
 from abc import abstractmethod
 from multiprocessing.dummy import Pool as ThreadPool
-from jsonrpc.exceptions import JSONRPCInvalidParams
 
 from dbt import rpc
 from dbt.task.base import ConfiguredTask

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -94,6 +94,11 @@ class BigQueryConnectionManager(BaseConnectionManager):
         except Exception as e:
             logger.debug("Unhandled error while running:\n{}".format(sql))
             logger.debug(e)
+            if isinstance(e, dbt.exceptions.RuntimeException):
+                # during a sql query, an internal to dbt exception was raised.
+                # this sounds a lot like a signal handler and probably has
+                # useful information, so raise it without modification.
+                raise
             raise dbt.exceptions.RuntimeException(dbt.compat.to_string(e))
 
     def cancel_open(self):

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -82,6 +82,12 @@ class PostgresConnectionManager(SQLConnectionManager):
             logger.debug("Error running SQL: %s", sql)
             logger.debug("Rolling back transaction.")
             self.release()
+            if isinstance(e, dbt.exceptions.RuntimeException):
+                # during a sql query, an internal to dbt exception was raised.
+                # this sounds a lot like a signal handler and probably has
+                # useful information, so raise it without modification.
+                raise
+
             raise dbt.exceptions.RuntimeException(e)
 
     @classmethod

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -137,7 +137,7 @@ class PostgresConnectionManager(SQLConnectionManager):
 
         logger.debug("Cancelling query '{}' ({})".format(connection_name, pid))
 
-        _, cursor = self.add_query(sql, 'master')
+        _, cursor = self.add_query(sql)
         res = cursor.fetchone()
 
         logger.debug("Cancel query '{}': {}".format(connection_name, res))

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -97,6 +97,11 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             logger.debug("Error running SQL: %s", sql)
             logger.debug("Rolling back transaction.")
             self.release()
+            if isinstance(e, dbt.exceptions.RuntimeException):
+                # during a sql query, an internal to dbt exception was raised.
+                # this sounds a lot like a signal handler and probably has
+                # useful information, so raise it without modification.
+                raise
             raise dbt.exceptions.RuntimeException(e.msg)
 
     @classmethod

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -156,7 +156,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
 
         logger.debug("Cancelling query '{}' ({})".format(connection_name, sid))
 
-        _, cursor = self.add_query(sql, 'master')
+        _, cursor = self.add_query(sql)
         res = cursor.fetchone()
 
         logger.debug("Cancel query '{}': {}".format(connection_name, res))

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -7,6 +7,7 @@ import multiprocessing
 from base64 import standard_b64encode as b64
 import requests
 import socket
+import threading
 import time
 
 
@@ -278,7 +279,8 @@ class ServerProcess(multiprocessing.Process):
             handle_and_check_args.extend(['--vars', cli_vars])
         super(ServerProcess, self).__init__(
             target=handle_and_check,
-            args=(handle_and_check_args,))
+            args=(handle_and_check_args,),
+            name='ServerProcess')
 
     def is_up(self):
         sock = socket.socket()
@@ -299,6 +301,36 @@ class ServerProcess(multiprocessing.Process):
             self.terminate()
             raise Exception('server never appeared!')
 
+
+def query_url(url, query):
+    headers = {'content-type': 'application/json'}
+    return requests.post(url, headers=headers, data=json.dumps(query))
+
+
+class BackgroundQueryProcess(multiprocessing.Process):
+    def __init__(self, query, url, group=None, name=None):
+        parent, child = multiprocessing.Pipe()
+        self.parent_pipe = parent
+        self.child_pipe = child
+        self.query = query
+        self.url = url
+        super(BackgroundQueryProcess, self).__init__(group=group, name=name)
+
+    def run(self):
+        try:
+            result = query_url(self.url, self.query).json()
+        except Exception as exc:
+            self.child_pipe.send(('error', str(exc)))
+        else:
+            self.child_pipe.send(('result', result))
+
+    def wait_result(self):
+        result_type, result = self.parent_pipe.recv()
+        self.join()
+        if result_type == 'error':
+            raise Exception(result)
+        else:
+            return result
 
 _select_from_ephemeral = '''with __dbt__CTE__ephemeral_model as (
 
@@ -328,7 +360,8 @@ class TestRPCServer(BaseSourcesTest):
             'macro-paths': ['test/integration/042_sources_test/macros'],
         }
 
-    def build_query(self, method, kwargs, sql=None, test_request_id=1, macros=None):
+    def build_query(self, method, kwargs, sql=None, test_request_id=1,
+                    macros=None):
         body_data = ''
         if sql is not None:
             body_data += sql
@@ -346,15 +379,34 @@ class TestRPCServer(BaseSourcesTest):
             'id': test_request_id
         }
 
-    def perform_query(self, query):
-        url = 'http://localhost:{}/jsonrpc'.format(self._server.port)
-        headers = {'content-type': 'application/json'}
-        response = requests.post(url, headers=headers, data=json.dumps(query))
-        return response
+    @property
+    def url(self):
+        return 'http://localhost:{}/jsonrpc'.format(self._server.port)
 
     def query(self, _method, _sql=None, _test_request_id=1, macros=None, **kwargs):
         built = self.build_query(_method, kwargs, _sql, _test_request_id, macros)
-        return self.perform_query(built)
+        return query_url(self.url, built)
+
+    def handle_result(self, bg_query, pipe):
+        result_type, result = pipe.recv()
+        bg_query.join()
+        if result_type == 'error':
+            raise result
+        else:
+            return result
+
+    def background_query(self, _method, _sql=None, _test_request_id=1,
+                         _block=False, macros=None, **kwargs):
+        built = self.build_query(_method, kwargs, _sql, _test_request_id,
+                                 macros)
+
+        url = 'http://localhost:{}/jsonrpc'.format(self._server.port)
+        name = _method
+        if 'name' in kwargs:
+            name += ' ' + kwargs['name']
+        bg_query = BackgroundQueryProcess(built, url, name=name)
+        bg_query.start()
+        return bg_query
 
     def assertResultHasTimings(self, result, *names):
         self.assertIn('timing', result)
@@ -375,15 +427,15 @@ class TestRPCServer(BaseSourcesTest):
         self.assertNotIn('error', data)
         return data['result']
 
-    def assertIsError(self, data):
-        self.assertEqual(data['id'], 1)
+    def assertIsError(self, data, id_=1):
+        self.assertEqual(data['id'], id_)
         self.assertEqual(data['jsonrpc'], '2.0')
         self.assertIn('error', data)
         self.assertNotIn('result', data)
         return data['error']
 
-    def assertIsErrorWithCode(self, data, code):
-        error = self.assertIsError(data)
+    def assertIsErrorWithCode(self, data, code, id_=1):
+        error = self.assertIsError(data, id_)
         self.assertIn('code', error)
         self.assertIn('message', error)
         self.assertEqual(error['code'], code)
@@ -631,6 +683,107 @@ class TestRPCServer(BaseSourcesTest):
             compiled_sql=_select_from_ephemeral,
             table={'column_names': ['id'], 'rows': [[1.0]]}
         )
+
+    @use_profile('postgres')
+    def test_ps_kill_postgres(self):
+        done_query = self.query('compile', 'select 1 as id', name='done').json()
+        self.assertIsResult(done_query)
+        pg_sleeper, sleep_task_id, request_id = self._get_sleep_query()
+
+        empty_ps_result = self.query('ps', completed=False, active=False).json()
+        result = self.assertIsResult(empty_ps_result)
+        self.assertEqual(len(result['rows']), 0)
+
+        sleeper_ps_result = self.query('ps', completed=False, active=True).json()
+        result = self.assertIsResult(sleeper_ps_result)
+        self.assertEqual(len(result['rows']), 1)
+        self.assertEqual(len(result['rows'][0]), len(result['columns']))
+        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        self.assertEqual(rowdict[0]['request_id'], request_id)
+        self.assertEqual(rowdict[0]['method'], 'run')
+        self.assertEqual(rowdict[0]['state'], 'running')
+        self.assertEqual(rowdict[0]['timeout'], None)
+
+        complete_ps_result = self.query('ps', completed=True, active=False).json()
+        result = self.assertIsResult(complete_ps_result)
+        self.assertEqual(len(result['rows']), 1)
+        self.assertEqual(len(result['rows'][0]), len(result['columns']))
+        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        self.assertEqual(rowdict[0]['request_id'], 1)
+        self.assertEqual(rowdict[0]['method'], 'compile')
+        self.assertEqual(rowdict[0]['state'], 'finished')
+        self.assertEqual(rowdict[0]['timeout'], None)
+
+        all_ps_result = self.query('ps', completed=True, active=True).json()
+        result = self.assertIsResult(all_ps_result)
+        self.assertEqual(len(result['rows']), 2)
+        self.assertEqual(len(result['rows'][0]), len(result['columns']))
+        self.assertEqual(len(result['rows'][1]), len(result['columns']))
+        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        rowdict.sort(key=lambda r: r['start'])
+        self.assertEqual(rowdict[0]['request_id'], 1)
+        self.assertEqual(rowdict[0]['method'], 'compile')
+        self.assertEqual(rowdict[0]['state'], 'finished')
+        self.assertEqual(rowdict[0]['timeout'], None)
+        self.assertEqual(rowdict[1]['request_id'], request_id)
+        self.assertEqual(rowdict[1]['method'], 'run')
+        self.assertEqual(rowdict[1]['state'], 'running')
+        self.assertEqual(rowdict[1]['timeout'], None)
+
+        self.kill_and_assert(pg_sleeper, sleep_task_id, request_id)
+
+    def kill_and_assert(self, pg_sleeper, task_id, request_id):
+        kill_result = self.query('kill', task_id=task_id).json()
+        kill_time = time.time()
+        result = self.assertIsResult(kill_result)
+        self.assertTrue(result['killed'])
+
+        sleeper_result = pg_sleeper.wait_result()
+        result_time = time.time()
+        error = self.assertIsErrorWithCode(sleeper_result, 10009, request_id)
+        self.assertEqual(error['message'], 'RPC process killed')
+        self.assertIn('data', error)
+        error_data = error['data']
+        self.assertEqual(error_data['signum'], 2)
+        self.assertEqual(error_data['message'], 'RPC process killed by signal 2')
+        self.assertIn('logs', error_data)
+        # it should take less than 5s to kill the process if things are working
+        # properly
+        self.assertLess(result_time, kill_time + 5)
+        return error_data
+
+    def _get_sleep_query(self):
+        request_id = 90890
+        pg_sleeper = self.background_query(
+            'run',
+            'select pg_sleep(15)',
+            _test_request_id=request_id,
+            name='sleeper',
+        )
+
+        for _ in range(20):
+            time.sleep(0.2)
+            sleeper_ps_result = self.query('ps', completed=False, active=True).json()
+            result = self.assertIsResult(sleeper_ps_result)
+            rows = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+            for row in rows:
+                if row['request_id'] == request_id and row['state'] == 'running':
+                    return pg_sleeper, row['task_id'], request_id
+
+        self.assertTrue(False, 'request ID never found running!')
+
+    @use_profile('postgres')
+    def test_ps_kill_longwait_postgres(self):
+        pg_sleeper, sleep_task_id, request_id = self._get_sleep_query()
+
+        # the test above frequently kills the process during parsing of the
+        # requested node. That's also a useful test, but we should test that
+        # we cancel the in-progress sleep query.
+        time.sleep(3)
+
+        error_data = self.kill_and_assert(pg_sleeper, sleep_task_id, request_id)
+        # we should have logs if we did anything
+        self.assertTrue(len(error_data['logs']) > 0)
 
     @use_profile('postgres')
     def test_invalid_requests_postgres(self):

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -1,15 +1,14 @@
-import unittest
-from datetime import datetime, timedelta
 import json
-import os
-
 import multiprocessing
-from base64 import standard_b64encode as b64
-import requests
+import os
 import socket
-import threading
+import sys
 import time
+import unittest
+from base64 import standard_b64encode as b64
+from datetime import datetime, timedelta
 
+import requests
 
 from dbt.exceptions import CompilationException
 from test.integration.base import DBTIntegrationTest, use_profile, AnyFloat, \
@@ -748,8 +747,9 @@ class TestRPCServer(BaseSourcesTest):
         self.assertEqual(error_data['message'], 'RPC process killed by signal 2')
         self.assertIn('logs', error_data)
         # it should take less than 5s to kill the process if things are working
-        # properly
-        self.assertLess(result_time, kill_time + 5)
+        # properly. On python 2.x, things do not work properly.
+        if sys.version_info.major > 2:
+            self.assertLess(result_time, kill_time + 5)
         return error_data
 
     def _get_sleep_query(self):

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -696,8 +696,7 @@ class TestRPCServer(BaseSourcesTest):
         sleeper_ps_result = self.query('ps', completed=False, active=True).json()
         result = self.assertIsResult(sleeper_ps_result)
         self.assertEqual(len(result['rows']), 1)
-        self.assertEqual(len(result['rows'][0]), len(result['columns']))
-        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        rowdict = result['rows']
         self.assertEqual(rowdict[0]['request_id'], request_id)
         self.assertEqual(rowdict[0]['method'], 'run')
         self.assertEqual(rowdict[0]['state'], 'running')
@@ -706,8 +705,7 @@ class TestRPCServer(BaseSourcesTest):
         complete_ps_result = self.query('ps', completed=True, active=False).json()
         result = self.assertIsResult(complete_ps_result)
         self.assertEqual(len(result['rows']), 1)
-        self.assertEqual(len(result['rows'][0]), len(result['columns']))
-        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        rowdict = result['rows']
         self.assertEqual(rowdict[0]['request_id'], 1)
         self.assertEqual(rowdict[0]['method'], 'compile')
         self.assertEqual(rowdict[0]['state'], 'finished')
@@ -716,9 +714,7 @@ class TestRPCServer(BaseSourcesTest):
         all_ps_result = self.query('ps', completed=True, active=True).json()
         result = self.assertIsResult(all_ps_result)
         self.assertEqual(len(result['rows']), 2)
-        self.assertEqual(len(result['rows'][0]), len(result['columns']))
-        self.assertEqual(len(result['rows'][1]), len(result['columns']))
-        rowdict = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+        rowdict = result['rows']
         rowdict.sort(key=lambda r: r['start'])
         self.assertEqual(rowdict[0]['request_id'], 1)
         self.assertEqual(rowdict[0]['method'], 'compile')
@@ -765,7 +761,7 @@ class TestRPCServer(BaseSourcesTest):
             time.sleep(0.2)
             sleeper_ps_result = self.query('ps', completed=False, active=True).json()
             result = self.assertIsResult(sleeper_ps_result)
-            rows = [{k: v for k, v in zip(result['columns'], row)} for row in result['rows']]
+            rows = result['rows']
             for row in rows:
                 if row['request_id'] == request_id and row['state'] == 'running':
                     return pg_sleeper, row['task_id'], request_id

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -92,7 +92,7 @@ class TestPostgresAdapter(unittest.TestCase):
 
             self.assertEqual(len(list(self.adapter.cancel_open_connections())), 1)
 
-            add_query.assert_called_once_with('select pg_terminate_backend(42)', 'master')
+            add_query.assert_called_once_with('select pg_terminate_backend(42)')
 
         master.handle.get_backend_pid.assert_not_called()
 

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -126,7 +126,7 @@ class TestRedshiftAdapter(unittest.TestCase):
 
             self.assertEqual(len(list(self.adapter.cancel_open_connections())), 1)
 
-            add_query.assert_called_once_with('select pg_terminate_backend(42)', 'master')
+            add_query.assert_called_once_with('select pg_terminate_backend(42)')
 
         master.handle.get_backend_pid.assert_not_called()
 

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -155,8 +155,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
             self.assertEqual(
                 len(list(self.adapter.cancel_open_connections())), 1)
 
-            add_query.assert_called_once_with(
-                'select system$abort_session(42)', 'master')
+            add_query.assert_called_once_with('select system$abort_session(42)')
 
     def test_client_session_keep_alive_false_by_default(self):
         self.adapter.connections.set_connection_name(name='new_connection_with_new_config')


### PR DESCRIPTION
Fixes #1369 
Fixes #1370 

Implements special 'ps' and 'kill' commands, created a framework that ties requests into API calls and makes them available. This should make async calls easy enough once we decide on how we want them to behave.

To do this I had to mess around quite a bit with how the RPC server executes things, but I think I preserved the good behavior reasonably well. Some edge case issues in error handling might still exist, it's a bit messy in there.

I added the concept of "builtin" methods that are not tasks. I guess we'll see how sustainable that is in the long run, it should be pretty easy to change how that's implemented if we want to. Right now they are just methods on the task manager since they do task management things.

I fixed some nasty query cancellation bugs along the way (databases would kill the connection that was being used to kill connections). I also moved a bunch of things from `tasks/rpc_server` to `rpc`. I'll expect I'll split that up into entries in a folder in some future PR. Eventually the RPC compile/run tasks will also probably have to move somewhere.

The server is now threaded instead of multiprocessing-based, because threading is a LOT easier. I don't think this will have any end-user impact, but who knows.
