### PR TITLE
Remove agate from nodes

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -349,8 +349,7 @@ PARSED_NODE_CONTRACT = deep_merge(
 class ParsedNode(APIObject):
     SCHEMA = PARSED_NODE_CONTRACT
 
-    def __init__(self, agate_table=None, **kwargs):
-        self.agate_table = agate_table
+    def __init__(self, **kwargs):
         kwargs.setdefault('columns', {})
         kwargs.setdefault('description', '')
         super().__init__(**kwargs)
@@ -373,23 +372,11 @@ class ParsedNode(APIObject):
         return self.depends_on['nodes']
 
     def to_dict(self):
-        """Similar to 'serialize', but tacks the agate_table attribute in too.
-        Why we need this:
-            - networkx demands that the attr_dict it gets (the node) be a dict
-                or subclass and does not respect the abstract Mapping class
-            - many jinja things access the agate_table attribute (member) of
-                the node dict.
-            - the nodes are passed around between those two contexts in a way
-                that I don't quite have clear enough yet.
-        """
         ret = self.serialize()
-        # note: not a copy/deep copy.
-        ret['agate_table'] = self.agate_table
         return ret
 
     def to_shallow_dict(self):
         ret = self._contents.copy()
-        ret['agate_table'] = self.agate_table
         return ret
 
     def patch(self, patch):

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -144,9 +144,11 @@ class RunModelResult(NodeSerializable):
     SCHEMA = RUN_MODEL_RESULT_CONTRACT
 
     def __init__(self, node, error=None, skip=False, status=None, failed=None,
-                 thread_id=None, timing=None, execution_time=0):
+                 thread_id=None, timing=None, execution_time=0,
+                 agate_table=None):
         if timing is None:
             timing = []
