### PR TITLE
remove archive configs

### DIFF
--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -12,6 +12,15 @@ from .profile import Profile
 from .project import Project
 
 
+_ARCHIVE_REMOVED_MESSAGE = '''
+The `archive` section in `dbt_project.yml` is no longer supported. Please use a
+`snapshot` block instead. For more information on snapshot blocks and a script
+to help migrate these archives, please consult the 0.14.0 migration guide:
+
+https://docs.getdbt.com/v0.14/docs/upgrading-to-014
+'''.strip()
+
+
 class RuntimeConfig(Project, Profile):
     """The runtime configuration, as constructed from its components. There's a
     lot because there is a lot of stuff!
@@ -64,12 +73,14 @@ class RuntimeConfig(Project, Profile):
         self.validate()
 
     @classmethod
-    def from_parts(cls, project, profile, args, allow_archive_blocks=False):
+    def from_parts(cls, project, profile, args, allow_archive_configs=False):
         """Instantiate a RuntimeConfig from its components.
 
         :param profile Profile: A parsed dbt Profile.
         :param project Project: A parsed dbt Project.
         :param args argparse.Namespace: The parsed command-line arguments.
+        :param allow_archive_configs bool: If True, ignore archive blocks in
+            configs. This flag exists to enable archive migration.
         :returns RuntimeConfig: The new configuration.
         """
         quoting = deepcopy(
@@ -77,11 +88,9 @@ class RuntimeConfig(Project, Profile):
             .DEFAULTS['quote_policy']
         )
         quoting.update(project.quoting)
-        if project.archive and not allow_archive_blocks:
+        if project.archive and not allow_archive_configs:
             # if the user has an `archive` section, raise an error
-            raise DbtProjectError(
-                'Invalid project configuration: "archive" is not allowed'
-            )
+            raise DbtProjectError(_ARCHIVE_REMOVED_MESSAGE)
 
         return cls(
             project_name=project.project_name,
@@ -169,13 +178,13 @@ class RuntimeConfig(Project, Profile):
             self.validate_version()
 
     @classmethod
-    def from_args(cls, args, allow_archive_blocks=False):
+    def from_args(cls, args, allow_archive_configs=False):
         """Given arguments, read in dbt_project.yml from the current directory,
         read in packages.yml if it exists, and use them to find the profile to
         load.
 
         :param args argparse.Namespace: The arguments as parsed from the cli.
-        :param allow_archive_blocks bool: If True, ignore archive blocks in
+        :param allow_archive_configs bool: If True, ignore archive blocks in
             configs. This flag exists to enable archive migration.
         :raises DbtProjectError: If the project is invalid or missing.
         :raises DbtProfileError: If the profile is invalid or missing.
@@ -194,5 +203,5 @@ class RuntimeConfig(Project, Profile):
             project=project,
             profile=profile,
             args=args,
-            allow_archive_blocks=allow_archive_blocks
+            allow_archive_configs=allow_archive_configs
         )

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -2,7 +2,7 @@ from dbt.api.object import APIObject
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.utils import deep_merge
 
-# TODO: add description fields.
+
 ARCHIVE_TABLE_CONFIG_CONTRACT = {
     'type': 'object',
     'additionalProperties': False,

--- a/core/dbt/loader.py
+++ b/core/dbt/loader.py
@@ -10,8 +10,8 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.utils import timestring
 
 from dbt.parser import MacroParser, ModelParser, SeedParser, AnalysisParser, \
-    DocumentationParser, DataTestParser, HookParser, ArchiveParser, \
-    SchemaParser, ParserUtils, ArchiveBlockParser
+    DocumentationParser, DataTestParser, HookParser, SchemaParser, \
+    ParserUtils, ArchiveBlockParser
 
 from dbt.contracts.project import ProjectList
 
@@ -63,18 +63,6 @@ class GraphLoader(object):
                 resource_type=NodeType.Macro,
             ))
 
-    def _load_archives_from_project(self):
-        archive_parser = ArchiveParser(self.root_project, self.all_projects,
-                                       self.macro_manifest)
-        for key, node in archive_parser.load_and_parse().items():
-            # we have another archive parser, so we have to check for
-            # collisions
-            existing = self.nodes.get(key)
-            if existing:
-                dbt.exceptions.raise_duplicate_resource_name(existing, node)
-            else:
-                self.nodes[key] = node
-
     def _load_seeds(self):
         parser = SeedParser(self.root_project, self.all_projects,
                             self.macro_manifest)
@@ -98,7 +86,6 @@ class GraphLoader(object):
                                  self.macro_manifest)
         self.nodes.update(hook_parser.load_and_parse())
 
-        self._load_archives_from_project()
         self._load_seeds()
 
     def _load_docs(self):

--- a/core/dbt/parser/__init__.py
+++ b/core/dbt/parser/__init__.py
@@ -1,6 +1,5 @@
 
 from .analysis import AnalysisParser
-from .archives import ArchiveParser
 from .archives import ArchiveBlockParser
 from .data_test import DataTestParser
 from .docs import DocumentationParser
