### PR TITLE
Split Parsed and Compiled nodes into subtypes (#1601)

### DIFF
--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -45,25 +45,41 @@ class UnparsedNodeType(StrEnum):
     RPCCall = str(NodeType.RPCCall)
 
 
+class RunHookType(StrEnum):
+    Start = 'on-run-start'
+    End = 'on-run-end'
+
+
+class AnalysisType(StrEnum):
+    Analysis = str(NodeType.Analysis)
+
+
 class DocumentationType(StrEnum):
     Documentation = str(NodeType.Documentation)
 
 
-class RunHookType(StrEnum):
-    Start = 'on-run-start'
-    End = 'on-run-end'
+class MacroType(StrEnum):
+    Macro = str(NodeType.Macro)
+
+
+class ModelType(StrEnum):
+    Model = str(NodeType.Model)
 
 
 class OperationType(StrEnum):
     Operation = str(NodeType.Operation)
 
 
+class RPCCallType(StrEnum):
+    RPCCall = str(NodeType.RPCCall)
+
+
+class SeedType(StrEnum):
+    Seed = str(NodeType.Seed)
+
+
 class SnapshotType(StrEnum):
     Snapshot = str(NodeType.Snapshot)
-
-
-class MacroType(StrEnum):
-    Macro = str(NodeType.Macro)
 
 
 class SourceType(StrEnum):

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -49,6 +49,9 @@ class RunHookType(StrEnum):
     Start = 'on-run-start'
     End = 'on-run-end'
 
+# It would be nice to use hologram.StrLiteral for these, but it results in
+# un-pickleable types :(
+
 
 class AnalysisType(StrEnum):
     Analysis = str(NodeType.Analysis)

--- a/core/dbt/parser/analysis.py
+++ b/core/dbt/parser/analysis.py
@@ -1,6 +1,8 @@
-
-from dbt.parser.base_sql import BaseSqlParser
 import os
+from typing import Dict, Any
+
+from dbt.contracts.graph.parsed import ParsedAnalysisNode, ParsedRPCNode
+from dbt.parser.base_sql import BaseSqlParser
 
 
 class AnalysisParser(BaseSqlParser):
@@ -8,7 +10,18 @@ class AnalysisParser(BaseSqlParser):
     def get_compiled_path(cls, name, relative_path):
         return os.path.join('analysis', relative_path)
 
+    def parse_from_dict(
+        self,
+        parsed_dict: Dict[str, Any]
+    ) -> ParsedAnalysisNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedAnalysisNode.from_dict(parsed_dict)
 
-class RPCCallParser(AnalysisParser):
+
+class RPCCallParser(BaseSqlParser):
     def get_compiled_path(cls, name, relative_path):
         return os.path.join('rpc', relative_path)
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedRPCNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedRPCNode.from_dict(parsed_dict)

--- a/core/dbt/parser/data_test.py
+++ b/core/dbt/parser/data_test.py
@@ -1,4 +1,6 @@
+from typing import Dict, Any
 
+from dbt.contracts.graph.parsed import ParsedTestNode
 from dbt.parser.base_sql import BaseSqlParser
 import dbt.utils
 
@@ -7,3 +9,7 @@ class DataTestParser(BaseSqlParser):
     @classmethod
     def get_compiled_path(cls, name, relative_path):
         return dbt.utils.get_pseudo_test_path(name, relative_path, 'data_test')
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedTestNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedTestNode.from_dict(parsed_dict)

--- a/core/dbt/parser/docs.py
+++ b/core/dbt/parser/docs.py
@@ -1,12 +1,14 @@
+import os
+from typing import Dict, Any
+
+import jinja2.runtime
+
 import dbt.exceptions
 from dbt.parser.base import BaseParser
 from dbt.contracts.graph.unparsed import UnparsedDocumentationFile
 from dbt.contracts.graph.parsed import ParsedDocumentation
 from dbt.clients.jinja import extract_toplevel_blocks, get_template
 from dbt.clients import system
-
-import jinja2.runtime
-import os
 
 
 class DocumentationParser(BaseParser):
@@ -94,3 +96,9 @@ class DocumentationParser(BaseParser):
                     )
                 to_return[parsed.unique_id] = parsed
         return to_return
+
+    def parse_from_dict(
+        self, parsed_dict: Dict[str, Any]
+    ) -> ParsedDocumentation:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedDocumentation.from_dict(parsed_dict)

--- a/core/dbt/parser/hooks.py
+++ b/core/dbt/parser/hooks.py
@@ -1,10 +1,11 @@
-
 import collections
+from typing import Dict, Any
 
 import dbt.flags
 import dbt.contracts.project
 import dbt.utils
 
+from dbt.contracts.graph.parsed import ParsedHookNode
 from dbt.contracts.graph.unparsed import UnparsedRunHook
 from dbt.parser.base_sql import BaseSqlParser
 from dbt.node_types import NodeType, RunHookType
@@ -74,3 +75,7 @@ class HookParser(BaseSqlParser):
             hook_nodes.update(project_hooks)
 
         return hook_nodes
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedHookNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedHookNode.from_dict(parsed_dict)

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, Any
 
 import jinja2.runtime
 
@@ -70,6 +71,9 @@ class MacroParser(BaseParser):
             to_return[unique_id] = new_node
 
         return to_return
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedMacro:
+        return ParsedMacro.from_dict(parsed_dict)
 
     def load_and_parse(self, package_name, root_dir, relative_dirs,
                        resource_type, tags=None):

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -1,4 +1,6 @@
+from typing import Dict, Any
 
+from dbt.contracts.graph.parsed import ParsedModelNode
 from dbt.parser.base_sql import BaseSqlParser
 
 
@@ -6,3 +8,7 @@ class ModelParser(BaseSqlParser):
     @classmethod
     def get_compiled_path(cls, name, relative_path):
         return relative_path
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedModelNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedModelNode.from_dict(parsed_dict)

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -286,7 +286,7 @@ class SchemaBaseTestParser(MacrosKnownParser):
                 )
                 continue
 
