### PR TITLE
fix dbt debug connections (#1422)

### DIFF
--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -268,7 +268,8 @@ class DebugTask(BaseTask):
     def _connection_result(self):
         adapter = get_adapter(self.profile)
         try:
-            adapter.execute('select 1 as id')
+            with adapter.connection_named('debug'):
+                adapter.execute('select 1 as id')
         except Exception as exc:
             self.messages.append(COULD_NOT_CONNECT_MESSAGE.format(
                 err=str(exc),


### PR DESCRIPTION
Fixes #1422 

Fix a bug in `dbt debug` where it doesn't properly open a connection when it tries to connect to the server, so it always fails.

Before:
```
  Connection test: ERROR

dbt was unable to connect to the specified database.
The database returned the following error:

  >connection never acquired for thread (94480, 4745348544), have []

Check your database credentials and try again. For more information, visit:
https://docs.getdbt.com/docs/configure-your-profile
```

After:
```
  Connection test: OK connection ok
```