### PR TITLE
Set application name in snowflake connections

### DIFF
--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -131,6 +131,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                 autocommit=False,
                 client_session_keep_alive=credentials.get(
                     'client_session_keep_alive', False),
+                application='dbt',
                 **auth_args
             )
 

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -164,7 +164,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
-                warehouse='test_warehouse', private_key=None)
+                warehouse='test_warehouse', private_key=None, application='dbt')
         ])
 
     def test_client_session_keep_alive_true(self):
@@ -178,7 +178,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=False,
                 client_session_keep_alive=True, database='test_database',
                 role=None, schema='public', user='test_user',
-                warehouse='test_warehouse', private_key=None)
+                warehouse='test_warehouse', private_key=None, application='dbt')
         ])
 
     def test_user_pass_authentication(self):
@@ -192,7 +192,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_database',
                 password='test_password', role=None, schema='public',
-                user='test_user', warehouse='test_warehouse', private_key=None)
+                user='test_user', warehouse='test_warehouse', private_key=None,
+                application='dbt')
         ])
 
     def test_authenticator_user_pass_authentication(self):
@@ -207,7 +208,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse',
-                authenticator='test_sso_url', private_key=None)
+                authenticator='test_sso_url', private_key=None,
+                application='dbt')
         ])
 
     def test_authenticator_externalbrowser_authentication(self):
@@ -222,7 +224,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='externalbrowser',
-                private_key=None)
+                private_key=None, application='dbt')
         ])
 
     @patch('dbt.adapters.snowflake.SnowflakeConnectionManager._get_private_key', return_value='test_key')
@@ -239,5 +241,6 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=False,
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
-                warehouse='test_warehouse', private_key='test_key')
+                warehouse='test_warehouse', private_key='test_key',
+                application='dbt')
         ])


### PR DESCRIPTION
The `application` connection parameter is used by Snowflake to identify which applications are running specific queries. While this was unset, dbt's queries would be identified as coming from the `PythonConnector` application. This config instead helps identify the queries as coming from dbt.

closes #1622 