-    def parse_from_dict(self, parsed_dict):
+    def parse_from_dict(self, parsed_dict) -> ParsedTestNode:
         return ParsedTestNode.from_dict(parsed_dict)
 
     def build_test_node(self, test_target, package_name, test, root_dir, path,

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -23,7 +23,7 @@ from dbt.utils import get_pseudo_test_path
 from dbt.contracts.graph.unparsed import UnparsedNode, UnparsedNodeUpdate, \
     UnparsedSourceDefinition
 from dbt.contracts.graph.parsed import ParsedNodePatch, ParsedTestNode, \
-    ParsedSourceDefinition
+    ParsedSourceDefinition, ParsedNode
 from dbt.parser.base import MacrosKnownParser
 from dbt.config.renderer import ConfigRenderer
 from dbt.exceptions import JSONValidationException, validator_error_message
@@ -286,7 +286,7 @@ class SchemaBaseTestParser(MacrosKnownParser):
                 )
                 continue
 
-    def _parse_from_dict(self, parsed_dict):
+    def parse_from_dict(self, parsed_dict):
         return ParsedTestNode.from_dict(parsed_dict)
 
     def build_test_node(self, test_target, package_name, test, root_dir, path,
@@ -612,9 +612,9 @@ class SchemaParser:
         return version
 
     def load_and_parse(self, package_name, root_dir, relative_dirs):
-        new_tests = {}  # test unique ID -> ParsedNode
-        node_patches = {}  # model name -> dict
-        new_sources = {}  # source unique ID -> ParsedSourceDefinition
+        new_tests: Dict[str, ParsedNode] = {}
+        node_patches: Dict[str, dict] = {}
+        new_sources: Dict[str, ParsedSourceDefinition] = {}
 
         iterator = self.find_schema_yml(package_name, root_dir, relative_dirs)
 

--- a/core/dbt/parser/seeds.py
+++ b/core/dbt/parser/seeds.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, Any
 
 import dbt.flags
 import dbt.clients.agate_helper
@@ -9,6 +10,7 @@ import dbt.exceptions
 
 from dbt.node_types import NodeType
 from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.contracts.graph.parsed import ParsedSeedNode
 from dbt.contracts.graph.unparsed import UnparsedNode
 from dbt.parser.base import MacrosKnownParser
 
@@ -57,3 +59,7 @@ class SeedParser(MacrosKnownParser):
             result[node_path] = parsed
 
         return result
+
+    def parse_from_dict(self, parsed_dict: Dict[str, Any]) -> ParsedSeedNode:
+        """Given a dictionary, return the parsed entity for this parser"""
+        return ParsedSeedNode.from_dict(parsed_dict)

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -56,7 +56,7 @@ class SnapshotParser(BaseSqlParser):
 
         return fqn
 
-    def parse_from_dict(self, parsed_dict):
+    def parse_from_dict(self, parsed_dict) -> IntermediateSnapshotNode:
         return IntermediateSnapshotNode.from_dict(parsed_dict)
 
     @staticmethod

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -56,7 +56,7 @@ class SnapshotParser(BaseSqlParser):
 
         return fqn
 
-    def _parse_from_dict(self, parsed_dict):
+    def parse_from_dict(self, parsed_dict):
         return IntermediateSnapshotNode.from_dict(parsed_dict)
 
     @staticmethod

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -554,34 +554,34 @@ class TestDocsGenerate(DBTIntegrationTest):
                                                       cluster='first_name,email')
         nesting_columns = {
             'field_1': {
-                "name": "field_1",
-                "index": 1,
-                "type": "INT64",
-                "comment": None
+                'name': 'field_1',
+                'index': 1,
+                'type': 'INT64',
+                'comment': None
             },
             'field_2': {
-                "name": "field_2",
-                "index": 2,
-                "type": "INT64",
-                "comment": None
+                'name': 'field_2',
+                'index': 2,
+                'type': 'INT64',
+                'comment': None
             },
             'field_3': {
-                "name": "field_3",
-                "index": 3,
-                "type": "INT64",
-                "comment": None
+                'name': 'field_3',
+                'index': 3,
+                'type': 'INT64',
+                'comment': None
             },
             'nested_field.field_4': {
-                "name": "nested_field.field_4",
-                "index": 4,
-                "type": "INT64",
-                "comment": None
+                'name': 'nested_field.field_4',
+                'index': 4,
+                'type': 'INT64',
+                'comment': None
             },
             'nested_field.field_5': {
-                "name": "nested_field.field_5",
-                "index": 5,
-                "type": "INT64",
-                "comment": None
+                'name': 'nested_field.field_5',
+                'index': 5,
+                'type': 'INT64',
+                'comment': None
             }
         }
 
@@ -625,31 +625,31 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'stats': table_stats,
                 'columns': self._clustered_bigquery_columns('DATETIME'),
             },
-            "model.test.nested_view": {
+            'model.test.nested_view': {
                 'unique_id': 'model.test.nested_view',
-                "metadata": {
-                    "schema": my_schema_name,
+                'metadata': {
+                    'schema': my_schema_name,
                     'database': self.default_database,
-                    "name": "nested_view",
-                    "type": "view",
-                    "owner": role,
-                    "comment": None
+                    'name': 'nested_view',
+                    'type': 'view',
+                    'owner': role,
+                    'comment': None
                 },
                 'stats': self._bigquery_stats(False),
-                "columns": nesting_columns,
+                'columns': nesting_columns,
             },
-            "model.test.nested_table": {
+            'model.test.nested_table': {
                 'unique_id': 'model.test.nested_table',
-                "metadata": {
-                    "schema": my_schema_name,
+                'metadata': {
+                    'schema': my_schema_name,
                     'database': self.default_database,
-                    "name": "nested_table",
-                    "type": "table",
-                    "owner": role,
-                    "comment": None
+                    'name': 'nested_table',
+                    'type': 'table',
+                    'owner': role,
+                    'comment': None
                 },
                 'stats': table_stats,
-                "columns": nesting_columns,
+                'columns': nesting_columns,
             }
         }
 
@@ -847,7 +847,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'depends_on': {'nodes': ['seed.test.seed'], 'macros': []},
                     'unique_id': 'model.test.model',
                     'fqn': ['test', 'model'],
-                    'index': None,
                     'tags': [],
                     'config': model_config,
                     'schema': my_schema_name,
@@ -892,7 +891,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'quoting': {},
                         'tags': [],
                     },
-                    'index': None,
                     'patch_path': None,
                     'path': 'seed.csv',
                     'name': 'seed',
@@ -1085,7 +1083,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'docrefs': [],
                     'fqn': ['test', 'ephemeral_copy'],
-                    'index': None,
                     'name': 'ephemeral_copy',
                     'original_file_path': self.dir('ref_models/ephemeral_copy.sql'),
                     'package_name': 'test',
@@ -1151,7 +1148,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         }
                     ],
                     'fqn': ['test', 'ephemeral_summary'],
