### PR TITLE
Fix run operation return codes (#1377)

### DIFF
--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -28,12 +28,14 @@ class RunOperationTask(ConfiguredTask):
         package_name, macro_name = self._get_macro_parts()
         macro_kwargs = self._get_kwargs()
 
-        res = adapter.execute_macro(
-            macro_name,
-            project=package_name,
-            kwargs=macro_kwargs,
-            manifest=manifest
-        )
+        with adapter.connection_named('macro_{}'.format(macro_name)):
+            res = adapter.execute_macro(
+                macro_name,
+                project=package_name,
+                kwargs=macro_kwargs,
+                manifest=manifest
+            )
+            adapter.commit_if_has_connection()
 
         return res
 

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -21,7 +21,7 @@ class RunOperationTask(ConfiguredTask):
     def _get_kwargs(self):
         return dbt.utils.parse_cli_vars(self.args.args)
 
-    def run_unsafe(self):
+    def _run_unsafe(self):
         manifest = GraphLoader.load_all(self.config)
         adapter = get_adapter(self.config)
 
@@ -41,7 +41,7 @@ class RunOperationTask(ConfiguredTask):
 
     def run(self):
         try:
-            result = self.run_unsafe()
+            result = self._run_unsafe()
         except dbt.exceptions.Exception as exc:
             logger.error(
                 'Encountered a dbt exception while running a macro: {}'

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -35,7 +35,6 @@ class RunOperationTask(ConfiguredTask):
                 kwargs=macro_kwargs,
                 manifest=manifest
             )
-            adapter.commit_if_has_connection()
 
         return res
 
@@ -44,14 +43,14 @@ class RunOperationTask(ConfiguredTask):
             result = self._run_unsafe()
         except dbt.exceptions.Exception as exc:
             logger.error(
-                'Encountered a dbt exception while running a macro: {}'
+                'Encountered an error while running operation: {}'
                 .format(exc)
             )
             logger.debug('', exc_info=True)
             return False, None
         except Exception as exc:
             logger.error(
-                'Encountered an uncaught exception while running a macro: {}'
+                'Encountered an uncaught exception while running operation: {}'
                 .format(exc)
             )
             logger.debug('', exc_info=True)

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -29,6 +29,7 @@ class RunOperationTask(ConfiguredTask):
         macro_kwargs = self._get_kwargs()
 
         with adapter.connection_named('macro_{}'.format(macro_name)):
+            adapter.clear_transaction()
             res = adapter.execute_macro(
                 macro_name,
                 project=package_name,

--- a/test/integration/044_run_operations_test/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_test/macros/happy_macros.sql
@@ -1,0 +1,16 @@
+{% macro no_args() %}
+  {% if execute %}
+    {% call statement() %}
+      create table "{{ schema }}"."no_args" (id int)
+    {% endcall %}
+  {% endif %}
+{% endmacro %}
+
+
+{% macro table_name_args(table_name) %}
+  {% if execute %}
+    {% call statement() %}
+      create table "{{ schema }}"."{{ table_name }}" (id int)
+    {% endcall %}
+  {% endif %}
+{% endmacro %}

--- a/test/integration/044_run_operations_test/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_test/macros/happy_macros.sql
@@ -1,7 +1,8 @@
 {% macro no_args() %}
   {% if execute %}
-    {% call statement() %}
-      create table "{{ schema }}"."no_args" (id int)
+    {% call statement(auto_begin=True) %}
+      create table "{{ schema }}"."no_args" (id int);
+      commit;
     {% endcall %}
   {% endif %}
 {% endmacro %}
@@ -9,8 +10,9 @@
 
 {% macro table_name_args(table_name) %}
   {% if execute %}
-    {% call statement() %}
-      create table "{{ schema }}"."{{ table_name }}" (id int)
+    {% call statement(auto_begin=True) %}
+      create table "{{ schema }}"."{{ table_name }}" (id int);
+      commit;
     {% endcall %}
   {% endif %}
 {% endmacro %}

--- a/test/integration/044_run_operations_test/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_test/macros/happy_macros.sql
@@ -16,3 +16,9 @@
     {% endcall %}
   {% endif %}
 {% endmacro %}
+
+{% macro vacuum(table_name) %}
+  {% call statement(auto_begin=false) %}
+    vacuum "{{ schema }}"."{{ table_name }}"
+  {% endcall %}
+{% endmacro %}

--- a/test/integration/044_run_operations_test/macros/sad_macros.sql
+++ b/test/integration/044_run_operations_test/macros/sad_macros.sql
@@ -1,0 +1,7 @@
+{% macro syntax_error() %}
+  {% if execute %}
+    {% call statement() %}
+        select NOPE NOT A VALID QUERY
+    {% endcall %}
+  {% endif %}
+{% endmacro %}

--- a/test/integration/044_run_operations_test/models/model.sql
+++ b/test/integration/044_run_operations_test/models/model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/044_run_operations_test/test_run_operations.py
+++ b/test/integration/044_run_operations_test/test_run_operations.py
@@ -1,0 +1,52 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+import yaml
+
+
+class TestOperations(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "run_operations_044"
+
+    @property
+    def models(self):
+        return "test/integration/044_run_operations_test/models"
+
+    @property
+    def project_config(self):
+        return {
+            "macro-paths": ['test/integration/044_run_operations_test/macros'],
+        }
+
+    def run_operation(self, macro, expect_pass=True, extra_args=None, **kwargs):
+        args = ['run-operation']
+        if macro:
+            args.extend(('--macro', macro))
+        if kwargs:
+            args.extend(('--args', yaml.safe_dump(kwargs)))
+        if extra_args:
+            args.extend(extra_args)
+        return self.run_dbt(args, expect_pass=expect_pass)
+
+    @use_profile('postgres')
+    def test__postgres_macro_noargs(self):
+        self.run_operation('no_args')
+        self.assertTableDoesExist('no_args')
+
+    @use_profile('postgres')
+    def test__postgres_macro_args(self):
+        self.run_operation('table_name_args', table_name='my_fancy_table')
+        self.assertTableDoesExist('my_fancy_table')
+
+    @use_profile('postgres')
+    def test__postgres_macro_exception(self):
+        self.run_operation('syntax_error', False)
+
+    @use_profile('postgres')
+    def test__postgres_macro_missing(self):
+        self.run_operation('this_macro_does_not_exist', False)
+
+    @use_profile('postgres')
+    def test__postgres_cannot_connect(self):
+        self.run_operation('no_args',
+                           extra_args=['--target', 'noaccess'],
+                           expect_pass=False)

--- a/test/integration/044_run_operations_test/test_run_operations.py
+++ b/test/integration/044_run_operations_test/test_run_operations.py
@@ -50,3 +50,9 @@ class TestOperations(DBTIntegrationTest):
         self.run_operation('no_args',
                            extra_args=['--target', 'noaccess'],
                            expect_pass=False)
+
+    @use_profile('postgres')
+    def test__postgres_vacuum(self):
+        self.run_dbt(['run'])
+        # this should succeed
+        self.run_operation('vacuum', table_name='model')


### PR DESCRIPTION
Fixes #1377 

When we run an operation, set the return code on error.

Also, since wilt-chamberlain totally broke the run-operation command in multiple ways, I fixed all that. And added tests so I don't do that again.

I also added a commit call that happens after successfully executing the macro. Maybe that would be better as a flag? I just wanted it for testing, but I can't really see _not_ wanting to commit.