### PR TITLE
add sugar over statements (run_query)

### DIFF
--- a/core/dbt/include/global_project/macros/etc/query.sql
+++ b/core/dbt/include/global_project/macros/etc/query.sql
@@ -1,0 +1,8 @@
+
+{% macro run_query(sql) %}
+  {% call statement("run_query_statement", fetch_result=true, auto_begin=false) %}
+    {{ sql }}
+  {% endcall %}
+
+  {% do return(load_result("run_query_statement").table) %}
+{% endmacro %}

--- a/test/integration/044_run_operations_test/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_test/macros/happy_macros.sql
@@ -17,15 +17,28 @@
   {% endif %}
 {% endmacro %}
 
+{% macro select_something(name) %}
+  {% set query %}
+    select 'hello, {{ name }}' as name
+  {% endset %}
+  {% set table = run_query(query) %}
+
+  {% if table.columns['name'][0] != 'hello, world' %}
+    {% do exceptions.raise_compiler_error("unexpected result: " ~ table) %}
+  {% endif %}
+{% endmacro %}
+
 {% macro vacuum(table_name) %}
-  {% call statement(auto_begin=false) %}
+  {% set query %}
     vacuum "{{ schema }}"."{{ table_name }}"
-  {% endcall %}
+  {% endset %}
+  {% do run_query(query) %}
 {% endmacro %}
 
 
 {% macro vacuum_ref(ref_target) %}
-  {% call statement('stmt', auto_begin=false) %}
+  {% set query %}
     vacuum {{ ref(ref_target) }}
-  {% endcall %}
+  {% endset %}
+  {% do run_query(query) %}
 {% endmacro %}

--- a/test/integration/044_run_operations_test/test_run_operations.py
+++ b/test/integration/044_run_operations_test/test_run_operations.py
@@ -60,3 +60,7 @@ class TestOperations(DBTIntegrationTest):
         self.run_dbt(['run'])
         # this should succeed
         self.run_operation('vacuum_ref', ref_target='model')
+
+    @use_profile('postgres')
+    def test__postgres_select(self):
+        self.run_operation('select_something', name='world')


### PR DESCRIPTION
Closes #1563 

```
{% macro my_macro(name) %}
    {% set sql %}
      select 'hello, {{ name }}' as name
    {% endset %}
    {% set table = run_query(sql) %}

{% endmacro %}
```

```
$ dbt run-operation my_macro --args 'name: drew'
```

:boom: