### PR TITLE
Use merge pattern for Archival queries

### DIFF
--- a/core/dbt/include/global_project/macros/etc/datetime.sql
+++ b/core/dbt/include/global_project/macros/etc/datetime.sql
@@ -54,3 +54,7 @@
     {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}
 {% endmacro %}
 
+{% macro py_current_timestring() %}
+    {% set dt = modules.datetime.datetime.now() %}
+    {% do return(dt.strftime("%Y%m%d%H%M%S%f")) %}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/archive/archive_merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/archive_merge.sql
@@ -1,0 +1,27 @@
+
+{% macro archive_merge_sql(target, source, insert_cols) -%}
+  {{ adapter_macro('archive_merge_sql', target, source, insert_cols) }}
+{%- endmacro %}
+
+
+{% macro default__archive_merge_sql(target, source, insert_cols) -%}
+    {%- set insert_cols_csv = insert_cols| map(attribute="name") | join(', ') -%}
+
+    merge into {{ target }} as DBT_INTERNAL_DEST
+    using {{ source }} as DBT_INTERNAL_SOURCE
+    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
+
+    when matched
+     and DBT_INTERNAL_DEST.dbt_valid_to is null
+     and DBT_INTERNAL_SOURCE.dbt_change_type = 'update'
+        then update
+        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+
+    when not matched
+     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
+        then insert ({{ insert_cols_csv }})
+        values ({{ insert_cols_csv }})
+    ;
+{% endmacro %}
+
+

