### PR TITLE
Improve tracking failure handling (#1063)

### DIFF
--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -44,7 +44,7 @@ class TimeoutEmitter(Emitter):
     def http_get(self, payload):
         sp_logger.info("Sending GET request to %s..." % self.endpoint)
         sp_logger.debug("Payload: %s" % payload)
-        r = requests.get(self.endpoint, params=payload, timeout=1.0)
+        r = requests.get(self.endpoint, params=payload, timeout=2.0)
 
         msg = "GET request finished with status code: " + str(r.status_code)
         if self.is_good_status_code(r.status_code):


### PR DESCRIPTION
Fixes #1063

Add a 1s timeout to tracking http calls
Add an on-failure handler that disables tracking after the first failure

To test this, I added this to my `/etc/hosts`: `127.0.0.1 fishtownanalytics.sinter-collect.com`

Then I ran this from a root python prompt:

```
import socket
s = socket.socket()
s.bind(('localhost', 443))
conns = []
while True:
  conns.append(s.accept()[0])
```

And ran `dbt run` with tracking enabled in my profile. Before this change, dbt hangs forever. After, it pauses for 1 second once and then disables tracking until the next `dbt` invocation.

I chose this model over a thread-based one because it makes process teardown and cancellation a whole lot easier.

The only actual change to `http_get` in the overridden `TimeoutEmitter` is the `timeout=1.0` argument to `requests.get`, the rest is just pep8 formatting.

I experimented with various times but I found anything longer than a second felt pretty annoying.