### PR TITLE
improve strict undefined

### DIFF
--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 STRICT_MODE = False
 FULL_REFRESH = False
 USE_CACHE = True
@@ -5,8 +7,21 @@ WARN_ERROR = False
 TEST_NEW_PARSER = False
 
 
+PARSE_MODE = False
+
+
+@contextmanager
+def parse_context():
+    global PARSE_MODE
+    initial = PARSE_MODE
+    PARSE_MODE = True
+    yield
+    PARSE_MODE = initial
+
+
 def reset():
-    global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER
+    global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER, \
+        PARSE_MODE
 
     STRICT_MODE = False
     FULL_REFRESH = False
@@ -16,7 +31,8 @@ def reset():
 
 
 def set_from_args(args):
-    global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER
+    global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER, \
+        PARSE_MODE
     USE_CACHE = getattr(args, 'use_cache', True)
 
     FULL_REFRESH = getattr(args, 'full_refresh', False)
@@ -27,3 +43,4 @@ def set_from_args(args):
     )
 
     TEST_NEW_PARSER = getattr(args, 'test_new_parser', False)
+    PARSE_MODE = False

--- a/core/dbt/loader.py
+++ b/core/dbt/loader.py
@@ -8,7 +8,6 @@ import dbt.flags
 from dbt.node_types import NodeType
 from dbt.contracts.graph.manifest import Manifest
 from dbt.utils import timestring
-
 from dbt.parser import MacroParser, ModelParser, SeedParser, AnalysisParser, \
     DocumentationParser, DataTestParser, HookParser, SchemaParser, \
     ParserUtils, SnapshotParser
@@ -160,7 +159,8 @@ class GraphLoader(object):
             ProjectList(**projects)
 
         loader = cls(root_config, projects)
-        loader.load(internal_manifest=internal_manifest)
+        with dbt.flags.parse_context():
+            loader.load(internal_manifest=internal_manifest)
         return loader.create_manifest()
 
     @classmethod

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -294,8 +294,11 @@ class CompileRunner(BaseRunner):
         return RunModelResult(compiled_node)
 
     def compile(self, manifest):
-        return compile_node(self.adapter, self.config, self.node, manifest, {})
-
+        extra_context = {}
+        if self.node.resource_type == NodeType.Operation:
+            extra_context = {'schemas': [], 'results': []}
+        return compile_node(self.adapter, self.config, self.node, manifest,
+                            extra_context)
 
 class ModelRunner(CompileRunner):
     def get_node_representation(self):

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -300,6 +300,7 @@ class CompileRunner(BaseRunner):
         return compile_node(self.adapter, self.config, self.node, manifest,
                             extra_context)
 
+
 class ModelRunner(CompileRunner):
     def get_node_representation(self):
         if self.config.credentials.database == self.node.database:

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -21,7 +21,6 @@ from dbt.compat import QueueEmpty
 from dbt import flags
 from dbt.logger import RPC_LOGGER as logger
 from dbt.logger import add_queue_handler
-from dbt.clients.jinja import WARNING_CACHE
 import dbt.exceptions
 
 
@@ -143,8 +142,6 @@ def _nt_setup(config, args):
     """
     # reset flags
     flags.set_from_args(args)
-    # reset the warning cache
-    WARNING_CACHE.clear()
     # reload the active plugin
     load_plugin(config.credentials.type)
 

--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -21,6 +21,7 @@ from dbt.compat import QueueEmpty
 from dbt import flags
 from dbt.logger import RPC_LOGGER as logger
 from dbt.logger import add_queue_handler
+from dbt.clients.jinja import WARNING_CACHE
 import dbt.exceptions
 
 
@@ -142,6 +143,8 @@ def _nt_setup(config, args):
     """
     # reset flags
     flags.set_from_args(args)
+    # reset the warning cache
+    WARNING_CACHE.clear()
     # reload the active plugin
     load_plugin(config.credentials.type)
 

--- a/test/integration/014_hook_tests/test_run_hooks.py
+++ b/test/integration/014_hook_tests/test_run_hooks.py
@@ -46,6 +46,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
                 "drop table {{ target.schema }}.end_hook_order_test",
                 "create table {{ target.schema }}.schemas ( schema text )",
                 "insert into {{ target.schema }}.schemas values ({% for schema in schemas %}( '{{ schema }}' ){% if not loop.last %},{% endif %}{% endfor %})",
+                "{% for result in results %} {{ log(result) }} {% endfor %}",
             ]
         }
 
