### PR TITLE
Fix: missing vars in disabled models fail compilation (#434)

### DIFF
--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -239,29 +239,32 @@ class Var(object):
     def pretty_dict(self, data):
         return json.dumps(data, sort_keys=True, indent=4)
 
+    def get_missing_var(self, var_name):
+        pretty_vars = self.pretty_dict(self.local_vars)
+        msg = self.UndefinedVarError.format(
+            var_name, self.model_name, pretty_vars
+        )
+        dbt.exceptions.raise_compiler_error(msg, self.model)
+
     def assert_var_defined(self, var_name, default):
         if var_name not in self.local_vars and default is self._VAR_NOTSET:
-            pretty_vars = self.pretty_dict(self.local_vars)
-            dbt.exceptions.raise_compiler_error(
-                self.UndefinedVarError.format(
-                    var_name, self.model_name, pretty_vars
-                ),
-                self.model
-            )
+            return self.get_missing_var(var_name)
 
-    def __call__(self, var_name, default=_VAR_NOTSET):
-        self.assert_var_defined(var_name, default)
-
-        if var_name not in self.local_vars:
-            return default
-
+    def get_rendered_var(self, var_name):
         raw = self.local_vars[var_name]
-
         # if bool/int/float/etc are passed in, don't compile anything
         if not isinstance(raw, basestring):
             return raw
 
         return dbt.clients.jinja.get_rendered(raw, self.context)
+
+    def __call__(self, var_name, default=_VAR_NOTSET):
+        if var_name in self.local_vars:
+            return self.get_rendered_var(var_name)
+        elif default is not self._VAR_NOTSET:
+            return default
+        else:
+            return self.get_missing_var(var_name)
 
 
 def write(node, target_path, subdirectory):
@@ -395,7 +398,8 @@ def generate_base(model, model_dict, config, manifest, source_config,
     return context
 
 
-def modify_generated_context(context, model, model_dict, config, manifest):
+def modify_generated_context(context, model, model_dict, config, manifest,
+                             provider):
     cli_var_overrides = config.cli_vars
 
     context = _add_tracking(context)
@@ -408,7 +412,8 @@ def modify_generated_context(context, model, model_dict, config, manifest):
 
     context["write"] = write(model_dict, config.target_path, 'run')
     context["render"] = render(context, model_dict)
-    context["var"] = Var(model, context=context, overrides=cli_var_overrides)
+    context["var"] = provider.Var(model, context=context,
+                                  overrides=cli_var_overrides)
     context['context'] = context
 
     return context
@@ -427,7 +432,7 @@ def generate_execute_macro(model, config, manifest, provider):
                             provider)
 
     return modify_generated_context(context, model, model_dict, config,
-                                    manifest)
+                                    manifest, provider)
 
 
 def generate_model(model, config, manifest, source_config, provider):
@@ -448,7 +453,7 @@ def generate_model(model, config, manifest, source_config, provider):
     })
 
     return modify_generated_context(context, model, model_dict, config,
-                                    manifest)
+                                    manifest, provider)
 
 
 def generate(model, config, manifest, source_config=None, provider=None):

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -97,6 +97,12 @@ class Config(object):
         return ''
 
 
+class Var(dbt.context.common.Var):
+    def get_missing_var(self, var_name):
+        # in the parser, just always return None.
+        return None
+
+
 def generate(model, runtime_config, manifest, source_config):
     # during parsing, we don't have a connection, but we might need one, so we
     # have to acquire it.

--- a/core/dbt/context/runtime.py
+++ b/core/dbt/context/runtime.py
@@ -118,6 +118,10 @@ class Config:
         return to_return
 
 
+class Var(dbt.context.common.Var):
+    pass
+
+
 def generate(model, runtime_config, manifest):
     return dbt.context.common.generate(
         model, runtime_config, manifest, None, dbt.context.runtime)

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -3,7 +3,9 @@ import unittest
 
 from dbt.contracts.graph.parsed import ParsedNode
 from dbt.context.common import Var
+from dbt.context.parser import Var as ParserVar
 import dbt.exceptions
+
 
 class TestVar(unittest.TestCase):
     def setUp(self):
@@ -59,3 +61,21 @@ class TestVar(unittest.TestCase):
         self.assertEqual(var('foo', 'bar'), 'bar')
         with self.assertRaises(dbt.exceptions.CompilationException):
             var('foo')
+
+    def test_parser_var_default_something(self):
+        var = ParserVar(self.model, self.context, overrides={'foo': 'baz'})
+        self.assertEqual(var('foo'), 'baz')
+        self.assertEqual(var('foo', 'bar'), 'baz')
+
+    def test_parser_var_default_none(self):
+        var = ParserVar(self.model, self.context, overrides={'foo': None})
+        self.assertEqual(var('foo'), None)
+        self.assertEqual(var('foo', 'bar'), None)
+
+    def test_parser_var_not_defined(self):
+        # at parse-time, we should not raise if we encounter a missing var
+        # that way disabled models don't get parse errors
+        var = ParserVar(self.model, self.context, overrides={})
+
+        self.assertEqual(var('foo', 'bar'), 'bar')
+        self.assertEqual(var('foo'), None)


### PR DESCRIPTION
Fixes #434 

When a var is missing during parsing, just always return `None`. Wait until runtime (compilation, etc) to actually fail about it.

This avoids requiring a var to be set even when a model is disabled, but still fails as appropriate when a var isn't set for an enabled model at compile time.

I've based this on PR #1426 as they touch basically the same stuff.
