### PR TITLE
Propagate ParserMacroCapture undefineds into the calls (#1424)

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -219,7 +219,7 @@ def create_macro_capture_env(node):
             return self
 
         def __call__(self, *args, **kwargs):
-            return True
+            return self
 
     return ParserMacroCapture
 

--- a/test/integration/006_simple_dependency_test/sad_iteration_models/iterate.sql
+++ b/test/integration/006_simple_dependency_test/sad_iteration_models/iterate.sql
@@ -1,0 +1,2 @@
+{% for x in no_such_dependency.no_such_method() %}
+{% endfor %}

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -5,6 +5,7 @@ import dbt.semver
 import dbt.config
 import dbt.exceptions
 
+
 class TestSimpleDependency(DBTIntegrationTest):
 
     @property
@@ -43,6 +44,25 @@ class TestSimpleDependency(DBTIntegrationTest):
                  if r.node.schema == self.base_schema()]),
             2
         )
+
+
+class TestMissingDependency(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "local_dependency_006"
+
+    @property
+    def models(self):
+        return "test/integration/006_simple_dependency_test/sad_iteration_models"
+
+    @use_profile('postgres')
+    def test_postgres_missing_dependency(self):
+        # dbt should raise a dbt exception, not raise a parse-time TypeError.
+        with self.assertRaises(dbt.exceptions.Exception) as exc:
+            self.run_dbt(['compile'])
+        message = str(exc.exception)
+        self.assertIn('no_such_dependency', message)
+        self.assertIn('is undefined', message)
 
 
 class TestSimpleDependencyWithSchema(TestSimpleDependency):


### PR DESCRIPTION
Fixes #1424 

Just return `self` from `ParserMacroCapture.__call__` instead of returning `True`. That lets jinja handle the case and return the nice error message we intended to return.

I'm sure that at some point the `return True` was necessary, but all the tests I've run locally (the postgres suite) seem to be totally happy with this change. And the error is much nicer.

This is happily completely orthogonal to #1416 since it's an issue in the part of jinja undefined handling that I very explicitly didn't change in that PR, so hooray for that!