### PR TITLE
Only link schemas with executable things in them

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -39,6 +39,11 @@ class PostgresAdapter(SQLAdapter):
         return ''
 
     def _link_cached_database_relations(self, schemas):
+        """
+
+        :param Set[str] schemas: The set of schemas that should have links
+            added.
+        """
         database = self.config.credentials.database
         table = self.execute_macro(GET_RELATIONS_MACRO_NAME)
 
@@ -74,8 +79,11 @@ class PostgresAdapter(SQLAdapter):
 
     def _link_cached_relations(self, manifest):
         schemas = set()
-        for db, schema in manifest.get_used_schemas():
-            self.verify_database(db)
+        # only link executable nodes
+        info_schema_name_map = self._get_cache_schemas(manifest,
+                                                       exec_only=True)
+        for db, schema in info_schema_name_map.search():
+            self.verify_database(db.database)
             schemas.add(schema)
 
         try:

--- a/test/integration/007_graph_selection_tests/test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_graph_selection.py
@@ -234,6 +234,6 @@ class TestGraphSelection(DBTIntegrationTest):
         user_last_end = users.timing[1]['completed_at']
         dep_first_start = dep.timing[0]['started_at']
         self.assertTrue(
-            user_last_end < dep_first_start,
+            user_last_end <= dep_first_start,
             'dependency started before its transitive parent ({} > {})'.format(user_last_end, dep_first_start)
         )

--- a/test/integration/042_sources_test/models/schema.yml
+++ b/test/integration/042_sources_test/models/schema.yml
@@ -53,3 +53,7 @@ sources:
     tables:
       - name: test_table
         identifier: other_source_table
+  - name: external_source
+    schema: "{{ var('test_run_alt_schema', var('test_run_schema')) }}"
+    tables:
+      - name: table

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -40,6 +40,33 @@ class BaseSourcesTest(DBTIntegrationTest):
 
 
 class TestSources(BaseSourcesTest):
+    def _create_schemas(self):
+        super(TestSources, self)._create_schemas()
+        self._create_schema_named(self.default_database,
+                                  self.alternative_schema())
+
+    def alternative_schema(self):
+        return self.unique_schema() + '_other'
+
+    def setUp(self):
+        super(TestSources, self).setUp()
+        self.run_sql(
+            'create table {}.dummy_table (id int)'.format(self.unique_schema())
+        )
+        self.run_sql(
+            'create view {}.external_view as (select * from {}.dummy_table)'
+            .format(self.alternative_schema(), self.unique_schema())
+        )
+
+    def run_dbt_with_vars(self, cmd, *args, **kwargs):
+        cmd.extend([
+            '--vars',
+            '{{test_run_schema: {}, test_run_alt_schema: {}}}'.format(
+                self.unique_schema(), self.alternative_schema()
+            )
+        ])
+        return self.run_dbt(cmd, *args, **kwargs)
+
     @use_profile('postgres')
     def test_postgres_basic_source_def(self):
         results = self.run_dbt_with_vars(['run'])
@@ -112,6 +139,7 @@ class TestSources(BaseSourcesTest):
             ['expected_multi_source', 'multi_source_model'],
         )
         self.assertTableDoesNotExist('nonsource_descendant')
+
 
 class TestSourceFreshness(BaseSourcesTest):
     def setUp(self):
@@ -256,3 +284,4 @@ class TestMalformedSources(BaseSourcesTest):
     def test_postgres_malformed_schema_strict_will_break_run(self):
         with self.assertRaises(CompilationException):
             self.run_dbt_with_vars(['run'], strict=True)
+


### PR DESCRIPTION
Fixes #1393 

The issue was that dbt decided what to put into the cache by using `_get_cache_schemas(manifest, exec_only=True)` (no sources!). But it generates the list of what schemas can have links using `manifest.get_used_schemas()`, which does include sources. It then decides that it can add that link and blows up.