@@ -14,7 +13,6 @@ from .util import ParserUtils
 
 __all__ = [
     'AnalysisParser',
-    'ArchiveParser',
     'ArchiveBlockParser',
     'DataTestParser',
     'DocumentationParser',

--- a/test/integration/023_exit_codes_test/archives-bad/b.sql
+++ b/test/integration/023_exit_codes_test/archives-bad/b.sql
@@ -1,0 +1,4 @@
+{% archive good_archive %}
+    {{ config(target_schema=schema, target_database=database, strategy='timestamp', unique_key='id', updated_at='updated_at_not_real')}}
+    select * from {{ schema }}.good
+{% endarchive %}

--- a/test/integration/023_exit_codes_test/archives-good/g.sql
+++ b/test/integration/023_exit_codes_test/archives-good/g.sql
@@ -1,0 +1,4 @@
+{% archive good_archive %}
+    {{ config(target_schema=schema, target_database=database, strategy='timestamp', unique_key='id', updated_at='updated_at')}}
+    select * from {{ schema }}.good
+{% endarchive %}

--- a/test/integration/023_exit_codes_test/test_exit_codes.py
+++ b/test/integration/023_exit_codes_test/test_exit_codes.py
@@ -13,23 +13,11 @@ class TestExitCodes(DBTIntegrationTest):
     def models(self):
         return "test/integration/023_exit_codes_test/models"
 
+
     @property
     def project_config(self):
         return {
-            "archive": [
-                {
-                    "source_schema": self.unique_schema(),
-                    "target_schema": self.unique_schema(),
-                    "tables": [
-                        {
-                            "source_table": "good",
-                            "target_table": "good_archive",
-                            "updated_at": 'updated_at',
-                            "unique_key": 'id'
-                        }
-                    ]
-                }
-            ]
+            "archive-paths": ['test/integration/023_exit_codes_test/archives-good'],
         }
 
     @use_profile('postgres')
@@ -91,20 +79,7 @@ class TestExitCodesArchiveFail(DBTIntegrationTest):
     @property
     def project_config(self):
         return {
-            "archive": [
-                {
-                    "source_schema": self.unique_schema(),
-                    "target_schema": self.unique_schema(),
-                    "tables": [
-                        {
-                            "source_table": "good",
-                            "target_table": "good_archive",
-                            "updated_at": 'updated_at_not_real',
-                            "unique_key": 'id'
-                        }
-                    ]
-                }
-            ]
+            "archive-paths": ['test/integration/023_exit_codes_test/archives-bad'],
         }
 
     @use_profile('postgres')

--- a/test/integration/033_event_tracking_test/archives/a.sql
+++ b/test/integration/033_event_tracking_test/archives/a.sql
@@ -1,0 +1,4 @@
+{% archive archived %}
+    {{ config(target_schema=schema, target_database=database, strategy='timestamp', unique_key='id', updated_at='updated_at')}}
+    select * from {{ schema }}.archivable
+{% endarchive %}

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -561,20 +561,7 @@ class TestEventTrackingArchive(TestEventTracking):
     @property
     def project_config(self):
         return {
-            "archive": [
-                {
-                    "source_schema": self.unique_schema(),
-                    "target_schema": self.unique_schema(),
-                    "tables": [
-                        {
-                            "source_table": "archivable",
-                            "target_table": "archived",
-                            "updated_at": '"updated_at"',
-                            "unique_key": '"id"'
-                        }
-                    ]
-                }
-            ]
+            "archive-paths": ['test/integration/033_event_tracking_test/archives']
         }
 
     @use_profile("postgres")

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1066,7 +1066,7 @@ class TestRuntimeConfig(BaseConfigTest):
         profile = self.get_profile()
         with self.assertRaises(dbt.exceptions.DbtProjectError) as raised:
             dbt.config.RuntimeConfig.from_parts(project, profile, self.args)
-        self.assertIn('Invalid project configuration: "archive" is not allowed', str(raised.exception))
+        self.assertIn('The `archive` section in `dbt_project.yml` is no longer supported', str(raised.exception))
 
     def test_archive_allowed(self):
         archive_cfg = {
@@ -1086,7 +1086,7 @@ class TestRuntimeConfig(BaseConfigTest):
         profile = self.get_profile()
 
         cfg = dbt.config.RuntimeConfig.from_parts(project, profile, self.args,
-                                                  allow_archive_blocks=True)
+                                                  allow_archive_configs=True)
         self.assertEqual(cfg.archive, [archive_cfg])
 
 
@@ -1150,14 +1150,14 @@ class TestRuntimeConfigFilesWithArchive(BaseFileTest):
 
     def test_archive_ok_from_args(self):
         with temp_cd(self.project_dir):
-            config = dbt.config.RuntimeConfig.from_args(self.args, allow_archive_blocks=True)
+            config = dbt.config.RuntimeConfig.from_args(self.args, allow_archive_configs=True)
 
         self.assertEqual(config.archive, self.default_project_data['archive'])
 
     def test_archive_error(self):
         with temp_cd(self.project_dir), self.assertRaises(dbt.exceptions.DbtProjectError) as raised:
             dbt.config.RuntimeConfig.from_args(self.args)
-        self.assertIn('Invalid project configuration: "archive" is not allowed', str(raised.exception))
+        self.assertIn('The `archive` section in `dbt_project.yml` is no longer supported', str(raised.exception))
 
 
 class TestVariableRuntimeConfigFiles(BaseFileTest):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1049,6 +1049,45 @@ class TestRuntimeConfig(BaseConfigTest):
         raised = self.from_parts(dbt.exceptions.DbtProjectError)
         self.assertIn('The package version requirement can never be satisfied', str(raised.exception))
 
+    def test_archive_not_allowed(self):
+        self.default_project_data['archive'] = [{
+            "source_schema": 'a',
+            "target_schema": 'b',
+            "tables": [
+                {
+                    "source_table": "seed",
+                    "target_table": "archive_actual",
+                    "updated_at": 'updated_at',
+                    "unique_key": '''id || '-' || first_name'''
+                },
+            ],
+        }]
+        project = self.get_project()
+        profile = self.get_profile()
+        with self.assertRaises(dbt.exceptions.DbtProjectError) as raised:
+            dbt.config.RuntimeConfig.from_parts(project, profile, self.args)
+        self.assertIn('Invalid project configuration: "archive" is not allowed', str(raised.exception))
+
+    def test_archive_allowed(self):
+        archive_cfg = {
+            "source_schema": 'a',
+            "target_schema": 'b',
+            "tables": [
+                {
+                    "source_table": "seed",
+                    "target_table": "archive_actual",
+                    "updated_at": 'updated_at',
+                    "unique_key": '''id || '-' || first_name'''
+                },
+            ],
+        }
+        self.default_project_data['archive'] = [archive_cfg]
+        project = self.get_project()
+        profile = self.get_profile()
+
+        cfg = dbt.config.RuntimeConfig.from_parts(project, profile, self.args,
+                                                  allow_archive_blocks=True)
+        self.assertEqual(cfg.archive, [archive_cfg])
 
 
 class TestRuntimeConfigFiles(BaseFileTest):
@@ -1062,7 +1101,6 @@ class TestRuntimeConfigFiles(BaseFileTest):
     def test_from_args(self):
         with temp_cd(self.project_dir):
             config = dbt.config.RuntimeConfig.from_args(self.args)
-        self.assertEqual(config.project_name, 'my_test_project')
         self.assertEqual(config.version, '0.0.1')
         self.assertEqual(config.profile_name, 'default')
         # on osx, for example, these are not necessarily equal due to /private
@@ -1085,6 +1123,41 @@ class TestRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.archive, [])
         self.assertEqual(config.seeds, {})
         self.assertEqual(config.packages, PackageConfig(packages=[]))
