### PR TITLE
Fix the test dockerfile to get the logfile's default encoding right

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,4 @@ RUN cd /usr/app && \
 RUN pyenv local dbt36 dbt37 dbt27
 
 ENV PYTHONIOENCODING=utf-8
+ENV LANG C.UTF-8

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -1,4 +1,5 @@
 import dbt.flags
+import dbt.ui.colors
 import logging
 import logging.handlers
 import os


### PR DESCRIPTION
Set the default file encoding via LANG to the locale provided by libc, so this works:
`python -c 'open("out.txt", "w").write(chr(0x7777))'`

I also fixed a missing import that only comes up if you try to import `dbt.logger` directly.