### PR TITLE
Refactor node selection

### DIFF
--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -125,52 +125,67 @@ def warn_if_useless_spec(spec, nodes):
     dbt.exceptions.warn_or_error(msg, log_fmt='{} and was ignored\n')
 
 
-class NodeSelector(object):
-    def __init__(self, linker, manifest):
-        self.linker = linker
+class ManifestSelector(object):
+    def __init__(self, manifest):
         self.manifest = manifest
 
-    def _node_iterator(self, graph, exclude, include):
-        for node in graph.nodes():
-            real_node = self.manifest.nodes[node]
-            if include is not None and real_node.resource_type not in include:
+    def _node_iterator(self, included_nodes, exclude, include):
+        for unique_id, node in self.manifest.nodes.items():
+            if unique_id not in included_nodes:
                 continue
-            if exclude is not None and real_node.resource_type in exclude:
+            if include is not None and node.resource_type not in include:
                 continue
-            yield node, real_node
+            if exclude is not None and node.resource_type in exclude:
+                continue
+            yield unique_id, node
 
-    def parsed_nodes(self, graph):
+    def parsed_nodes(self, included_nodes):
         return self._node_iterator(
-            graph,
+            included_nodes,
             exclude=(NodeType.Source,),
             include=None)
 
-    def source_nodes(self, graph):
+    def source_nodes(self, included_nodes):
         return self._node_iterator(
-            graph,
+            included_nodes,
             exclude=None,
             include=(NodeType.Source,))
 
