### PR TITLE
Warn on unpinned git packages (#1446)

### DIFF
--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -188,6 +188,9 @@ GIT_PACKAGE_CONTRACT = {
             'items': {'type': 'string'},
             'description': 'The git revision to use, if it is not tip',
         },
+        'warn-unpinned': {
+            'type': 'boolean',
+        }
     },
     'required': ['git'],
 }

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -15,6 +15,7 @@ import dbt.clients.registry as registry
 from dbt.compat import basestring
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.semver import VersionSpecifier, UnboundedVersionSpecifier
+from dbt.ui import printer
 from dbt.utils import AttrDict
 from dbt.api.object import APIObject
 from dbt.contracts.project import LOCAL_PACKAGE_CONTRACT, \
@@ -255,7 +256,7 @@ class GitPackage(Package):
         return "revision {}".format(self.version_name())
 
     def incorporate(self, other):
-        # if one is True, make both be True.
+        # if one is False, make both be False.
         warn_unpinned = self.warn_unpinned and other.warn_unpinned
 
         return GitPackage(git=self.git,
@@ -300,10 +301,10 @@ class GitPackage(Package):
         path = self._checkout(project)
         if self.version[0] == 'master' and self.warn_unpinned:
             dbt.exceptions.warn_or_error(
-                'Version for {} not pinned - "master" may introduce breaking '
-                'changes without warning! See {}'
+                'The git package "{}" is not pinned.\n\tThis can introduce '
+                'breaking changes into your project without warning!\n\nSee {}'
                 .format(self.git, PIN_PACKAGE_URL),
-                log_fmt='WARNING: {}'
+                log_fmt=printer.yellow('WARNING: {}')
             )
         loaded = project.from_project_root(path, {})
         return ProjectPackageMetadata(loaded)

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -25,6 +25,7 @@ from dbt.task.base import ProjectOnlyTask
 
 DOWNLOADS_PATH = None
 REMOVE_DOWNLOADS = False
+PIN_PACKAGE_URL = 'https://docs.getdbt.com/docs/package-management#section-specifying-package-versions' # noqa
 
 
 def _initialize_downloads():
@@ -215,6 +216,8 @@ class GitPackage(Package):
     SCHEMA = GIT_PACKAGE_CONTRACT
 
     def __init__(self, *args, **kwargs):
+        if 'warn_unpinned' in kwargs:
+            kwargs['warn-unpinned'] = kwargs.pop('warn_unpinned')
         super(GitPackage, self).__init__(*args, **kwargs)
         self._checkout_name = hashlib.md5(six.b(self.git)).hexdigest()
         self.version = self._contents.get('revision')
@@ -252,8 +255,12 @@ class GitPackage(Package):
         return "revision {}".format(self.version_name())
 
     def incorporate(self, other):
+        # if one is True, make both be True.
+        warn_unpinned = self.warn_unpinned and other.warn_unpinned
+
         return GitPackage(git=self.git,
-                          revision=(self.version + other.version))
+                          revision=(self.version + other.version),
+                          warn_unpinned=warn_unpinned)
 
     def _resolve_version(self):
         requested = set(self.version)
@@ -262,6 +269,10 @@ class GitPackage(Package):
                 'git dependencies should contain exactly one version. '
                 '{} contains: {}'.format(self.git, requested))
         self.version = requested.pop()
