### PR TITLE
use ilike instead of = for database when listing schemas (#1411)

### DIFF
--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -193,7 +193,7 @@
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
     select distinct schema_name
     from {{ information_schema_name(database) }}.schemata
-    where catalog_name='{{ database }}'
+    where catalog_name ilike '{{ database }}'
   {% endcall %}
   {{ return(load_result('list_schemas').table) }}
 {% endmacro %}


### PR DESCRIPTION
Fixes #1411 

I am actually not really sure if that where clause is useful at all, given that information schema queries are database-specific, but this should be less wrong, at least.