-                    'index': None,
                     'name': 'ephemeral_summary',
                     'original_file_path': self.dir('ref_models/ephemeral_summary.sql'),
                     'package_name': 'test',
@@ -1218,7 +1214,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         }
                     ],
                     'fqn': ['test', 'view_summary'],
-                    'index': None,
                     'name': 'view_summary',
                     'original_file_path': self.dir('ref_models/view_summary.sql'),
                     'package_name': 'test',
@@ -1257,7 +1252,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'docrefs': [],
                     'fqn': ['test', 'seed'],
-                    'index': None,
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
                     'package_name': 'test',
@@ -1432,7 +1426,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
                     'fqn': ['test', 'clustered'],
-                    'index': None,
                     'build_path': None,
                     'name': 'clustered',
                     'original_file_path': clustered_sql_path,
@@ -1491,7 +1484,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
                     'fqn': ['test', 'multi_clustered'],
-                    'index': None,
                     'name': 'multi_clustered',
                     'original_file_path': multi_clustered_sql_path,
                     'package_name': 'test',
@@ -1550,7 +1542,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'nodes': ['model.test.nested_table']
                     },
                     'fqn': ['test', 'nested_view'],
-                    'index': None,
                     'name': 'nested_view',
                     'original_file_path': nested_view_sql_path,
                     'package_name': 'test',
@@ -1609,7 +1600,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'nodes': []
                     },
                     'fqn': ['test', 'nested_table'],
-                    'index': None,
                     'name': 'nested_table',
                     'original_file_path': nested_table_sql_path,
                     'package_name': 'test',