+
+    @property
+    def warn_unpinned(self):
+        return self.get('warn-unpinned', True)
 
     def _checkout(self, project):
         """Performs a shallow clone of the repository into the downloads
@@ -287,6 +298,13 @@ class GitPackage(Package):
 
     def _fetch_metadata(self, project):
         path = self._checkout(project)
+        if self.version[0] == 'master' and self.warn_unpinned:
+            dbt.exceptions.warn_or_error(
+                'Version for {} not pinned - "master" may introduce breaking '
+                'changes without warning! See {}'
+                .format(self.git, PIN_PACKAGE_URL),
+                log_fmt='WARNING: {}'
+            )
         loaded = project.from_project_root(path, {})
         return ProjectPackageMetadata(loaded)
 

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -17,7 +17,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
     def packages_config(self):
         return {
             "packages": [
-                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project'}
+                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project', 'warn-unpinned': False}
             ]
         }
 

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -145,6 +145,7 @@ class TestCustomSchemaTests(DBTIntegrationTest):
                 },
                 {
                     'git': 'https://github.com/fishtown-analytics/dbt-integration-project',
+                    'warn-unpinned': False,
                 },
             ]
         }

--- a/test/integration/016_macro_tests/test_macros.py
+++ b/test/integration/016_macro_tests/test_macros.py
@@ -19,7 +19,7 @@ class TestMacros(DBTIntegrationTest):
     def packages_config(self):
         return {
             'packages': [
-                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project'},
+                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project', 'warn-unpinned': False}
             ]
         }
 
@@ -92,7 +92,7 @@ class TestMisusedMacros(DBTIntegrationTest):
     def packages_config(self):
         return {
             'packages': [
-                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project'}
+                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project', 'warn-unpinned': False}
             ]
         }
 

--- a/test/integration/023_exit_codes_test/test_exit_codes.py
+++ b/test/integration/023_exit_codes_test/test_exit_codes.py
@@ -132,7 +132,7 @@ class TestExitCodesDeps(DBTIntegrationTest):
     def packages_config(self):
         return {
             "packages": [
-                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project'}
+                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project', 'warn-unpinned': False}
             ]
         }
 

--- a/test/integration/025_duplicate_model_test/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_model.py
@@ -103,6 +103,7 @@ class TestDuplicateModelEnabledAcrossPackages(DBTIntegrationTest):
                 {
                     'git': 'https://github.com/fishtown-analytics/dbt-integration-project',
                     'revision': 'master',
+                    'warn-unpinned': False,
                 },
             ],
         }
@@ -139,6 +140,7 @@ class TestDuplicateModelDisabledAcrossPackages(DBTIntegrationTest):
                 {
                     'git': 'https://github.com/fishtown-analytics/dbt-integration-project',
                     'revision': 'master',
+                    'warn-unpinned': False,
                 },
             ],
         }

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -81,6 +81,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'packages': [
                 {
                     'git': 'https://github.com/fishtown-analytics/dbt-integration-project',
+                    'warn-unpinned': False,
                 },
             ],
         }

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -177,7 +177,7 @@ class TestEventTrackingSuccess(TestEventTracking):
     def packages_config(self):
         return {
             'packages': [
-                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project'},
+                {'git': 'https://github.com/fishtown-analytics/dbt-integration-project', 'warn-unpinned': False},
             ],
         }
 


### PR DESCRIPTION
Fixes #1446

This fails the run in strict mode and logs a warning otherwise.

With no repository set and no value for `warn-unpinned`:
```
$ cat packages.yml
packages:
  - git: "https://github.com/fishtown-analytics/dbt-utils"
$ dbt deps
Running with dbt=0.13.0
WARNING: Version for https://github.com/fishtown-analytics/dbt-utils not pinned - "master" may introduce breaking changes without warning! See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
Installing https://github.com/fishtown-analytics/dbt-utils@master
  Installed from revision master
$ dbt --strict deps
Running with dbt=0.13.0
Encountered an error:
Compilation Error
  Version for https://github.com/fishtown-analytics/dbt-utils not pinned - "master" may introduce breaking changes without warning! See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
```


With a version set:

```
$ cat packages.yml
packages:
  - git: "https://github.com/fishtown-analytics/dbt-utils"
    revision: 0.1.0
$ dbt --strict deps
Running with dbt=0.13.0
Installing https://github.com/fishtown-analytics/dbt-utils@0.1.0
  Installed from revision 0.1.0
```


With warn-unpinned set to False:
```
$ cat packages.yml
packages:
  - git: "https://github.com/fishtown-analytics/dbt-utils"
    warn-unpinned: false
$ dbt deps
Running with dbt=0.13.0
Installing https://github.com/fishtown-analytics/dbt-utils@master
  Installed from revision master
$ dbt --strict deps
Running with dbt=0.13.0
Installing https://github.com/fishtown-analytics/dbt-utils@master
  Installed from revision master
```