-    def get_nodes_by_qualified_name(self, graph, qualified_name_selector):
-        """Yield all nodes in the graph that match the qualified_name_selector.
+    def search(self, included_nodes, selector):
+        raise NotImplementedError('subclasses should implement this')
 
-        :param str qualified_name_selector: The selector or node name
+
+class QualifiedNameSelector(ManifestSelector):
+    FILTER = SELECTOR_FILTERS.FQN
+
+    def search(self, included_nodes, selector):
+        """Yield all nodes in the graph that match the selector.
+
+        :param str selector: The selector or node name
         """
-        qualified_name = qualified_name_selector.split(".")
-        package_names = get_package_names(graph)
-        for node, real_node in self.parsed_nodes(graph):
+        qualified_name = selector.split(".")
+        package_names = {node.split(".")[1] for node in included_nodes}
+        for node, real_node in self.parsed_nodes(included_nodes):
             if _node_is_match(qualified_name, package_names, real_node.fqn):
                 yield node
 
-    def get_nodes_by_tag(self, graph, tag_name):
+
+class TagSelector(ManifestSelector):
+    FILTER = SELECTOR_FILTERS.TAG
+
+    def search(self, included_nodes, selector):
         """ yields nodes from graph that have the specified tag """
-        for node, real_node in self.parsed_nodes(graph):
-            if tag_name in real_node.tags:
+        for node, real_node in self.parsed_nodes(included_nodes):
+            if selector in real_node.tags:
                 yield node
 
-    def get_nodes_by_source(self, graph, source_full_name):
+
+class SourceSelector(ManifestSelector):
+    FILTER = SELECTOR_FILTERS.SOURCE
+
+    def search(self, included_nodes, selector):
         """yields nodes from graph are the specified source."""
-        parts = source_full_name.split('.')
+        parts = selector.split('.')
         if len(parts) == 1:
             target_source, target_table = parts[0], None
         elif len(parts) == 2:
@@ -180,74 +195,119 @@ class NodeSelector(object):
                 'Invalid source selector value "{}". Sources must be of the '
                 'form `${{source_name}}` or '
                 '`${{source_name}}.${{target_name}}`'
-            ).format(source_full_name)
+            ).format(selector)
             raise dbt.exceptions.RuntimeException(msg)
 
-        for node, real_node in self.source_nodes(graph):
+        for node, real_node in self.source_nodes(included_nodes):
             if target_source not in (real_node.source_name, SELECTOR_GLOB):
                 continue
             if target_table in (None, real_node.name, SELECTOR_GLOB):
                 yield node
 
-    def select_childrens_parents(self, graph, selected):
-        ancestors_for = self.select_children(graph, selected) | selected
-        return self.select_parents(graph, ancestors_for) | ancestors_for
 
-    def select_children(self, graph, selected):
+class InvalidSelectorError(Exception):
+    pass
+
+
+class MultiSelector(object):
+    """The base class of the node selector. It only about the manifest and
+    selector types, including the glob operator, but does not handle any graph
+    related behavior.
+    """
+    SELECTORS = [QualifiedNameSelector, TagSelector, SourceSelector]
+
+    def __init__(self, manifest):
+        self.manifest = manifest
+
+    def get_selector(self, selector_type):
+        for cls in self.SELECTORS:
+            if cls.FILTER == selector_type:
+                return cls(self.manifest)
+
+        raise InvalidSelectorError(selector_type)
+
+    def select_included(self, included_nodes, selector_type, selector_value):
+        selector = self.get_selector(selector_type)
+        return set(selector.search(included_nodes, selector_value))
+
+
+class Graph(object):
+    """A wrapper around the networkx graph that understands SelectionCriteria
+    and how they interact with the graph.
+    """
+    def __init__(self, graph):
+        self.graph = graph
+
+    def nodes(self):
+        return set(self.graph.nodes())
+
+    def __iter__(self):
+        return iter(self.graph.nodes())
+
+    def select_childrens_parents(self, selected):
+        ancestors_for = self.select_children(selected) | selected
+        return self.select_parents(ancestors_for) | ancestors_for
+
+    def select_children(self, selected):
         descendants = set()
         for node in selected:
-            descendants.update(nx.descendants(graph, node))
+            descendants.update(nx.descendants(self.graph, node))
         return descendants
 
-    def select_parents(self, graph, selected):
+    def select_parents(self, selected):
         ancestors = set()
         for node in selected:
-            ancestors.update(nx.ancestors(graph, node))
+            ancestors.update(nx.ancestors(self.graph, node))
         return ancestors
 
-    def collect_models(self, graph, selected, spec):
+    def select_successors(self, selected):
+        successors = set()
+        for node in selected:
+            successors.update(self.graph.successors(node))
+        return successors
+
+    def collect_models(self, selected, spec):
         additional = set()
         if spec.select_childrens_parents:
-            additional.update(self.select_childrens_parents(graph, selected))
+            additional.update(self.select_childrens_parents(selected))
         if spec.select_parents:
-            additional.update(self.select_parents(graph, selected))
+            additional.update(self.select_parents(selected))
         if spec.select_children:
-            additional.update(self.select_children(graph, selected))
+            additional.update(self.select_children(selected))
         return additional
 
-    def collect_tests(self, graph, model_nodes):
-        test_nodes = set()
-        for node in model_nodes:
-            # include tests that depend on this node. if we aren't running
-            # tests, they'll be filtered out later.
-            child_tests = [n for n in graph.successors(node)
-                           if self.manifest.nodes[n].resource_type ==
-                           NodeType.Test]
-            test_nodes.update(child_tests)
-        return test_nodes
+    def subgraph(self, nodes):
+        cls = type(self)
+        return cls(self.graph.subgraph(nodes))
+
+
+class NodeSelector(MultiSelector):
+    def __init__(self, graph, manifest):
+        self.full_graph = Graph(graph)
+        super(NodeSelector, self).__init__(manifest)
 
     def get_nodes_from_spec(self, graph, spec):
-        filter_map = {
-            SELECTOR_FILTERS.FQN: self.get_nodes_by_qualified_name,
-            SELECTOR_FILTERS.TAG: self.get_nodes_by_tag,
-            SELECTOR_FILTERS.SOURCE: self.get_nodes_by_source,
-        }
-
-        filter_method = filter_map.get(spec.selector_type)
-
-        if filter_method is None:
-            valid_selectors = ", ".join(filter_map.keys())
+        try:
+            collected = self.select_included(graph.nodes(),
+                                             spec.selector_type,
+                                             spec.selector_value)
+        except InvalidSelectorError:
+            valid_selectors = ", ".join(s.FILTER for s in self.SELECTORS)
             logger.info("The '{}' selector specified in {} is invalid. Must "
                         "be one of [{}]".format(
                             spec.selector_type,
                             spec.raw,
                             valid_selectors))
-
             return set()
 
-        collected = set(filter_method(graph, spec.selector_value))
-        collected.update(self.collect_models(graph, collected, spec))
-        collected.update(self.collect_tests(graph, collected))
+        specified = graph.collect_models(collected, spec)
+        collected.update(specified)
+
+        tests = {
+            n for n in graph.select_successors(collected)
+            if self.manifest.nodes[n].resource_type == NodeType.Test
+        }
+        collected.update(tests)
 
         return collected
 
@@ -272,12 +332,6 @@ class NodeSelector(object):
             return True
         return not node.get('empty') and is_enabled(node)
 
-    def get_valid_nodes(self, graph):
-        return [
-            node_name for node_name in graph.nodes()
-            if self._is_graph_member(node_name)
-        ]
-
     def _is_match(self, node_name, resource_types, tags, required):
         node = self.manifest.nodes[node_name]
         if node.resource_type not in resource_types:
@@ -292,14 +346,15 @@ class NodeSelector(object):
         return True
 
     def get_selected(self, include, exclude, resource_types, tags, required):
-        graph = self.linker.graph
-
         include = coalesce(include, ['*'])
         exclude = coalesce(exclude, [])
         tags = coalesce(tags, [])
 
-        to_run = self.get_valid_nodes(graph)
-        filtered_graph = graph.subgraph(to_run)
+        graph_members = {
+            node_name for node_name in self.full_graph.nodes()
+            if self._is_graph_member(node_name)
+        }
+        filtered_graph = self.full_graph.subgraph(graph_members)
         selected_nodes = self.select_nodes(filtered_graph, include, exclude)
 
         filtered_nodes = set()
@@ -332,7 +387,7 @@ class NodeSelector(object):
         if not include_spec:
             return set()
 
-        all_ancestors = self.select_nodes(self.linker.graph, include_spec, [])
+        all_ancestors = self.select_nodes(self.full_graph, include_spec, [])
 
         res = []
         for ancestor in all_ancestors:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -60,7 +60,9 @@ class GraphRunnableTask(ManifestTask):
         self._raise_next_tick = None
 
     def select_nodes(self):
-        selector = dbt.graph.selector.NodeSelector(self.linker, self.manifest)
+        selector = dbt.graph.selector.NodeSelector(
+            self.linker.graph, self.manifest
+        )
         selected_nodes = selector.select(self.build_query())
         return selected_nodes
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -79,7 +79,7 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         adapter = self.get_adapter('oauth')
         try:
             connection = adapter.acquire_connection('dummy')
-            self.assertEquals(connection.get('type'), 'bigquery')
+            self.assertEqual(connection.get('type'), 'bigquery')
 
         except dbt.exceptions.ValidationException as e:
             self.fail('got ValidationException: {}'.format(str(e)))
@@ -94,7 +94,7 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         adapter = self.get_adapter('service_account')
         try:
             connection = adapter.acquire_connection('dummy')
-            self.assertEquals(connection.get('type'), 'bigquery')
+            self.assertEqual(connection.get('type'), 'bigquery')
 
         except dbt.exceptions.ValidationException as e:
             self.fail('got ValidationException: {}'.format(str(e)))

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -128,11 +128,11 @@ class GraphTest(unittest.TestCase):
         compiler = self.get_compiler(config)
         linker = compiler.compile(manifest)
 
-        self.assertEquals(
+        self.assertEqual(
             linker.nodes(),
             ['model.test_models_compile.model_one'])
 
-        self.assertEquals(
+        self.assertEqual(
             linker.edges(),
             [])
 
@@ -196,7 +196,7 @@ class GraphTest(unittest.TestCase):
             key = 'model.test_models_compile.{}'.format(model)
             actual = manifest.nodes[key].get('config', {}) \
                                              .get('materialized')
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
     def test__model_incremental(self):
         self.use_models({

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -16,7 +16,7 @@ class BaseGraphSelectionTest(unittest.TestCase):
         pass
 
     def setUp(self):
-        self.package_graph = self.create_graph()
+        self.package_graph = graph_selector.Graph(self.create_graph())
         nodes = {
             node: mock.MagicMock(fqn=node.split('.')[1:], tags=[])
             for node in self.package_graph
@@ -54,7 +54,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             exclude
         )
 
-        self.assertEquals(selected, expected)
+        self.assertEqual(selected, expected)
 
 
     def test__single_node_selection_in_package(self):
@@ -176,7 +176,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
         found = graph_selector.get_package_names(self.package_graph)
 
         expected = set(['X', 'Y'])
-        self.assertEquals(found, expected)
+        self.assertEqual(found, expected)
 
     def assert_is_selected_node(self, node, spec, should_work):
         self.assertEqual(

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -23,8 +23,7 @@ class BaseGraphSelectionTest(unittest.TestCase):
         }
         self.add_tags(nodes)
         self.manifest = mock.MagicMock(nodes=nodes)
-        self.linker = mock.MagicMock(graph=self.package_graph)
-        self.selector = graph_selector.NodeSelector(self.linker, self.manifest)
+        self.selector = graph_selector.NodeSelector(self.package_graph, self.manifest)
 
 
 class GraphSelectionTest(BaseGraphSelectionTest):

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -58,15 +58,15 @@ class TestPostgresAdapter(unittest.TestCase):
         except BaseException as e:
             self.fail('acquiring connection failed with unknown exception: {}'
                       .format(str(e)))
-        self.assertEquals(connection.type, 'postgres')
+        self.assertEqual(connection.type, 'postgres')
         psycopg2.connect.assert_called_once()
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
     def test_acquire_connection(self, psycopg2):
         connection = self.adapter.acquire_connection('dummy')
 
-        self.assertEquals(connection.state, 'open')
-        self.assertNotEquals(connection.handle, None)
+        self.assertEqual(connection.state, 'open')
+        self.assertNotEqual(connection.handle, None)
         psycopg2.connect.assert_called_once()
 
     def test_cancel_open_connections_empty(self):

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -61,13 +61,13 @@ class TestRedshiftAdapter(unittest.TestCase):
 
     def test_implicit_database_conn(self):
         creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
-        self.assertEquals(creds, self.config.credentials)
+        self.assertEqual(creds, self.config.credentials)
 
     def test_explicit_database_conn(self):
         self.config.method = 'database'
 
         creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
-        self.assertEquals(creds, self.config.credentials)
+        self.assertEqual(creds, self.config.credentials)
 
     def test_explicit_iam_conn(self):
         self.config.credentials = self.config.credentials.incorporate(
@@ -80,7 +80,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
 
         expected_creds = self.config.credentials.incorporate(password='tmp_password')
-        self.assertEquals(creds, expected_creds)
+        self.assertEqual(creds, expected_creds)
 
     def test_invalid_auth_method(self):
         # we have to set method this way, otherwise it won't validate

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -18,7 +18,7 @@ class TestDeepMerge(unittest.TestCase):
 
         for case in cases:
             actual = dbt.utils.deep_merge(*case['args'])
-            self.assertEquals(
+            self.assertEqual(
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
@@ -38,7 +38,7 @@ class TestMerge(unittest.TestCase):
 
         for case in cases:
             actual = dbt.utils.deep_merge(*case['args'])
-            self.assertEquals(
+            self.assertEqual(
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
@@ -88,10 +88,10 @@ class TestDeepMap(unittest.TestCase):
             ],
         }
         actual = dbt.utils.deep_map(self.intify_all, self.input_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
         actual = dbt.utils.deep_map(self.intify_all, expected)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
 
     @staticmethod
@@ -121,20 +121,20 @@ class TestDeepMap(unittest.TestCase):
             ],
         }
         actual = dbt.utils.deep_map(self.special_keypath, self.input_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
         actual = dbt.utils.deep_map(self.special_keypath, expected)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__noop(self):
         actual = dbt.utils.deep_map(lambda x, _: x, self.input_value)
-        self.assertEquals(actual, self.input_value)
+        self.assertEqual(actual, self.input_value)
 
     def test_trivial(self):
         cases = [[], {}, 1, 'abc', None, True]
         for case in cases:
             result = dbt.utils.deep_map(lambda x, _: x, case)
-            self.assertEquals(result, case)
+            self.assertEqual(result, case)
 
         with self.assertRaises(dbt.exceptions.DbtConfigError):
             dbt.utils.deep_map(lambda x, _: x, {'foo': object()})


### PR DESCRIPTION
Refactor node selection to split the part that knows about graphs (and therefore children/parents) from the part that only knows about the manifest (names and globs).

This is part of the groundwork for #1212 