### PR TITLE
Change postgres `get_catalog` to not use `information_schema`

### DIFF
--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -8,65 +8,35 @@
     {% set database = information_schemas[0].database %}
     {{ adapter.verify_database(database) }}
 
-    with table_owners as (
+    select
+        '{{ database }}' as table_database,
+        sch.nspname as table_schema,
+        tbl.relname as table_name,
+        case tbl.relkind
+            when 'r' then 'BASE TABLE'
+            else 'VIEW'
+        end as table_kind,
+        null::text as table_comment,
+        col.attname as column_name,
+        col.attnum as column_index,
+        pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,
+        null::text as column_comment,
+        pg_get_userbyid(tbl.relowner) as table_owner
 
-        select
-            '{{ database }}' as table_database,
-            schemaname as table_schema,
-            tablename as table_name,
-            tableowner as table_owner
+    from pg_catalog.pg_namespace sch
+    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
+    join pg_catalog.pg_attribute col on col.attrelid = tbl.oid
 
-        from pg_tables
+    where sch.nspname != 'information_schema'
+      and sch.nspname not like 'pg_%' -- avoid postgres system schemas
+      and tbl.relpersistence = 'p' -- [p]ermanent table. Other values are [u]nlogged table, [t]emporary table
+      and tbl.relkind in ('r', 'v', 'm') -- o[r]dinary table, [v]iew, [m]aterialized view. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [f]oreign table
+      and col.attnum >= 1 -- negative numbers are used for system columns such as oid
 
-        union all
-
-        select
-            '{{ database }}' as table_database,
-            schemaname as table_schema,
-            viewname as table_name,
-            viewowner as table_owner
-
-        from pg_views
-
-    ),
-
-    tables as (
-
-        select
-            table_catalog as table_database,
-            table_schema,
-            table_name,
-            table_type
-
-        from information_schema.tables
-
-    ),
-
-    columns as (
-
-        select
-            table_catalog as table_database,
-            table_schema,
-            table_name,
-            null as table_comment,
-            column_name,
-            ordinal_position as column_index,
-            data_type as column_type,
-            null as column_comment
-
-        from information_schema.columns
-
-    )
-
-    select *
-    from tables
-    join columns using (table_database, table_schema, table_name)
-    join table_owners using (table_database, table_schema, table_name)
-
-    where table_schema != 'information_schema'
-      and table_schema not like 'pg_%'
-
-    order by column_index
+    order by
+        sch.nspname,
+        tbl.relname,
+        col.attnum
 
   {%- endcall -%}
 

--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -13,8 +13,8 @@
         sch.nspname as table_schema,
         tbl.relname as table_name,
         case tbl.relkind
-            when 'r' then 'BASE TABLE'
-            else 'VIEW'
+            when 'v' then 'VIEW'
+            else 'BASE TABLE'
         end as table_type,
         null::text as table_comment,
         col.attname as column_name,

--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -15,7 +15,7 @@
         case tbl.relkind
             when 'r' then 'BASE TABLE'
             else 'VIEW'
-        end as table_kind,
+        end as table_type,
         null::text as table_comment,
         col.attname as column_name,
         col.attnum as column_index,

--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -29,9 +29,11 @@
 
     where sch.nspname != 'information_schema'
       and sch.nspname not like 'pg_%' -- avoid postgres system schemas
+      and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session
       and tbl.relpersistence = 'p' -- [p]ermanent table. Other values are [u]nlogged table, [t]emporary table
-      and tbl.relkind in ('r', 'v', 'm') -- o[r]dinary table, [v]iew, [m]aterialized view. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [f]oreign table
-      and col.attnum >= 1 -- negative numbers are used for system columns such as oid
+      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view
+      and col.attnum > 0 -- negative numbers are used for system columns such as oid
+      and not col.attisdropped -- column as not been dropped
 
     order by
         sch.nspname,


### PR DESCRIPTION
 - `information_schema` in Postgres is not very performant due to the complex views used to create it
 - use underlying `pg_catalog` tables/views instead
 - returns the same rows/columns as the `information_schema` version
 - order of rows is different, this is because there was only a partial sort on the `information_schema` version
 - `column_type` will return different values to before
   - some arrays were `ARRAY`, will now be `{type}[]`
   - user-defined types were previously `USER_DEFINED`, now will be the name of the user-defined type 
     ^ main point of this PR
 - performance is 2-5x faster, depending on query caching