--- a/core/dbt/include/global_project/macros/materializations/archive/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/archive/strategies.sql
@@ -1,0 +1,114 @@
+{#
+    Dispatch strategies by name, optionally qualified to a package
+#}
+{% macro strategy_dispatch(name) -%}
+{% set original_name = name %}
+  {% if '.' in name %}
+    {% set package_name, name = name.split(".", 1) %}
+  {% else %}
+    {% set package_name = none %}
+  {% endif %}
+
+  {% if package_name is none %}
+    {% set package_context = context %}
+  {% elif package_name in context %}
+    {% set package_context = context[package_name] %}
+  {% else %}
+    {% set error_msg %}
+        Could not find package '{{package_name}}', called with '{{original_name}}'
+    {% endset %}
+    {{ exceptions.raise_compiler_error(error_msg | trim) }}
+  {% endif %}
+
+  {%- set search_name = 'archive_' ~ name ~ '_strategy' -%}
+
+  {% if search_name not in package_context %}
+    {% set error_msg %}
+        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'
+    {% endset %}
+    {{ exceptions.raise_compiler_error(error_msg | trim) }}
+  {% endif %}
+  {{ return(package_context[search_name]) }}
+{%- endmacro %}
+
+
+{#
+    Create SCD Hash SQL fields cross-db
+#}
+{% macro archive_hash_arguments(args) %}
+  {{ adapter_macro('archive_hash_arguments', args) }}
+{% endmacro %}
+
+
+{% macro default__archive_hash_arguments(args) %}
+    md5({% for arg in args %}
+        coalesce(cast({{ arg }} as varchar ), '') {% if not loop.last %} || '|' || {% endif %}
+    {% endfor %})
+{% endmacro %}
+
+
+{#
+    Get the current time cross-db
+#}
+{% macro archive_get_time() -%}
+  {{ adapter_macro('archive_get_time') }}
+{%- endmacro %}
+
+{% macro default__archive_get_time() -%}
+  {{ current_timestamp() }}
+{%- endmacro %}
+
+
+{#
+    Core strategy definitions
+#}
+{% macro archive_timestamp_strategy(node, archived_rel, current_rel, config) %}
+    {% set primary_key = config['unique_key'] %}
+    {% set updated_at = config['updated_at'] %}
+
+    {% set row_changed_expr -%}
+        ({{ archived_rel }}.{{ updated_at }} < {{ current_rel }}.{{ updated_at }})
+    {%- endset %}
+
+    {% set scd_id_expr = archive_hash_arguments([primary_key, updated_at]) %}
+
+    {% do return({
+        "unique_key": primary_key,
+        "updated_at": updated_at,
+        "row_changed": row_changed_expr,
+        "scd_id": scd_id_expr
+    }) %}
+{% endmacro %}
+
+
+{% macro archive_check_strategy(node, archived_rel, current_rel, config) %}
+    {% set check_cols_config = config['check_cols'] %}
+    {% set primary_key = config['unique_key'] %}
+    {% set updated_at = archive_get_time() %}
+
+    {% if check_cols_config == 'all' %}
+        {% set check_cols = get_columns_in_query(node['injected_sql']) %}
+    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
+        {% set check_cols = check_cols_config %}
+    {% else %}
+        {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
+    {% endif %}
+
+    {% set row_changed_expr -%}
+        (
+        {% for col in check_cols %}
+            {{ archived_rel }}.{{ col }} != {{ current_rel }}.{{ col }}
+            {%- if not loop.last %} or {% endif %}
+        {% endfor %}
+        )
+    {%- endset %}
+
+    {% set scd_id_expr = archive_hash_arguments(check_cols) %}
+
+    {% do return({
+        "unique_key": primary_key,
+        "updated_at": updated_at,
+        "row_changed": row_changed_expr,
+        "scd_id": scd_id_expr
+    }) %}
+{% endmacro %}

--- a/core/dbt/parser/archives.py
+++ b/core/dbt/parser/archives.py
@@ -106,7 +106,6 @@ class ArchiveParser(MacrosKnownParser):
                 self.all_projects.get(archive.package_name),
                 archive_config=archive_config)
 
-            # TODO : Add tests for this
             to_return[node_path] = set_archive_attributes(parsed_node)
 
         return to_return

--- a/core/dbt/parser/archives.py
+++ b/core/dbt/parser/archives.py
@@ -11,6 +11,19 @@ import dbt.utils
 import os
 
 
+def set_archive_attributes(node):
+    config_keys = {
+        'target_database': 'database',
+        'target_schema': 'schema'
+    }
+
+    for config_key, node_key in config_keys.items():
+        if config_key in node.config:
+            setattr(node, node_key, node.config[config_key])
+
+    return node
+
+
 class ArchiveParser(MacrosKnownParser):
     @classmethod
     def parse_archives_from_project(cls, config):
@@ -87,11 +100,14 @@ class ArchiveParser(MacrosKnownParser):
                                       archive.package_name,
                                       archive.name)
 
-            to_return[node_path] = self.parse_node(
+            parsed_node = self.parse_node(
                 archive,
                 node_path,
                 self.all_projects.get(archive.package_name),
                 archive_config=archive_config)
+
+            # TODO : Add tests for this
+            to_return[node_path] = set_archive_attributes(parsed_node)
 
         return to_return
 
@@ -138,7 +154,9 @@ class ArchiveBlockParser(BaseSqlParser):
     def validate_archives(node):
         if node.resource_type == NodeType.Archive:
             try:
-                return ParsedArchiveNode(**node.to_shallow_dict())
+                parsed_node = ParsedArchiveNode(**node.to_shallow_dict())
+                return set_archive_attributes(parsed_node)
+
             except dbt.exceptions.JSONValidationException as exc:
                 raise dbt.exceptions.CompilationException(str(exc), node)
         else:

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -343,22 +343,6 @@ class BigQueryAdapter(BaseAdapter):
 
         return res
 
-    @available.parse(_stub_relation)
-    def create_temporary_table(self, sql, **kwargs):
-        # BQ queries always return a temp table with their results
-        query_job, _ = self.connections.raw_execute(sql)
-        bq_table = query_job.destination
-
-        return self.Relation.create(
-            database=bq_table.project,
-            schema=bq_table.dataset_id,
-            identifier=bq_table.table_id,
-            quote_policy={
-                'schema': True,
-                'identifier': True
-            },
-            type=BigQueryRelation.Table)
-
     @available.parse_none
     def alter_table_add_columns(self, relation, columns):
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -34,6 +34,11 @@
   create or replace table {{ relation }}
   {{ partition_by(raw_partition_by) }}
   {{ cluster_by(raw_cluster_by) }}
+  {% if temporary %}
+  OPTIONS(
+      expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 12 hour)
+  )
+  {% endif %}
   as (
     {{ sql }}
   );
@@ -52,6 +57,12 @@
 
 {% macro bigquery__drop_schema(database_name, schema_name) -%}
   {{ adapter.drop_schema(database_name, schema_name) }}
+{% endmacro %}
+
+{% macro bigquery__drop_relation(relation) -%}
+  {% call statement('drop_relation') -%}
+    drop {{ relation.type }} if exists {{ relation }}
+  {%- endcall %}
 {% endmacro %}
 
 {% macro bigquery__get_columns_in_relation(relation) -%}

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/archive.sql
@@ -1,9 +1,3 @@
-{% macro bigquery__create_temporary_table(sql, relation) %}
-    {% set tmp_relation = adapter.create_temporary_table(sql) %}
-    {{ return(tmp_relation) }}
-{% endmacro %}
-
-
 {% macro bigquery__archive_hash_arguments(args) %}
   to_hex(md5(concat({% for arg in args %}coalesce(cast({{ arg }} as string), ''){% if not loop.last %}, '|',{% endif %}{% endfor %})))
 {% endmacro %}
@@ -12,11 +6,7 @@
   {{ adapter.alter_table_add_columns(relation, columns) }}
 {% endmacro %}
 
-
-{% macro bigquery__archive_update(target_relation, tmp_relation) %}
-    update {{ target_relation }} as dest
-    set dest.dbt_valid_to = tmp.dbt_valid_to
-    from {{ tmp_relation }} as tmp
-    where tmp.dbt_scd_id = dest.dbt_scd_id
-      and change_type = 'update';
+{% macro bigquery__post_archive(staging_relation) %}
+  -- Clean up the archive temp table
+  {% do drop_relation(staging_relation) %}
 {% endmacro %}

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -91,3 +91,19 @@
 {% macro postgres__current_timestamp() -%}
   now()
 {%- endmacro %}
+
+{% macro postgres__archive_get_time() -%}
+  {{ current_timestamp() }}::timestamp without time zone
+{%- endmacro %}
+
+{% macro postgres__make_temp_relation(base_relation, suffix) %}
+    {% set tmp_identifier = base_relation.identifier ~ suffix ~ py_current_timestring() %}
+    {% do return(base_relation.incorporate(
+                                  table_name=tmp_identifier,
+                                  path={
+                                    "identifier": tmp_identifier,
+                                    "schema": none,
+                                    "database": none
+                                  })) -%}
+{% endmacro %}
+

--- a/plugins/postgres/dbt/include/postgres/macros/materializations/archive_merge.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/materializations/archive_merge.sql
@@ -1,0 +1,18 @@
+
+{% macro postgres__archive_merge_sql(target, source, insert_cols) -%}
+    {%- set insert_cols_csv = insert_cols | map(attribute="name") | join(', ') -%}
+
+    update {{ target }}
+    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+    from {{ source }} as DBT_INTERNAL_SOURCE
+    where DBT_INTERNAL_SOURCE.dbt_scd_id = {{ target }}.dbt_scd_id
+      and DBT_INTERNAL_SOURCE.dbt_change_type = 'update'
+      and {{ target }}.dbt_valid_to is null;
+
+    insert into {{ target }} ({{ insert_cols_csv }})
+    select {% for column in insert_cols -%}
+        DBT_INTERNAL_SOURCE.{{ column.name }} {%- if not loop.last %}, {%- endif %}
+    {%- endfor %}
+    from {{ source }} as DBT_INTERNAL_SOURCE
+    where DBT_INTERNAL_SOURCE.dbt_change_type = 'insert';
+{% endmacro %}

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -1,3 +1,4 @@
+
 {% macro dist(dist) %}
   {%- if dist is not none -%}
       {%- set dist = dist.strip().lower() -%}
@@ -55,15 +56,6 @@
     {{ sql }}
   ) {{ bind_qualifier }};
 {% endmacro %}
-
-
-{% macro redshift__create_archive_table(relation, columns) -%}
-  create table if not exists {{ relation }} (
-    {{ column_list_for_create_table(columns) }}
-  )
-  {{ dist('dbt_updated_at') }}
-  {{ sort('compound', ['dbt_scd_id']) }};
-{%- endmacro %}
 
 
 {% macro redshift__create_schema(database_name, schema_name) -%}
@@ -171,10 +163,15 @@
 {% macro redshift__check_schema_exists(information_schema, schema) -%}
   {{ return(postgres__check_schema_exists(information_schema, schema)) }}
 {%- endmacro %}
-list_schemas
-
-%}
 
 {% macro redshift__current_timestamp() -%}
   getdate()
 {%- endmacro %}
+
+{% macro redshift__archive_get_time() -%}
+  {{ current_timestamp() }}::timestamp
+{%- endmacro %}
+
+{% macro redshift__make_temp_relation(base_relation, suffix) %}
+    {% do return(postgres__make_temp_relation(base_relation, suffix)) %}
+{% endmacro %}

--- a/plugins/redshift/dbt/include/redshift/macros/materializations/archive_merge.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/materializations/archive_merge.sql
@@ -1,0 +1,4 @@
+
+{% macro redshift__archive_merge_sql(target, source, insert_cols) -%}
+    {{ postgres__archive_merge_sql(target, source, insert_cols) }}
+{% endmacro %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -79,6 +79,10 @@
   convert_timezone('UTC', current_timestamp())
 {%- endmacro %}
 
+{% macro snowflake__archive_get_time() -%}
+  to_timestamp_ntz({{ current_timestamp() }})
+{%- endmacro %}
+
 
 {% macro snowflake__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -11,10 +11,7 @@
                                                 identifier=identifier,
                                                 type='table') -%}
 
-  {%- set tmp_relation = api.Relation.create(database=database,
-                                             schema=schema,
-                                             identifier=identifier ~ "__dbt_tmp",
-                                             type='table') -%}
+  {%- set tmp_relation = make_temp_relation(target_relation) %}
 
   -- setup
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
@@ -42,7 +39,7 @@
        {{ create_table_as(true, tmp_relation, sql) }}
     {%- endcall -%}
 
-    {{ adapter.expand_target_column_types(temp_table=tmp_relation.identifier,
+    {{ adapter.expand_target_column_types(from_relation=tmp_relation,
                                           to_relation=target_relation) }}
     {% set incremental_sql %}
     (

--- a/test/integration/004_simple_archive_test/seed.sql
+++ b/test/integration/004_simple_archive_test/seed.sql
@@ -1,4 +1,4 @@
-    create table {database}.{schema}.seed (
+create table {database}.{schema}.seed (
 	id INTEGER,
 	first_name VARCHAR(50),
 	last_name VARCHAR(50),
@@ -20,7 +20,7 @@ create table {database}.{schema}.archive_expected (
 	updated_at TIMESTAMP WITHOUT TIME ZONE,
 	dbt_valid_from TIMESTAMP WITHOUT TIME ZONE,
 	dbt_valid_to   TIMESTAMP WITHOUT TIME ZONE,
-	dbt_scd_id     VARCHAR(256),
+	dbt_scd_id     VARCHAR(32),
 	dbt_updated_at TIMESTAMP WITHOUT TIME ZONE
 );
 
@@ -79,8 +79,6 @@ select
     md5(id || '-' || first_name || '|' || updated_at::text) as dbt_scd_id
 from {database}.{schema}.seed;
 
-
-
 create table {database}.{schema}.archive_castillo_expected (
     id INTEGER,
     first_name VARCHAR(50),
@@ -93,8 +91,9 @@ create table {database}.{schema}.archive_castillo_expected (
     updated_at TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_from TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_to   TIMESTAMP WITHOUT TIME ZONE,
-    dbt_scd_id     VARCHAR(256),
+    dbt_scd_id     VARCHAR(32),
     dbt_updated_at TIMESTAMP WITHOUT TIME ZONE
+
 );
 
 -- one entry
@@ -139,7 +138,7 @@ create table {database}.{schema}.archive_alvarez_expected (
     updated_at TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_from TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_to   TIMESTAMP WITHOUT TIME ZONE,
-    dbt_scd_id     VARCHAR(256),
+    dbt_scd_id     VARCHAR(32),
     dbt_updated_at TIMESTAMP WITHOUT TIME ZONE
 );
 
@@ -185,7 +184,7 @@ create table {database}.{schema}.archive_kelly_expected (
     updated_at TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_from TIMESTAMP WITHOUT TIME ZONE,
     dbt_valid_to   TIMESTAMP WITHOUT TIME ZONE,
-    dbt_scd_id     VARCHAR(256),
+    dbt_scd_id     VARCHAR(32),
     dbt_updated_at TIMESTAMP WITHOUT TIME ZONE
 );
 

--- a/test/integration/004_simple_archive_test/test-archives-bq/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-bq/archive.sql
@@ -9,6 +9,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from `{{target.database}}`.`{{schema}}`.seed
+    select * from `{{database}}`.`{{schema}}`.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-bq/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-bq/archive.sql
@@ -9,6 +9,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from `{{database}}`.`{{schema}}`.seed
+    select * from `{{target.database}}`.`{{schema}}`.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
@@ -7,6 +7,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.seed
+    select * from {{target.database}}.{{schema}}.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-invalid/archive.sql
@@ -7,6 +7,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed
+    select * from {{database}}.{{schema}}.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-longtext/longtext.sql
+++ b/test/integration/004_simple_archive_test/test-archives-longtext/longtext.sql
@@ -8,5 +8,5 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.super_long
+    select * from {{database}}.{{schema}}.super_long
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-longtext/longtext.sql
+++ b/test/integration/004_simple_archive_test/test-archives-longtext/longtext.sql
@@ -8,5 +8,5 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.super_long
+    select * from {{target.database}}.{{schema}}.super_long
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-pg/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-pg/archive.sql
@@ -9,6 +9,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.seed
+    select * from {{target.database}}.{{schema}}.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-pg/archive.sql
+++ b/test/integration/004_simple_archive_test/test-archives-pg/archive.sql
@@ -3,12 +3,12 @@
     {{
         config(
             target_database=var('target_database', database),
-            target_schema=schema,
+            target_schema=var('target_schema', schema),
             unique_key='id || ' ~ "'-'" ~ ' || first_name',
             strategy='timestamp',
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed
+    select * from {{target.database}}.{{target.schema}}.seed
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-select/archives.sql
+++ b/test/integration/004_simple_archive_test/test-archives-select/archives.sql
@@ -9,7 +9,7 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed where last_name = 'Castillo'
+    select * from {{database}}.{{schema}}.seed where last_name = 'Castillo'
 
 {% endarchive %}
 
@@ -24,7 +24,7 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed where last_name = 'Alvarez'
+    select * from {{database}}.{{schema}}.seed where last_name = 'Alvarez'
 
 {% endarchive %}
 

--- a/test/integration/004_simple_archive_test/test-archives-select/archives.sql
+++ b/test/integration/004_simple_archive_test/test-archives-select/archives.sql
@@ -40,6 +40,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed where last_name = 'Kelly'
+    select * from {{database}}.{{schema}}.seed where last_name = 'Kelly'
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-archives-select/archives.sql
+++ b/test/integration/004_simple_archive_test/test-archives-select/archives.sql
@@ -9,7 +9,7 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.seed where last_name = 'Castillo'
+    select * from {{target.database}}.{{schema}}.seed where last_name = 'Castillo'
 
 {% endarchive %}
 
@@ -24,7 +24,7 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.seed where last_name = 'Alvarez'
+    select * from {{target.database}}.{{schema}}.seed where last_name = 'Alvarez'
 
 {% endarchive %}
 
@@ -40,6 +40,6 @@
             updated_at='updated_at',
         )
     }}
-    select * from {{database}}.{{schema}}.seed where last_name = 'Kelly'
+    select * from {{target.database}}.{{schema}}.seed where last_name = 'Kelly'
 
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
@@ -8,7 +8,7 @@
             check_cols=('email',),
         )
     }}
-    select * from `{{target.database}}`.`{{schema}}`.seed
+    select * from `{{database}}`.`{{schema}}`.seed
 {% endarchive %}
 
 
@@ -23,5 +23,5 @@
             check_cols='all',
         )
     }}
-    select * from `{{target.database}}`.`{{schema}}`.seed
+    select * from `{{database}}`.`{{schema}}`.seed
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives-bq/archive.sql
@@ -8,7 +8,7 @@
             check_cols=('email',),
         )
     }}