@@ -1629,7 +1619,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'seed.test.seed': {
                     'build_path': None,
-                    'index': None,
                     'patch_path': None,
                     'path': 'seed.csv',
                     'name': 'seed',
@@ -1696,41 +1685,40 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
         config_vars = {'alternate_db': self.default_database}
         return {
-            "nodes": {
-                "model.test.model": {
-                    "build_path": None,
-                    "index": None,
-                    "name": "model",
-                    "root_path": self.test_root_dir,
-                    "resource_type": "model",
-                    "path": "model.sql",
-                    "original_file_path": model_sql_path,
-                    "package_name": "test",
-                    "raw_sql": LineIndifferent(_read_file(model_sql_path).rstrip('\r\n')),
-                    "refs": [["seed"]],
-                    "sources": [],
-                    "depends_on": {
-                        "nodes": ["seed.test.seed"],
-                        "macros": [],
+            'nodes': {
+                'model.test.model': {
+                    'build_path': None,
+                    'name': 'model',
+                    'root_path': self.test_root_dir,
+                    'resource_type': 'model',
+                    'path': 'model.sql',
+                    'original_file_path': model_sql_path,
+                    'package_name': 'test',
+                    'raw_sql': LineIndifferent(_read_file(model_sql_path).rstrip('\r\n')),
+                    'refs': [['seed']],
+                    'sources': [],
+                    'depends_on': {
+                        'nodes': ['seed.test.seed'],
+                        'macros': [],
                     },
-                    "unique_id": "model.test.model",
-                    "fqn": ["test", "model"],
-                    "tags": [],
-                    "config": {
-                        "bind": False,
-                        "column_types": {},
-                        "enabled": True,
-                        "materialized": "view",
-                        "persist_docs": {},
-                        "post-hook": [],
-                        "pre-hook": [],
-                        "quoting": {},
-                        "tags": [],
-                        "vars": config_vars,
+                    'unique_id': 'model.test.model',
+                    'fqn': ['test', 'model'],
+                    'tags': [],
+                    'config': {
+                        'bind': False,
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'view',
+                        'persist_docs': {},
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'tags': [],
+                        'vars': config_vars,
                     },
-                    "schema": my_schema_name,
+                    'schema': my_schema_name,
                     'database': self.default_database,
-                    "alias": "model",
+                    'alias': 'model',
                     'description': 'The test model',
                     'columns': {
                         'id': {
@@ -1757,52 +1745,51 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'patch_path': self.dir('rs_models/schema.yml'),
                     'docrefs': [],
                 },
-                "seed.test.seed": {
-                    "build_path": None,
-                    "index": None,
-                    "patch_path": None,
-                    "path": "seed.csv",
-                    "name": "seed",
-                    "root_path": self.test_root_dir,
-                    "resource_type": "seed",
-                    "raw_sql": "-- csv --",
-                    "package_name": "test",
-                    "original_file_path": self.dir("seed/seed.csv"),
-                    "refs": [],
-                    "sources": [],
-                    "depends_on": {
-                        "nodes": [],
-                        "macros": [],
+                'seed.test.seed': {
+                    'build_path': None,
+                    'patch_path': None,
+                    'path': 'seed.csv',
+                    'name': 'seed',
+                    'root_path': self.test_root_dir,
+                    'resource_type': 'seed',
+                    'raw_sql': '-- csv --',
+                    'package_name': 'test',
+                    'original_file_path': self.dir('seed/seed.csv'),
+                    'refs': [],
+                    'sources': [],
+                    'depends_on': {
+                        'nodes': [],
+                        'macros': [],
                     },
-                    "unique_id": "seed.test.seed",
-                    "fqn": ["test", "seed"],
-                    "tags": [],
-                    "config": {
-                        "column_types": {},
-                        "enabled": True,
-                        "materialized": "seed",
-                        "persist_docs": {},
-                        "post-hook": [],
-                        "pre-hook": [],
-                        "quoting": {},
-                        "tags": [],
-                        "vars": {},
+                    'unique_id': 'seed.test.seed',
+                    'fqn': ['test', 'seed'],
+                    'tags': [],
+                    'config': {
+                        'column_types': {},
+                        'enabled': True,
+                        'materialized': 'seed',
+                        'persist_docs': {},
+                        'post-hook': [],
+                        'pre-hook': [],
+                        'quoting': {},
+                        'tags': [],
+                        'vars': {},
                     },
-                    "schema": my_schema_name,
+                    'schema': my_schema_name,
                     'database': self.default_database,
-                    "alias": "seed",
+                    'alias': 'seed',
                     'columns': {},
                     'description': '',
                     'docrefs': [],
                 },
             },
-            "parent_map": {
-                "model.test.model": ["seed.test.seed"],
-                "seed.test.seed": []
+            'parent_map': {
+                'model.test.model': ['seed.test.seed'],
+                'seed.test.seed': []
             },
-            "child_map": {
-                "model.test.model": [],
-                "seed.test.seed": ["model.test.model"]
+            'child_map': {
+                'model.test.model': [],
+                'seed.test.seed': ['model.test.model']
             },
             'docs': {
                 'dbt.__overview__': ANY,
@@ -1917,7 +1904,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'model'],
-                    'index': None,
                     'injected_sql': compiled_sql,
                     'name': 'model',
                     'original_file_path': model_sql_path,
@@ -1969,7 +1955,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'seed'],
-                    'index': None,
                     'injected_sql': '-- csv --',
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
@@ -2233,7 +2218,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     ],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'ephemeral_summary'],
-                    'index': None,
                     'injected_sql': ephemeral_injected_sql,
                     'name': 'ephemeral_summary',
                     'original_file_path': self.dir('ref_models/ephemeral_summary.sql'),
@@ -2322,7 +2306,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'view_summary'],
-                    'index': None,
                     'injected_sql': view_compiled_sql,
                     'name': 'view_summary',
                     'original_file_path': self.dir('ref_models/view_summary.sql'),
@@ -2378,7 +2361,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
                     'fqn': ['test', 'seed'],
-                    'index': None,
                     'injected_sql': '-- csv --',
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),

--- a/test/unit/test_compiler.py
+++ b/test/unit/test_compiler.py
@@ -6,7 +6,7 @@ import dbt.flags
 import dbt.compilation
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.parsed import NodeConfig, DependsOn
-from dbt.contracts.graph.compiled import CompiledNode, InjectedCTE
+from dbt.contracts.graph.compiled import CompiledModelNode, InjectedCTE
 from dbt.node_types import NodeType
 
 from datetime import datetime
@@ -54,7 +54,7 @@ class CompilerTest(unittest.TestCase):
         input_graph = Manifest(
             macros={},
             nodes={
-                'model.root.view': CompiledNode(
+                'model.root.view': CompiledModelNode(
                     name='view',
                     database='dbt',
                     schema='analytics',
@@ -80,7 +80,7 @@ class CompilerTest(unittest.TestCase):
                         'with cte as (select * from something_else) '
                         'select * from __dbt__CTE__ephemeral')
                 ),
-                'model.root.ephemeral': CompiledNode(
+                'model.root.ephemeral': CompiledModelNode(
                     name='ephemeral',
                     database='dbt',
                     schema='analytics',
@@ -132,7 +132,7 @@ class CompilerTest(unittest.TestCase):
         input_graph = Manifest(
             macros={},
             nodes={
-                'model.root.view': CompiledNode(
+                'model.root.view': CompiledModelNode(
                     name='view',
                     database='dbt',
                     schema='analytics',
@@ -158,7 +158,7 @@ class CompilerTest(unittest.TestCase):
                     compiled_sql=('with cte as (select * from something_else) '
                                   'select * from source_table')
                 ),
-                'model.root.view_no_cte': CompiledNode(
+                'model.root.view_no_cte': CompiledModelNode(
                     name='view_no_cte',
                     database='dbt',
                     schema='analytics',
@@ -218,7 +218,7 @@ class CompilerTest(unittest.TestCase):
         input_graph = Manifest(
             macros={},
             nodes={
-                'model.root.view': CompiledNode(
+                'model.root.view': CompiledModelNode(
                     name='view',
                     database='dbt',
                     schema='analytics',
@@ -242,7 +242,7 @@ class CompilerTest(unittest.TestCase):
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral'
                 ),
-                'model.root.ephemeral': CompiledNode(
+                'model.root.ephemeral': CompiledModelNode(
                     name='ephemeral',
                     database='dbt',
                     schema='analytics',
@@ -295,7 +295,7 @@ class CompilerTest(unittest.TestCase):
         input_graph = Manifest(
             macros={},
             nodes={
-                'model.root.view': CompiledNode(
+                'model.root.view': CompiledModelNode(
                     name='view',
                     database='dbt',
                     schema='analytics',
@@ -319,7 +319,7 @@ class CompilerTest(unittest.TestCase):
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral'
                 ),
-                'model.root.ephemeral': CompiledNode(
+                'model.root.ephemeral': CompiledModelNode(
                     name='ephemeral',
                     database='dbt',
                     schema='analytics',
@@ -343,7 +343,7 @@ class CompilerTest(unittest.TestCase):
                     injected_sql='',
                     compiled_sql='select * from __dbt__CTE__ephemeral_level_two' # noqa
                 ),
-                'model.root.ephemeral_level_two': CompiledNode(
+                'model.root.ephemeral_level_two': CompiledModelNode(
                     name='ephemeral_level_two',
                     database='dbt',
                     schema='analytics',

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -1,20 +1,21 @@
 import unittest
 from unittest import mock
 
-from dbt.contracts.graph.parsed import ParsedNode, NodeConfig, DependsOn
+from dbt.contracts.graph.parsed import ParsedModelNode, NodeConfig, DependsOn
 from dbt.context import parser, runtime
+from dbt.node_types import NodeType
 import dbt.exceptions
 from .mock_adapter import adapter_factory
 
 
 class TestVar(unittest.TestCase):
     def setUp(self):
-        self.model = ParsedNode(
+        self.model = ParsedModelNode(
             alias='model_one',
             name='model_one',
             database='dbt',
             schema='analytics',
-            resource_type='model',
+            resource_type=NodeType.Model,
             unique_id='model.root.model_one',
             fqn=['root', 'model_one'],
             package_name='root',

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -1,3 +1,5 @@
+import pickle
+
 from dbt.contracts.graph.compiled import (
     CompiledModelNode, InjectedCTE, CompiledTestNode
 )
@@ -92,6 +94,7 @@ class TestCompiledModelNode(ContractTestCase):
             'alias': 'bar',
         }
         self.assert_from_dict(node, minimum)
+        pickle.loads(pickle.dumps(node))
 
     def test_basic_compiled(self):
         node_dict = {
@@ -284,6 +287,7 @@ class TestCompiledTestNode(ContractTestCase):
             'alias': 'bar',
         }
         self.assert_from_dict(node, minimum)
+        pickle.loads(pickle.dumps(node))
 
     def test_basic_compiled(self):
         node_dict = {

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -1,5 +1,5 @@
 from dbt.contracts.graph.compiled import (
-    CompiledNode, InjectedCTE, CompiledTestNode
+    CompiledModelNode, InjectedCTE, CompiledTestNode
 )
 from dbt.contracts.graph.parsed import (
     DependsOn, NodeConfig, TestConfig
@@ -9,8 +9,8 @@ from dbt.node_types import NodeType
 from .utils import ContractTestCase
 
 
-class TestCompiledNode(ContractTestCase):
-    ContractType = CompiledNode
+class TestCompiledModelNode(ContractTestCase):
+    ContractType = CompiledModelNode
 
     def test_basic_uncompiled(self):
         node_dict = {

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -1,10 +1,10 @@
 from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import (
-    ParsedNode, DependsOn, NodeConfig, ColumnInfo, Hook, ParsedTestNode,
+    ParsedModelNode, DependsOn, NodeConfig, ColumnInfo, Hook, ParsedTestNode,
     TestConfig, ParsedSnapshotNode, TimestampSnapshotConfig, All, Docref,
     GenericSnapshotConfig, CheckSnapshotConfig, TimestampStrategy,
     CheckStrategy, IntermediateSnapshotNode, ParsedNodePatch, ParsedMacro,
-    MacroDependsOn, ParsedSourceDefinition, ParsedDocumentation,
+    MacroDependsOn, ParsedSourceDefinition, ParsedDocumentation, ParsedHookNode
 )
 from dbt.contracts.graph.unparsed import Quoting, FreshnessThreshold
 
@@ -53,8 +53,8 @@ class TestNodeConfig(ContractTestCase):
         self.assert_symmetric(cfg, cfg_dict)
 
 
-class TestParsedNode(ContractTestCase):
-    ContractType = ParsedNode
+class TestParsedModelNode(ContractTestCase):
+    ContractType = ParsedModelNode
 
     def test_ok(self):
         node_dict = {
@@ -404,7 +404,7 @@ class TestParsedNode(ContractTestCase):
 
 
 class TestParsedHookNode(ContractTestCase):
-    ContractType = ParsedNode
+    ContractType = ParsedHookNode
 
     def test_ok(self):
         node_dict = {

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -1,3 +1,5 @@
+import pickle
+
 from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import (
     ParsedModelNode, DependsOn, NodeConfig, ColumnInfo, Hook, ParsedTestNode,
@@ -51,6 +53,7 @@ class TestNodeConfig(ContractTestCase):
         cfg._extra['extra'] = 'even more'
 
         self.assert_symmetric(cfg, cfg_dict)
+        pickle.loads(pickle.dumps(cfg))
 
 
 class TestParsedModelNode(ContractTestCase):
@@ -130,6 +133,7 @@ class TestParsedModelNode(ContractTestCase):
             'alias': 'bar',
         }
         self.assert_from_dict(node, minimum)
+        pickle.loads(pickle.dumps(node))
 
     def test_complex(self):
         node_dict = {
@@ -479,6 +483,7 @@ class TestParsedHookNode(ContractTestCase):
             'alias': 'bar',
         }
         self.assert_from_dict(node, minimum)
+        pickle.loads(pickle.dumps(node))
 
     def test_complex(self):
         node_dict = {
@@ -662,6 +667,7 @@ class TestParsedTestNode(ContractTestCase):
             'alias': 'bar',
         }
         self.assert_from_dict(node, minimum)
+        pickle.loads(pickle.dumps(node))
 
     def test_complex(self):
         node_dict = {
@@ -872,6 +878,7 @@ class TestTimestampSnapshotConfig(ContractTestCase):
             target_schema='some_snapshot_schema',
         )
         self.assert_symmetric(cfg, cfg_dict)
+        pickle.loads(pickle.dumps(cfg))
 
     def test_populated(self):
         cfg_dict = {
@@ -972,6 +979,7 @@ class TestCheckSnapshotConfig(ContractTestCase):
             target_schema='some_snapshot_schema',
         )
         self.assert_symmetric(cfg, cfg_dict)
+        pickle.loads(pickle.dumps(cfg))
 
     def test_populated(self):
         cfg_dict = {
@@ -1091,6 +1099,7 @@ class TestGenericSnapshotConfig(ContractTestCase):
         )
         cfg._extra.update({'magic_key': 'magic'})
         self.assert_symmetric(cfg, cfg_dict)
+        pickle.loads(pickle.dumps(cfg))
 
 
 class TestParsedSnapshotNode(ContractTestCase):
@@ -1199,6 +1208,7 @@ class TestParsedSnapshotNode(ContractTestCase):
         )
         self.assertTrue(node.is_refable)
         self.assertFalse(node.is_ephemeral)
+        pickle.loads(pickle.dumps(node))
 
     def test_check_ok(self):
         node_dict = {
@@ -1455,6 +1465,7 @@ class TestParsedNodePatch(ContractTestCase):
             ],
         )
         self.assert_symmetric(patch, dct)
+        pickle.loads(pickle.dumps(patch))
 
 
 class TestParsedMacro(ContractTestCase):
@@ -1487,6 +1498,7 @@ class TestParsedMacro(ContractTestCase):
         )
         self.assert_symmetric(macro, macro_dict)
         self.assertEqual(macro.local_vars(), {})
+        pickle.loads(pickle.dumps(macro))
 
     def test_invalid_missing_unique_id(self):
         bad_missing_uid = {
@@ -1544,6 +1556,7 @@ class TestParsedDocumentation(ContractTestCase):
             block_contents='some doc contents'
         )
         self.assert_symmetric(doc, doc_dict)
+        pickle.loads(pickle.dumps(doc))
 
     def test_invalid_missing(self):
         bad_missing_contents = {
@@ -1638,6 +1651,7 @@ class TestParsedSourceDefinition(ContractTestCase):
             'unique_id': 'test.source.my_source.my_source_table',
         }
         self.assert_from_dict(source_def, minimum)
+        pickle.loads(pickle.dumps(source_def))
 
     def test_invalid_missing(self):
         bad_missing_name = {

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -1,3 +1,4 @@
+import pickle
 from datetime import timedelta
 
 from dbt.contracts.graph.unparsed import (
@@ -31,6 +32,7 @@ class TestUnparsedMacro(ContractTestCase):
             resource_type=NodeType.Macro,
         )
         self.assert_symmetric(macro, macro_dict)
+        pickle.loads(pickle.dumps(macro))
 
     def test_invalid_missing_field(self):
         macro_dict = {
@@ -83,6 +85,7 @@ class TestUnparsedNode(ContractTestCase):
 
         self.assert_fails_validation(node_dict, cls=UnparsedRunHook)
         self.assert_fails_validation(node_dict, cls=UnparsedMacro)
+        pickle.loads(pickle.dumps(node))
 
     def test_empty(self):
         node_dict = {
@@ -148,6 +151,7 @@ class TestUnparsedRunHook(ContractTestCase):
         )
         self.assert_symmetric(node, node_dict)
         self.assert_fails_validation(node_dict, cls=UnparsedNode)
+        pickle.loads(pickle.dumps(node))
 
     def test_bad_type(self):
         node_dict = {
@@ -189,6 +193,7 @@ class TestFreshnessThreshold(ContractTestCase):
         self.assertEqual(threshold.status(error_seconds), FreshnessStatus.Error)
         self.assertEqual(threshold.status(warn_seconds), FreshnessStatus.Warn)
         self.assertEqual(threshold.status(pass_seconds), FreshnessStatus.Pass)
+        pickle.loads(pickle.dumps(threshold))
 
     def test_merged(self):
         t1 = self.ContractType(
@@ -230,6 +235,7 @@ class TestQuoting(ContractTestCase):
         self.assert_symmetric(
             c, {'database': True, 'schema': False, 'identifier': False}
         )
+        pickle.loads(pickle.dumps(c))
 
 
 class TestUnparsedSourceDefinition(ContractTestCase):
@@ -308,6 +314,7 @@ class TestUnparsedSourceDefinition(ContractTestCase):
         }
         self.assert_from_dict(source, from_dict)
         self.assert_symmetric(source, to_dict)
+        pickle.loads(pickle.dumps(source))
 
 
 class TestUnparsedDocumentationFile(ContractTestCase):
@@ -331,6 +338,7 @@ class TestUnparsedDocumentationFile(ContractTestCase):
         self.assert_symmetric(doc, doc_dict)
         self.assertEqual(doc.resource_type, NodeType.Documentation)
         self.assert_fails_validation(doc_dict, UnparsedNode)
+        pickle.loads(pickle.dumps(doc))
 
     def test_extra_field(self):
         self.assert_fails_validation({})
@@ -389,6 +397,7 @@ class TestUnparsedNodeUpdate(ContractTestCase):
             ],
         }
         self.assert_symmetric(update, dct)
+        pickle.loads(pickle.dumps(update))
 
     def test_bad_test_type(self):
         dct = {

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -7,8 +7,10 @@ from datetime import datetime
 import dbt.flags
 from dbt import tracking
 from dbt.contracts.graph.manifest import Manifest, ManifestMetadata
-from dbt.contracts.graph.parsed import ParsedNode, DependsOn, NodeConfig
-from dbt.contracts.graph.compiled import CompiledNode
+from dbt.contracts.graph.parsed import (
+    ParsedModelNode, DependsOn, NodeConfig, ParsedSeedNode
+)
+from dbt.contracts.graph.compiled import CompiledModelNode
 from dbt.node_types import NodeType
 import freezegun
 
@@ -18,7 +20,6 @@ REQUIRED_PARSED_NODE_KEYS = frozenset({
     'depends_on', 'database', 'schema', 'name', 'resource_type',
     'package_name', 'root_path', 'path', 'original_file_path', 'raw_sql',
     'docrefs', 'description', 'columns', 'fqn', 'build_path', 'patch_path',
-    'index',
 })
 
 REQUIRED_COMPILED_NODE_KEYS = frozenset(REQUIRED_PARSED_NODE_KEYS | {
@@ -46,7 +47,7 @@ class ManifestTest(unittest.TestCase):
         })
 
         self.nested_nodes = {
-            'model.snowplow.events': ParsedNode(
+            'model.snowplow.events': ParsedModelNode(
                 name='events',
                 database='dbt',
                 schema='analytics',
@@ -65,7 +66,7 @@ class ManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.events': ParsedNode(
+            'model.root.events': ParsedModelNode(
                 name='events',
                 database='dbt',
                 schema='analytics',
@@ -84,7 +85,7 @@ class ManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.dep': ParsedNode(
+            'model.root.dep': ParsedModelNode(
                 name='dep',
                 database='dbt',
                 schema='analytics',
@@ -103,7 +104,7 @@ class ManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.nested': ParsedNode(
+            'model.root.nested': ParsedModelNode(
                 name='nested',
                 database='dbt',
                 schema='analytics',
@@ -122,7 +123,7 @@ class ManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.sibling': ParsedNode(
+            'model.root.sibling': ParsedModelNode(
                 name='sibling',
                 database='dbt',
                 schema='analytics',
@@ -141,7 +142,7 @@ class ManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.multi': ParsedNode(
+            'model.root.multi': ParsedModelNode(
                 name='multi',
                 database='dbt',
                 schema='analytics',
@@ -316,7 +317,7 @@ class ManifestTest(unittest.TestCase):
 
     def test_get_resource_fqns(self):
         nodes = copy.copy(self.nested_nodes)
-        nodes['seed.root.seed'] = ParsedNode(
+        nodes['seed.root.seed'] = ParsedSeedNode(
             name='seed',
             database='dbt',
             schema='analytics',
@@ -371,7 +372,7 @@ class MixedManifestTest(unittest.TestCase):
         })
 
         self.nested_nodes = {
-            'model.snowplow.events': CompiledNode(
+            'model.snowplow.events': CompiledModelNode(
                 name='events',
                 database='dbt',
                 schema='analytics',
@@ -395,7 +396,7 @@ class MixedManifestTest(unittest.TestCase):
                 injected_sql=None,
                 extra_ctes=[]
             ),
-            'model.root.events': CompiledNode(
+            'model.root.events': CompiledModelNode(
                 name='events',
                 database='dbt',
                 schema='analytics',
@@ -419,7 +420,7 @@ class MixedManifestTest(unittest.TestCase):
                 injected_sql='and this also does not matter',
                 extra_ctes=[]
             ),
-            'model.root.dep': ParsedNode(
+            'model.root.dep': ParsedModelNode(
                 name='dep',
                 database='dbt',
                 schema='analytics',
@@ -438,7 +439,7 @@ class MixedManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.nested': ParsedNode(
+            'model.root.nested': ParsedModelNode(
                 name='nested',
                 database='dbt',
                 schema='analytics',
@@ -457,7 +458,7 @@ class MixedManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.sibling': ParsedNode(
+            'model.root.sibling': ParsedModelNode(
                 name='sibling',
                 database='dbt',
                 schema='analytics',
@@ -476,7 +477,7 @@ class MixedManifestTest(unittest.TestCase):
                 root_path='',
                 raw_sql='does not matter'
             ),
-            'model.root.multi': ParsedNode(
+            'model.root.multi': ParsedModelNode(
                 name='multi',
                 database='dbt',
                 schema='analytics',

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -13,7 +13,7 @@ from dbt.parser.source_config import SourceConfig
 
 from dbt.node_types import NodeType
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.parsed import ParsedNode, ParsedMacro, \
+from dbt.contracts.graph.parsed import ParsedModelNode, ParsedMacro, \
     ParsedNodePatch, ParsedSourceDefinition, NodeConfig, DependsOn, \
     ColumnInfo, ParsedTestNode, TestConfig
 from dbt.contracts.graph.unparsed import FreshnessThreshold, Quoting, Time, \
@@ -950,7 +950,19 @@ class ParserTest(BaseParserTest):
             'column_types': {},
             'tags': [],
         })
-        self.test_config = self.model_config.replace(severity='ERROR')
+
+        self.test_config = TestConfig.from_dict({
+            'enabled': True,
+            'materialized': 'view',
+            'persist_docs': {},
+            'post-hook': [],
+            'pre-hook': [],
+            'vars': {},
+            'quoting': {},
+            'column_types': {},
+            'tags': [],
+            'severity': 'ERROR',
+        })
 
         self.disabled_config = NodeConfig.from_dict({
             'enabled': False,
@@ -983,7 +995,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',
@@ -1041,7 +1053,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',
@@ -1088,7 +1100,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',
@@ -1142,7 +1154,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.base': ParsedNode(
+                'model.root.base': ParsedModelNode(
                     alias='base',
                     name='base',
                     database='test',
@@ -1164,7 +1176,7 @@ class ParserTest(BaseParserTest):
                     columns={}
 
                 ),
-                'model.root.events_tx': ParsedNode(
+                'model.root.events_tx': ParsedModelNode(
                     alias='events_tx',
                     name='events_tx',
                     database='test',
@@ -1245,7 +1257,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.events': ParsedNode(
+                'model.root.events': ParsedModelNode(
                     alias='events',
                     name='events',
                     database='test',
@@ -1267,7 +1279,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.sessions': ParsedNode(
+                'model.root.sessions': ParsedModelNode(
                     alias='sessions',
                     name='sessions',
                     database='test',
@@ -1289,7 +1301,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={},
                 ),
-                'model.root.events_tx': ParsedNode(
+                'model.root.events_tx': ParsedModelNode(
                     alias='events_tx',
                     name='events_tx',
                     database='test',
@@ -1311,7 +1323,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.sessions_tx': ParsedNode(
+                'model.root.sessions_tx': ParsedModelNode(
                     alias='sessions_tx',
                     name='sessions_tx',
                     database='test',
@@ -1333,7 +1345,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.multi': ParsedNode(
+                'model.root.multi': ParsedModelNode(
                     alias='multi',
                     name='multi',
                     database='test',
@@ -1417,7 +1429,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.snowplow.events': ParsedNode(
+                'model.snowplow.events': ParsedModelNode(
                     alias='events',
                     name='events',
                     database='test',
@@ -1439,7 +1451,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.snowplow.sessions': ParsedNode(
+                'model.snowplow.sessions': ParsedModelNode(
                     alias='sessions',
                     name='sessions',
                     database='test',
@@ -1461,7 +1473,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.snowplow.events_tx': ParsedNode(
+                'model.snowplow.events_tx': ParsedModelNode(
                     alias='events_tx',
                     name='events_tx',
                     database='test',
@@ -1483,7 +1495,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.snowplow.sessions_tx': ParsedNode(
+                'model.snowplow.sessions_tx': ParsedModelNode(
                     alias='sessions_tx',
                     name='sessions_tx',
                     database='test',
@@ -1505,7 +1517,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.multi': ParsedNode(
+                'model.root.multi': ParsedModelNode(
                     alias='multi',
                     name='multi',
                     database='test',
@@ -1534,7 +1546,7 @@ class ParserTest(BaseParserTest):
 
     def test__process_refs__packages(self):
         nodes = {
-            'model.snowplow.events': ParsedNode(
+            'model.snowplow.events': ParsedModelNode(
                 name='events',
                 alias='events',
                 database='test',
@@ -1553,7 +1565,7 @@ class ParserTest(BaseParserTest):
                 root_path=get_os_path('/usr/src/app'),
                 raw_sql='does not matter',
             ),
-            'model.root.events': ParsedNode(
+            'model.root.events': ParsedModelNode(
                 name='events',
                 alias='events',
                 database='test',
@@ -1572,7 +1584,7 @@ class ParserTest(BaseParserTest):
                 root_path=get_os_path('/usr/src/app'),
                 raw_sql='does not matter',
             ),
-            'model.root.dep': ParsedNode(
+            'model.root.dep': ParsedModelNode(
                 name='dep',
                 alias='dep',
                 database='test',
@@ -1632,7 +1644,6 @@ class ParserTest(BaseParserTest):
                         'columns': {},
                         'description': '',
                         'build_path': None,
-                        'index': None,
                         'patch_path': None,
                     },
                     'model.root.events': {
@@ -1660,7 +1671,6 @@ class ParserTest(BaseParserTest):
                         'columns': {},
                         'description': '',
                         'build_path': None,
-                        'index': None,
                         'patch_path': None,
                     },
                     'model.root.dep': {
@@ -1688,7 +1698,6 @@ class ParserTest(BaseParserTest):
                         'columns': {},
                         'description': '',
                         'build_path': None,
-                        'index': None,
                         'patch_path': None,
                     }
                 }
@@ -1718,7 +1727,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',
@@ -1794,7 +1803,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.table': ParsedNode(
+                'model.root.table': ParsedModelNode(
                     alias='table',
                     name='table',
                     database='test',
@@ -1816,7 +1825,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.ephemeral': ParsedNode(
+                'model.root.ephemeral': ParsedModelNode(
                     alias='ephemeral',
                     name='ephemeral',
                     database='test',
@@ -1838,7 +1847,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.view': ParsedNode(
+                'model.root.view': ParsedModelNode(
                     alias='view',
                     name='view',
                     database='test',
@@ -1979,7 +1988,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             parsed={
-                'model.root.table': ParsedNode(
+                'model.root.table': ParsedModelNode(
                     alias='table',
                     name='table',
                     database='test',
@@ -2001,7 +2010,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.ephemeral': ParsedNode(
+                'model.root.ephemeral': ParsedModelNode(
                     alias='ephemeral',
                     name='ephemeral',
                     database='test',
@@ -2023,7 +2032,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.root.view': ParsedNode(
+                'model.root.view': ParsedModelNode(
                     alias='view',
                     name='view',
                     database='test',
@@ -2045,7 +2054,7 @@ class ParserTest(BaseParserTest):
                     description='',
                     columns={}
                 ),
-                'model.snowplow.multi_sort': ParsedNode(
+                'model.snowplow.multi_sort': ParsedModelNode(
                     alias='multi_sort',
                     name='multi_sort',
                     database='test',
@@ -2069,7 +2078,7 @@ class ParserTest(BaseParserTest):
                 ),
             },
             disabled=[
-                ParsedNode(
+                ParsedModelNode(
                     name='disabled',
                     resource_type=NodeType.Model,
                     package_name='snowplow',
@@ -2089,7 +2098,7 @@ class ParserTest(BaseParserTest):
                     fqn=['snowplow', 'disabled'],
                     columns={}
                 ),
-                ParsedNode(
+                ParsedModelNode(
                     name='package',
                     resource_type=NodeType.Model,
                     package_name='snowplow',
@@ -2132,7 +2141,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(tests),
             {
-                'test.root.no_events': ParsedNode(
+                'test.root.no_events': ParsedTestNode(
                     alias='no_events',
                     name='no_events',
                     database='test',
@@ -2173,7 +2182,6 @@ class ParserTest(BaseParserTest):
             resource_type=NodeType.Macro)
 
         self.assertTrue(callable(result['macro.root.simple'].generator))
-
 
         self.assertEqual(
             result,
@@ -2250,7 +2258,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',
@@ -2296,7 +2304,7 @@ class ParserTest(BaseParserTest):
         self._assert_parsed_sql_nodes(
             parser.parse_sql_nodes(models),
             {
-                'model.root.model_one': ParsedNode(
+                'model.root.model_one': ParsedModelNode(
                     alias='model_one',
                     name='model_one',
                     database='test',


### PR DESCRIPTION
Fixes #1601 
Fixes #1486 

This includes a few test changes to account for removed fields based on types

This PR doesn't remove the `raw_sql` field from seeds or anything like that, as that's a bit more involved - right now dbt really assumes that all nodes have that field and it's easier to leave it for the moment. In the future when compilation is cleaned up a bit it will probably make sense to remove that.