### PR TITLE
(#1626) fix for RPC error with BQ nested fields

### DIFF
--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -3,6 +3,7 @@ from codecs import BOM_UTF8
 import dbt.compat
 
 import agate
+import json
 
 BOM = BOM_UTF8.decode('utf-8')  # '\ufeff'
 
@@ -33,11 +34,21 @@ def table_from_data(data, column_names):
         return table.select(column_names)
 
 
-def table_from_data_explicit(data, column_names):
+def table_from_data_flat(data, column_names):
     "Convert list of dictionaries into an Agate table"
 
-    rows = [list(r.values()) for r in data]
-    return agate.Table(rows, column_names)
+    rows = []
+    for _row in data:
+        row = []
+        for value in list(_row.values()):
+            if isinstance(value, (dict, list, tuple)):
+                row.append(json.dumps(value))
+            else:
+                row.append(value)
+        rows.append(row)
+
+    table = agate.Table(rows, column_names)
+    return table.select(column_names)
 
 
 def empty_table():

--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -47,8 +47,7 @@ def table_from_data_flat(data, column_names):
                 row.append(value)
         rows.append(row)
 
-    table = agate.Table(rows, column_names)
-    return table.select(column_names)
+    return agate.Table(rows, column_names)
 
 
 def empty_table():

--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -33,6 +33,13 @@ def table_from_data(data, column_names):
         return table.select(column_names)
 
 
+def table_from_data_explicit(data, column_names):
+    "Convert list of dictionaries into an Agate table"
+
+    rows = [list(r.values()) for r in data]
+    return agate.Table(rows, column_names)
+
+
 def empty_table():
     "Returns an empty Agate table. To be used in place of None"
 

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -181,8 +181,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
     @classmethod
     def get_table_from_response(cls, resp):
         column_names = [field.name for field in resp.schema]
-        rows = [dict(row.items()) for row in resp]
-        return dbt.clients.agate_helper.table_from_data(rows, column_names)
+        return dbt.clients.agate_helper.table_from_data_explicit(resp,
+                                                                 column_names)
 
     def raw_execute(self, sql, fetch=False):
         conn = self.get_thread_connection()

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -181,8 +181,8 @@ class BigQueryConnectionManager(BaseConnectionManager):
     @classmethod
     def get_table_from_response(cls, resp):
         column_names = [field.name for field in resp.schema]
-        return dbt.clients.agate_helper.table_from_data_explicit(resp,
-                                                                 column_names)
+        return dbt.clients.agate_helper.table_from_data_flat(resp,
+                                                             column_names)
 
     def raw_execute(self, sql, fetch=False):
         conn = self.get_thread_connection()

--- a/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
+++ b/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
@@ -1,0 +1,63 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+
+class TestBaseBigQueryRun(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "bigquery_test_022"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['macros'],
+        }
+
+    @use_profile('bigquery')
+    def test__bigquery_fetch_nested_records(self):
+        sql = """
+        select
+          struct(
+            cast('Michael' as string) as fname,
+            cast('Stonebreaker' as string) as lname
+          ) as user,
+          [
+            struct(1 as val_1, 2 as val_2),
+            struct(3 as val_1, 4 as val_2)
+          ] as val
+
+        union all
+
+        select
+          struct(
+            cast('Johnny' as string) as fname,
+            cast('Brickmaker' as string) as lname
+          ) as user,
+          [
+            struct(7 as val_1, 8 as val_2),
+            struct(9 as val_1, 0 as val_2)
+          ] as val
+        """
+
+
+        status, res = self.adapter.execute(sql, fetch=True)
+
+        self.assertEqual(len(res), 2, "incorrect row count")
+
+        expected = {
+            "user": [
+                "{'fname': 'Michael', 'lname': 'Stonebreaker'}",
+                "{'fname': 'Johnny', 'lname': 'Brickmaker'}"
+            ],
+            "val": [
+                "[{'val_1': 1, 'val_2': 2}, {'val_1': 3, 'val_2': 4}]",
+                "[{'val_1': 7, 'val_2': 8}, {'val_1': 9, 'val_2': 0}]"
+            ]
+        }
+
+        for i, key in enumerate(expected):
+            line = "row {} for key {}".format(i, key)
+            self.assertEqual(expected[key][i], res[i][key], line)

--- a/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
+++ b/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
@@ -1,4 +1,5 @@
 from test.integration.base import DBTIntegrationTest, use_profile
+import json
 
 class TestBaseBigQueryRun(DBTIntegrationTest):
 
@@ -49,15 +50,18 @@ class TestBaseBigQueryRun(DBTIntegrationTest):
 
         expected = {
             "user": [
-                "{'fname': 'Michael', 'lname': 'Stonebreaker'}",
-                "{'fname': 'Johnny', 'lname': 'Brickmaker'}"
+                '{"fname": "Michael", "lname": "Stonebreaker"}',
+                '{"fname": "Johnny", "lname": "Brickmaker"}'
             ],
             "val": [
-                "[{'val_1': 1, 'val_2': 2}, {'val_1': 3, 'val_2': 4}]",
-                "[{'val_1': 7, 'val_2': 8}, {'val_1': 9, 'val_2': 0}]"
+                '[{"val_1": 1, "val_2": 2}, {"val_1": 3, "val_2": 4}]',
+                '[{"val_1": 7, "val_2": 8}, {"val_1": 9, "val_2": 0}]'
             ]
         }
 
         for i, key in enumerate(expected):
-            line = "row {} for key {}".format(i, key)
-            self.assertEqual(expected[key][i], res[i][key], line)
+            line = "row {} for key {} ({} vs {})".format(i, key, expected[key][i], res[i][key])
+            # py2 serializes these in an unordered way - deserialize to compare
+            v1 = expected[key][i]
+            v2 = res[i][key]
+            self.assertEqual(json.loads(v1), json.loads(v2), line)


### PR DESCRIPTION
First cut here - wanted to open this up for review.

In #1626, some issues with passing a list of dicts to `agate.Table.from_object` are outlined. This PR changes the BigQuery plugin to bypass `from_object`, instead creating an object explicitly from a specified set of rows and columns. This has the _very_ negative effect of requiring us to serialize iterables as json (if we didn't do this manually, Agate would just use their `repr`s which is pretty unhelpful) -- see the included integration tests for an example.

I think it _may_ be appropriate to convert these nested/repeated records from dicts/lists (respectively) into json strings. Previously, dbt would fail with an error if _any_ columns returned by `adapter.execute` were nested or repeated, so just returning without error is a marked improvement over the existing behavior.

I'm not sure if there's a good way to reconcile Agate's behavior with BigQuery's nested/repeated records. Depending on how we choose to proceed, this issue either represents another nail in Agate's coffin for dbt, or a tacit decision to not leverage nested/repeated records on BigQuery. My personal stance is that we should ditch Agate as soon as we're able.

I believe BQ is the only place where a call to `execute` can return data that isn't strictly a list of dicts that map strings onto scalars. We can use `table_from_data_flat` in other adapters to bypass the type inference that Agate does -- that might be a good idea as well, though possibly one for another PR.