### PR TITLE
Add environment variables for macro debugging flags (#1628)

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -1,6 +1,7 @@
 import codecs
 import linecache
 import os
+import tempfile
 
 import jinja2
 import jinja2._compat
@@ -16,6 +17,34 @@ import dbt.utils
 from dbt.clients._jinja_blocks import BlockIterator
 
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
+
+
+def _linecache_inject(source, write):
+    if write:
+        # this is the only reliable way to accomplish this. Obviously, it's
+        # really darn noisy and will fill your temporary directory
+        tmp_file = tempfile.NamedTemporaryFile(
+            prefix='dbt-macro-compiled-',
+            suffix='.py',
+            delete=False,
+            mode='w+',
+            encoding='utf-8',
+        )
+        tmp_file.write(source)
+        filename = tmp_file.name
+    else:
+        filename = codecs.encode(os.urandom(12), 'hex').decode('ascii')
+
+    # encode, though I don't think this matters
+    filename = jinja2._compat.encode_filename(filename)
+    # put ourselves in the cache
+    linecache.cache[filename] = (
+        len(source),
+        None,
+        [line + '\n' for line in source.splitlines()],
+        filename
+    )
+    return filename
 
 
 class MacroFuzzParser(jinja2.parser.Parser):
@@ -43,22 +72,16 @@ class MacroFuzzEnvironment(jinja2.sandbox.SandboxedEnvironment):
 
     def _compile(self, source, filename):
         """Override jinja's compilation to stash the rendered source inside
-        the python linecache for debugging.
+        the python linecache for debugging when the appropriate environment
+        variable is set.
+
+        If the value is 'write', also write the files to disk.
+        WARNING: This can write a ton of data if you aren't careful.
         """
-        if filename == '<template>':
-            # make a better filename
-            filename = 'dbt-{}'.format(
-                codecs.encode(os.urandom(12), 'hex').decode('ascii')
-            )
-            # encode, though I don't think this matters
-            filename = jinja2._compat.encode_filename(filename)
-            # put ourselves in the cache
-            linecache.cache[filename] = (
-                len(source),
-                None,
-                [line + '\n' for line in source.splitlines()],
-                filename
-            )
+        macro_compile = os.environ.get('DBT_MACRO_DEBUGGING')
+        if filename == '<template>' and macro_compile:
+            write = macro_compile == 'write'
+            filename = _linecache_inject(source, write)
 
         return super(MacroFuzzEnvironment, self)._compile(source, filename)
 

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -195,6 +195,13 @@ def _load_result(sql_results):
     return call
 
 
+def _debug_here():
+    import sys
+    import ipdb
+    frame = sys._getframe(3)
+    ipdb.set_trace(frame)
+
+
 def _add_sql_handlers(context):
     sql_results = {}
     return dbt.utils.merge(context, {
@@ -415,6 +422,8 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "target": target,
         "try_or_compiler_error": try_or_compiler_error(model)
     })
+    if os.environ.get('DBT_MACRO_DEBUGGING'):
+        context['debug'] = _debug_here
 
     return context
 


### PR DESCRIPTION
Fixes #1628 by adding `DBT_MACRO_DEBUGGING` environment variable support, by default no linecache is set.

While I'm in here adding debugger environment variables, I added two useful tricks I've been using locally so I don't have to keep manually patching them in:
 - when the environment variable is set to `write`, write the files to disk so the debugging experience is more pleasant. This writes a lot of files and doesn't clean them up! But boy is it helpful sometimes, just to see where you are.
 - when the environment variable is set, a special entry is inserted into the default context: `{{ debug() }}` will drop you into a debugger at the current line in the compiled macro. This is pretty helpful when you're debugging low-level macro weirdness and don't want to step through a million internal jinja functions just to see where you are.


``` 
$ cat models/x.sql
{{ debug() }}
select * from {{ source('src', 'seedtable') }}
```

With `DBT_MACRO_DEBUGGING` set:
```
$ DBT_MACRO_DEBUGGING=true dbt compile
Running with dbt=0.14.0
> /Users/jake/src/fishtown/projects/debug/bfb3707e2a6c4e27ff565365(14)root()

ipdb> l 9,12
      9     l_0_debug = resolve('debug')
     10     l_0_source = resolve('source')
     11     pass
     12     yield '%s\nselect * from %s' % (
```

With `DBT_MACRO_DEBUGGING=write` set:
```
$ DBT_MACRO_DEBUGGING=write dbt compile
Running with dbt=0.14.0
> /var/folders/31/mrzqbbtd3rn4hmgbhrtkfyxm0000gn/T/dbt-macro-compiled-cxvhhgu7.py(14)root()
     13         environment.call(context, (undefined(name='debug') if l_0_debug is missing else l_0_debug)),
---> 14         environment.call(context, (undefined(name='source') if l_0_source is missing else l_0_source), 'src', 'seedtable'),
     15     )

ipdb> l 9,12
      9     l_0_debug = resolve('debug')
     10     l_0_source = resolve('source')
     11     pass
     12     yield '%s\nselect * from %s' % (
```

The extra context really shines in longer macro/function call chains when you're walking up and down the stack trying to figure out why all your `ref()` calls started returning `None` after your minor tweak to the parser or whatever.