+        self.agate_table = agate_table
         super().__init__(
             node=node,
             error=error,

--- a/core/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -98,6 +98,7 @@
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
   {%- set csv_table = load_agate_table(model['original_file_path']) -%}
+  {%- do store_result('agate_table', status='OK', agate_table=csv_table) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 

--- a/core/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -97,7 +97,7 @@
   {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
-  {%- set agate_table = load_agate_table(model['original_file_path']) -%}
+  {%- set agate_table = load_agate_table() -%}
   {%- do store_result('agate_table', status='OK', agate_table=agate_table) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/core/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -1,24 +1,23 @@
 
-{% macro create_csv_table(model) -%}
-  {{ adapter_macro('create_csv_table', model) }}
+{% macro create_csv_table(model, csv_table) -%}
+  {{ adapter_macro('create_csv_table', model, csv_table) }}
 {%- endmacro %}
 
-{% macro reset_csv_table(model, full_refresh, old_relation) -%}
-  {{ adapter_macro('reset_csv_table', model, full_refresh, old_relation) }}
+{% macro reset_csv_table(model, full_refresh, old_relation, csv_table) -%}
+  {{ adapter_macro('reset_csv_table', model, full_refresh, old_relation, csv_table) }}
 {%- endmacro %}
 
-{% macro load_csv_rows(model) -%}
-  {{ adapter_macro('load_csv_rows', model) }}
+{% macro load_csv_rows(model, csv_table) -%}
+  {{ adapter_macro('load_csv_rows', model, csv_table) }}
 {%- endmacro %}
 
-{% macro default__create_csv_table(model) %}
-  {%- set agate_table = model['agate_table'] -%}
+{% macro default__create_csv_table(model, csv_table) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
 
   {% set sql %}
     create table {{ this.render(False) }} (
-        {%- for col_name in agate_table.column_names -%}
-            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
+        {%- for col_name in csv_table.column_names -%}
+            {%- set inferred_type = adapter.convert_type(csv_table, loop.index0) -%}
             {%- set type = column_override.get(col_name, inferred_type) -%}
             {{ col_name | string }} {{ type }} {%- if not loop.last -%}, {%- endif -%}
         {%- endfor -%}
@@ -33,11 +32,11 @@
 {% endmacro %}
 
 
-{% macro default__reset_csv_table(model, full_refresh, old_relation) %}
+{% macro default__reset_csv_table(model, full_refresh, old_relation, csv_table) %}
     {% set sql = "" %}
     {% if full_refresh %}
         {{ adapter.drop_relation(old_relation) }}
-        {% set sql = create_csv_table(model) %}
+        {% set sql = create_csv_table(model, csv_table) %}
     {% else %}
         {{ adapter.truncate_relation(old_relation) }}
         {% set sql = "truncate table " ~ old_relation %}
@@ -47,14 +46,13 @@
 {% endmacro %}
 
 
-{% macro basic_load_csv_rows(model, batch_size) %}
-    {% set agate_table = model['agate_table'] %}
-    {% set cols_sql = ", ".join(agate_table.column_names) %}
+{% macro basic_load_csv_rows(model, batch_size, csv_table) %}
+    {% set cols_sql = ", ".join(csv_table.column_names) %}
     {% set bindings = [] %}
 
     {% set statements = [] %}
 
-    {% for chunk in agate_table.rows | batch(batch_size) %}
+    {% for chunk in csv_table.rows | batch(batch_size) %}
         {% set bindings = [] %}
 
         {% for row in chunk %}
@@ -64,7 +62,7 @@
         {% set sql %}
             insert into {{ this.render(False) }} ({{ cols_sql }}) values
             {% for row in chunk -%}
-                ({%- for column in agate_table.column_names -%}
+                ({%- for column in csv_table.column_names -%}
                     %s
                     {%- if not loop.last%},{%- endif %}
                 {%- endfor -%})
@@ -84,8 +82,8 @@
 {% endmacro %}
 
 
-{% macro default__load_csv_rows(model) %}
-  {{ return(basic_load_csv_rows(model, 10000) )}}
+{% macro default__load_csv_rows(model, csv_table) %}
+  {{ return(basic_load_csv_rows(model, 10000, csv_table) )}}
 {% endmacro %}
 
 
@@ -99,7 +97,7 @@
   {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
-  {%- set csv_table = model["agate_table"] -%}
+  {%- set csv_table = load_agate_table(model['original_file_path']) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -111,14 +109,14 @@
   {% if exists_as_view %}
     {{ exceptions.raise_compiler_error("Cannot seed to '{}', it is a view".format(old_relation)) }}
   {% elif exists_as_table %}
-    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation) %}
+    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, csv_table) %}
   {% else %}
-    {% set create_table_sql = create_csv_table(model) %}
+    {% set create_table_sql = create_csv_table(model, csv_table) %}
   {% endif %}
 
   {% set status = 'CREATE' if full_refresh_mode else 'INSERT' %}
   {% set num_rows = (csv_table.rows | length) %}
-  {% set sql = load_csv_rows(model) %}
+  {% set sql = load_csv_rows(model, csv_table) %}
 
   {% call noop_statement('main', status ~ ' ' ~ num_rows) %}
     {{ create_table_sql }};

--- a/core/dbt/linker.py
+++ b/core/dbt/linker.py
@@ -6,11 +6,6 @@ import threading
 from dbt.node_types import NodeType
 
 
-GRAPH_SERIALIZE_BLACKLIST = [
-    'agate_table'
-]
-
-
 def from_file(graph_file):
     linker = Linker()
     linker.read_graph(graph_file)
@@ -264,10 +259,6 @@ class Linker:
 def _updated_graph(graph, manifest):
     graph = graph.copy()
     for node_id in graph.nodes():
-        # serialize() removes the agate table
         data = manifest.nodes[node_id].serialize()
-        for key in GRAPH_SERIALIZE_BLACKLIST:
-            if key in data:
-                del data[key]
         graph.add_node(node_id, **data)
     return graph

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -139,16 +139,10 @@ class MacrosKnownParser(BaseParser):
 
     def _build_intermediate_node_dict(self, config, node_dict, node_path,
                                       package_project_config, tags, fqn,
-                                      agate_table, snapshot_config,
-                                      column_name):
+                                      snapshot_config, column_name):
         """Update the unparsed node dictionary and build the basis for an
         intermediate ParsedNode that will be passed into the renderer
         """
-        # because this takes and returns dicts, subclasses can safely override
-        # this and mutate its results using super() both before and after.
-        if agate_table is not None:
-            node_dict['agate_table'] = agate_table
-
         # Set this temporarily. Not the full config yet (as config() hasn't
         # been called from jinja yet). But the Var() call below needs info
         # about project level configs b/c they might contain refs.
@@ -245,11 +239,10 @@ class MacrosKnownParser(BaseParser):
                                                                 hook_type)
 
     def parse_node(self, node, node_path, package_project_config, tags=None,
-                   fqn_extra=None, fqn=None, agate_table=None,
-                   snapshot_config=None, column_name=None):
+                   fqn_extra=None, fqn=None, snapshot_config=None,
+                   column_name=None):
         """Parse a node, given an UnparsedNode and any other required information.
 
-        agate_table should be set if the node came from a seed file.
         snapshot_config should be set if the node is an Snapshot node.
         column_name should be set if the node is a Test node associated with a
         particular column.
@@ -270,7 +263,7 @@ class MacrosKnownParser(BaseParser):
 
         parsed_dict = self._build_intermediate_node_dict(
             config, node.serialize(), node_path, config, tags, fqn,
-            agate_table, snapshot_config, column_name
+            snapshot_config, column_name
         )
         parsed_node = ParsedNode(**parsed_dict)
 

--- a/core/dbt/task/seed.py
+++ b/core/dbt/task/seed.py
@@ -27,7 +27,7 @@ class SeedTask(RunTask):
         dbt.ui.printer.print_run_end_messages(results)
 
     def show_table(self, result):
-        table = result.node.agate_table
+        table = result.agate_table
         rand_table = table.order_by(lambda x: random.random())
 
         schema = result.node.schema

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
@@ -1,15 +1,16 @@
 
-{% macro bigquery__create_csv_table(model, csv_table) %}
+{% macro bigquery__create_csv_table(model, agate_table) %}
     -- no-op
 {% endmacro %}
 
-{% macro bigquery__reset_csv_table(model, full_refresh, old_relation, csv_table) %}
+{% macro bigquery__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
     {{ adapter.drop_relation(old_relation) }}
 {% endmacro %}
 
-{% macro bigquery__load_csv_rows(model, csv_table) %}
+{% macro bigquery__load_csv_rows(model, agate_table) %}
 
   {%- set column_override = model['config'].get('column_types', {}) -%}
-  {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'], csv_table, column_override) }}
+  {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'],
+  							agate_table, column_override) }}
 
 {% endmacro %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
@@ -1,15 +1,15 @@
 
-{% macro bigquery__create_csv_table(model) %}
+{% macro bigquery__create_csv_table(model, csv_table) %}
     -- no-op
 {% endmacro %}
 
-{% macro bigquery__reset_csv_table(model, full_refresh, old_relation) %}
+{% macro bigquery__reset_csv_table(model, full_refresh, old_relation, csv_table) %}
     {{ adapter.drop_relation(old_relation) }}
 {% endmacro %}
 
-{% macro bigquery__load_csv_rows(model) %}
+{% macro bigquery__load_csv_rows(model, csv_table) %}
 
   {%- set column_override = model['config'].get('column_types', {}) -%}
-  {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'], model['agate_table'], column_override) }}
+  {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'], csv_table, column_override) }}
 
 {% endmacro %}

--- a/test/integration/005_simple_seed_test/test_seed_type_override.py
+++ b/test/integration/005_simple_seed_test/test_seed_type_override.py
@@ -41,7 +41,7 @@ class TestSimpleSeedColumnOverridePostgres(TestSimpleSeedColumnOverride):
 
     @use_profile('postgres')
     def test_simple_seed_with_column_override_postgres(self):
-        results = self.run_dbt(["seed"])
+        results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
@@ -64,7 +64,7 @@ class TestSimpleSeedColumnOverrideRedshift(TestSimpleSeedColumnOverride):
 
     @use_profile('redshift')
     def test_simple_seed_with_column_override_redshift(self):
-        results = self.run_dbt(["seed"])
+        results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
@@ -87,7 +87,7 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
 
     @use_profile('snowflake')
     def test_simple_seed_with_column_override_snowflake(self):
-        results = self.run_dbt(["seed"])
+        results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
@@ -110,7 +110,7 @@ class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
 
     @use_profile('bigquery')
     def test_simple_seed_with_column_override_bigquery(self):
-        results = self.run_dbt(["seed"])
+        results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -33,8 +33,7 @@ class TestSimpleSeed(DBTIntegrationTest):
         self.assertTablesEqual("seed_actual","seed_expected")
 
         # this should truncate the seed_actual table, then re-insert.
-        # also, '--show' should not crash dbt!
-        results = self.run_dbt(["seed", '--show'])
+        results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         self.assertTablesEqual("seed_actual","seed_expected")
 

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -161,8 +161,7 @@ class TestSeedParsing(DBTIntegrationTest):
         self.assertEqual(len(self.run_dbt(['run'])), 1)
 
         # make sure 'dbt seed' fails, otherwise our test is invalid!
-        with self.assertRaises(CompilationException):
-            self.run_dbt(['seed'])
+        self.run_dbt(['seed'], expect_pass=False)
 
 
 class TestSimpleSeedWithBOM(DBTIntegrationTest):

--- a/test/integration/023_exit_codes_test/test_exit_codes.py
+++ b/test/integration/023_exit_codes_test/test_exit_codes.py
@@ -116,6 +116,7 @@ class TestExitCodesDeps(DBTIntegrationTest):
         _, success = self.run_dbt_and_check(['deps'])
         self.assertTrue(success)
 
+
 class TestExitCodesDepsFail(DBTIntegrationTest):
     @property
     def schema(self):
@@ -124,7 +125,6 @@ class TestExitCodesDepsFail(DBTIntegrationTest):
     @property
     def models(self):
         return "models"
-
 
     @property
     def packages_config(self):
@@ -139,12 +139,10 @@ class TestExitCodesDepsFail(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test_deps(self):
-        # this should fail
-        try:
-            _, success = self.run_dbt_and_check(['deps'])
-            self.assertTrue(False)
-        except dbt.exceptions.InternalException as e:
-            pass
+        with self.assertRaises(dbt.exceptions.InternalException):
+            # this should fail
+            self.run_dbt_and_check(['deps'])
+
 
 class TestExitCodesSeed(DBTIntegrationTest):
     @property
@@ -167,6 +165,7 @@ class TestExitCodesSeed(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
         self.assertTrue(success)
 
+
 class TestExitCodesSeedFail(DBTIntegrationTest):
     @property
     def schema(self):
@@ -184,8 +183,5 @@ class TestExitCodesSeedFail(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test_seed(self):
-        try:
-            _, success = self.run_dbt_and_check(['seed'])
-            self.assertTrue(False)
-        except dbt.exceptions.CompilationException as e:
-            pass
+        _, success = self.run_dbt_and_check(['seed'])
+        self.assertFalse(success)

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -267,7 +267,7 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(set(flat_graph), set(['nodes', 'macros']))
         self.assertEqual(flat_graph['macros'], {})
         self.assertEqual(set(flat_nodes), set(self.nested_nodes))
-        expected_keys = set(ParsedNode.SCHEMA['required']) | {'agate_table'}
+        expected_keys = set(ParsedNode.SCHEMA['required'])
         for node in flat_nodes.values():
             self.assertEqual(set(node), expected_keys)
 
@@ -632,8 +632,8 @@ class MixedManifestTest(unittest.TestCase):
         self.assertEqual(set(flat_graph), set(['nodes', 'macros']))
         self.assertEqual(flat_graph['macros'], {})
         self.assertEqual(set(flat_nodes), set(self.nested_nodes))
-        parsed_keys = set(ParsedNode.SCHEMA['required']) | {'agate_table'}
-        compiled_keys = set(CompiledNode.SCHEMA['required']) | {'agate_table'}
+        parsed_keys = set(ParsedNode.SCHEMA['required'])
+        compiled_keys = set(CompiledNode.SCHEMA['required'])
         compiled_count = 0
         for node in flat_nodes.values():
             if node.get('compiled'):

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -1707,7 +1707,6 @@ class ParserTest(BaseParserTest):
                         'original_file_path': 'events.sql',
                         'root_path': get_os_path('/usr/src/app'),
                         'raw_sql': 'does not matter',
-                        'agate_table': None,
                         'columns': {},
                         'description': '',
                     },
@@ -1733,7 +1732,6 @@ class ParserTest(BaseParserTest):
                         'original_file_path': 'events.sql',
                         'root_path': get_os_path('/usr/src/app'),
                         'raw_sql': 'does not matter',
-                        'agate_table': None,
                         'columns': {},
                         'description': '',
                     },
@@ -1759,7 +1757,6 @@ class ParserTest(BaseParserTest):
                         'original_file_path': 'multi.sql',
                         'root_path': get_os_path('/usr/src/app'),
                         'raw_sql': 'does not matter',
-                        'agate_table': None,
                         'columns': {},
                         'description': '',
                     }


### PR DESCRIPTION
Fixes #1566 

Remove the agate_table attribute from nodes, and instead plumb it through to the results object. As part of this, we only load seeds at materialization runtime, and so we only detect errors during seed execution instead of parsing, which kind of stinks. But on the plus side, now we do load seeds in parallel, which is pretty cool and maybe it makes up for that loss.

This is still kind of lame and we'll have to avoid serializing it when dataclass_jsonschema-ifying results, but I feel a lot better about it not being inextricably linked! Now you can imagine just including the data that we'd use in `dbt seed --show` in the result and printing that out, it was kind of tough to imagine doing this with the old model. Maybe in the future seed results will have their own result type, and will include a `.preview` that is just the first 10 lines of the agate table, that's all we actually use anyway.