### PR TITLE
exclude ephemeral addins in dbt ls command

### DIFF
--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -135,6 +135,7 @@ class ListTask(GraphRunnableTask):
             "exclude": self.args.exclude,
             "resource_types": self.resource_types,
             "tags": [],
+            "addin_ephemeral_nodes": False
         }
 
     def interpret_results(self, results):

--- a/test/integration/047_dbt_ls_test/models/ephemeral.sql
+++ b/test/integration/047_dbt_ls_test/models/ephemeral.sql
@@ -1,0 +1,4 @@
+
+{{ config(materialized='ephemeral') }}
+
+select 1 as id

--- a/test/integration/047_dbt_ls_test/models/outer.sql
+++ b/test/integration/047_dbt_ls_test/models/outer.sql
@@ -1,1 +1,1 @@
-select 1 as id
+select * from {{ ref('ephemeral') }}


### PR DESCRIPTION
Just noticed this one: `dbt ls --model my_model` would return `my_model`, as well as all of the ephemeral models in the project due to the changes in this commit https://github.com/fishtown-analytics/dbt/commit/c0aabc7d0b63aa26014c13828911fd55f2a89117

This PR adds an additional query parameter, `addin_ephemeral_nodes`, which controls whether or not addins are included in the selection. This is `False` for ls, but defaults to `True` for all other dbt invocations.

I can make this an argument to `select()` instead, but this looked like the path of least resistance.