-    select * from `{{database}}`.`{{schema}}`.seed
+    select * from `{{target.database}}`.`{{schema}}`.seed
 {% endarchive %}
 
 
@@ -23,5 +23,5 @@
             check_cols='all',
         )
     }}
-    select * from `{{database}}`.`{{schema}}`.seed
+    select * from `{{target.database}}`.`{{schema}}`.seed
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
@@ -9,7 +9,7 @@
             check_cols=['email'],
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed
+    select * from {{database}}.{{schema}}.seed
 
 {% endarchive %}
 
@@ -24,5 +24,5 @@
             check_cols='all',
         )
     }}
-    select * from {{target.database}}.{{schema}}.seed
+    select * from {{database}}.{{schema}}.seed
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
+++ b/test/integration/004_simple_archive_test/test-check-col-archives/archive.sql
@@ -9,7 +9,7 @@
             check_cols=['email'],
         )
     }}
-    select * from {{database}}.{{schema}}.seed
+    select * from {{target.database}}.{{schema}}.seed
 
 {% endarchive %}
 
@@ -24,5 +24,5 @@
             check_cols='all',
         )
     }}
-    select * from {{database}}.{{schema}}.seed
+    select * from {{target.database}}.{{schema}}.seed
 {% endarchive %}

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -397,7 +397,7 @@ class TestCrossSchemaArchiveFiles(TestSimpleArchive):
         return self.run_dbt(['archive', '--vars', '{{"target_schema": {}}}'.format(self.target_schema())])
 
     @use_profile('postgres')
