### PR TITLE
Fix/test cleanup

### DIFF
--- a/test/integration/035_changing_relation_type_test/test_changing_relation_type.py
+++ b/test/integration/035_changing_relation_type_test/test_changing_relation_type.py
@@ -20,23 +20,23 @@ class TestChangingRelationType(DBTIntegrationTest):
         # between materializations that create tables and views.
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: table'])
-        self.assertEquals(results[0].node['config']['materialized'], 'table')
+        self.assertEqual(results[0].node['config']['materialized'], 'table')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: incremental'])
-        self.assertEquals(results[0].node['config']['materialized'], 'incremental')
+        self.assertEqual(results[0].node['config']['materialized'], 'incremental')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
     @use_profile("postgres")
@@ -59,23 +59,23 @@ class TestChangingRelationType(DBTIntegrationTest):
         # and then remove these bq-specific tests
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: table'])
-        self.assertEquals(results[0].node['config']['materialized'], 'table')
+        self.assertEqual(results[0].node['config']['materialized'], 'table')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: view', "--full-refresh"])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: incremental'])
-        self.assertEquals(results[0].node['config']['materialized'], 'incremental')
+        self.assertEqual(results[0].node['config']['materialized'], 'incremental')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: view', "--full-refresh"])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
     @use_profile('presto')
@@ -83,13 +83,13 @@ class TestChangingRelationType(DBTIntegrationTest):
         # presto can't do incremental materializations so there's less to this
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: table'])
-        self.assertEquals(results[0].node['config']['materialized'], 'table')
+        self.assertEqual(results[0].node['config']['materialized'], 'table')
         self.assertEqual(len(results),  1)
 
         results = self.run_dbt(['run', '--vars', 'materialized: view'])
-        self.assertEquals(results[0].node['config']['materialized'], 'view')
+        self.assertEqual(results[0].node['config']['materialized'], 'view')
         self.assertEqual(len(results),  1)

