### PR TITLE
[Wilt Chamberlain] fix for dupe check_cols values in snapshot strategy

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -500,7 +500,7 @@ SNAPSHOT_CONFIG_CONTRACT = {
         ]
     },
     'required': [
-        'target_database', 'target_schema', 'unique_key', 'strategy',
+        'target_schema', 'unique_key', 'strategy',
     ],
 }
 

--- a/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
@@ -106,7 +106,8 @@
         )
     {%- endset %}
 
-    {% set scd_id_expr = snapshot_hash_arguments(check_cols) %}
+    {% set scd_id_cols = [primary_key] + (check_cols | list) %}
+    {% set scd_id_expr = snapshot_hash_arguments(scd_id_cols) %}
 
     {% do return({
         "unique_key": primary_key,

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -8,6 +8,15 @@ import dbt.utils
 
 
 def set_snapshot_attributes(node):
+    # Default the target database to the database specified in the target
+    # This line allows target_database to be optional in the snapshot config
+    if 'target_database' not in node.config:
+        node.config['target_database'] = node.database
+
+    # Set the standard node configs (database+schema) to be the specified
+    # values from target_database and target_schema. This ensures that the
+    # database and schema names are interopolated correctly when snapshots
+    # are ref'd from other models
     config_keys = {
         'target_database': 'database',
         'target_schema': 'schema'

--- a/test/integration/004_simple_snapshot_test/seed_pg.sql
+++ b/test/integration/004_simple_snapshot_test/seed_pg.sql
@@ -26,9 +26,11 @@ create table {database}.{schema}.snapshot_expected (
 
 
 -- seed inserts
+--  use the same email for two users to verify that duplicated check_cols values
+--  are handled appropriately
 insert into {database}.{schema}.seed (id, first_name, last_name, email, gender, ip_address, updated_at) values
-(1, 'Judith', 'Kennedy', 'jkennedy0@phpbb.com', 'Female', '54.60.24.128', '2015-12-24 12:19:28'),
-(2, 'Arthur', 'Kelly', 'akelly1@eepurl.com', 'Male', '62.56.24.215', '2015-10-28 16:22:15'),
+(1, 'Judith', 'Kennedy', '(not provided)', 'Female', '54.60.24.128', '2015-12-24 12:19:28'),
+(2, 'Arthur', 'Kelly', '(not provided)', 'Male', '62.56.24.215', '2015-10-28 16:22:15'),
 (3, 'Rachel', 'Moreno', 'rmoreno2@msu.edu', 'Female', '31.222.249.23', '2016-04-05 02:05:30'),
 (4, 'Ralph', 'Turner', 'rturner3@hp.com', 'Male', '157.83.76.114', '2016-08-08 00:06:51'),
 (5, 'Laura', 'Gonzales', 'lgonzales4@howstuffworks.com', 'Female', '30.54.105.168', '2016-09-01 08:25:38'),

--- a/test/integration/004_simple_snapshot_test/test-snapshots-invalid/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-snapshots-invalid/snapshot.sql
@@ -1,7 +1,6 @@
 {% snapshot no_target_database %}
     {{
         config(
-            target_schema=schema,
             unique_key='id || ' ~ "'-'" ~ ' || first_name',
             strategy='timestamp',
             updated_at='updated_at',

--- a/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
+++ b/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
@@ -353,7 +353,7 @@ class TestBadSnapshot(DBTIntegrationTest):
         with self.assertRaises(dbt.exceptions.CompilationException) as exc:
             self.run_dbt(['compile'], expect_pass=False)
 
-        self.assertIn('target_database', str(exc.exception))
+        self.assertIn('target_schema', str(exc.exception))
 
 
 class TestCheckCols(TestSimpleSnapshotFiles):


### PR DESCRIPTION
- Makes `target_database` optional in snapshots (I'm not sure if the way I implemented it was the best way to do this)
- Preprends the `dbt_scd_id` hash with the unique id of the row, avoiding hash conflicts

The existing behavior of the `check_cols` strategy could fail in a subtle way if the specified `check_cols` values for two rows were equivalent:

Given:

| id | name | color |
| - | - | - |
| 1 | alice | red |
| 2 | bob | red |

Assume that bob's color changes to blue:

| id | name | color |
| - | - | - |
| 1 | alice | red |
| 2 | bob | blue |

The generated snapshot query would invalidate any records where `dbt_scd_id = md5('red')`. This would inadvertently update alice as well as bob!

This PR includes the unique id in the hash, so the resulting snapshot would invalidate records where `dbt_scd_id = md5('2' || 'red')`, which is localized to just bob's record.