-    def test__postgres_ref_archive_cross_schema(self):
+    def test__postgres__simple_archive(self):
         self.run_sql_file('test/integration/004_simple_archive_test/seed_pg.sql')
 
         results = self.run_archive()

--- a/test/integration/004_simple_archive_test/test_simple_archive.py
+++ b/test/integration/004_simple_archive_test/test_simple_archive.py
@@ -382,7 +382,17 @@ class TestCrossDBArchiveFiles(TestCrossDBArchive):
         return self.run_dbt(['archive', '--vars', '{{"target_database": {}}}'.format(self.alternative_database)])
 
 
-class TestCrossSchemaArchiveFiles(TestSimpleArchive):
+class TestCrossSchemaArchiveFiles(DBTIntegrationTest):
+    NUM_ARCHIVE_MODELS = 1
+
+    @property
+    def schema(self):
+        return "simple_archive_004"
+
+    @property
+    def models(self):
+        return "test/integration/004_simple_archive_test/models"
+
     @property
     def project_config(self):
         paths = ['test/integration/004_simple_archive_test/test-archives-pg']
@@ -397,7 +407,7 @@ class TestCrossSchemaArchiveFiles(TestSimpleArchive):
         return self.run_dbt(['archive', '--vars', '{{"target_schema": {}}}'.format(self.target_schema())])
 
     @use_profile('postgres')
