### PR TITLE
Fix casing comparisons on dbt-created relations (#1555)

### DIFF
--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -343,7 +343,8 @@ class ModelRunner(CompileRunner):
         materialization_macro.generator(context)()
 
         # we must have built a new model, add it to the cache
-        relation = self.adapter.Relation.create_from_node(self.config, model)
+        relation = self.adapter.Relation.create_from_node(self.config, model,
+                                                          dbt_created=True)
         self.adapter.cache_new_relation(relation)
 
         result = context['load_result']('main')

--- a/plugins/bigquery/dbt/adapters/bigquery/relation.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/relation.py
@@ -15,13 +15,14 @@ class BigQueryRelation(BaseRelation):
         'quote_policy': {
             'database': True,
             'schema': True,
-            'identifier': True
+            'identifier': True,
         },
         'include_policy': {
             'database': True,
             'schema': True,
-            'identifier': True
-        }
+            'identifier': True,
+        },
+        'dbt_created': False,
     }
 
     SCHEMA = {
@@ -43,9 +44,10 @@ class BigQueryRelation(BaseRelation):
             'include_policy': BaseRelation.POLICY_SCHEMA,
             'quote_policy': BaseRelation.POLICY_SCHEMA,
             'quote_character': {'type': 'string'},
+            'dbt_created': {'type': 'boolean'},
         },
         'required': ['metadata', 'type', 'path', 'include_policy',
-                     'quote_policy', 'quote_character']
+                     'quote_policy', 'quote_character', 'dbt_created']
     }
 
     def matches(self, database=None, schema=None, identifier=None):
@@ -60,7 +62,7 @@ class BigQueryRelation(BaseRelation):
             pass
 
         for k, v in search.items():
-            if self.get_path_part(k) != v:
+            if not self._is_exactish_match(k, v):
                 return False
 
         return True

--- a/plugins/snowflake/dbt/adapters/snowflake/relation.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/relation.py
@@ -16,7 +16,8 @@ class SnowflakeRelation(BaseRelation):
             'database': True,
             'schema': True,
             'identifier': True,
-        }
+        },
+        'dbt_created': False,
     }
 
     SCHEMA = {
@@ -38,9 +39,10 @@ class SnowflakeRelation(BaseRelation):
             'include_policy': BaseRelation.POLICY_SCHEMA,
             'quote_policy': BaseRelation.POLICY_SCHEMA,
             'quote_character': {'type': 'string'},
+            'dbt_created': {'type': 'boolean'},
         },
         'required': ['metadata', 'type', 'path', 'include_policy',
-                     'quote_policy', 'quote_character']
+                     'quote_policy', 'quote_character', 'dbt_created']
     }
 
     @classmethod

--- a/test/integration/001_simple_copy_test/models/get_and_ref.sql
+++ b/test/integration/001_simple_copy_test/models/get_and_ref.sql
@@ -1,0 +1,3 @@
+{%- do adapter.get_relation(database=target.database, schema=target.schema, identifier='materialized') -%}
+
+select * from {{ ref('materialized') }}

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -24,17 +24,17 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized", "get_and_ref"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized", "get_and_ref"])
 
     @use_profile("postgres")
     def test__postgres__dbt_doesnt_run_empty_models(self):
@@ -43,7 +43,7 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
         models = self.get_models_in_schema()
 
@@ -57,7 +57,7 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(expect_pass=False)
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
         for result in results:
             if 'incremental' in result.node.name:
                 self.assertIn('not implemented for presto', result.error)
@@ -71,17 +71,17 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({
             "test-paths": [self.dir("tests")],
@@ -99,9 +99,9 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({
             "data-paths": [self.dir("seed-update")],
@@ -110,9 +110,9 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({
             "test-paths": [self.dir("tests")],
@@ -150,22 +150,24 @@ class TestSimpleCopy(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertTablesEqual("seed","view_model")
-        self.assertTablesEqual("seed","incremental")
-        self.assertTablesEqual("seed","materialized")
+        self.assertTablesEqual("seed", "view_model")
+        self.assertTablesEqual("seed", "incremental")
+        self.assertTablesEqual("seed", "materialized")
+        self.assertTablesEqual("seed", "get_and_ref")
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
 
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertTablesEqual("seed","view_model")
-        self.assertTablesEqual("seed","incremental")
-        self.assertTablesEqual("seed","materialized")
+        self.assertTablesEqual("seed", "view_model")
+        self.assertTablesEqual("seed", "incremental")
+        self.assertTablesEqual("seed", "materialized")
+        self.assertTablesEqual("seed", "get_and_ref")
 
 
 class TestSimpleCopyQuotingIdentifierOn(BaseTestSimpleCopy):
@@ -186,9 +188,9 @@ class TestSimpleCopyQuotingIdentifierOn(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized", "get_and_ref"])
 
         self.use_default_project({
             "data-paths": [self.dir("seed-update")],
@@ -196,9 +198,9 @@ class TestSimpleCopyQuotingIdentifierOn(BaseTestSimpleCopy):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized"])
+        self.assertManyTablesEqual(["seed", "view_model", "incremental", "materialized", "get_and_ref"])
 
         # can't run the test as this one's identifiers will be the wrong case
 
@@ -218,18 +220,18 @@ class TestSnowflakeSimpleLowercasedSchemaCopy(BaseLowercasedSchemaTest):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({"data-paths": [self.dir("seed-update")]})
 
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()
-        self.assertEqual(len(results),  6)
+        self.assertEqual(len(results),  7)
 
-        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED"])
+        self.assertManyTablesEqual(["SEED", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"])
 
         self.use_default_project({
             "test-paths": [self.dir("tests")],


### PR DESCRIPTION
Fixes #1555 

This might fix #1557 - hard to say as I couldn't figure out how to reproduce this one. I agree it's probably related though.

When dbt creates a relation in the db, add a special flag to the relation (defaults to False)
When checking a node name match:
 - if that flag is present and quoting is disabled, do a lowercase compare
 - otherwise remain case sensitive
