### PR TITLE
Fix for unrendered source column descriptions

### DIFF
--- a/core/dbt/parser/util.py
+++ b/core/dbt/parser/util.py
@@ -162,10 +162,9 @@ class ParserUtils(object):
         source.set('source_description', source_description)
 
         for column_name, column_def in source.columns.items():
-            column_description = column_def.get('description', '')
-            column_description = dbt.clients.jinja.get_rendered(
-                    column_description, context)
-            column_def['description'] = column_description
+            column_desc = column_def.get('description', '')
+            column_desc = dbt.clients.jinja.get_rendered(column_desc, context)
+            column_def['description'] = column_desc
 
     @classmethod
     def process_docs(cls, manifest, current_project):

--- a/core/dbt/parser/util.py
+++ b/core/dbt/parser/util.py
@@ -161,6 +161,12 @@ class ParserUtils(object):
         source.set('description', table_description)
         source.set('source_description', source_description)
 
+        for column_name, column_def in source.columns.items():
+            column_description = column_def.get('description', '')
+            column_description = dbt.clients.jinja.get_rendered(
+                    column_description, context)
+            column_def['description'] = column_description
+
     @classmethod
     def process_docs(cls, manifest, current_project):
         for node in manifest.nodes.values():

--- a/test/integration/029_docs_generate_tests/ref_models/docs.md
+++ b/test/integration/029_docs_generate_tests/ref_models/docs.md
@@ -21,3 +21,7 @@ My source
 {% docs table_info %}
 My table
 {% enddocs %}
+
+{% docs column_info %}
+An ID field
+{% enddocs %}

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -28,4 +28,4 @@ sources:
           identifier: True
         columns:
           - name: id
-            description: "An ID field"
+            description: "{{ doc('column_info') }}"

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1267,6 +1267,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'My table',
                     'docrefs': [
                          {
+                             "documentation_package": "",
+                             "documentation_name": "column_info",
+                             "column_name": "id",
+                         },
+                         {
                              'documentation_name': 'table_info',
                              'documentation_package': ''
                          },
@@ -1294,6 +1299,17 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'docs': {
                 'dbt.__overview__': ANY,
+                "test.column_info": {
+                    "block_contents": "An ID field",
+                    "file_contents": docs_file,
+                    "name": "column_info",
+                    "original_file_path": docs_path,
+                    "package_name": "test",
+                    "path": "docs.md",
+                    "resource_type": "docs",
+                    "root_path": OneOf(self.test_root_dir, self.initial_dir),
+                    "unique_id": "test.column_info",
+                },
                 'test.ephemeral_summary': {
                     'block_contents': (
                         'A summmary table of the ephemeral copy of the seed data'


### PR DESCRIPTION
closes #1619

- Renders the `columns` in a `source`
- Adds tests