-    def test__postgres__simple_archive(self):
+    def test__postgres__cross_schema_archive(self):
         self.run_sql_file('test/integration/004_simple_archive_test/seed_pg.sql')
 
         results = self.run_archive()

--- a/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
+++ b/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
@@ -51,8 +51,6 @@ class BaseTestConcurrentTransaction(DBTIntegrationTest):
                 self.query_state[rel] = 'bad'
 
         except Exception as e:
-            logger.info("Caught exception: {}".format(e))
-            traceback.print_exc()
             if 'concurrent transaction' in str(e):
                 self.query_state[rel] = 'error: {}'.format(e)
             else:

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -610,7 +610,7 @@ class TestEventTrackingArchive(TestEventTracking):
                 model_id='3cdcd0fef985948fd33af308468da3b9',
                 index=1,
                 total=1,
-                status='INSERT 0 1',
+                status='SELECT 1',
                 materialization='archive'
             ),
             self.build_context('archive', 'end', result_type='ok')

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -129,8 +129,7 @@ class DBTIntegrationTest(unittest.TestCase):
                         'user': os.getenv('REDSHIFT_TEST_USER'),
                         'pass': os.getenv('REDSHIFT_TEST_PASS'),
                         'dbname': os.getenv('REDSHIFT_TEST_DBNAME'),
