### PR TITLE
Make is_incremental live up to its name

### DIFF
--- a/core/dbt/include/global_project/macros/etc/is_incremental.sql
+++ b/core/dbt/include/global_project/macros/etc/is_incremental.sql
@@ -5,6 +5,9 @@
         {{ return(False) }}
     {% else %}
         {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}
-        {{ return(relation is not none and relation.type == 'table' and not flags.FULL_REFRESH) }}
+        {{ return(relation is not none
+                  and relation.type == 'table'
+                  and model.config.materialized == 'incremental'
+                  and not flags.FULL_REFRESH) }}
     {% endif %}
 {% endmacro %}

--- a/test/integration/017_runtime_materialization_tests/models/materialized.sql
+++ b/test/integration/017_runtime_materialization_tests/models/materialized.sql
@@ -5,3 +5,7 @@
 }}
 
 select * from {{ this.schema }}.seed
+
+{% if is_incremental() %}
+    {% do exceptions.raise_compiler_error("is_incremental() evaluated to True in a table") %}
+{% endif %}

--- a/test/integration/017_runtime_materialization_tests/models/view.sql
+++ b/test/integration/017_runtime_materialization_tests/models/view.sql
@@ -5,3 +5,7 @@
 }}
 
 select * from {{ this.schema }}.seed
+
+{% if is_incremental() %}
+    {% do exceptions.raise_compiler_error("is_incremental() evaluated to True in a view") %}
+{% endif %}


### PR DESCRIPTION
closes #1249

Make `is_incremental` check if the specified materialization name is actually `incremental`. Before, this macro just checked that:
1. the relation existed in the dbt
2. it was of type `table`

The new logic is more strict, but also more sensible.