### PR TITLE
add --project-dir flag to allow specifying project directory

### DIFF
--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -222,6 +222,16 @@ def _build_base_subparser():
     base_subparser = argparse.ArgumentParser(add_help=False)
 
     base_subparser.add_argument(
+        '--project-dir',
+        default=None,
+        type=str,
+        help="""
+        Which directory to look in for the dbt_project.yml file.
+        Default is the current working directory and its parents.
+        """
+    )
+
+    base_subparser.add_argument(
         '--profiles-dir',
         default=PROFILES_DIR,
         type=str,

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -103,7 +103,7 @@ def get_nearest_project_dir(args):
             raise dbt.exceptions.RuntimeException(
                 "fatal: Invalid --project-dir flag. Not a dbt project. "
                 "Missing dbt_project.yml file"
-	    )
+            )
 
     root_path = os.path.abspath(os.sep)
     cwd = os.getcwd()


### PR DESCRIPTION
In particular, this is the directory that contains the dbt_project.yml
file and all the related project files and directories.

Without this flag, it is necessary to cd to the project directory before
running dbt.

Please note that this change does not include unit tests, so is not ready for merging yet.

See https://github.com/fishtown-analytics/dbt/issues/1544