@@ -89,6 +90,7 @@ class TestPrePostRunHooks(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__pre_and_post_run_hooks(self):
+        self.run_dbt(['compile'])  # test for #1554
         self.run_dbt(['run'])
 
         self.check_hooks('start')

--- a/test/integration/030_statement_test/macros/macro_stmt.sql
+++ b/test/integration/030_statement_test/macros/macro_stmt.sql
@@ -1,0 +1,22 @@
+{% macro load_result_testing(relation) %}
+    {%- call statement('test_stmt', fetch_result=True) %}
+
+      select
+        count(*) as "num_records"
+
+      from {{ relation }}
+
+    {% endcall -%}
+    {% set result = load_result('test_stmt') %}
+
+    {% set res_table = result['table'] %}
+    {% set res_matrix = result['data'] %}
+    {% for result in res_matrix %}
+        {% set matrix_value = res_matrix[loop.index0][0] %}
+        {% set table_value = res_table[loop.index0]['num_records'] %}
+        select 'matrix' as source, {{ matrix_value }} as value
+        union all
+        select 'table' as source, {{ table_value }} as value
+        {{ "" if loop.last else "union all" }}
+    {% endfor %}
+{% endmacro %}

--- a/test/integration/030_statement_test/macros/macro_stmt.sql
+++ b/test/integration/030_statement_test/macros/macro_stmt.sql
@@ -2,7 +2,7 @@
     {%- call statement('test_stmt', fetch_result=True) %}
 
       select
-        count(*) as "num_records"
+        count(*) as {{ adapter.quote("num_records") }}
 
       from {{ relation }}
 

--- a/test/integration/030_statement_test/models-bq/statement_macro.sql
+++ b/test/integration/030_statement_test/models-bq/statement_macro.sql
@@ -1,0 +1,1 @@
+{{ load_result_testing(ref('seed')) }}

--- a/test/integration/030_statement_test/models/statement_macro.sql
+++ b/test/integration/030_statement_test/models/statement_macro.sql
@@ -1,0 +1,1 @@
+{{ load_result_testing(ref('seed')) }}

--- a/test/integration/030_statement_test/test_statements.py
+++ b/test/integration/030_statement_test/test_statements.py
@@ -22,9 +22,10 @@ class TestStatements(DBTIntegrationTest):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results), 2)
         results = self.run_dbt()
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
-        self.assertTablesEqual("statement_actual","statement_expected")
+        self.assertTablesEqual("statement_actual", "statement_expected")
+        self.assertTablesEqual("statement_macro", "statement_expected")
 
     @use_profile("snowflake")
     def test_snowflake_statements(self):
@@ -33,9 +34,9 @@ class TestStatements(DBTIntegrationTest):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results), 2)
         results = self.run_dbt()
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
-        self.assertManyTablesEqual(["STATEMENT_ACTUAL", "STATEMENT_EXPECTED"])
+        self.assertManyTablesEqual(["STATEMENT_ACTUAL", "STATEMENT_EXPECTED", "STATEMENT_MACRO"])
 
     @use_profile("presto")
     def test_presto_statements(self):
@@ -44,9 +45,10 @@ class TestStatements(DBTIntegrationTest):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results), 2)
         results = self.run_dbt()
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
-        self.assertTablesEqual("statement_actual","statement_expected")
+        self.assertTablesEqual("statement_actual", "statement_expected")
+        self.assertTablesEqual("statement_macro", "statement_expected")
 
 class TestStatementsBigquery(DBTIntegrationTest):
 
@@ -69,7 +71,7 @@ class TestStatementsBigquery(DBTIntegrationTest):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results), 2)
         results = self.run_dbt()
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
-        self.assertTablesEqual("statement_actual","statement_expected")
-
+        self.assertTablesEqual("statement_actual", "statement_expected")
+        self.assertTablesEqual("statement_macro", "statement_expected")

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -20,7 +20,7 @@ from mock import patch
 import dbt.main as dbt
 import dbt.flags as flags
 from dbt.adapters.factory import get_adapter, reset_adapters
-from dbt.clients.jinja import template_cache
+from dbt.clients.jinja import template_cache, WARNING_CACHE
 from dbt.config import RuntimeConfig
 from dbt.compat import basestring
 from dbt.context import common
@@ -324,6 +324,7 @@ class DBTIntegrationTest(unittest.TestCase):
         self._created_schemas = set()
         flags.reset()
         template_cache.clear()
+        WARNING_CACHE.clear()
         # disable capturing warnings
         logging.captureWarnings(False)
 
@@ -520,10 +521,6 @@ class DBTIntegrationTest(unittest.TestCase):
         final_args.append('--log-cache-events')
 
         logger.info("Invoking dbt with {}".format(final_args))
-        if args is None:
-            args = ["run"]
-
-        logger.info("Invoking dbt with {}".format(args))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):
@@ -546,7 +543,6 @@ class DBTIntegrationTest(unittest.TestCase):
         if kwargs is None:
             kwargs = {}
         base_kwargs.update(kwargs)
-
 
         to_return = to_return.format(**base_kwargs)
 


### PR DESCRIPTION
Fixes #1544 

- During parsing, leave undefined values as non-strict
- Create a warning cache to avoid duplicate warnings when macros contain an undefined value
- When compiling hooks, add empty `results` and `schemas` to their context.
- Added some tests to expose this behavior