### PR TITLE
render severity configurations (#1512) (#1511)

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -240,11 +240,14 @@ def create_warn_undefined_env(node):
                     raise
                 else:
                     msg = 'Compilation warning in {}:\n\t{}'
-                    model_desc = "{} {} ({})".format(
-                        self.node.get('resource_type'),
-                        self.node.get('name', 'unknown'),
-                        self.node.get('original_file_path')
-                    )
+                    if self.node is None:
+                        model_desc = 'rendering'
+                    else:
+                        model_desc = "{} {} ({})".format(
+                            self.node.get('resource_type'),
+                            self.node.get('name', 'unknown'),
+                            self.node.get('original_file_path')
+                        )
                     logger.warning(msg.format(model_desc, str(exc)))
 
         def __eq__(self, other):

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -85,7 +85,8 @@ CONFIG_CONTRACT = {
             ]
         },
         'severity': {
-            'enum': ['ERROR', 'WARN'],
+            'type': 'string',
+            'pattern': '([eE][rR][rR][oO][rR]|[wW][aA][rR][nN])',
         },
     },
     'required': [

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -152,7 +152,8 @@ def print_test_result_line(result, schema_name, index, total):
         color = red
 
     elif result.status > 0:
-        if result.node.config['severity'] == 'ERROR' or dbt.flags.WARN_ERROR:
+        severity = result.node.config['severity'].upper()
+        if severity == 'ERROR' or dbt.flags.WARN_ERROR:
             info = 'FAIL {}'.format(result.status)
             color = red
             result.fail = True

--- a/test/integration/045_test_severity_tests/models/schema.yml
+++ b/test/integration/045_test_severity_tests/models/schema.yml
@@ -5,7 +5,7 @@ models:
       - name: email
         tests:
           - not_null:
-              severity: WARN
+              severity: "{{ 'error' if var('strict', false) else 'warn' }}"
 sources:
   - name: source
     schema: "{{ var('test_run_schema') }}"
@@ -16,4 +16,4 @@ sources:
           - name: email
             tests:
               - not_null:
-                  severity: WARN
+                  severity: "{{ 'error' if var('strict', false) else 'warn' }}"

--- a/test/integration/045_test_severity_tests/test_severity.py
+++ b/test/integration/045_test_severity_tests/test_severity.py
@@ -13,6 +13,7 @@ class TestSeverity(DBTIntegrationTest):
     def project_config(self):
         return {
             'data-paths': ['data'],
+            'test-paths': ['tests'],
         }
 
     def run_dbt_with_vars(self, cmd, strict_var, *args, **kwargs):
@@ -24,7 +25,7 @@ class TestSeverity(DBTIntegrationTest):
     def test_postgres_severity_warnings(self):
         self.run_dbt_with_vars(['seed'], 'false', strict=False)
         self.run_dbt_with_vars(['run'], 'false', strict=False)
-        results = self.run_dbt_with_vars(['test'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test', '--schema'], 'false', strict=False)
         self.assertEqual(len(results), 2)
         self.assertFalse(results[0].fail)
         self.assertEqual(results[0].status, 2)
@@ -35,7 +36,7 @@ class TestSeverity(DBTIntegrationTest):
     def test_postgres_severity_rendered_errors(self):
         self.run_dbt_with_vars(['seed'], 'false', strict=False)
         self.run_dbt_with_vars(['run'], 'false', strict=False)
-        results = self.run_dbt_with_vars(['test'], 'true', strict=False, expect_pass=False)
+        results = self.run_dbt_with_vars(['test', '--schema'], 'true', strict=False, expect_pass=False)
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0].fail)
         self.assertEqual(results[0].status, 2)
@@ -46,10 +47,36 @@ class TestSeverity(DBTIntegrationTest):
     def test_postgres_severity_warnings_strict(self):
         self.run_dbt_with_vars(['seed'], 'false', strict=False)
         self.run_dbt_with_vars(['run'], 'false', strict=False)
-        results = self.run_dbt_with_vars(['test'], 'false', expect_pass=False)
+        results = self.run_dbt_with_vars(['test', '--schema'], 'false', expect_pass=False)
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0].fail)
         self.assertEqual(results[0].status, 2)
         self.assertTrue(results[1].fail)
         self.assertEqual(results[1].status, 2)
 
+    @use_profile('postgres')
+    def test_postgres_data_severity_warnings(self):
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test', '--data'], 'false', strict=False)
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].fail)
+        self.assertEqual(results[0].status, 2)
+
+    @use_profile('postgres')
+    def test_postgres_data_severity_rendered_errors(self):
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test', '--data'], 'true', strict=False, expect_pass=False)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].fail)
+        self.assertEqual(results[0].status, 2)
+
+    @use_profile('postgres')
+    def test_postgres_data_severity_warnings_strict(self):
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test', '--data'], 'false', expect_pass=False)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].fail)
+        self.assertEqual(results[0].status, 2)

--- a/test/integration/045_test_severity_tests/test_severity.py
+++ b/test/integration/045_test_severity_tests/test_severity.py
@@ -15,16 +15,16 @@ class TestSeverity(DBTIntegrationTest):
             'data-paths': ['data'],
         }
 
-    def run_dbt_with_vars(self, cmd, *args, **kwargs):
+    def run_dbt_with_vars(self, cmd, strict_var, *args, **kwargs):
         cmd.extend(['--vars',
-                    '{{test_run_schema: {}}}'.format(self.unique_schema())])
+                    '{{test_run_schema: {}, strict: {}}}'.format(self.unique_schema(), strict_var)])
         return self.run_dbt(cmd, *args, **kwargs)
 
     @use_profile('postgres')
     def test_postgres_severity_warnings(self):
-        self.run_dbt_with_vars(['seed'], strict=False)
-        self.run_dbt_with_vars(['run'], strict=False)
-        results = self.run_dbt_with_vars(['test'], strict=False)
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test'], 'false', strict=False)
         self.assertEqual(len(results), 2)
         self.assertFalse(results[0].fail)
         self.assertEqual(results[0].status, 2)
@@ -32,12 +32,24 @@ class TestSeverity(DBTIntegrationTest):
         self.assertEqual(results[1].status, 2)
 
     @use_profile('postgres')
-    def test_postgres_severity_warnings_errors(self):
-        self.run_dbt_with_vars(['seed'], strict=False)
-        self.run_dbt_with_vars(['run'], strict=False)
-        results = self.run_dbt_with_vars(['test'], expect_pass=False)
+    def test_postgres_severity_rendered_errors(self):
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test'], 'true', strict=False, expect_pass=False)
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0].fail)
         self.assertEqual(results[0].status, 2)
         self.assertTrue(results[1].fail)
         self.assertEqual(results[1].status, 2)
+
+    @use_profile('postgres')
+    def test_postgres_severity_warnings_strict(self):
+        self.run_dbt_with_vars(['seed'], 'false', strict=False)
+        self.run_dbt_with_vars(['run'], 'false', strict=False)
+        results = self.run_dbt_with_vars(['test'], 'false', expect_pass=False)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0].fail)
+        self.assertEqual(results[0].status, 2)
+        self.assertTrue(results[1].fail)
+        self.assertEqual(results[1].status, 2)
+

--- a/test/integration/045_test_severity_tests/tests/data.sql
+++ b/test/integration/045_test_severity_tests/tests/data.sql
@@ -1,0 +1,2 @@
+{{ config(severity='error' if var('strict', false) else 'warn') }}
+select * from {{ ref('model') }} where email is null


### PR DESCRIPTION
Fixes #1511 and #1512  by rendering the "severity" field in test configurations.