### PR TITLE
Add MaterializedView relation type, update Snowflake adapter

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -10,11 +10,13 @@ class BaseRelation(APIObject):
     Table = "table"
     View = "view"
     CTE = "cte"
+    MaterializedView = "materializedview"
 
     RelationTypes = [
         Table,
         View,
-        CTE
+        CTE,
+        MaterializedView
     ]
 
     DEFAULTS = {

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -58,6 +58,7 @@
       table_schema as schema,
       case when table_type = 'BASE TABLE' then 'table'
            when table_type = 'VIEW' then 'view'
+           when table_type = 'MATERIALIZED VIEW' then 'materializedview'
            else table_type
       end as table_type
     from {{ information_schema }}.tables


### PR DESCRIPTION
Fix for issue https://github.com/fishtown-analytics/dbt/issues/1430

-- Adds MaterializedView to the list of RelationTypes in the BaseRelation class
-- Updates the snowflake__list_relations_without_caching macro to handle 'MATERIALIZED VIEW' table_type

I didn't find any unit tests for the BaseRelation parsing, so I just tested manually. Let me know if there's a good way to add a test for this.

Prior to the fix running a model in this project returned:

``` Running with dbt=0.13.0
* Deprecation Warning: The adapter function `adapter.already_exists` is deprecated and will be removed in
 a future release of dbt. Please use `adapter.get_relation` instead.
 Documentation for get_relation can be found here:
 https://docs.getdbt.com/reference#adapter

Encountered an error:
Runtime Error
  Invalid arguments passed to "SnowflakeRelation" instance: type.'MATERIALIZED VIEW' is not one of ['table', 'view', 'cte', None]  
```

After the fix the model runs successfully:

```
Running with dbt=0.13.0
* Deprecation Warning: The adapter function `adapter.already_exists` is deprecated and will be removed in
 a future release of dbt. Please use `adapter.get_relation` instead.
 Documentation for get_relation can be found here:
 https://docs.getdbt.com/reference#adapter

Found 140 models, 364 tests, 0 archives, 0 analyses, 103 macros, 0 operations, 0 seed files, 0 sources

09:31:09 | Concurrency: 3 threads (target='production_bi')
09:31:09 |
09:31:09 | 1 of 1 START table model bi.the_model................... [RUN]
09:31:17 | 1 of 1 OK created table model bi.the_model.............. [SUCCESS 1 in 8.01s]
09:31:17 |
09:31:17 | Finished running 1 table models in 14.96s.

Completed successfully

Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
```