### PR TITLE
set PYTHONIOENCODING on the dockerfile to suppress encoding errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,5 @@ RUN cd /usr/app && \
     pyenv rehash
 
 RUN pyenv local dbt36 dbt37 dbt27
+
+ENV PYTHONIOENCODING=utf-8


### PR DESCRIPTION
Without this, when logging the (perfectly successful) snapshots with funky unicode characters, the docker image spits stack traces to stderr.

I'm going to push the docker image with this in a moment, but I've locally verified it. The tests won't show the new behavior because it's an issue with the image.


The old bad output looks like this:
```
 --- Logging error ---
Traceback (most recent call last):
  File "/home/dbt_test_user/.pyenv/versions/3.6.8/lib/python3.6/logging/__init__.py", line 996, in emit
    stream.write(msg)
UnicodeEncodeError: 'ascii' codec can't encode character '\xe5' in position 183: ordinal not in range(128)
Call stack:
  File "/home/dbt_test_user/.pyenv/versions/3.6.8/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/home/dbt_test_user/.pyenv/versions/3.6.8/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/dbt_test_user/.pyenv/versions/3.6.8/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/dbt_test_user/.pyenv/versions/3.6.8/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/app/core/dbt/task/runnable.py", line 112, in call_runner
    result = runner.run_with_hooks(self.manifest)
  File "/usr/app/core/dbt/node_runners.py", line 72, in run_with_hooks
    result = self.safe_run(manifest)
  File "/usr/app/core/dbt/node_runners.py", line 195, in safe_run
    result = self.compile_and_execute(manifest, ctx)
  File "/usr/app/core/dbt/node_runners.py", line 139, in compile_and_execute
    result = self.run(ctx.node, manifest)
  File "/usr/app/core/dbt/node_runners.py", line 237, in run
    return self.execute(compiled_node, manifest)
  File "/usr/app/core/dbt/node_runners.py", line 349, in execute
    materialization_macro.generator(context)()
  File "/usr/app/core/dbt/clients/jinja.py", line 103, in call
    return macro(*args, **kwargs)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 575, in __call__
    return self._invoke(arguments, autoescape)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 110, in _invoke
    return original_invoke(self, arguments, autoescape)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "dbt-4063a2a1b4836330ae41cd57", line 60, in macro
    t_2.append(environment.call(context, (undefined(name='statement') if l_1_statement is missing else l_1_statement), 'main', caller=caller))
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/sandbox.py", line 438, in call
    return __context.call(__obj, *args, **kwargs)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 262, in call
    return __obj(*args, **kwargs)
  File "/usr/app/core/dbt/clients/jinja.py", line 103, in call
    return macro(*args, **kwargs)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 575, in __call__
    return self._invoke(arguments, autoescape)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 110, in _invoke
    return original_invoke(self, arguments, autoescape)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "dbt-b2e72f7d6987772bb601a8cb", line 41, in macro
    (l_1_status, l_1_res) = environment.call(context, environment.getattr((undefined(name='adapter') if l_1_adapter is missing else l_1_adapter), 'execute'), (undefined(name='sql') if l_1_sql is missing else l_1_sql), auto_begin=l_1_auto_begin, fetch=l_1_fetch_result)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/sandbox.py", line 438, in call
    return __context.call(__obj, *args, **kwargs)
  File "/usr/app/.tox/explicit-py36/lib/python3.6/site-packages/jinja2/runtime.py", line 262, in call
    return __obj(*args, **kwargs)
  File "/usr/app/core/dbt/adapters/base/impl.py", line 236, in execute
    fetch=fetch
  File "/usr/app/core/dbt/adapters/sql/connections.py", line 92, in execute
    _, cursor = self.add_query(sql, auto_begin)
  File "/usr/app/core/dbt/adapters/sql/connections.py", line 55, in add_query
    logger.debug('On %s: %s', connection.name, sql)
Message: 'On %s: %s'
Arguments: ('materialized', 'create  table\n    "dbt"."test15616883748829_simple_copy_001"."materialized__dbt_tmp"\n  as (\n    \n\n-- this is a unicode character: \xe5\nselect * from "dbt"."test15616883748829_simple_copy_001"."seed"\n  );')
```

And it's all gone now...