### PR TITLE
Case insensitive schema compare fix.

### DIFF
--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -193,7 +193,7 @@
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
     select distinct schema_name
     from {{ information_schema_name(database) }}.schemata
-    where catalog_name ilike '{{ database }}'
+    where lower(catalog_name) like '{{ database }}'
   {% endcall %}
   {{ return(load_result('list_schemas').table) }}
 {% endmacro %}


### PR DESCRIPTION
Presto doesn't have `ILIKE`, so I've added `LIKE` and lowercase the schema name with `LOWER()`.