### PR TITLE
Add Postgres CTAS adapter macro with support for unlogged parameter

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -14,6 +14,8 @@ class PostgresAdapter(SQLAdapter):
     ConnectionManager = PostgresConnectionManager
     Column = PostgresColumn
 
+    AdapterSpecificConfigs = frozenset({'unlogged'})
+
     @classmethod
     def date_function(cls):
         return 'now()'

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -1,3 +1,15 @@
+{% macro postgres__create_table_as(temporary, relation, sql) -%}
+  {%- set unlogged = config.get('unlogged', default=false) -%}
+
+  create {% if temporary -%}
+    temporary
+  {%- elif unlogged -%}
+    unlogged
+  {%- endif %} table {{ relation }}
+  as (
+    {{ sql }}
+  );
+{%- endmacro %}
 
 {% macro postgres__create_schema(database_name, schema_name) -%}
   {% if database_name -%}


### PR DESCRIPTION
This gives the developer the ability to pass in an `unlogged` parameter in their model config, which is executed during the CTAS.

Issue: #1648