### PR TITLE
archives: do not create existing schema (#758)

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/archive/archive.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/archive.sql
@@ -253,7 +253,14 @@
   {%- set target_table = model.get('alias', model.get('name')) -%}
   {%- set strategy = config.get('strategy') -%}
 
-  {{ create_schema(target_database, target_schema) }}
+  {% set information_schema = api.Relation.create(
+    database=target_database,
+    schema=target_schema,
+    identifier=target_table).information_schema() %}
+
+  {% if not check_schema_exists(information_schema, target_schema) %}
+    {{ create_schema(target_database, target_schema) }}
+  {% endif %}
 
   {%- set target_relation = adapter.get_relation(
       database=target_database,

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -75,6 +75,7 @@ class BigQueryAdapter(BaseAdapter):
             '`rename_relation` is not implemented for this adapter!'
         )
 
+    @available
     def list_schemas(self, database):
         conn = self.connections.get_thread_connection()
         client = conn.handle
@@ -83,6 +84,11 @@ class BigQueryAdapter(BaseAdapter):
             all_datasets = client.list_datasets(project=database,
                                                 include_all=True)
             return [ds.dataset_id for ds in all_datasets]
+
+    @available
+    def check_schema_exists(self, database, schema):
+        superself = super(BigQueryAdapter, self)
+        return superself.check_schema_exists(database, schema)
 
     def get_columns_in_relation(self, relation):
         try:

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -74,6 +74,6 @@
 {% endmacro %}
 
 
-{% macro bigquery__check_schema_exists(database, schema) %}
-  {{ return(adapter.check_schema_exists(database, schema)) }}
+{% macro bigquery__check_schema_exists(information_schema, schema) %}
+  {{ return(adapter.check_schema_exists(information_schema.database, schema)) }}
 {% endmacro %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -67,3 +67,13 @@
 {% macro bigquery__current_timestamp() -%}
   CURRENT_TIMESTAMP()
 {%- endmacro %}
+
+
+{% macro bigquery__list_schemas(database) %}
+  {{ return(adapter.list_schemas()) }}
+{% endmacro %}
+
+
+{% macro bigquery__check_schema_exists(database, schema) %}
+  {{ return(adapter.check_schema_exists(database, schema)) }}
+{% endmacro %}


### PR DESCRIPTION
Fixes #758 

This is based on #1361 

During archive creation, check if a schema exists before creating it.

We should probably cache the results of `list_schemas` or `check_schema_exists`.