+        self.assertEqual(config.project_name, 'my_test_project')
+
+
+class TestRuntimeConfigFilesWithArchive(BaseFileTest):
+    def setUp(self):
+        super(TestRuntimeConfigFilesWithArchive, self).setUp()
+        self.default_project_data['archive'] = [
+            {
+                "source_schema": 'a',
+                "target_schema": 'b',
+                "tables": [
+                    {
+                        "source_table": "c",
+                        "target_table": "d",
+                        "updated_at": 'date_field',
+                        "unique_key": 'id',
+                    },
+                ],
+            }
+        ]
+        self.write_profile(self.default_profile_data)
+        self.write_project(self.default_project_data)
+        # and after the fact, add the project root
+        self.default_project_data['project-root'] = self.project_dir
+
+    def test_archive_ok_from_args(self):
+        with temp_cd(self.project_dir):
+            config = dbt.config.RuntimeConfig.from_args(self.args, allow_archive_blocks=True)
+
+        self.assertEqual(config.archive, self.default_project_data['archive'])
+
+    def test_archive_error(self):
+        with temp_cd(self.project_dir), self.assertRaises(dbt.exceptions.DbtProjectError) as raised:
+            dbt.config.RuntimeConfig.from_args(self.args)
+        self.assertIn('Invalid project configuration: "archive" is not allowed', str(raised.exception))
 
 
 class TestVariableRuntimeConfigFiles(BaseFileTest):
@@ -1136,4 +1209,3 @@ class TestVariableRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.models['bar']['materialized'], 'blah')
         self.assertEqual(config.seeds['foo']['post-hook'], "{{ env_var('env_value_target') }}")
         self.assertEqual(config.seeds['bar']['materialized'], 'blah')
-


### PR DESCRIPTION
Fixes #1498 

Remove support for archive configs from `dbt_project.yml`, with a special "escape hatch" for the archive migration script to use. Whichever one of this and #1481 gets merged second should add an `allow_archive_blocks=True` to that script.

In 0.15.0 or whatever, we'll fully remove that flag and the supporting contracts logic, but for now it's easiest to leave it in.

Bonus: this removes a bunch of slow snowflake/bigquery archival tests 🎉 