-                        'schema': self.unique_schema(),
-                        'keepalives_idle': 5
+                        'schema': self.unique_schema()
                     }
                 },
                 'target': 'default2'
@@ -535,14 +534,10 @@ class DBTIntegrationTest(unittest.TestCase):
             conn.handle.commit()
             conn.transaction_open = False
 
-    def run_sql_common(self, sql, fetch, conn, verbose=False):
+    def run_sql_common(self, sql, fetch, conn):
         with conn.handle.cursor() as cursor:
             try:
-                if verbose:
-                    logger.debug('running sql: {}'.format(sql))
                 cursor.execute(sql)
-                if verbose:
-                    logger.debug('result from sql: {}'.format(cursor.statusmessage))
                 conn.handle.commit()
                 if fetch == 'one':
                     return cursor.fetchone()
@@ -551,9 +546,9 @@ class DBTIntegrationTest(unittest.TestCase):
                 else:
                     return
             except BaseException as e:
+                conn.handle.rollback()
                 print(sql)
                 print(e)
-                conn.handle.rollback()
                 raise e
             finally:
                 conn.transaction_open = False
@@ -1020,9 +1015,7 @@ class DBTIntegrationTest(unittest.TestCase):
 
         text_types = {'text', 'character varying', 'character', 'varchar'}
 
