### PR TITLE
nosetest -> pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [report]
 include =
   core/dbt/*
-  plugins/adapters/dbt/*
+  plugins/*/dbt/*

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,10 @@
 freezegun==0.3.9
-nose>=1.3.7
+pytest==4.4.0
+pytest-cov==2.6.1
 mock>=1.3.0
 flake8>=3.5.0
 pytz==2017.2
 bumpversion==0.5.3
-coverage==4.2
+coverage==4.4
 tox==2.5.0
 ipdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: "/root/.virtualenvs/dbt/bin/nosetests"
+    command: "/root/.virtualenvs/dbt/bin/pytest"
     env_file:
       - ./test.env
     volumes:

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -1,4 +1,3 @@
-from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest, use_profile
 
 

--- a/test/integration/005_simple_seed_test/test_seed_type_override.py
+++ b/test/integration/005_simple_seed_test/test_seed_type_override.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestSimpleSeedColumnOverride(DBTIntegrationTest):
@@ -40,7 +39,7 @@ class TestSimpleSeedColumnOverridePostgres(TestSimpleSeedColumnOverride):
             "birthday": "date",
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed_with_column_override_postgres(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
@@ -63,7 +62,7 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
     def profile_config(self):
         return self.snowflake_profile()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_simple_seed_with_column_override_snowflake(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
@@ -86,7 +85,7 @@ class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
     def profile_config(self):
         return self.bigquery_profile()
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_simple_seed_with_column_override_bigquery(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 from dbt.exceptions import CompilationException
 
@@ -24,7 +23,7 @@ class TestSimpleSeed(DBTIntegrationTest):
             "data-paths": ['test/integration/005_simple_seed_test/data']
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
@@ -37,7 +36,7 @@ class TestSimpleSeed(DBTIntegrationTest):
         self.assertTablesEqual("seed_actual","seed_expected")
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed_with_drop(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
@@ -72,7 +71,7 @@ class TestSimpleSeedCustomSchema(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed_with_schema(self):
         schema_name = "{}_{}".format(self.unique_schema(), 'custom_schema')
 
@@ -86,7 +85,7 @@ class TestSimpleSeedCustomSchema(DBTIntegrationTest):
         self.assertTablesEqual("seed_actual","seed_expected", table_a_schema=schema_name)
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed_with_drop_and_schema(self):
         schema_name = "{}_{}".format(self.unique_schema(), 'custom_schema')
 
@@ -126,7 +125,7 @@ class TestSimpleSeedDisabled(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_seed_with_disabled(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
@@ -153,7 +152,7 @@ class TestSeedParsing(DBTIntegrationTest):
             "data-paths": ['test/integration/005_simple_seed_test/data-bad']
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_dbt_run_skips_seeds(self):
         # run does not try to parse the seed files
         self.assertEqual(len(self.run_dbt(['run'])), 1)

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import mock
 
 import dbt.semver
@@ -32,7 +31,7 @@ class TestSimpleDependency(DBTIntegrationTest):
     def configured_schema(self):
         return self.unique_schema() + '_configured'
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_local_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
@@ -62,7 +61,7 @@ class TestSimpleDependencyWithSchema(TestSimpleDependency):
     def configured_schema(self):
         return 'configured_{}_macro'.format(self.unique_schema())
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     @mock.patch('dbt.config.project.get_installed_version')
     def test_postgres_local_dependency_out_of_date(self, mock_get):
         mock_get.return_value = dbt.semver.VersionSpecifier.from_version_string('0.0.1')
@@ -71,7 +70,7 @@ class TestSimpleDependencyWithSchema(TestSimpleDependency):
             self.run_dbt(['run'])
         self.assertIn('--no-version-check', str(exc.exception))
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     @mock.patch('dbt.config.project.get_installed_version')
     def test_postgres_local_dependency_out_of_date_no_check(self, mock_get):
         mock_get.return_value = dbt.semver.VersionSpecifier.from_version_string('0.0.1')

--- a/test/integration/006_simple_dependency_test/test_simple_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestSimpleDependency(DBTIntegrationTest):
 
@@ -25,7 +24,7 @@ class TestSimpleDependency(DBTIntegrationTest):
             ]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
@@ -47,7 +46,7 @@ class TestSimpleDependency(DBTIntegrationTest):
         self.assertTablesEqual("seed","view_model")
         self.assertTablesEqual("seed","incremental")
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency_with_models(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run", '--models', 'view_model+'])
@@ -105,7 +104,7 @@ class TestSimpleDependencyBranch(DBTIntegrationTest):
         self.assertEqual(created_models['view_summary'], 'view')
         self.assertEqual(created_models['incremental'], 'table')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.deps_run_assert_equality()
 
@@ -115,7 +114,7 @@ class TestSimpleDependencyBranch(DBTIntegrationTest):
 
         self.deps_run_assert_equality()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_empty_models_not_compiled_in_dependencies(self):
         self.deps_run_assert_equality()
 

--- a/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class BaseTestSimpleDependencyWithConfigs(DBTIntegrationTest):
 
@@ -40,7 +39,7 @@ class TestSimpleDependencyWithConfigs(BaseTestSimpleDependencyWithConfigs):
             },
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
@@ -83,7 +82,7 @@ class TestSimpleDependencyWithOverriddenConfigs(BaseTestSimpleDependencyWithConf
         }
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
@@ -127,7 +126,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigs(BaseTestSimpleDepen
         }
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.use_default_project()
 
@@ -183,7 +182,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigsAndMaterializations(
         }
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestGraphSelection(DBTIntegrationTest):
 
@@ -26,7 +25,7 @@ class TestGraphSelection(DBTIntegrationTest):
             )
             self.assertFalse(exists)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__specific_model(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -40,7 +39,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('emails' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__tags(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -54,7 +53,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTrue('users_rollup' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__tags_and_children(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -69,7 +68,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertTrue('users' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__specific_model(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -83,7 +82,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('EMAILS' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__specific_model_and_children(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -98,7 +97,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('emails', created_models)
         self.assert_correct_schemas()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__specific_model_and_children(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -114,7 +113,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('EMAILS' in created_models)
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__specific_model_and_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -128,7 +127,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('emails' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__specific_model_and_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -145,7 +144,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('EMAILS' in created_models)
 
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__specific_model_with_exclusion(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -161,7 +160,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('emails' in created_models)
         self.assert_correct_schemas()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__specific_model_with_exclusion(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
 
@@ -176,7 +175,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertFalse('USERS_ROLLUP' in created_models)
         self.assertFalse('EMAILS' in created_models)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__locally_qualified_name(self):
         results = self.run_dbt(['run', '--models', 'test.subdir'])
         self.assertEqual(len(results), 2)
@@ -189,7 +188,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertIn('nested_users', created_models)
         self.assert_correct_schemas()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__childrens_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         results = self.run_dbt(['run', '--models', '@base_users'])
@@ -202,7 +201,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('subdir', created_models)
         self.assertNotIn('nested_users', created_models)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__more_childrens_parents(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         results = self.run_dbt(['run', '--models', '@users'])
@@ -216,7 +215,7 @@ class TestGraphSelection(DBTIntegrationTest):
         self.assertNotIn('subdir', created_models)
         self.assertNotIn('nested_users', created_models)
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__skip_intermediate(self):
         self.run_sql_file("test/integration/007_graph_selection_tests/seed.sql")
         results = self.run_dbt(['run', '--models', '@users'])

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, FakeArgs
+from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 
 from dbt.task.test import TestTask
 
@@ -40,7 +39,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
 
         self.assertEqual(ran_tests, expected_sorted)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_no_specifiers(self):
         self.run_schema_and_assert(
             None,
@@ -51,7 +50,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
              'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_model(self):
         self.run_schema_and_assert(
             ['users'],
@@ -59,7 +58,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_users_id']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_tag(self):
         self.run_schema_and_assert(
             ['tag:bi'],
@@ -68,7 +67,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
              'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_model_and_children(self):
         self.run_schema_and_assert(
             ['users+'],
@@ -76,7 +75,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_users_id', 'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_tag_and_children(self):
         self.run_schema_and_assert(
             ['tag:base+'],
@@ -86,7 +85,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
              'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_model_and_parents(self):
         self.run_schema_and_assert(
             ['+users_rollup'],
@@ -94,7 +93,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_users_id', 'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_model_and_parents_with_exclude(self):
         self.run_schema_and_assert(
             ['+users_rollup'],
@@ -102,7 +101,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_users_id']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_exclude_only(self):
         self.run_schema_and_assert(
             None,
@@ -110,7 +109,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_emails_email', 'unique_table_model_id', 'unique_users_id']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_specify_model_in_pkg(self):
         self.run_schema_and_assert(
             ['test.users_rollup'],
@@ -120,7 +119,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_with_glob(self):
         self.run_schema_and_assert(
             ['*'],
@@ -128,7 +127,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_emails_email', 'unique_table_model_id', 'unique_users_rollup_gender']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_dep_package_only(self):
         self.run_schema_and_assert(
             ['dbt_integration_project'],
@@ -136,7 +135,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_table_model_id']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_model_in_dep_pkg(self):
         self.run_schema_and_assert(
             ['dbt_integration_project.table_model'],
@@ -144,7 +143,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
             ['unique_table_model_id']
         )
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__schema_tests_exclude_pkg(self):
         self.run_schema_and_assert(
             None,

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -1,4 +1,3 @@
-from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 import os
 
@@ -27,7 +26,7 @@ class TestSchemaTests(DBTIntegrationTest):
         test_task = TestTask(args, self.config)
         return test_task.run()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_schema_tests(self):
         results = self.run_dbt()
         self.assertEqual(len(results), 5)
@@ -77,7 +76,7 @@ class TestMalformedSchemaTests(DBTIntegrationTest):
         test_task = TestTask(args, self.config)
         return test_task.run()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_malformed_schema_test_wont_brick_run(self):
         # dbt run should work (Despite broken schema test)
         results = self.run_dbt(strict=False)
@@ -88,7 +87,7 @@ class TestMalformedSchemaTests(DBTIntegrationTest):
         self.assertEqual(len(ran_tests), 5)
         self.assertEqual(sum(x.status for x in ran_tests), 0)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_malformed_schema_strict_will_break_run(self):
         with self.assertRaises(CompilationException):
             self.run_dbt(strict=True)
@@ -112,7 +111,7 @@ class TestHooksInTests(DBTIntegrationTest):
             "on-run-end": ["{{ exceptions.raise_compiler_error('hooks called in tests -- error') if execute }}"],
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_hooks_dont_run_for_tests(self):
         # This would fail if the hooks ran
         results = self.run_dbt(['test', '--model', 'ephemeral'])
@@ -169,7 +168,7 @@ class TestCustomSchemaTests(DBTIntegrationTest):
         test_task = TestTask(args, self.config)
         return test_task.run()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_schema_tests(self):
         self.run_dbt(["deps"])
         results = self.run_dbt()

--- a/test/integration/009_data_tests_test/test_data_tests.py
+++ b/test/integration/009_data_tests_test/test_data_tests.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, FakeArgs
+from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 
 from dbt.task.test import TestTask
 import os
@@ -30,7 +29,7 @@ class TestDataTests(DBTIntegrationTest):
         test_task = TestTask(args, self.config)
         return test_task.run()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_data_tests(self):
         self.use_profile('postgres')
 
@@ -59,7 +58,7 @@ class TestDataTests(DBTIntegrationTest):
         self.assertNotEqual(len(test_results), 0)
         self.assertEqual(len(test_results), len(defined_tests))
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_snowflake_data_tests(self):
         self.use_profile('snowflake')
 

--- a/test/integration/010_permission_tests/test_permissions.py
+++ b/test/integration/010_permission_tests/test_permissions.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestPermissions(DBTIntegrationTest):
 
@@ -15,7 +14,7 @@ class TestPermissions(DBTIntegrationTest):
     def models(self):
         return "test/integration/010_permission_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_no_create_schema_permissions(self):
         # the noaccess user does not have permissions to create a schema -- this should fail
         failed = False
@@ -27,7 +26,7 @@ class TestPermissions(DBTIntegrationTest):
 
         self.assertTrue(failed)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_create_schema_permissions(self):
         # now it should work!
         self.run_sql('grant create on database {} to noaccess'.format(self.default_database))

--- a/test/integration/011_invalid_model_tests/test_invalid_models.py
+++ b/test/integration/011_invalid_model_tests/test_invalid_models.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 from dbt.exceptions import ValidationException
 
@@ -19,7 +18,7 @@ class TestInvalidDisabledModels(DBTIntegrationTest):
     def models(self):
         return "test/integration/011_invalid_model_tests/models-2"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_view_with_incremental_attributes(self):
 
         try:
@@ -45,7 +44,7 @@ class TestInvalidModelReference(DBTIntegrationTest):
     def models(self):
         return "test/integration/011_invalid_model_tests/models-3"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_view_with_incremental_attributes(self):
 
         try:

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 import os
 
@@ -84,7 +83,7 @@ class TestContextVars(DBTIntegrationTest):
 
         return ctx
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_env_vars_dev(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)
@@ -110,7 +109,7 @@ class TestContextVars(DBTIntegrationTest):
 
         self.assertEqual(ctx['env_var'], '1')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_env_vars_prod(self):
         results = self.run_dbt(['run', '--target', 'prod'])
         self.assertEqual(len(results), 1)

--- a/test/integration/014_hook_tests/test_model_hooks.py
+++ b/test/integration/014_hook_tests/test_model_hooks.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 from dbt.exceptions import CompilationException
 
 
@@ -146,7 +145,7 @@ class TestPrePostModelHooks(BaseTestPrePost):
     def models(self):
         return "test/integration/014_hook_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_pre_and_post_model_hooks(self):
         self.run_dbt(['run'])
 
@@ -176,7 +175,7 @@ class TestPrePostModelHooksOnSeeds(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_hooks_on_seeds(self):
         res = self.run_dbt(['seed'])
         self.assertEqual(len(res), 1, 'Expected exactly one item')
@@ -195,14 +194,14 @@ class TestPrePostModelHooksInConfig(BaseTestPrePost):
     def models(self):
         return "test/integration/014_hook_tests/configured-models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_pre_and_post_model_hooks_model(self):
         self.run_dbt(['run'])
 
         self.check_hooks('start')
         self.check_hooks('end')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_pre_and_post_model_hooks_model_and_project(self):
         self.use_default_project({
             'models': {
@@ -247,7 +246,7 @@ class TestDuplicateHooksInConfigs(DBTIntegrationTest):
     def models(self):
         return "test/integration/014_hook_tests/error-models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_run_duplicate_hook_defs(self):
         with self.assertRaises(CompilationException) as exc:
             self.run_dbt(['run'])

--- a/test/integration/014_hook_tests/test_model_hooks_bq.py
+++ b/test/integration/014_hook_tests/test_model_hooks_bq.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 MODEL_PRE_HOOK = """
    insert into {{this.schema}}.on_model_hook (
@@ -106,7 +105,7 @@ class TestBigqueryPrePostModelHooks(DBTIntegrationTest):
         self.assertTrue(ctx['run_started_at'] is not None and len(ctx['run_started_at']) > 0, 'run_started_at was not set')
         self.assertTrue(ctx['invocation_id'] is not None and len(ctx['invocation_id']) > 0, 'invocation_id was not set')
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_pre_and_post_model_hooks_bigquery(self):
         self.run_dbt(['run'])
 
@@ -135,7 +134,7 @@ class TestBigqueryPrePostModelHooksOnSeeds(DBTIntegrationTest):
             }
         }
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_hooks_on_seeds_bigquery(self):
         res = self.run_dbt(['seed'])
         self.assertEqual(len(res), 1, 'Expected exactly one item')

--- a/test/integration/014_hook_tests/test_run_hooks.py
+++ b/test/integration/014_hook_tests/test_run_hooks.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestPrePostRunHooks(DBTIntegrationTest):
 
@@ -88,7 +87,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
         self.assertTrue(ctx['run_started_at'] is not None and len(ctx['run_started_at']) > 0, 'run_started_at was not set')
         self.assertTrue(ctx['invocation_id'] is not None and len(ctx['invocation_id']) > 0, 'invocation_id was not set')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__pre_and_post_run_hooks(self):
         self.run_dbt(['run'])
 
@@ -99,7 +98,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
         self.assertTableDoesNotExist("end_hook_order_test")
         self.assert_used_schemas()
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__pre_and_post_seed_hooks(self):
         self.run_dbt(['seed'])
 

--- a/test/integration/014_hook_tests/test_run_hooks_bq.py
+++ b/test/integration/014_hook_tests/test_run_hooks_bq.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestBigqueryPrePostRunHooks(DBTIntegrationTest):
 
@@ -78,7 +77,7 @@ class TestBigqueryPrePostRunHooks(DBTIntegrationTest):
         self.assertTrue(ctx['run_started_at'] is not None and len(ctx['run_started_at']) > 0, 'run_started_at was not set')
         self.assertTrue(ctx['invocation_id'] is not None and len(ctx['invocation_id']) > 0, 'invocation_id was not set')
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_bigquery_pre_and_post_run_hooks(self):
         self.run_dbt(['run'])
 
@@ -88,7 +87,7 @@ class TestBigqueryPrePostRunHooks(DBTIntegrationTest):
         self.assertTableDoesNotExist("start_hook_order_test")
         self.assertTableDoesNotExist("end_hook_order_test")
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_bigquery_pre_and_post_seed_hooks(self):
         self.run_dbt(['seed'])
 

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, DBT_PROFILES
+from test.integration.base import DBTIntegrationTest, DBT_PROFILES, use_profile
 import os, shutil, yaml
 
 class TestCLIInvocation(DBTIntegrationTest):
@@ -17,13 +16,13 @@ class TestCLIInvocation(DBTIntegrationTest):
     def models(self):
         return "test/integration/015_cli_invocation_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_toplevel_dbt_run(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)
         self.assertTablesEqual("seed", "model")
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_subdir_dbt_run(self):
         os.chdir(os.path.join(self.models, "subdir1"))
 
@@ -86,7 +85,7 @@ class TestCLIInvocationWithProfilesDir(DBTIntegrationTest):
     def models(self):
         return "test/integration/015_cli_invocation_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_toplevel_dbt_run_with_profile_dir_arg(self):
         results = self.run_dbt(['run', '--profiles-dir', 'dbt-profile'])
         self.assertEqual(len(results), 1)

--- a/test/integration/016_macro_tests/test_macros.py
+++ b/test/integration/016_macro_tests/test_macros.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestMacros(DBTIntegrationTest):
@@ -35,7 +34,7 @@ class TestMacros(DBTIntegrationTest):
             "macro-paths": ["test/integration/016_macro_tests/macros"],
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_working_macros(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
@@ -64,7 +63,7 @@ class TestInvalidMacros(DBTIntegrationTest):
             "macro-paths": ["test/integration/016_macro_tests/bad-macros"]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_invalid_macro(self):
 
         try:
@@ -107,7 +106,7 @@ class TestMisusedMacros(DBTIntegrationTest):
     # fails, it does not raise a runtime exception. change this test to verify
     # that the model finished with ERROR state.
     #
-    # @attr(type='postgres')
+    # @use_profile('postgres')
     # def test_working_macros(self):
     #     self.run_dbt(["deps"])
 

--- a/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
+++ b/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestRuntimeMaterialization(DBTIntegrationTest):
 
@@ -19,7 +18,7 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
     def models(self):
         return "test/integration/017_runtime_materialization_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_full_refresh(self):
         # initial full-refresh should have no effect
         results = self.run_dbt(['run', '--full-refresh'])
@@ -44,7 +43,7 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTablesEqual("seed","incremental")
         self.assertTablesEqual("seed","materialized")
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_non_destructive(self):
         results = self.run_dbt(['run', '--non-destructive'])
         self.assertEqual(len(results), 3)
@@ -64,7 +63,7 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTablesEqual("seed","incremental")
         self.assertTablesEqual("seed","materialized")
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_full_refresh_and_non_destructive(self):
         results = self.run_dbt(['run', '--full-refresh', '--non-destructive'])
         self.assertEqual(len(results), 3)
@@ -85,7 +84,7 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTablesEqual("seed","incremental")
         self.assertTablesEqual("seed","materialized")
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_postgres_delete__dbt_tmp_relation(self):
         # This creates a __dbt_tmp view - make sure it doesn't interfere with the dbt run
         self.run_sql_file("test/integration/017_runtime_materialization_tests/create_view__dbt_tmp.sql")
@@ -96,7 +95,7 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTablesEqual("seed","view")
 
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_snowflake_backup_different_type(self):
         self.run_sql_file(
             'test/integration/017_runtime_materialization_tests/create_backup_and_original.sql'

--- a/test/integration/018_adapter_ddl_tests/test_adapter_ddl.py
+++ b/test/integration/018_adapter_ddl_tests/test_adapter_ddl.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 class TestAdapterDDL(DBTIntegrationTest):
 
@@ -16,7 +15,7 @@ class TestAdapterDDL(DBTIntegrationTest):
     def models(self):
         return "test/integration/018_adapter_ddl_tests/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_sort_and_dist_keys_are_nops_on_postgres(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)

--- a/test/integration/019_analysis_tests/test_analyses.py
+++ b/test/integration/019_analysis_tests/test_analyses.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import os
 
 
@@ -26,7 +25,7 @@ class TestAnalyses(DBTIntegrationTest):
         with open(path) as fp:
             self.assertEqual(fp.read().strip(), expected)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_analyses(self):
         compiled_analysis_path = os.path.normpath('target/compiled/test/analysis')
         path_1 = os.path.join(compiled_analysis_path, 'analysis.sql')

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestEphemeral(DBTIntegrationTest):
@@ -11,7 +10,7 @@ class TestEphemeral(DBTIntegrationTest):
     def models(self):
         return "test/integration/020_ephemeral_test/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres(self):
         self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
 
@@ -22,7 +21,7 @@ class TestEphemeral(DBTIntegrationTest):
         self.assertTablesEqual("seed", "double_dependent")
         self.assertTablesEqual("seed", "super_dependent")
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake(self):
         self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
 
@@ -42,7 +41,7 @@ class TestEphemeralErrorHandling(DBTIntegrationTest):
     def models(self):
         return "test/integration/020_ephemeral_test/ephemeral-errors"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres_upstream_error(self):
         self.run_sql_file("test/integration/020_ephemeral_test/seed.sql")
 

--- a/test/integration/021_concurrency_test/test_concurrency.py
+++ b/test/integration/021_concurrency_test/test_concurrency.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestConcurrency(DBTIntegrationTest):
@@ -11,7 +10,7 @@ class TestConcurrency(DBTIntegrationTest):
     def models(self):
         return "test/integration/021_concurrency_test/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__concurrency(self):
         self.run_sql_file("test/integration/021_concurrency_test/seed.sql")
 
@@ -37,7 +36,7 @@ class TestConcurrency(DBTIntegrationTest):
         self.assertTableDoesNotExist("invalid")
         self.assertTableDoesNotExist("skip")
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__snowflake__concurrency(self):
         self.run_sql_file("test/integration/021_concurrency_test/seed.sql")
 

--- a/test/integration/022_bigquery_test/test_bigquery_adapter_functions.py
+++ b/test/integration/022_bigquery_test/test_bigquery_adapter_functions.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, FakeArgs
+from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 
 
 class TestBigqueryAdapterFunctions(DBTIntegrationTest):
@@ -16,7 +15,7 @@ class TestBigqueryAdapterFunctions(DBTIntegrationTest):
     def profile_config(self):
         return self.bigquery_profile()
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test__bigquery_adapter_functions(self):
         results = self.run_dbt()
         self.assertEqual(len(results), 3)

--- a/test/integration/022_bigquery_test/test_bigquery_date_partitioning.py
+++ b/test/integration/022_bigquery_test/test_bigquery_date_partitioning.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, FakeArgs
+from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 
 
 class TestBigqueryDatePartitioning(DBTIntegrationTest):
@@ -16,7 +15,7 @@ class TestBigqueryDatePartitioning(DBTIntegrationTest):
     def profile_config(self):
         return self.bigquery_profile()
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test__bigquery_date_partitioning(self):
         results = self.run_dbt()
         self.assertEqual(len(results), 6)

--- a/test/integration/023_exit_codes_test/test_exit_codes.py
+++ b/test/integration/023_exit_codes_test/test_exit_codes.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest, FakeArgs
+from test.integration.base import DBTIntegrationTest, FakeArgs, use_profile
 
 import dbt.exceptions
 
@@ -33,21 +32,21 @@ class TestExitCodes(DBTIntegrationTest):
             ]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_exit_code_run_succeed(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'good'])
         self.assertEqual(len(results), 1)
         self.assertTrue(success)
         self.assertTableDoesExist('good')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__exit_code_run_fail(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'bad'])
         self.assertEqual(len(results), 1)
         self.assertFalse(success)
         self.assertTableDoesNotExist('bad')
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test___schema_test_pass(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'good'])
         self.assertEqual(len(results), 1)
@@ -56,7 +55,7 @@ class TestExitCodes(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
         self.assertTrue(success)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test___schema_test_fail(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'dupe'])
         self.assertEqual(len(results), 1)
@@ -65,13 +64,13 @@ class TestExitCodes(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
         self.assertFalse(success)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test___compile(self):
         results, success = self.run_dbt_and_check(['compile'])
         self.assertEqual(len(results), 7)
         self.assertTrue(success)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test___archive_pass(self):
         self.run_dbt_and_check(['run', '--model', 'good'])
         results, success = self.run_dbt_and_check(['archive'])
@@ -108,7 +107,7 @@ class TestExitCodesArchiveFail(DBTIntegrationTest):
             ]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test___archive_fail(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'good'])
         self.assertTrue(success)
@@ -137,7 +136,7 @@ class TestExitCodesDeps(DBTIntegrationTest):
             ]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_deps(self):
         _, success = self.run_dbt_and_check(['deps'])
         self.assertTrue(success)
@@ -163,7 +162,7 @@ class TestExitCodesDepsFail(DBTIntegrationTest):
             ]
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_deps(self):
         # this should fail
         try:
@@ -187,7 +186,7 @@ class TestExitCodesSeed(DBTIntegrationTest):
             "data-paths": ['test/integration/023_exit_codes_test/data-good']
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_seed(self):
         results, success = self.run_dbt_and_check(['seed'])
         self.assertEqual(len(results), 1)
@@ -208,7 +207,7 @@ class TestExitCodesSeedFail(DBTIntegrationTest):
             "data-paths": ['test/integration/023_exit_codes_test/data-bad']
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_seed(self):
         try:
             _, success = self.run_dbt_and_check(['seed'])

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -1,4 +1,3 @@
-from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest, use_profile
 
 
@@ -12,7 +11,7 @@ class TestCustomSchema(DBTIntegrationTest):
     def models(self):
         return "test/integration/024_custom_schema_test/models"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__custom_schema_no_prefix(self):
         self.use_default_project()
         self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
@@ -67,7 +66,7 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__custom_schema_with_prefix(self):
         self.use_default_project()
         self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")
@@ -160,7 +159,7 @@ class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__postgres__custom_schema_from_macro(self):
         self.use_default_project()
         self.run_sql_file("test/integration/024_custom_schema_test/seed.sql")

--- a/test/integration/025_duplicate_model_test/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_model.py
@@ -1,7 +1,5 @@
-from nose.plugins.attrib import attr
-
 from dbt.exceptions import CompilationException
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestDuplicateModelEnabled(DBTIntegrationTest):
@@ -34,7 +32,7 @@ class TestDuplicateModelEnabled(DBTIntegrationTest):
             }
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test_duplicate_model_enabled(self):
         message = "dbt found two resources with the name"
         try:
@@ -74,7 +72,7 @@ class TestDuplicateModelDisabled(DBTIntegrationTest):
             }
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test_duplicate_model_disabled(self):
         try:
             results = self.run_dbt(["run"])
@@ -109,7 +107,7 @@ class TestDuplicateModelEnabledAcrossPackages(DBTIntegrationTest):
             ],
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test_duplicate_model_enabled_across_packages(self):
         self.run_dbt(["deps"])
         message = "dbt found two resources with the name"
@@ -145,7 +143,7 @@ class TestDuplicateModelDisabledAcrossPackages(DBTIntegrationTest):
             ],
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test_duplicate_model_disabled_across_packages(self):
         self.run_dbt(["deps"])
         try:

--- a/test/integration/025_timezones_test/test_timezones.py
+++ b/test/integration/025_timezones_test/test_timezones.py
@@ -1,6 +1,5 @@
 from freezegun import freeze_time
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestTimezones(DBTIntegrationTest):
@@ -43,7 +42,7 @@ class TestTimezones(DBTIntegrationTest):
         """.format(schema=self.unique_schema())
 
     @freeze_time("2017-01-01 03:00:00", tz_offset=0)
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_run_started_at(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)

--- a/test/integration/026_aliases_test/test_aliases.py
+++ b/test/integration/026_aliases_test/test_aliases.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestAliases(DBTIntegrationTest):
@@ -27,19 +26,19 @@ class TestAliases(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__alias_model_name(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 4)
         self.run_dbt(['test'])
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test__alias_model_name_bigquery(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 4)
         self.run_dbt(['test'])
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test__alias_model_name_snowflake(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 4)
@@ -60,7 +59,7 @@ class TestAliasErrors(DBTIntegrationTest):
             "macro-paths": ['test/integration/026_aliases_test/macros'],
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__alias_dupe_throws_exception(self):
         message = ".*identical database representation.*"
         with self.assertRaisesRegexp(Exception, message):
@@ -81,7 +80,7 @@ class TestSameAliasDifferentSchemas(DBTIntegrationTest):
             "macro-paths": ['test/integration/026_aliases_test/macros'],
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__same_alias_succeeds_in_different_schemas(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 3)

--- a/test/integration/027_cycle_test/test_cycles.py
+++ b/test/integration/027_cycle_test/test_cycles.py
@@ -1,6 +1,5 @@
 from freezegun import freeze_time
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestSimpleCycle(DBTIntegrationTest):
@@ -14,7 +13,7 @@ class TestSimpleCycle(DBTIntegrationTest):
         return "test/integration/027_cycle_test/simple_cycle_models"
 
     @property
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_cycle(self):
         message = "Found a cycle.*"
         with self.assertRaisesRegexp(Exception, message):
@@ -31,7 +30,7 @@ class TestComplexCycle(DBTIntegrationTest):
         return "test/integration/027_cycle_test/complex_cycle_models"
 
     @property
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test_simple_cycle(self):
         message = "Found a cycle.*"
         with self.assertRaisesRegexp(Exception, message):

--- a/test/integration/028_cli_vars/test_cli_var_override.py
+++ b/test/integration/028_cli_vars/test_cli_var_override.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import yaml
 
 
@@ -22,7 +21,7 @@ class TestCLIVarOverride(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__overriden_vars_global(self):
         self.use_default_project()
         self.use_profile('postgres')
@@ -53,7 +52,7 @@ class TestCLIVarOverridePorject(DBTIntegrationTest):
             }
         }
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__overriden_vars_project_level(self):
 
         # This should be "override"

--- a/test/integration/028_cli_vars/test_cli_vars.py
+++ b/test/integration/028_cli_vars/test_cli_vars.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import yaml
 
 
@@ -12,7 +11,7 @@ class TestCLIVars(DBTIntegrationTest):
     def models(self):
         return "test/integration/028_cli_vars/models_complex"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__cli_vars_longform(self):
         self.use_profile('postgres')
         self.use_default_project()
@@ -39,7 +38,7 @@ class TestCLIVarsSimple(DBTIntegrationTest):
     def models(self):
         return "test/integration/028_cli_vars/models_simple"
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__cli_vars_shorthand(self):
         self.use_profile('postgres')
         self.use_default_project()
@@ -49,7 +48,7 @@ class TestCLIVarsSimple(DBTIntegrationTest):
         results = self.run_dbt(["test", "--vars", "simple: abc"])
         self.assertEqual(len(results), 1)
 
-    @attr(type='postgres')
+    @use_profile('postgres')
     def test__cli_vars_longer(self):
         self.use_profile('postgres')
         self.use_default_project()

--- a/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
+++ b/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import threading
 from dbt.adapters.factory import get_adapter
 
@@ -94,7 +93,7 @@ class TableTestConcurrentTransaction(BaseTestConcurrentTransaction):
     def models(self):
         return "test/integration/032_concurrent_transaction_test/models-table"
 
-    @attr(type="redshift")
+    @use_profile("redshift")
     def test__redshift__concurrent_transaction_table(self):
         self.reset()
         self.run_test()
@@ -104,7 +103,7 @@ class ViewTestConcurrentTransaction(BaseTestConcurrentTransaction):
     def models(self):
         return "test/integration/032_concurrent_transaction_test/models-view"
 
-    @attr(type="redshift")
+    @use_profile("redshift")
     def test__redshift__concurrent_transaction_view(self):
         self.reset()
         self.run_test()
@@ -114,7 +113,7 @@ class IncrementalTestConcurrentTransaction(BaseTestConcurrentTransaction):
     def models(self):
         return "test/integration/032_concurrent_transaction_test/models-incremental"
 
-    @attr(type="redshift")
+    @use_profile("redshift")
     def test__redshift__concurrent_transaction_incremental(self):
         self.reset()
         self.run_test()

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 import mock
 import hashlib
 import os
@@ -189,7 +188,7 @@ class TestEventTrackingSuccess(TestEventTracking):
             "test-paths": [self.dir("test")],
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_compile(self):
         expected_calls = [
             call(
@@ -217,7 +216,7 @@ class TestEventTrackingSuccess(TestEventTracking):
             expected_contexts
         )
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_deps(self):
         package_context = [
             {
@@ -260,7 +259,7 @@ class TestEventTrackingSuccess(TestEventTracking):
 
         self.run_event_test(["deps"], expected_calls, expected_contexts)
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_seed(self):
         def seed_context(project_id, user_id, invocation_id, version):
             return [{
@@ -314,7 +313,7 @@ class TestEventTrackingSuccess(TestEventTracking):
 
         self.run_event_test(["seed"], expected_calls, expected_contexts)
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_models(self):
         expected_calls = [
             call(
@@ -376,7 +375,7 @@ class TestEventTrackingSuccess(TestEventTracking):
             expected_contexts
         )
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_model_error(self):
         # cmd = ["run", "--model", "model_error"]
         # self.run_event_test(cmd, event_run_model_error, expect_pass=False)
@@ -422,7 +421,7 @@ class TestEventTrackingSuccess(TestEventTracking):
             expect_pass=False
         )
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_tests(self):
         # TODO: dbt does not track events for tests, but it should!
         self.run_dbt(["run", "--model", "example", "example_2"])
@@ -462,7 +461,7 @@ class TestEventTrackingCompilationError(TestEventTracking):
             "source-paths": [self.dir("model-compilation-error")],
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_with_compilation_error(self):
         expected_calls = [
             call(
@@ -528,7 +527,7 @@ class TestEventTrackingUnableToConnect(TestEventTracking):
             }
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_unable_to_connect(self):
         expected_calls = [
             call(
@@ -578,7 +577,7 @@ class TestEventTrackingArchive(TestEventTracking):
             ]
         }
 
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_archive(self):
         self.run_dbt(["run", "--models", "archivable"])
 
@@ -625,7 +624,7 @@ class TestEventTrackingArchive(TestEventTracking):
 
 
 class TestEventTrackingCatalogGenerate(TestEventTracking):
-    @attr(type="postgres")
+    @use_profile("postgres")
     def test__event_tracking_catalog_generate(self):
         # create a model for the catalog
         self.run_dbt(["run", "--models", "example"])

--- a/test/integration/034_redshift_test/test_late_binding_view.py
+++ b/test/integration/034_redshift_test/test_late_binding_view.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from nose.plugins.attrib import attr
 from test.integration.base import DBTIntegrationTest, use_profile
 
 

--- a/test/integration/040_override_database_test/test_override_database.py
+++ b/test/integration/040_override_database_test/test_override_database.py
@@ -1,5 +1,4 @@
-from nose.plugins.attrib import attr
-from test.integration.base import DBTIntegrationTest
+from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class BaseOverrideDatabase(DBTIntegrationTest):
@@ -42,11 +41,11 @@ class TestModelOverride(BaseOverrideDatabase):
             (func('view_4'), self.unique_schema(), self.alternative_database),
         ])
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_bigquery_database_override(self):
         self.run_database_override()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_snowflake_database_override(self):
         self.run_database_override()
 
@@ -82,11 +81,11 @@ class TestProjectModelOverride(BaseOverrideDatabase):
             (func('view_4'), self.unique_schema(), self.alternative_database),
         ])
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_bigquery_database_override(self):
         self.run_database_override()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_snowflake_database_override(self):
         self.run_database_override()
 
@@ -112,10 +111,10 @@ class TestProjectSeedOverride(BaseOverrideDatabase):
             (func('view_4'), self.unique_schema(), self.alternative_database),
         ])
 
-    @attr(type='bigquery')
+    @use_profile('bigquery')
     def test_bigquery_database_override(self):
         self.run_database_override()
 
-    @attr(type='snowflake')
+    @use_profile('snowflake')
     def test_snowflake_database_override(self):
         self.run_database_override()

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime
 from functools import wraps
 
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 
 import dbt.flags as flags
@@ -998,7 +998,7 @@ def use_profile(profile_name):
             self.assertEqual(self.adapter_type, 'snowflake')
     """
     def outer(wrapped):
-        @attr(type=profile_name)
+        @getattr(pytest.mark, 'profile_'+profile_name)
         @wraps(wrapped)
         def func(self, *args, **kwargs):
             return wrapped(self, *args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,14 @@ deps =
 
 [testenv:unit-py27]
 basepython = python2.7
-commands = /bin/bash -c '$(which nosetests) -v {posargs} test/unit'
+commands = /bin/bash -c '{envpython} -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
 [testenv:unit-py36]
 basepython = python3.6
-commands = /bin/bash -c '{envpython} $(which nosetests) -v {posargs} test/unit'
+commands = /bin/bash -c '{envpython} -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -27,7 +27,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=postgres {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -38,7 +38,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=snowflake {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -49,7 +49,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=bigquery {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -60,7 +60,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=redshift {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -72,7 +72,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=presto {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/presto
@@ -83,7 +83,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=postgres --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov {posargs} test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_postgres --cov=dbt --cov-branch --cov-report html:htmlcov {posargs} test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -94,7 +94,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=snowflake {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -105,7 +105,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=bigquery {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -116,7 +116,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=redshift {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -128,7 +128,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=presto {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/presto
@@ -139,7 +139,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v {posargs}'
+commands = /bin/bash -c '{envpython} -m pytest -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -149,7 +149,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} $(which nosetests) -v {posargs}'
+commands = /bin/bash -c '{envpython} -m pytest -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -160,7 +160,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v -a type=postgres -a type=snowflake -a type=bigquery --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration test/unit
+commands = pytest -v -m 'profile_postgres or profile_snowflake or profile_bigquery or profile_redshift' --cov=dbt --cov-branch --cov-report html:htmlcov test/integration test/unit
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -171,7 +171,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/unit
+commands = pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -183,7 +183,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v -a type=postgres {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration
+commands = pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -196,7 +196,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v -a type=snowflake {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration
+commands = pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -209,7 +209,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v -a type=bigquery {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration
+commands = pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -222,7 +222,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = nosetests -v -a type=redshift {posargs} --with-coverage --cover-branches --cover-html --cover-html-dir=htmlcov test/integration
+commands = pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres

--- a/tox.ini
+++ b/tox.ini
@@ -171,7 +171,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit
+commands = python -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -183,7 +183,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -196,7 +196,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -209,7 +209,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -222,7 +222,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres


### PR DESCRIPTION
Switch from using nosetest to using pytest for tests. Includes coverage, etc.

One really, really nice feature is that if you add `--pdb --pdbcls=IPython.terminal.debugger:Pdb` to your pytest invocation, you can be automatically dropped into `ipdb` (the good one!) on test failure. This makes debugging test failures far more pleasant.