### PR TITLE
(#1574) track adapter type and rpc requests

### DIFF
--- a/core/dbt/rpc.py
+++ b/core/dbt/rpc.py
@@ -22,6 +22,7 @@ from dbt import flags
 from dbt.logger import RPC_LOGGER as logger
 from dbt.logger import add_queue_handler
 import dbt.exceptions
+import dbt.tracking
 
 
 class RPCException(JSONRPCDispatchException):
@@ -56,6 +57,12 @@ class RPCException(JSONRPCDispatchException):
     @classmethod
     def from_error(cls, err):
         return cls(err.code, err.message, err.data, err.data.get('logs'))
+
+
+def track_rpc_request(task):
+    dbt.tracking.track_rpc_request({
+        "task": task
+    })
 
 
 def invalid_params(data):
@@ -429,6 +436,7 @@ class ResponseManager(JSONRPCResponseManager):
         except JSONRPCInvalidRequestException:
             return JSONRPC20Response(error=JSONRPCInvalidRequest()._data)
 
+        track_rpc_request(request.method)
         dispatcher = RequestDispatcher(
             http_request,
             request,

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -92,7 +92,8 @@ class TestEventTracking(DBTIntegrationTest):
         self,
         command,
         progress,
-        result_type=None
+        result_type=None,
+        adapter_type='postgres'
     ):
 
         def populate(
@@ -103,7 +104,7 @@ class TestEventTracking(DBTIntegrationTest):
         ):
             return [
                 {
-                    'schema': 'iglu:com.dbt/invocation/jsonschema/1-0-0',
+                    'schema': 'iglu:com.dbt/invocation/jsonschema/1-0-1',
                     'data': {
                         'project_id': project_id,
                         'user_id': user_id,
@@ -116,7 +117,8 @@ class TestEventTracking(DBTIntegrationTest):
 
                         'options': None,  # TODO : Add options to compile cmd!
                         'result_type': result_type,
-                        'result': None
+                        'result': None,
+                        'adapter_type': adapter_type
                     }
                 },
                 {
@@ -252,9 +254,9 @@ class TestEventTrackingSuccess(TestEventTracking):
         ]
 
         expected_contexts = [
-            self.build_context('deps', 'start'),
+            self.build_context('deps', 'start', adapter_type=None),
             package_context,
-            self.build_context('deps', 'end', result_type='ok')
+            self.build_context('deps', 'end', result_type='ok', adapter_type=None)
         ]
 
         self.run_event_test(["deps"], expected_calls, expected_contexts)


### PR DESCRIPTION
- track adapter type (pulled from `adapter.type()` intentionally to avoid reaching into profile data)
- track rpc requests