-        self.assertEqual(len(table_a_result), len(table_b_result),
-                         "{} vs. {}".format(table_a_result, table_b_result))
-
+        self.assertEqual(len(table_a_result), len(table_b_result))
         for a_column, b_column in zip(table_a_result, table_b_result):
             a_name, a_type, a_size = a_column
             b_name, b_type, b_size = b_column

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,14 @@ deps =
 
 [testenv:unit-py27]
 basepython = python2.7
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
 [testenv:unit-py36]
 basepython = python3.6
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -27,7 +27,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -38,7 +38,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -49,7 +49,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -60,7 +60,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -72,7 +72,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/presto
@@ -83,7 +83,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_postgres --cov=dbt --cov-branch --cov-report html:htmlcov {posargs} test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres --cov=dbt --cov-branch --cov-report html:htmlcov {posargs} test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -94,7 +94,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -105,7 +105,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -116,7 +116,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -128,7 +128,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_presto {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration/*'
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/presto
@@ -139,7 +139,7 @@ basepython = python2.7
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs}'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -149,7 +149,7 @@ basepython = python3.6
 passenv = *
 setenv =
     HOME=/home/dbt_test_user
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs}'
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs}'
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -160,7 +160,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = pytest -v -m 'profile_postgres or profile_snowflake or profile_bigquery or profile_redshift' --cov=dbt --cov-branch --cov-report html:htmlcov test/integration test/unit
+commands = pytest --durations 0 -v -m 'profile_postgres or profile_snowflake or profile_bigquery or profile_redshift' --cov=dbt --cov-branch --cov-report html:htmlcov test/integration test/unit
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -171,7 +171,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = python -m pytest -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit
+commands = python -m pytest --durations 0 -v {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/unit
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -183,7 +183,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = python -m pytest -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest --durations 0 -v -m profile_postgres {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres
@@ -196,7 +196,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = python -m pytest -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest --durations 0 -v -m profile_snowflake {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/snowflake
@@ -209,7 +209,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = python -m pytest -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest --durations 0 -v -m profile_bigquery {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/bigquery
@@ -222,7 +222,7 @@ passenv = *
 setenv =
     DBT_CONFIG_DIR = ~/.dbt
     DBT_INVOCATION_ENV = ci-appveyor
-commands = python -m pytest -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
+commands = python -m pytest --durations 0 -v -m profile_redshift {posargs} --cov=dbt --cov-branch --cov-report html:htmlcov test/integration
 deps =
     -e {toxinidir}/core
     -e {toxinidir}/plugins/postgres


### PR DESCRIPTION
### Archival + Merge

This PR rounds out the changes for the 0.14.0 implementation of Archival.

**Archive changes**:
- Use a `merge` statement where supported (closes #1339)
- Build the initial archive table with a `create table as ( ... )` statement
- Use supplied timestamp column type as `valid_to` type in archive table (closes #938)
- Make it possible to define user-supplied archive strategies
- Set the `ParsedNode` `database` and `schema` fields correctly
- 

**Other changes**:
- Set a destination table when generating BigQuery temp tables (closes #1423)
- Make `expand_target_column_types` take a relation instead of a string
- Add timing info to `pytest` config

**Breaking changes**:
The `expand_target_column_types` adapter method now takes a relation, not a string. This is also used in the dbt-utils implementation of [insert_by_period](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/materializations/insert_by_period_materialization.sql#L134)