### PR TITLE
Output run hooks (#696)

### DIFF
--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -67,6 +67,10 @@ logging.getLogger('werkzeug').setLevel(CRITICAL)
 
 # provide this for the cache.
 CACHE_LOGGER = logging.getLogger('dbt.cache')
+# add a dummy handler to avoid `No handlers could be found for logger`
+nothing_handler = logging.StreamHandler()
+nothing_handler.setLevel(CRITICAL)
+CACHE_LOGGER.addHandler(nothing_handler)
 # provide this for RPC connection logging
 RPC_LOGGER = logging.getLogger('dbt.rpc')
 

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -89,6 +89,7 @@ class RunTask(CompileTask):
 
             # convert all whitespace sequences to single spaces
             hook_text = ' '.join(sql.split())
+            hook_text = '{}.{}.{}'.format(hook.package_name, hook_type, idx)
             print_hook_start_line(hook_text, idx, num_hooks)
 
             with Timer() as timer:

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -88,9 +88,9 @@ class RunTask(CompileTask):
                                     extra_context)
 
             # convert all whitespace sequences to single spaces
-            hook_text = ' '.join(sql.split())
             hook_text = '{}.{}.{}'.format(hook.package_name, hook_type, idx)
             print_hook_start_line(hook_text, idx, num_hooks)
+            status = 'OK'
 
             with Timer() as timer:
                 if len(sql.strip()) > 0:

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -87,7 +87,6 @@ class RunTask(CompileTask):
             sql = self.get_hook_sql(adapter, hook, idx, num_hooks,
                                     extra_context)
 
-            # convert all whitespace sequences to single spaces
             hook_text = '{}.{}.{}'.format(hook.package_name, hook_type, idx)
             print_hook_start_line(hook_text, idx, num_hooks)
             status = 'OK'

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -49,7 +49,8 @@ def print_timestamped_line(msg, use_color=None):
     logger.info("{} | {}".format(get_timestamp(), msg))
 
 
-def print_fancy_output_line(msg, status, index, total, execution_time=None):
+def print_fancy_output_line(msg, status, index, total, execution_time=None,
+                            truncate=False):
     if index is None or total is None:
         progress = ''
     else:
@@ -60,6 +61,8 @@ def print_fancy_output_line(msg, status, index, total, execution_time=None):
         message=msg)
 
     justified = prefix.ljust(80, ".")
+    if truncate and len(justified) > 77:
+        justified = justified[:77] + '...'
 
     if execution_time is None:
         status_time = ""
@@ -97,6 +100,17 @@ def get_counts(flat_nodes):
 def print_start_line(description, index, total):
     msg = "START {}".format(description)
     print_fancy_output_line(msg, 'RUN', index, total)
+
+
+def print_hook_start_line(statement, index, total):
+    msg = 'START hook: {}'.format(statement)
+    print_fancy_output_line(msg, 'RUN', index, total, truncate=True)
+
+
+def print_hook_end_line(statement, status, index, total, execution_time):
+    msg = 'OK hook: {}'.format(statement)
+    print_fancy_output_line(msg, status, index, total,
+                            execution_time=execution_time, truncate=True)
 
 
 def print_skip_line(model, schema, relation, index, num_models):

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -109,7 +109,8 @@ def print_hook_start_line(statement, index, total):
 
 def print_hook_end_line(statement, status, index, total, execution_time):
     msg = 'OK hook: {}'.format(statement)
-    print_fancy_output_line(msg, status, index, total,
+    # hooks don't fail into this path, so always green
+    print_fancy_output_line(msg, green(status), index, total,
                             execution_time=execution_time, truncate=True)
 
 

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -83,6 +83,8 @@ def get_counts(flat_nodes):
 
         if node.get('resource_type') == NodeType.Model:
             t = '{} {}'.format(get_materialization(node), t)
+        elif node.get('resource_type') == NodeType.Operation:
+            t = 'hook'
 
         counts[t] = counts.get(t, 0) + 1
 

--- a/test/integration/006_simple_dependency_test/early_hook_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/early_hook_dependency/dbt_project.yml
@@ -1,0 +1,5 @@
+name: early_hooks
+version: '1.0'
+on-run-start:
+  - create table {{ var('test_create_table') }} as (select 1 as id)
+  - create table {{ var('test_create_second_table') }} as (select 3 as id)

--- a/test/integration/006_simple_dependency_test/hook_models/actual.sql
+++ b/test/integration/006_simple_dependency_test/hook_models/actual.sql
@@ -1,0 +1,3 @@
+select * from {{ var('test_create_table') }}
+union all
+select * from {{ var('test_create_second_table') }}

--- a/test/integration/006_simple_dependency_test/hook_models/expected.sql
+++ b/test/integration/006_simple_dependency_test/hook_models/expected.sql
@@ -1,0 +1,6 @@
+{# surely there is a better way to do this! #}
+
+{% for _ in range(1, 5) %}
+select {{ loop.index }} as id
+{% if not loop.last %}union all{% endif %}
+{% endfor %}

--- a/test/integration/006_simple_dependency_test/late_hook_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/late_hook_dependency/dbt_project.yml
@@ -1,0 +1,5 @@
+name: late_hooks
+version: '1.0'
+on-run-start:
+  - insert into {{ var('test_create_table') }} values (2)
+  - insert into {{ var('test_create_second_table') }} values (4)


### PR DESCRIPTION
Fixes #696 

Output information about the on-run-start and on-run-end hooks before and after running dbt.

One wrinkle, the output isn't exactly as described in the issue - it's a bit tricky to move that `Concurrency` line before hooks run. Instead you get this order.

```
Running with dbt=0.13.0
Found 163 macros, 0 analyses, 0 archives, 0 sources, 0 seed files, 0 tests, 2 operations, 1 models

07:58:48 |
07:58:48 | Running 1 on-run-start hook
07:58:48 | 1 of 1 START select * from information_schema.schemata
07:58:48 |
07:58:48 | Concurrency: 2 threads (target='default')
07:58:48 |
07:58:48 | 1 of 1 START view model dbt_postgres.x............................... [RUN]
07:58:48 | 1 of 1 OK created view model dbt_postgres.x.......................... [CREATE VIEW in 0.08s]
07:58:48 |
07:58:48 | Running 1 on-run-end hook
07:58:48 | 1 of 1 START select * from information_schema.schemata
07:58:48 |
07:58:48 |
07:58:48 | Finished running 2 hooks, 1 view models in 0.45s.

Completed successfully

Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
```

We definitely can move that `Concurrency` line up, and the output would probably look a bit nicer, but it involves moving that into the task level instead of the node runner level and rearranging some things.