### PR TITLE
Log, but allow, failures during cleanup rollbacks.

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -251,7 +251,7 @@ class BaseConnectionManager(object):
         try:
             connection.handle.rollback()
         except Exception:
-            logger.exception('Failed to rollback {}'.format(connection.name))
+            logger.debug('Failed to rollback {}'.format(connection.name), exc_info=True)
 
     @classmethod
     def _close_handle(cls, connection):

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -248,7 +248,10 @@ class BaseConnectionManager(object):
     @classmethod
     def _rollback_handle(cls, connection):
         """Perform the actual rollback operation."""
-        connection.handle.rollback()
+        try:
+            connection.handle.rollback()
+        except Exception:
+            logger.exception('Failed to rollback {}'.format(connection.name))
 
     @classmethod
     def _close_handle(cls, connection):

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -251,7 +251,10 @@ class BaseConnectionManager(object):
         try:
             connection.handle.rollback()
         except Exception:
-            logger.debug('Failed to rollback {}'.format(connection.name), exc_info=True)
+            logger.debug(
+                'Failed to rollback {}'.format(connection.name),
+                exc_info=True
+            )
 
     @classmethod
     def _close_handle(cls, connection):


### PR DESCRIPTION
In Postgres, rollbacks can fail if the transaction was killed
by the database. One common scenario is that the
`idle_in_transaction_session_timeout` is enabled.

If the
transaction was cancelled, the connection is left open
in `dbt`. `dbt` attempts to close that connection after issuing
a `ROLLBACK`. But it fails since the transaction was severed.
Since the cleanup is carried out in a `finally` statement, the
`psycopg2.InternalDatabaseError` is thrown and prevents the
test case results from ever being shown.

Changes here wrap the `ROLLBACK` in a try-catch such that
if there is an exception thrown, it is logged appropriately,
but ultimately proceeds.

## Before

Prior to this change, a failed rollback during cleanup would prevent the test results from every being shown as the exception is thrown during the `finally` clause.

![Screen Shot 2019-07-31 at 10 32 04 AM](https://user-images.githubusercontent.com/43149844/62225672-87605780-b37e-11e9-8f50-239bd4f754c3.png)


## After

Here the exception is logged, but caught. Test case results are shown afterwards rather than `dbt` crashing.

![Screen Shot 2019-07-31 at 10 32 27 AM](https://user-images.githubusercontent.com/43149844/62225677-8af3de80-b37e-11e9-8f60-8598457be0f0.png)
