### PR TITLE
require versions in package defs (#1546)

### DIFF
--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -243,7 +243,7 @@ REGISTRY_PACKAGE_CONTRACT = {
             'description': 'The version of the package',
         },
     },
-    'required': ['package'],
+    'required': ['package', 'version'],
 }
 
 

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -118,6 +118,11 @@ class RegistryPackage(Package):
     SCHEMA = REGISTRY_PACKAGE_CONTRACT
 
     def __init__(self, *args, **kwargs):
+        if 'version' not in kwargs:
+            dbt.exceptions.raise_dependency_error(
+                'package dependency {} is missing a "version" field'
+                .format(kwargs.get('package'))
+            )
         super(RegistryPackage, self).__init__(*args, **kwargs)
         self._version = self._sanitize_version(self._contents['version'])
 

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -73,7 +73,7 @@ class TestHubPackage(unittest.TestCase):
         self.assertEqual(a.source_type(), 'hub')
 
     def test_invalid(self):
-        with self.assertRaises(dbt.exceptions.ValidationException):
+        with self.assertRaises(dbt.exceptions.DependencyException):
             RegistryPackage(package='namespace/name', key='invalid')
 
     def test_resolve_ok(self):


### PR DESCRIPTION
Fixed #1546 

seems better?:
```
$ dbt deps
Running with dbt=0.14.0-a1
Encountered an error:
package dependency fishtown-analytics/dbt_utils is missing a "version" field
```