### PR TITLE
detect duplicate archive and node names (#1480)

### DIFF
--- a/core/dbt/loader.py
+++ b/core/dbt/loader.py
@@ -63,6 +63,18 @@ class GraphLoader(object):
                 resource_type=NodeType.Macro,
             ))
 
+    def _load_archives_from_project(self):
+        archive_parser = ArchiveParser(self.root_project, self.all_projects,
+                                       self.macro_manifest)
+        for key, node in archive_parser.load_and_parse().items():
+            # we have another archive parser, so we have to check for
+            # collisions
+            existing = self.nodes.get(key)
+            if existing:
+                dbt.exceptions.raise_duplicate_resource_name(existing, node)
+            else:
+                self.nodes[key] = node
+
     def _load_seeds(self):
         parser = SeedParser(self.root_project, self.all_projects,
                             self.macro_manifest)
@@ -86,10 +98,7 @@ class GraphLoader(object):
                                  self.macro_manifest)
         self.nodes.update(hook_parser.load_and_parse())
 
-        archive_parser = ArchiveParser(self.root_project, self.all_projects,
-                                       self.macro_manifest)
-        self.nodes.update(archive_parser.load_and_parse())
-
+        self._load_archives_from_project()
         self._load_seeds()
 
     def _load_docs(self):

--- a/test/integration/004_simple_archive_test/models-collision/archive_actual.sql
+++ b/test/integration/004_simple_archive_test/models-collision/archive_actual.sql
@@ -1,0 +1,1 @@
+select 1 as id


### PR DESCRIPTION
Fixes #1480 

Works nicely with #1481 

```
$ dbt compile
Running with dbt=0.14.0-a1
Encountered an error:
Compilation Error
  dbt found two resources with the name "x_archive". Since these resources have the same name,
  dbt will be unable to find the correct resource when ref("x_archive") is used. To fix this,
  change the name of one of these resources:
  - model.minimal.x_archive (models/x_archive.sql)
  - archive.minimal.x_archive (archives/x_archive.sql)
```

```
$ dbt compile
Running with dbt=0.14.0-a1
Encountered an error:
Compilation Error
  dbt found two resources with the name "x_archive". Since these resources have the same name,
  dbt will be unable to find the correct resource when ref("x_archive") is used. To fix this,
  change the name of one of these resources:
  - archive.minimal.x_archive (archives/x_archive.sql)
  - archive.minimal.x_archive (dbt_project.yml)
```