### PR TITLE
add strategy switch for incremental merge behavior (snowflake)

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -4,8 +4,8 @@
   {{ adapter_macro('get_merge_sql', target, source, unique_key, dest_columns) }}
 {%- endmacro %}
 
-{% macro get_overwrite_merge_sql(target, source, unique_key, dest_columns) -%}
-  {{ adapter_macro('get_overwrite_merge_sql', target, source, unique_key, dest_columns) }}
+{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
+  {{ adapter_macro('get_delete_insert_merge_sql', target, source, unique_key, dest_columns) }}
 {%- endmacro %}
 
 
@@ -47,7 +47,7 @@
 {% endmacro %}
 
 
-{% macro common_get_overwrite_merge_sql(target, source, unique_key, dest_columns) -%}
+{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute="name") | join(', ') -%}
 
     {% if unique_key is not none %}
@@ -66,6 +66,6 @@
 
 {%- endmacro %}
 
-{% macro default__get_overwrite_merge_sql(target, source, unique_key, dest_columns) -%}
-    {{ common_get_overwrite_merge_sql(target, source, unique_key, dest_columns) }}
+{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
+    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) }}
 {% endmacro %}

--- a/core/dbt/parser/source_config.py
+++ b/core/dbt/parser/source_config.py
@@ -17,8 +17,7 @@ class SourceConfig(object):
         'database',
         'severity',
 
-        'strategy',
-        'incremental.strategy'
+        'incremental_strategy'
     }
 
     ConfigKeys = AppendListFields | ExtendDictFields | ClobberFields

--- a/core/dbt/parser/source_config.py
+++ b/core/dbt/parser/source_config.py
@@ -16,6 +16,9 @@ class SourceConfig(object):
         'unique_key',
         'database',
         'severity',
+
+        'strategy',
+        'incremental.strategy'
     }
 
     ConfigKeys = AppendListFields | ExtendDictFields | ClobberFields

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -13,6 +13,18 @@
 
   {%- set tmp_relation = make_temp_relation(target_relation) %}
 
+  {#-- Find and validate the incremental strategy #}
+  {%- set incremental_strategy = config.get("incremental.strategy", default="merge") -%}
+  {%- set strategy = config.get('strategy', default=incremental_strategy) -%}
+
+  {% set invalid_strategy_msg -%}
+    Invalid incremental strategy provided: {{ strategy }}
+    Expected one of: 'merge', 'overwrite'
+  {%- endset %}
+  {% if strategy not in ['merge', 'overwrite'] %}
+    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+  {% endif %}
+
   -- setup
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -41,15 +53,15 @@
 
     {{ adapter.expand_target_column_types(from_relation=tmp_relation,
                                           to_relation=target_relation) }}
-    {% set incremental_sql %}
-    (
-        select * from {{ tmp_relation }}
-    )
-    {% endset %}
-
     {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
     {%- call statement('main') -%}
-      {{ get_merge_sql(target_relation, incremental_sql, unique_key, dest_columns) }}
+      {% if strategy == 'merge' %}
+        {{ get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) }}
+      {% elif strategy == 'overwrite' %}
+        {{ get_overwrite_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) }}
+      {% else %}
+        {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
+      {% endif %}
     {% endcall %}
 
   {%- endif %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -14,14 +14,13 @@
   {%- set tmp_relation = make_temp_relation(target_relation) %}
 
   {#-- Find and validate the incremental strategy #}
-  {%- set incremental_strategy = config.get("incremental.strategy", default="merge") -%}
-  {%- set strategy = config.get('strategy', default=incremental_strategy) -%}
+  {%- set strategy = config.get("incremental_strategy", default="merge") -%}
 
   {% set invalid_strategy_msg -%}
     Invalid incremental strategy provided: {{ strategy }}
-    Expected one of: 'merge', 'overwrite'
+    Expected one of: 'merge', 'delete+insert'
   {%- endset %}
-  {% if strategy not in ['merge', 'overwrite'] %}
+  {% if strategy not in ['merge', 'delete+insert'] %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {% endif %}
 
@@ -57,8 +56,8 @@
     {%- call statement('main') -%}
       {% if strategy == 'merge' %}
         {{ get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) }}
-      {% elif strategy == 'overwrite' %}
-        {{ get_overwrite_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) }}
+      {% elif strategy == 'delete+insert' %}
+        {{ get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) }}
       {% else %}
         {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
       {% endif %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
@@ -1,17 +1,25 @@
-{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns) %}
+{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns) -%}
+
+    {#
+       Workaround for Snowflake not being happy with a merge on a constant-false predicate.
+       When no unique_key is provided, this macro will do a regular insert. If a unique_key
+       is provided, then this macro will do a proper merge instead.
+    #}
+
     {%- set dest_cols_csv = dest_columns | map(attribute="name") | join(', ') -%}
-        {%- if unique_key is none -%}
-            {# workaround for Snowflake not being happy with "on false" merge.
-            when no unique key is provided we'll do a regular insert, other times we'll
-            use the preferred merge. #}
-            insert into {{ target }} ({{ dest_cols_csv }})
-            (
-                select {{ dest_cols_csv }}
-                from {{ source_sql }}
-            );
-        {%- else -%}
-        {# call regular merge when a unique key is present. #}
+
+    {%- if unique_key is none -%}
+
+        insert into {{ target }} ({{ dest_cols_csv }})
+        (
+            select {{ dest_cols_csv }}
+            from {{ source_sql }}
+        );
+
+    {%- else -%}
+
         {{ common_get_merge_sql(target, source_sql, unique_key, dest_columns) }}
-        {%- endif -%}
+
+    {%- endif -%}
 
 {% endmacro %}

--- a/test/integration/001_simple_copy_test/models-snowflake/incremental_overwrite.sql
+++ b/test/integration/001_simple_copy_test/models-snowflake/incremental_overwrite.sql
@@ -1,0 +1,9 @@
+
+{{ config(materialized='incremental', unique_key='id') }}
+
+-- this will fail on snowflake with "merge" due
+-- to the nondeterministic join on id
+
+select 1 as id
+union all
+select 1 as id

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -259,3 +259,27 @@ class TestSnowflakeSimpleLowercasedSchemaQuoted(BaseLowercasedSchemaTest):
             "quoting": {"identifier": False, "schema": False},
         })
         results = self.run_dbt(["seed"], expect_pass=False)
+
+
+class TestSnowflakeIncrementalOverwrite(BaseTestSimpleCopy):
+    @property
+    def models(self):
+        return self.dir("models-snowflake")
+
+    @use_profile("snowflake")
+    def test__snowflake__incremental_overwrite(self):
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results),  1)
+
+        results = self.run_dbt(["run"], expect_pass=False)
+        self.assertEqual(len(results),  1)
+
+        # Setting the incremental_strategy should make this succeed
+        self.use_default_project({
+            "models": {"incremental_strategy": "delete+insert"}
+        })
+
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results),  1)
+
+


### PR DESCRIPTION
The big idea:
 - add a `strategy` that switches between `merge` and `delete+insert`
 - I added a top-level config, `incremental_strategy` which can be configured from `dbt_project.yml`

Usage:
1. in `dbt_project.yml`
```
models:
  incremental.strategy: delete+insert
```

2. in models
```
{{ config(materialized='incremental', unique_key='date_day', incremental_strategy='delete+insert') }}
```

TODO:
 - [x] add tests