### PR TITLE
Render source_description fields in sources (#1484)

### DIFF
--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1266,7 +1266,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'resource_type': 'source',
                     'root_path': os.getcwd(),
                     'schema': my_schema_name,
-                    'source_description': "{{ doc('source_info') }}",
+                    'source_description': 'My source',
                     'source_name': 'my_source',
                     'unique_id': 'source.test.my_source.my_table'
                 }


### PR DESCRIPTION
Fixes #1484 

We just never rendered this field, and even had a test asserting we never rendered it 🤦‍♂ 