--- a/test/integration/037_external_reference_test/test_external_reference.py
+++ b/test/integration/037_external_reference_test/test_external_reference.py
@@ -35,9 +35,9 @@ class TestExternalReference(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__external_reference(self):
-        self.assertEquals(len(self.run_dbt()), 1)
+        self.assertEqual(len(self.run_dbt()), 1)
         # running it again should succeed
-        self.assertEquals(len(self.run_dbt()), 1)
+        self.assertEqual(len(self.run_dbt()), 1)
 
 
 # The opposite of the test above -- check that external relations that
@@ -61,7 +61,7 @@ class TestExternalDependency(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__external_reference(self):
-        self.assertEquals(len(self.run_dbt()), 1)
+        self.assertEqual(len(self.run_dbt()), 1)
 
         # create a view outside of the dbt schema that depends on this model
         self.external_schema = self.unique_schema()+'zz'
@@ -74,5 +74,5 @@ class TestExternalDependency(DBTIntegrationTest):
         )
 
         # running it again should succeed
-        self.assertEquals(len(self.run_dbt()), 1)
+        self.assertEqual(len(self.run_dbt()), 1)
 

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1035,7 +1035,7 @@ class DBTIntegrationTest(unittest.TestCase):
 
         res = self.run_sql(cmp_query, fetch='one')
 
-        self.assertEquals(int(res[0]), 0, "Row count of table {} doesn't match row count of table {}. ({} rows different)".format(
+        self.assertEqual(int(res[0]), 0, "Row count of table {} doesn't match row count of table {}. ({} rows different)".format(
                 relation_a.identifier,
                 relation_b.identifier,
                 res[0]
@@ -1045,7 +1045,7 @@ class DBTIntegrationTest(unittest.TestCase):
     def assertTableDoesNotExist(self, table, schema=None):
         columns = self.get_table_columns(table, schema)
 
-        self.assertEquals(
+        self.assertEqual(
             len(columns),
             0
         )

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -79,7 +79,7 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         adapter = self.get_adapter('oauth')
         try:
             connection = adapter.acquire_connection('dummy')
-            self.assertEquals(connection.get('type'), 'bigquery')
+            self.assertEqual(connection.get('type'), 'bigquery')
 
         except dbt.exceptions.ValidationException as e:
             self.fail('got ValidationException: {}'.format(str(e)))
@@ -94,7 +94,7 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         adapter = self.get_adapter('service_account')
         try:
             connection = adapter.acquire_connection('dummy')
-            self.assertEquals(connection.get('type'), 'bigquery')
+            self.assertEqual(connection.get('type'), 'bigquery')
 
         except dbt.exceptions.ValidationException as e:
             self.fail('got ValidationException: {}'.format(str(e)))

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -4,7 +4,7 @@ import unittest
 from dbt.contracts.graph.parsed import ParsedNode
 from dbt.context import parser, runtime
 import dbt.exceptions
-from test.unit.mock_adapter import adapter_factory
+from .mock_adapter import adapter_factory
 
 
 

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -55,7 +55,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             exclude
         )
 
-        self.assertEquals(selected, expected)
+        self.assertEqual(selected, expected)
 
 
     def test__single_node_selection_in_package(self):
@@ -177,7 +177,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
         found = graph_selector.get_package_names(self.package_graph)
 
         expected = set(['X', 'Y'])
-        self.assertEquals(found, expected)
+        self.assertEqual(found, expected)
 
     def assert_is_selected_node(self, node, spec, should_work):
         self.assertEqual(

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -58,15 +58,15 @@ class TestPostgresAdapter(unittest.TestCase):
         except BaseException as e:
             self.fail('acquiring connection failed with unknown exception: {}'
                       .format(str(e)))
-        self.assertEquals(connection.type, 'postgres')
+        self.assertEqual(connection.type, 'postgres')
         psycopg2.connect.assert_called_once()
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
     def test_acquire_connection(self, psycopg2):
         connection = self.adapter.acquire_connection('dummy')
 
-        self.assertEquals(connection.state, 'open')
-        self.assertNotEquals(connection.handle, None)
+        self.assertEqual(connection.state, 'open')
+        self.assertNotEqual(connection.handle, None)
         psycopg2.connect.assert_called_once()
 
     def test_cancel_open_connections_empty(self):

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -61,13 +61,13 @@ class TestRedshiftAdapter(unittest.TestCase):
 
     def test_implicit_database_conn(self):
         creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
-        self.assertEquals(creds, self.config.credentials)
+        self.assertEqual(creds, self.config.credentials)
 
     def test_explicit_database_conn(self):
         self.config.method = 'database'
 
         creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
-        self.assertEquals(creds, self.config.credentials)
+        self.assertEqual(creds, self.config.credentials)
 
     def test_explicit_iam_conn(self):
         self.config.credentials = self.config.credentials.incorporate(
@@ -80,7 +80,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             creds = RedshiftAdapter.ConnectionManager.get_credentials(self.config.credentials)
 
         expected_creds = self.config.credentials.incorporate(password='tmp_password')
-        self.assertEquals(creds, expected_creds)
+        self.assertEqual(creds, expected_creds)
 
     def test_invalid_auth_method(self):
         # we have to set method this way, otherwise it won't validate

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -18,7 +18,7 @@ class TestDeepMerge(unittest.TestCase):
 
         for case in cases:
             actual = dbt.utils.deep_merge(*case['args'])
-            self.assertEquals(
+            self.assertEqual(
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
@@ -38,7 +38,7 @@ class TestMerge(unittest.TestCase):
 
         for case in cases:
             actual = dbt.utils.deep_merge(*case['args'])
-            self.assertEquals(
+            self.assertEqual(
                 case['expected'], actual,
                 'failed on {} (actual {}, expected {})'.format(
                     case['description'], actual, case['expected']))
@@ -88,10 +88,10 @@ class TestDeepMap(unittest.TestCase):
             ],
         }
         actual = dbt.utils.deep_map(self.intify_all, self.input_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
         actual = dbt.utils.deep_map(self.intify_all, expected)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
 
     @staticmethod
@@ -121,20 +121,20 @@ class TestDeepMap(unittest.TestCase):
             ],
         }
         actual = dbt.utils.deep_map(self.special_keypath, self.input_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
         actual = dbt.utils.deep_map(self.special_keypath, expected)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test__noop(self):
         actual = dbt.utils.deep_map(lambda x, _: x, self.input_value)
-        self.assertEquals(actual, self.input_value)
+        self.assertEqual(actual, self.input_value)
 
     def test_trivial(self):
         cases = [[], {}, 1, 'abc', None, True]
         for case in cases:
             result = dbt.utils.deep_map(lambda x, _: x, case)
-            self.assertEquals(result, case)
+            self.assertEqual(result, case)
 
         with self.assertRaises(dbt.exceptions.DbtConfigError):
             dbt.utils.deep_map(lambda x, _: x, {'foo': object()})


### PR DESCRIPTION
This branch contains some misc. test cleanup that I noticed while updating our internal build system with the latest dbt alpha release.  It includes fixes to remove deprecation warnings during testing and also a minor update to have test_context.py do a local import of mock_adapter.py (in a manner consistent with how other tests import utils.py).