### PR TITLE
Add the check archive strategy (#706)

### DIFF
--- a/core/dbt/api/object.py
+++ b/core/dbt/api/object.py
@@ -1,6 +1,6 @@
 import copy
 from collections import Mapping
-from jsonschema import Draft4Validator
+from jsonschema import Draft7Validator
 
 from dbt.exceptions import JSONValidationException
 from dbt.utils import deep_merge
@@ -79,7 +79,7 @@ class APIObject(Mapping):
         of this instance. If any attributes are missing or
         invalid, raise a ValidationException.
         """
-        validator = Draft4Validator(self.SCHEMA)
+        validator = Draft7Validator(self.SCHEMA)
 
         errors = set()  # make errors a set to avoid duplicates
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -452,9 +452,44 @@ ARCHIVE_CONFIG_CONTRACT = {
         'unique_key': {
             'type': 'string',
         },
-        'strategy': {
-            'enum': ['timestamp'],
-        },
+        'anyOf': [
+            {
+                'properties': {
+                    'strategy': {
+                        'enum': ['timestamp'],
+                    },
+                    'updated_at': {
+                        'type': 'string',
+                        'description': (
+                            'The column name with the timestamp to compare'
+                        ),
+                    },
+                },
+                'required': ['updated_at'],
+            },
+            {
+                'properties': {
+                    'strategy': {
+                        'enum': ['check'],
+                    },
+                    'check_cols': {
+                        'oneOf': [
+                            {
+                                'type': 'array',
+                                'items': {'type': 'string'},
+                                'description': 'The columns to check',
+                                'minLength': 1,
+                            },
+                            {
+                                'enum': ['all'],
+                                'description': 'Check all columns',
+                            },
+                        ],
+                    },
+                },
+                'required': ['check_cols'],
+            }
+        ]
     },
     'required': [
         'target_database', 'target_schema', 'unique_key', 'strategy',

--- a/core/dbt/include/global_project/macros/materializations/archive/archive.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/archive.sql
@@ -2,12 +2,12 @@
     Create SCD Hash SQL fields cross-db
 #}
 
-{% macro archive_scd_hash() %}
-  {{ adapter_macro('archive_scd_hash') }}
+{% macro archive_hash_arguments(args) %}
+  {{ adapter_macro('archive_hash_arguments', args) }}
 {% endmacro %}
 
-{% macro default__archive_scd_hash() %}
-    md5("dbt_pk" || '|' || "dbt_updated_at")
+{% macro default__archive_hash_arguments(args) %}
+    md5({% for arg in args %}{{ adapter.quote(arg) }}{% if not loop.last %} || '|' || {% endif %}{% endfor %})
 {% endmacro %}
 
 {% macro create_temporary_table(sql, relation) %}
@@ -55,16 +55,58 @@
 {% endmacro %}
 
 
-{#
-    Cross-db compatible archival implementation
-#}
-{% macro archive_select(source_sql, target_relation, source_columns, unique_key, updated_at) %}
+{% macro archive_get_time() -%}
+  {{ adapter_macro('archive_get_time') }}
+{%- endmacro %}
 
-    {% set timestamp_column = api.Column.create('_', 'timestamp') %}
+{% macro default__archive_get_time() -%}
+  {{ current_timestamp() }}
+{%- endmacro %}
+
+{% macro snowflake__archive_get_time() -%}
+  to_timestamp_ntz({{ current_timestamp() }})
+{%- endmacro %}
+
+{#
+{% macro archive_current_timestamp() -%}
+  {{ adapter_macro('archive_current_timestamp') }}
+{%- endmacro %}
+
+{% macro default__archive_current_timestamp() -%}
+  {{ current_timestamp() }}
+{%- endmacro %}
+
+{% macro snowflake__archive_current_timestamp() -%}
+  TO_TIMESTAMP_NTZ(archive_current_timestamp())
+{%- endmacro %}
+#}
+
+
+{% macro archive_select_generic(source_sql, target_relation, transforms, scd_hash) -%}
     with source as (
       {{ source_sql }}
     ),
+    {{ transforms }}
+    merged as (
 
+      select *, 'update' as {{ adapter.quote('change_type') }} from updates
+      union all
+      select *, 'insert' as {{ adapter.quote('change_type') }} from insertions
+
+    )
+
+    select *,
+        {{ scd_hash }} as {{ adapter.quote('dbt_scd_id') }}
+    from merged
+
+{%- endmacro %}
+
+{#
+    Cross-db compatible archival implementation
+#}
+{% macro archive_select_timestamp(source_sql, target_relation, source_columns, unique_key, updated_at) -%}
+    {% set timestamp_column = api.Column.create('_', 'timestamp') %}
+    {% set transforms -%}
     current_data as (
 
         select
@@ -100,10 +142,12 @@
         from current_data
         left outer join archived_data
           on archived_data.{{ adapter.quote('dbt_pk') }} = current_data.{{ adapter.quote('dbt_pk') }}
-        where archived_data.{{ adapter.quote('dbt_pk') }} is null or (
-          archived_data.{{ adapter.quote('dbt_pk') }} is not null and
-          current_data.{{ adapter.quote('dbt_updated_at') }} > archived_data.{{ adapter.quote('dbt_updated_at') }} and
-          archived_data.{{ adapter.quote('tmp_valid_to') }} is null
+        where
+          archived_data.{{ adapter.quote('dbt_pk') }} is null
+          or (
+                archived_data.{{ adapter.quote('dbt_pk') }} is not null
+            and archived_data.{{ adapter.quote('dbt_updated_at') }} < current_data.{{ adapter.quote('dbt_updated_at') }}
+            and archived_data.{{ adapter.quote('tmp_valid_to') }} is null
         )
     ),
 
@@ -119,21 +163,85 @@
           and archived_data.{{ adapter.quote('dbt_updated_at') }} < current_data.{{ adapter.quote('dbt_updated_at') }}
           and archived_data.{{ adapter.quote('tmp_valid_to') }} is null
     ),
+    {%- endset %}
+    {%- set scd_hash = archive_hash_arguments(['dbt_pk', 'dbt_updated_at']) -%}
+    {{ archive_select_generic(source_sql, target_relation, transforms, scd_hash) }}
+{%- endmacro %}
 
-    merged as (
 
-      select *, 'update' as {{ adapter.quote('change_type') }} from updates
-      union all
-      select *, 'insert' as {{ adapter.quote('change_type') }} from insertions
+{% macro archive_select_check_cols(source_sql, target_relation, source_columns, unique_key, check_cols) -%}
+    {%- set timestamp_column = api.Column.create('_', 'timestamp') -%}
 
-    )
+    {# if we recognize the primary key, it's the newest record, and anything we care about has changed, it's an update candidate #}
+    {%- set update_candidate -%}
+      archived_data.{{ adapter.quote('dbt_pk') }} is not null
+      and (
+        {%- for col in check_cols %}
+        current_data.{{ adapter.quote(col) }} <> archived_data.{{ adapter.quote(col) }}
+        {%- if not loop.last %} or {% endif %}
+      {% endfor -%}
+      )
+      and archived_data.{{ adapter.quote('tmp_valid_to') }} is null
+    {%- endset %}
 
-    select *,
-        {{ archive_scd_hash() }} as {{ adapter.quote('dbt_scd_id') }}
-    from merged
+    {% set transforms -%}
+    current_data as (
 
-{% endmacro %}
+        select
+            {% for col in source_columns %}
+                {{ adapter.quote(col.name) }} {% if not loop.last %},{% endif %}
+            {% endfor %},
+            {{ archive_get_time() }} as {{ adapter.quote('dbt_updated_at') }},
+            {{ unique_key }} as {{ adapter.quote('dbt_pk') }},
+            {{ archive_get_time() }} as {{ adapter.quote('dbt_valid_from') }},
+            {{ timestamp_column.literal('null') }} as {{ adapter.quote('tmp_valid_to') }}
+        from source
+    ),
 
+    archived_data as (
+
+        select
+            {% for col in source_columns %}
+                {{ adapter.quote(col.name) }},
+            {% endfor %}
+            {{ adapter.quote('dbt_updated_at') }},
+            {{ unique_key }} as {{ adapter.quote('dbt_pk') }},
+            {{ adapter.quote('dbt_valid_from') }},
+            {{ adapter.quote('dbt_valid_to') }} as {{ adapter.quote('tmp_valid_to') }}
+        from {{ target_relation }}
+
+    ),
+
+    insertions as (
+
+        select
+            current_data.*,
+            {{ timestamp_column.literal('null') }} as {{ adapter.quote('dbt_valid_to') }}
+        from current_data
+        left outer join archived_data
+          on archived_data.{{ adapter.quote('dbt_pk') }} = current_data.{{ adapter.quote('dbt_pk') }}
+        where
+          archived_data.{{ adapter.quote('dbt_pk') }} is null
+          or ( {{ update_candidate }} )
+    ),
+
+    updates as (
+
+        select
+            archived_data.*,
+            {{ archive_get_time() }} as {{ adapter.quote('dbt_valid_to') }}
+        from current_data
+        left outer join archived_data
+          on archived_data.{{ adapter.quote('dbt_pk') }} = current_data.{{ adapter.quote('dbt_pk') }}
+        where {{ update_candidate }}
+    ),
+    {%- endset %}
+
+    {%- set hash_components = ['dbt_pk'] %}
+    {%- do hash_components.extend(check_cols) -%}
+    {%- set scd_hash = archive_hash_arguments(hash_components) -%}
+    {{ archive_select_generic(source_sql, target_relation, transforms, scd_hash) }}
+{%- endmacro %}
 
 {# this is gross #}
 {% macro create_empty_table_as(sql) %}
@@ -157,6 +265,7 @@
   {%- set target_database = config.get('target_database') -%}
   {%- set target_schema = config.get('target_schema') -%}
   {%- set target_table = model.get('alias', model.get('name')) -%}
+  {%- set strategy = config.get('strategy') -%}
 
   {{ create_schema(target_database, target_schema) }}
 
@@ -179,14 +288,12 @@
   {%- set source_columns = adapter.get_columns_in_relation(source_info_model) -%}
 
   {%- set unique_key = config.get('unique_key') -%}
-  {%- set updated_at = config.get('updated_at') -%}
   {%- set dest_columns = source_columns + [
       api.Column.create('dbt_valid_from', 'timestamp'),
       api.Column.create('dbt_valid_to', 'timestamp'),
       api.Column.create('dbt_scd_id', 'string'),
       api.Column.create('dbt_updated_at', 'timestamp'),
   ] -%}
-
 
   {% call statement() %}
     {{ create_archive_table(target_relation, dest_columns) }}
@@ -204,7 +311,19 @@
   {% set tmp_table_sql -%}
 
       with dbt_archive_sbq as (
-        {{ archive_select(model['injected_sql'], target_relation, source_columns, unique_key, updated_at) }}
+
+      {% if strategy == 'timestamp' %}
+        {%- set updated_at = config.get('updated_at') -%}
+        {{ archive_select_timestamp(model['injected_sql'], target_relation, source_columns, unique_key, updated_at) }}
+      {% elif strategy == 'check' %}
+        {%- set check_cols = config.get('check_cols') -%}
+        {% if check_cols == 'all' %}
+          {% set check_cols = source_columns | map(attribute='name') | list %}
+        {% endif %}
+        {{ archive_select_check_cols(model['injected_sql'], target_relation, source_columns, unique_key, check_cols)}}
+      {% else %}
+        {{ exceptions.raise_compiler_error('Got invalid strategy "{}"'.format(strategy)) }}
+      {% endif %}
       )
       select * from dbt_archive_sbq
 

--- a/core/dbt/parser/archives.py
+++ b/core/dbt/parser/archives.py
@@ -36,6 +36,8 @@ class ArchiveParser(MacrosKnownParser):
 
                 source_schema = archive_config['source_schema']
                 cfg['target_schema'] = archive_config.get('target_schema')
+                # project-defined archives always use the 'timestamp' strategy.
+                cfg['strategy'] = 'timestamp'
 
                 fake_path = [cfg['target_database'], cfg['target_schema'],
                              cfg['target_table']]

--- a/core/setup.py
+++ b/core/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=2.18.0,<3',
         'colorama==0.3.9',
         'agate>=1.6,<2',
-        'jsonschema==2.6.0',
+        'jsonschema>=3.0.1,<4',
         'json-rpc>=1.12,<2',
         'werkzeug>=0.14.1,<0.15',
     ]

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
@@ -5,7 +5,7 @@
 
 
 {% macro bigquery__archive_hash_arguments(args) %}
-  to_hex(md5(concat({% for arg in args %}cast({{ adapter.quote(arg) }} as string){% if not loop.last %}, '|',{% endif %}{% endfor %})))
+  to_hex(md5(concat({% for arg in args %}cast({{ arg }} as string){% if not loop.last %}, '|',{% endif %}{% endfor %})))
 {% endmacro %}
 
 {% macro bigquery__create_columns(relation, columns) %}
@@ -15,8 +15,8 @@
 
 {% macro bigquery__archive_update(target_relation, tmp_relation) %}
     update {{ target_relation }} as dest
-    set dest.{{ adapter.quote('dbt_valid_to') }} = tmp.{{ adapter.quote('dbt_valid_to') }}
+    set dest.dbt_valid_to = tmp.dbt_valid_to
     from {{ tmp_relation }} as tmp
-    where tmp.{{ adapter.quote('dbt_scd_id') }} = dest.{{ adapter.quote('dbt_scd_id') }}
-      and {{ adapter.quote('change_type') }} = 'update';
+    where tmp.dbt_scd_id = dest.dbt_scd_id
+      and change_type = 'update';
 {% endmacro %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
@@ -4,10 +4,9 @@
 {% endmacro %}
 
 
-{% macro bigquery__archive_scd_hash() %}
-    to_hex(md5(concat(cast(`dbt_pk` as string), '|', cast(`dbt_updated_at` as string))))
+{% macro bigquery__archive_hash_arguments(args) %}
+  to_hex(md5(concat({% for arg in args %}cast({{ adapter.quote(arg) }} as string){% if not loop.last %}, '|',{% endif %}{% endfor %})))
 {% endmacro %}
-
 
 {% macro bigquery__create_columns(relation, columns) %}
   {{ adapter.alter_table_add_columns(relation, columns) }}

--- a/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
@@ -1,6 +1,4 @@
-{% archive archive_sad %}
-
-    {# missing target_database #}
+{% archive no_target_database %}
     {{
         config(
             target_schema=schema,

--- a/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
@@ -1,0 +1,27 @@
+{% archive archive_actual %}
+    {{
+        config(
+            target_database=var('target_database', database),
+            target_schema=schema,
+            unique_key='concat(cast(id as string) , "-", first_name)',
+            strategy='check',
+            check_cols=('email',),
+        )
+    }}
+    select * from `{{database}}`.`{{schema}}`.seed
+{% endarchive %}
+
+
+{# This should be exactly the same #}
+{% archive archive_checkall %}
+    {{
+        config(
+            target_database=var('target_database', database),
+            target_schema=schema,
+            unique_key='concat(cast(id as string) , "-", first_name)',
+            strategy='check',
+            check_cols='all',
+        )
+    }}
+    select * from `{{database}}`.`{{schema}}`.seed
+{% endarchive %}

--- a/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
@@ -1,0 +1,28 @@
+{% archive archive_actual %}
+
+    {{
+        config(
+            target_database=var('target_database', database),
+            target_schema=schema,
+            unique_key='"id" || ' ~ "'-'" ~ ' || "first_name"',
+            strategy='check',
+            check_cols=['email'],
+        )
+    }}
+    select * from {{database}}.{{schema}}.seed
+
+{% endarchive %}
+
+{# This should be exactly the same #}
+{% archive archive_checkall %}
+    {{
+        config(
+            target_database=var('target_database', database),
+            target_schema=schema,
+            unique_key='"id" || ' ~ "'-'" ~ ' || "first_name"',
+            strategy='check',
+            check_cols='all',
+        )
+    }}
+    select * from {{database}}.{{schema}}.seed
+{% endarchive %}

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -4,6 +4,8 @@ import dbt.exceptions
 
 
 class TestSimpleArchive(DBTIntegrationTest):
+    NUM_ARCHIVE_MODELS = 1
+
     @property
     def schema(self):
         return "simple_archive_004"
@@ -44,58 +46,67 @@ class TestSimpleArchive(DBTIntegrationTest):
         self.run_sql_file('test/integration/004_simple_archive_test/seed.sql')
 
         results = self.run_archive()
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
 
+    def assert_case_tables_equal(self, actual, expected):
+        if self.adapter_type == 'snowflake':
+            actual = actual.upper()
+            expected = expected.upper()
+
+        self.assertTablesEqual(actual, expected)
+
+    def assert_expected(self):
+        self.assert_case_tables_equal('archive_actual', 'archive_expected')
 
     @attr(type='postgres')
     def test__postgres__simple_archive(self):
         self.dbt_run_seed_archive()
 
-        self.assertTablesEqual("archive_expected","archive_actual")
+        self.assert_expected()
 
         self.run_sql_file("test/integration/004_simple_archive_test/invalidate_postgres.sql")
         self.run_sql_file("test/integration/004_simple_archive_test/update.sql")
 
         results = self.run_archive()
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
 
-        self.assertTablesEqual("archive_expected","archive_actual")
+        self.assert_expected()
 
     @attr(type='snowflake')
     def test__snowflake__simple_archive(self):
         self.dbt_run_seed_archive()
 
-        self.assertTablesEqual("ARCHIVE_EXPECTED", "ARCHIVE_ACTUAL")
+        self.assert_expected()
 
         self.run_sql_file("test/integration/004_simple_archive_test/invalidate_snowflake.sql")
         self.run_sql_file("test/integration/004_simple_archive_test/update.sql")
 
         results = self.run_archive()
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
 
-        self.assertTablesEqual("ARCHIVE_EXPECTED", "ARCHIVE_ACTUAL")
+        self.assert_expected()
 
     @attr(type='redshift')
     def test__redshift__simple_archive(self):
         self.dbt_run_seed_archive()
 
-        self.assertTablesEqual("archive_expected","archive_actual")
+        self.assert_expected()
 
         self.run_sql_file("test/integration/004_simple_archive_test/invalidate_postgres.sql")
         self.run_sql_file("test/integration/004_simple_archive_test/update.sql")
 
         results = self.run_archive()
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
 
-        self.assertTablesEqual("archive_expected","archive_actual")
+        self.assert_expected()
 
     @attr(type='presto')
     def test__presto__simple_archive_disabled(self):
         results = self.run_dbt(["seed"])
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
         # presto does not run archives
         results = self.run_dbt(["archive"], expect_pass=False)
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  self.NUM_ARCHIVE_MODELS)
         self.assertIn('not implemented for presto', results[0].error)
 
 
@@ -128,6 +139,9 @@ class TestSimpleArchiveBigquery(DBTIntegrationTest):
             ]
         }
 
+    def assert_expected(self):
+        self.assertTablesEqual('archive_actual', 'archive_expected')
+
     @attr(type='bigquery')
     def test__bigquery__simple_archive(self):
         self.use_default_project()
@@ -137,14 +151,14 @@ class TestSimpleArchiveBigquery(DBTIntegrationTest):
 
         self.run_dbt(["archive"])
 
-        self.assertTablesEqual("archive_expected", "archive_actual")
+        self.assert_expected()
 
         self.run_sql_file("test/integration/004_simple_archive_test/invalidate_bigquery.sql")
         self.run_sql_file("test/integration/004_simple_archive_test/update_bq.sql")
 
         self.run_dbt(["archive"])
 
-        self.assertTablesEqual("archive_expected", "archive_actual")
+        self.assert_expected()
 
 
     @attr(type='bigquery')
@@ -387,3 +401,101 @@ class TestBadArchive(DBTIntegrationTest):
             self.run_dbt(['compile'], expect_pass=False)
 
         self.assertIn('target_database', str(exc.exception))
+
+
+class TestCheckCols(TestSimpleArchiveFiles):
+    NUM_ARCHIVE_MODELS = 2
+    def _assertTablesEqualSql(self, relation_a, relation_b, columns=None):
+        # When building the equality tests, only test columns that don't start
+        # with 'dbt_', because those are time-sensitive
+        if columns is None:
+            columns = [c for c in self.get_relation_columns(relation_a) if not c[0].lower().startswith('dbt_')]
+        return super(TestCheckCols, self)._assertTablesEqualSql(
+            relation_a,
+            relation_b,
+            columns=columns
+        )
+
+    def assert_expected(self):
+        super(TestCheckCols, self).assert_expected()
+        self.assert_case_tables_equal('archive_checkall', 'archive_expected')
+
+    @property
+    def project_config(self):
+        return {
+            "data-paths": ['test/integration/004_simple_archive_test/data'],
+            "archive-paths": ['test/integration/004_simple_archive_test/test-check-col-archives'],
+        }
+
+
+class TestCheckColsBigquery(TestSimpleArchiveFilesBigquery):
+    def _assertTablesEqualSql(self, relation_a, relation_b, columns=None):
+        # When building the equality tests, only test columns that don't start
+        # with 'dbt_', because those are time-sensitive
+        if columns is None:
+            columns = [c for c in self.get_relation_columns(relation_a) if not c[0].lower().startswith('dbt_')]
+        return super(TestCheckColsBigquery, self)._assertTablesEqualSql(
+            relation_a,
+            relation_b,
+            columns=columns
+        )
+
+    def assert_expected(self):
+        super(TestCheckColsBigquery, self).assert_expected()
+        self.assertTablesEqual('archive_checkall', 'archive_expected')
+
+    @property
+    def project_config(self):
+        return {
+            "data-paths": ['test/integration/004_simple_archive_test/data'],
+            "archive-paths": ['test/integration/004_simple_archive_test/test-check-col-archives-bq'],
+        }
+
+    @attr(type='bigquery')
+    def test__bigquery__archive_with_new_field(self):
+        self.use_default_project()
+        self.use_profile('bigquery')
+
+        self.run_sql_file("test/integration/004_simple_archive_test/seed_bq.sql")
+
+        self.run_dbt(["archive"])
+
+        self.assertTablesEqual("archive_expected", "archive_actual")
+        self.assertTablesEqual("archive_expected", "archive_checkall")
+
+        self.run_sql_file("test/integration/004_simple_archive_test/invalidate_bigquery.sql")
+        self.run_sql_file("test/integration/004_simple_archive_test/update_bq.sql")
+
+        # This adds new fields to the source table, and updates the expected archive output accordingly
+        self.run_sql_file("test/integration/004_simple_archive_test/add_column_to_source_bq.sql")
+
+        # this should fail because `check="all"` will try to compare the nested field
+        self.run_dbt(['archive'], expect_pass=False)
+
+        self.run_dbt(["archive", '-m', 'archive_actual'])
+
+        # A more thorough test would assert that archived == expected, but BigQuery does not support the
+        # "EXCEPT DISTINCT" operator on nested fields! Instead, just check that schemas are congruent.
+
+        expected_cols = self.get_table_columns(
+            database=self.default_database,
+            schema=self.unique_schema(),
+            table='archive_expected'
+        )
+        archived_cols = self.get_table_columns(
+            database=self.default_database,
+            schema=self.unique_schema(),
+            table='archive_actual'
+        )
+
+        self.assertTrue(len(expected_cols) > 0, "source table does not exist -- bad test")
+        self.assertEqual(len(expected_cols), len(archived_cols), "actual and expected column lengths are different")
+
+        for (expected_col, actual_col) in zip(expected_cols, archived_cols):
+            expected_name, expected_type, _ = expected_col
+            actual_name, actual_type, _ = actual_col
+            self.assertTrue(expected_name is not None)
+            self.assertTrue(expected_type is not None)
+
+            self.assertEqual(expected_name, actual_name, "names are different")
+            self.assertEqual(expected_type, actual_type, "data types are different")

--- a/test/integration/043_custom_aliases_test/test_custom_aliases.py
+++ b/test/integration/043_custom_aliases_test/test_custom_aliases.py
@@ -1,4 +1,4 @@
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestAliases(DBTIntegrationTest):
@@ -16,7 +16,8 @@ class TestAliases(DBTIntegrationTest):
             "macro-paths": ['test/integration/043_custom_aliases_test/macros'],
         }
 
-    def test__customer_alias_name(self):
+    @use_profile('postgres')
+    def test_postgres_customer_alias_name(self):
         results = self.run_dbt(['run'])
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         self.run_dbt(['test'])


### PR DESCRIPTION
Fixes #706 


This is based on the archive-blocks PR branch (#1361)

TODO: Make the tests faster, probably by combining more of them
TODO: We probably need to cache column information about relations where we can, we make a ton of redundant calls on that front.