### PR TITLE
Add ExternalTable relation type, update Snowflake adapter (issue #1505)

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -11,12 +11,14 @@ class BaseRelation(APIObject):
     View = "view"
     CTE = "cte"
     MaterializedView = "materializedview"
+    ExternalTable = "externaltable"
 
     RelationTypes = [
         Table,
         View,
         CTE,
-        MaterializedView
+        MaterializedView,
+        ExternalTable
     ]
 
     DEFAULTS = {

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -55,6 +55,7 @@
       case when table_type = 'BASE TABLE' then 'table'
            when table_type = 'VIEW' then 'view'
            when table_type = 'MATERIALIZED VIEW' then 'materializedview'
+           when table_type = 'EXTERNAL TABLE' then 'externaltable'
            else table_type
       end as table_type
     from {{ information_schema }}.tables


### PR DESCRIPTION
**Why?**
Snowflake `EXTERNAL TABLE` is not a valid RelationType in `dbt`.

**What's new?**
- Added `ExternalTable` relation type .
- Updated Snowflake adapter.

**Notes**
- Related to issue https://github.com/fishtown-analytics/dbt/issues/1505