### PR TITLE
Remove sql_where

### DIFF
--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -30,16 +30,6 @@ class DBTRepositoriesDeprecation(DBTDeprecation):
   """
 
 
-class SqlWhereDeprecation(DBTDeprecation):
-    name = "sql_where"
-    description = """\
-The `sql_where` option for incremental models is deprecated and will be
-  removed in a future release. Check the docs for more information
-
-  {}
-  """.format(dbt.links.IncrementalDocs)
-
-
 class SeedDropExistingDeprecation(DBTDeprecation):
     name = 'drop-existing'
     description = """The --drop-existing argument to `dbt seed` has been
@@ -83,7 +73,6 @@ active_deprecations = set()
 deprecations_list = [
     DBTRepositoriesDeprecation(),
     SeedDropExistingDeprecation(),
-    SqlWhereDeprecation(),
 ]
 
 deprecations = {d.name: d for d in deprecations_list}

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -12,7 +12,6 @@
 {%- endmacro %}
 
 {% materialization incremental, default -%}
-  {%- set sql_where = config.get('sql_where') -%}
   {%- set unique_key = config.get('unique_key') -%}
 
   {%- set identifier = model['alias'] -%}
@@ -57,19 +56,7 @@
   {%- else -%}
      {%- call statement() -%}
 
-       {% set tmp_table_sql -%}
-         {# We are using a subselect instead of a CTE here to allow PostgreSQL to use indexes. -#}
-         select * from (
-           {{ sql }}
-         ) as dbt_incr_sbq
-
-         {% if sql_where %}
-         where ({{ sql_where }})
-           or ({{ sql_where }}) is null
-         {% endif %}
-       {%- endset %}
-
-       {{ dbt.create_table_as(True, tmp_relation, tmp_table_sql) }}
+       {{ dbt.create_table_as(True, tmp_relation, sql) }}
 
      {%- endcall -%}
 

--- a/core/dbt/loader.py
+++ b/core/dbt/loader.py
@@ -214,8 +214,6 @@ def _warn_for_unused_resource_config_paths(manifest, config):
 def _warn_for_deprecated_configs(manifest):
     for unique_id, node in manifest.nodes.items():
         is_model = node.resource_type == NodeType.Model
-        if is_model and 'sql_where' in node.config:
-            deprecations.warn('sql_where')
 
 
 def _check_manifest(manifest, config):

--- a/core/dbt/parser/source_config.py
+++ b/core/dbt/parser/source_config.py
@@ -13,7 +13,6 @@ class SourceConfig(object):
         'schema',
         'enabled',
         'materialized',
-        'sql_where',
         'unique_key',
         'database',
     }

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -2,7 +2,6 @@
 {% materialization incremental, adapter='bigquery' -%}
 
   {%- set unique_key = config.get('unique_key') -%}
-  {%- set sql_where = config.get('sql_where') -%}
 
   {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
   {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
@@ -34,12 +33,7 @@
   {% set source_sql -%}
      {#-- wrap sql in parens to make it a subquery --#}
      (
-        select * from (
-            {{ sql }}
-        )
-        {% if sql_where %}
-            where ({{ sql_where }}) or ({{ sql_where }}) is null
-        {% endif %}
+        {{ sql }}
     )
   {%- endset -%}
 

--- a/test/integration/012_deprecation_tests/models/sql_where.sql
+++ b/test/integration/012_deprecation_tests/models/sql_where.sql
@@ -1,3 +1,0 @@
-{{ config(sql_where='id > (select max(id) from {{this}})')}}
-
-select 1 as id

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -29,6 +29,6 @@ class TestDeprecations(DBTIntegrationTest):
     @use_profile('postgres')
     def test_postgres_deprecations(self):
         self.assertEqual(deprecations.active_deprecations, set())
-        results = self.run_dbt(strict=False)
-        self.assertEqual({'adapter:already_exists', 'sql_where'},
+        self.run_dbt(strict=False)
+        self.assertEqual({'adapter:already_exists'},
                          deprecations.active_deprecations)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -42,7 +42,6 @@ model_config = {
                 'sort': 'timestamp',
                 'materialized': 'incremental',
                 'dist': 'user_id',
-                'sql_where': 'created_at > (select max(created_at) from {{ this }})',
                 'unique_key': 'id'
             },
             'base': {

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -208,7 +208,6 @@ class GraphTest(unittest.TestCase):
                 "test_models_compile": {
                     "model_one": {
                         "materialized": "incremental",
-                        "sql_where": "created_at",
                         "unique_key": "id"
                     },
                 }


### PR DESCRIPTION
Fixes #1351


Remove sql_where, solving all `sql_where`-related issues permanently.