### PR TITLE
Only parse docs blocks contents when reading md files (#988)

### DIFF
--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -8,7 +8,7 @@ class NodeType(object):
     Macro = 'macro'
     Operation = 'operation'
     Seed = 'seed'
-    Documentation = 'documentation'
+    Documentation = 'docs'
     Source = 'source'
     RPCCall = 'rpc'
 

--- a/test/integration/029_docs_generate_tests/models/readme.md
+++ b/test/integration/029_docs_generate_tests/models/readme.md
@@ -1,0 +1,1 @@
+This is a readme.md file with {{ invalid-ish jinja }} in it

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1282,7 +1282,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.ephemeral_summary'
                 },
@@ -1293,7 +1293,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.source_info',
                 },
@@ -1304,7 +1304,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.summary_count'
                 },
@@ -1315,7 +1315,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.summary_first_name'
                 },
@@ -1326,7 +1326,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.table_info'
                 },
@@ -1340,7 +1340,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': docs_path,
                     'package_name': 'test',
                     'path': 'docs.md',
-                    'resource_type': 'documentation',
+                    'resource_type': 'docs',
                     'root_path': os.getcwd(),
                     'unique_id': 'test.view_summary'
                 },

--- a/test/unit/test_docs_blocks.py
+++ b/test/unit/test_docs_blocks.py
@@ -2,15 +2,11 @@ import os
 import mock
 import unittest
 
-from dbt.config import RuntimeConfig
 from dbt.node_types import NodeType
-import dbt.utils
 from dbt.parser import docs
 from dbt.contracts.graph.unparsed import UnparsedDocumentationFile
 
 from .utils import config_from_parts_or_dicts
-
-#DocumentationParser
 
 
 SNOWPLOW_SESSIONS_DOCS = r'''
@@ -98,7 +94,8 @@ class DocumentationParserTest(unittest.TestCase):
         self.subdir_project_config = config_from_parts_or_dicts(
             project=subdir_project, profile=profile_data
         )
-    @mock.patch('dbt.clients.system')
+
+    @mock.patch('dbt.parser.docs.system')
     def test_load_file(self, system):
         system.load_file_contents.return_value = TEST_DOCUMENTATION_FILE
         system.find_matching.return_value = [{

--- a/test/unit/test_jinja.py
+++ b/test/unit/test_jinja.py
@@ -271,6 +271,28 @@ class TestBlockLexer(unittest.TestCase):
         self.assertEqual(blocks[0].block_type_name, 'myblock')
         self.assertEqual(blocks[0].contents, '{% set x = ("{% endmyblock %}") %}  ')
 
+    def test_docs_block(self):
+        body = '{% docs __my_doc__ %} asdf {# nope {% enddocs %}} #} {% enddocs %} {% docs __my_other_doc__ %} asdf "{% enddocs %}'
+        all_blocks = extract_toplevel_blocks(body)
+        blocks = [b for b in all_blocks if b.block_type_name != '__dbt__data']
+        self.assertEqual(len(blocks), 2)
+        self.assertEqual(blocks[0].block_type_name, 'docs')
+        self.assertEqual(blocks[0].contents, ' asdf {# nope {% enddocs %}} #} ')
+        self.assertEqual(blocks[0].block_name, '__my_doc__')
+        self.assertEqual(blocks[1].block_type_name, 'docs')
+        self.assertEqual(blocks[1].contents, ' asdf "')
+        self.assertEqual(blocks[1].block_name, '__my_other_doc__')
+
+    def test_docs_block_expr(self):
+        body = '{% docs more_doc %} asdf {{ "{% enddocs %}" ~ "}}" }}{% enddocs %}'
+        all_blocks = extract_toplevel_blocks(body)
+        blocks = [b for b in all_blocks if b.block_type_name != '__dbt__data']
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].block_type_name, 'docs')
+        self.assertEqual(blocks[0].contents, ' asdf {{ "{% enddocs %}" ~ "}}" }}')
+        self.assertEqual(blocks[0].block_name, 'more_doc')
+
+
 bar_block = '''{% mytype bar %}
 {# a comment
     that inside it has


### PR DESCRIPTION
Fixes #988 

Also, related: Fix docs blocks parsing issues
Rename documentation node type to docs so we can filter on it (is this breaking?)
Fix block extractor bug with macros/docs that contain quotes
Fix block extractor bug with expressions
