### PR TITLE
add validation for extend dict fields that receive non-dicts

### DIFF
--- a/core/dbt/parser/source_config.py
+++ b/core/dbt/parser/source_config.py
@@ -139,7 +139,12 @@ class SourceConfig(object):
 
         for key in self.ExtendDictFields:
             dict_val = relevant_configs.get(key, {})
-            mutable_config[key].update(dict_val)
+            try:
+                mutable_config[key].update(dict_val)
+            except (ValueError, TypeError, AttributeError):
+                dbt.exceptions.raise_compiler_error(
+                    'Invalid config field: "{}" must be a dict'.format(key)
+                )
 
         for key in (self.ClobberFields | self.AdapterSpecificConfigs):
             if key in relevant_configs:

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -143,6 +143,17 @@ class SourceConfigTest(BaseParserTest):
 
         self.assertEqual(used_keys, frozenset(SourceConfig.ConfigKeys))
 
+    def test__source_config_wrong_type(self):
+        # ExtendDict fields should handle non-dict inputs gracefully
+        self.root_project_config.models = {'persist_docs': False}
+        cfg = SourceConfig(self.root_project_config, self.root_project_config,
+                           ['root', 'x'], NodeType.Model)
+
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            cfg.get_project_config(self.root_project_config)
+
+        self.assertIn('must be a dict', str(exc.exception))
+
 
 class SchemaParserTest(BaseParserTest):
     maxDiff = None


### PR DESCRIPTION
This fixes an error that popped up in Slack with the 0.14.0-a2 release. dbt already handles cases where ExtendDict configs are provided in-model, but it goes through a different codepath when these configs are specified in the `dbt_project.yml` file.

Given the following config:
```
models:
  persist_docs: true
```

The user will see an error like:
```
Invalid config field: "persist_docs" must be a dict
```

Whereas before, they would see:
```
'bool' object is not iterable
```