### PR TITLE
(#1597) summarize warnings at end of test invocations

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -25,21 +25,21 @@ graph_file_name = 'graph.gpickle'
 
 def print_compile_stats(stats):
     names = {
-        NodeType.Model: 'models',
-        NodeType.Test: 'tests',
-        NodeType.Snapshot: 'snapshots',
-        NodeType.Analysis: 'analyses',
-        NodeType.Macro: 'macros',
-        NodeType.Operation: 'operations',
-        NodeType.Seed: 'seed files',
-        NodeType.Source: 'sources',
+        NodeType.Model: 'model',
+        NodeType.Test: 'test',
+        NodeType.Snapshot: 'snapshot',
+        NodeType.Analysis: 'analyse',
+        NodeType.Macro: 'macro',
+        NodeType.Operation: 'operation',
+        NodeType.Seed: 'seed file',
+        NodeType.Source: 'source',
     }
 
     results = {k: 0 for k in names.keys()}
     results.update(stats)
 
     stat_line = ", ".join(
-        ["{} {}".format(ct, names.get(t)) for t, ct in results.items()])
+        [dbt.utils.pluralize(ct, names.get(t)) for t, ct in results.items()])
 
     logger.notice("Found {}".format(stat_line))
 

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -130,14 +130,16 @@ RUN_MODEL_RESULT_CONTRACT = deep_merge(PARTIAL_RESULT_CONTRACT, {
             'type': 'boolean',
             'description': 'True if this node was skipped',
         },
-        # This is assigned by dbt.ui.printer.print_test_result_line, if a test
-        # has no error and a non-zero status
+        'warn': {
+            'type': ['boolean', 'null'],
+            'description': 'True if this node succeeded with a warning',
+        },
         'fail': {
             'type': ['boolean', 'null'],
             'description': 'On tests, true if the test failed',
         },
     },
-    'required': ['skip', 'fail']
+    'required': ['skip', 'fail', 'warn']
 })
 
 
@@ -145,7 +147,7 @@ class RunModelResult(NodeSerializable):
     SCHEMA = RUN_MODEL_RESULT_CONTRACT
 
     def __init__(self, node, error=None, skip=False, status=None, failed=None,
-                 thread_id=None, timing=None, execution_time=0):
+                 warned=None, thread_id=None, timing=None, execution_time=0):
         if timing is None:
             timing = []
         super(RunModelResult, self).__init__(
@@ -154,6 +156,7 @@ class RunModelResult(NodeSerializable):
             skip=skip,
             status=status,
             fail=failed,
+            warn=warned,
             execution_time=execution_time,
             thread_id=thread_id,
             timing=timing,
@@ -163,6 +166,7 @@ class RunModelResult(NodeSerializable):
     error = named_property('error',
                            'If there was an error, the text of that error')
     skip = named_property('skip', 'True if the model was skipped')
+    warn = named_property('warn', 'True if this was a test and it warned')
     fail = named_property('fail', 'True if this was a test and it failed')
     status = named_property('status', 'The status of the model execution')
     execution_time = named_property('execution_time',
@@ -179,6 +183,10 @@ class RunModelResult(NodeSerializable):
     @property
     def failed(self):
         return self.fail
+
+    @property
+    def warned(self):
+        return self.warn
 
     @property
     def skipped(self):

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -100,7 +100,7 @@ def get_counts(flat_nodes):
         counts[t] = counts.get(t, 0) + 1
 
     stat_line = ", ".join(
-        ["{} {}s".format(v, k) for k, v in counts.items()])
+        [dbt.utils.pluralize(v, k) for k, v in counts.items()])
 
     return stat_line
 
@@ -145,24 +145,22 @@ def get_printable_result(result, success, error):
 
 def print_test_result_line(result, schema_name, index, total):
     model = result.node
-    info = 'PASS'
 
     if result.error is not None:
         info = "ERROR"
         color = red
 
-    elif result.status > 0:
-        severity = result.node.config['severity'].upper()
-        if severity == 'ERROR' or dbt.flags.WARN_ERROR:
-            info = 'FAIL {}'.format(result.status)
-            color = red
-            result.fail = True
-        else:
-            info = 'WARN {}'.format(result.status)
-            color = yellow
     elif result.status == 0:
         info = 'PASS'
         color = green
+
+    elif result.warn:
+        info = 'WARN {}'.format(result.status)
+        color = yellow
+
+    elif result.fail:
+        info = 'FAIL {}'.format(result.status)
+        color = red
 
     else:
         raise RuntimeError("unexpected status: {}".format(result.status))
@@ -259,6 +257,8 @@ def interpret_run_result(result):
         return 'error'
     elif result.skipped:
         return 'skip'
+    elif result.warned:
+        return 'warn'
     else:
         return 'pass'
 
@@ -268,6 +268,7 @@ def print_run_status_line(results):
         'error': 0,
         'skip': 0,
         'pass': 0,
+        'warn': 0,
         'total': 0,
     }
 
@@ -276,20 +277,28 @@ def print_run_status_line(results):
         stats[result_type] += 1
         stats['total'] += 1
 
-    stats_line = "\nDone. PASS={pass} ERROR={error} SKIP={skip} TOTAL={total}"
+    stats_line = "\nDone. PASS={pass} WARN={warn} ERROR={error} SKIP={skip} TOTAL={total}"  # noqa
     logger.info(stats_line.format(**stats))
 
 
-def print_run_result_error(result, newline=True):
+def print_run_result_error(result, newline=True, is_warning=False):
     if newline:
         logger.info("")
 
-    if result.failed:
-        logger.info(yellow("Failure in {} {} ({})").format(
+    if result.failed or (is_warning and result.warned):
+        if is_warning:
+            color = yellow
+            info = 'Warning'
+        else:
+            color = red
+            info = 'Failure'
+        logger.info(color("{} in {} {} ({})").format(
+            info,
             result.node.get('resource_type'),
             result.node.get('name'),
             result.node.get('original_file_path')))
-        logger.info("  Got {} results, expected 0.".format(result.status))
+        status = dbt.utils.pluralize(result.status, 'result')
+        logger.info("  Got {}, expected 0.".format(status))
 
         if result.node.get('build_path') is not None:
             logger.info("")
@@ -314,11 +323,16 @@ def print_skip_caused_by_error(model, schema, relation, index, num_models,
     print_run_result_error(result, newline=False)
 
 
-def print_end_of_run_summary(num_errors, early_exit=False):
+def print_end_of_run_summary(num_errors, num_warnings, early_exit=False):
+    error_plural = dbt.utils.pluralize(num_errors, 'error')
+    warn_plural = dbt.utils.pluralize(num_warnings, 'warning')
     if early_exit:
         message = yellow('Exited because of keyboard interrupt.')
     elif num_errors > 0:
-        message = red('Completed with {} errors:'.format(num_errors))
+        message = red("Completed with {} and {}:".format(
+            error_plural, warn_plural))
+    elif num_warnings > 0:
+        message = yellow('Completed with {}:'.format(warn_plural))
     else:
         message = green('Completed successfully')
 
@@ -328,9 +342,13 @@ def print_end_of_run_summary(num_errors, early_exit=False):
 
 def print_run_end_messages(results, early_exit=False):
     errors = [r for r in results if r.error is not None or r.failed]
-    print_end_of_run_summary(len(errors), early_exit)
+    warnings = [r for r in results if r.warned]
+    print_end_of_run_summary(len(errors), len(warnings), early_exit)
 
     for error in errors:
-        print_run_result_error(error)
+        print_run_result_error(error, is_warning=False)
+
+    for warning in warnings:
+        print_run_result_error(warning, is_warning=True)
 
     print_run_status_line(results)

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -481,3 +481,10 @@ def translate_aliases(kwargs, aliases):
         result[canonical_key] = value
 
     return result
+
+
+def pluralize(count, string):
+    if count == 1:
+        return "{} {}".format(count, string)
+    else:
+        return "{} {}s".format(count, string)

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1878,6 +1878,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'model',
                     'build_path': _normalize(
@@ -1930,6 +1931,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'seed',
                     'build_path': _normalize(
@@ -1980,6 +1982,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'not_null_model_id',
                     'build_path': _normalize('target/compiled/test/schema_test/not_null_model_id.sql'),
@@ -2030,6 +2033,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'nothing_model_',
                     'build_path': _normalize('target/compiled/test/schema_test/nothing_model_.sql'),
@@ -2079,6 +2083,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'unique_model_id',
                     'build_path': _normalize('target/compiled/test/schema_test/unique_model_id.sql'),
@@ -2156,6 +2161,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'ephemeral_summary',
                     'build_path': _normalize(
@@ -2244,6 +2250,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'view_summary',
                     'build_path': _normalize(
@@ -2331,6 +2338,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'error': None,
                 'execution_time': AnyFloat(),
                 'fail': None,
+                'warn': None,
                 'node': {
                     'alias': 'seed',
                     'build_path': _normalize(

--- a/test/integration/045_test_severity_tests/test_severity.py
+++ b/test/integration/045_test_severity_tests/test_severity.py
@@ -28,8 +28,10 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--schema'], 'false', strict=False)
         self.assertEqual(len(results), 2)
         self.assertFalse(results[0].fail)
+        self.assertTrue(results[0].warn)
         self.assertEqual(results[0].status, 2)
         self.assertFalse(results[1].fail)
+        self.assertTrue(results[1].warn)
         self.assertEqual(results[1].status, 2)
 
     @use_profile('postgres')
@@ -39,8 +41,10 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--schema'], 'true', strict=False, expect_pass=False)
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0].fail)
+        self.assertFalse(results[0].warn)
         self.assertEqual(results[0].status, 2)
         self.assertTrue(results[1].fail)
+        self.assertFalse(results[1].warn)
         self.assertEqual(results[1].status, 2)
 
     @use_profile('postgres')
@@ -50,8 +54,10 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--schema'], 'false', expect_pass=False)
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0].fail)
+        self.assertFalse(results[0].warn)
         self.assertEqual(results[0].status, 2)
         self.assertTrue(results[1].fail)
+        self.assertFalse(results[1].warn)
         self.assertEqual(results[1].status, 2)
 
     @use_profile('postgres')
@@ -61,6 +67,7 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--data'], 'false', strict=False)
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].fail)
+        self.assertTrue(results[0].warn)
         self.assertEqual(results[0].status, 2)
 
     @use_profile('postgres')
@@ -70,6 +77,7 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--data'], 'true', strict=False, expect_pass=False)
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].fail)
+        self.assertFalse(results[0].warn)
         self.assertEqual(results[0].status, 2)
 
     @use_profile('postgres')
@@ -79,4 +87,5 @@ class TestSeverity(DBTIntegrationTest):
         results = self.run_dbt_with_vars(['test', '--data'], 'false', expect_pass=False)
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].fail)
+        self.assertFalse(results[0].warn)
         self.assertEqual(results[0].status, 2)


### PR DESCRIPTION
Summary of changes:
 - Include `warn` as a status in the `RunModelResult` schema
   - set to True if a test fails with `severity='warning'`
 - Render out a list of warnings (in yellow) at the end of the run
 - Change list of errors at the end of the run to be red
 - Include warning count in the results status line
 - Touched up a lot of pluralization code while I was in here -- `1 warning` vs `1 warnings`

Some of the printer-related code here is a little gross... very happy to clean it up if there are ideas about how we can improve it.

### Example output
#### Errors + Warnings
```
Running with dbt=0.14.0
Found 1 model, 5 tests, 2 snapshots, 0 analyses, 230 macros, 0 operations, 1 seed file, 0 sources

12:34:50 | Concurrency: 8 threads (target='dev')
12:34:50 | 
12:34:50 | 1 of 5 START test error1................................... [RUN]
12:34:50 | 2 of 5 START test idk...................................... [RUN]
12:34:50 | 3 of 5 START test idk2..................................... [RUN]
12:34:50 | 4 of 5 START test idk3..................................... [RUN]
12:34:50 | 5 of 5 START test warn1.................................... [RUN]
12:34:50 | 1 of 5 FAIL 2 error1....................................... [FAIL 2 in 0.05s]
12:34:50 | 4 of 5 PASS idk3........................................... [PASS in 0.06s]
12:34:50 | 3 of 5 FAIL 1 idk2......................................... [FAIL 1 in 0.06s]
12:34:50 | 5 of 5 WARN 2 warn1........................................ [WARN 2 in 0.06s]
12:34:50 | 2 of 5 WARN 1 idk.......................................... [WARN 1 in 0.07s]
12:34:50 | 
12:34:50 | Finished running 5 tests in 0.79s.

Completed with 2 errors and 2 warnings:

Failure in test error1 (tests/error1.sql)
  Got 2 results, expected 0.

  compiled SQL at target/compiled/my_new_package/data_test/error1.sql

Failure in test idk2 (tests/idk2.sql)
  Got 1 result, expected 0.

  compiled SQL at target/compiled/my_new_package/data_test/idk2.sql

Warning in test warn1 (tests/warn1.sql)
  Got 2 results, expected 0.

  compiled SQL at target/compiled/my_new_package/data_test/warn1.sql

Warning in test idk (tests/idk.sql)
  Got 1 result, expected 0.

  compiled SQL at target/compiled/my_new_package/data_test/idk.sql

Done. PASS=1 WARN=2 ERROR=2 SKIP=0 TOTAL=5
```

#### Just warnings
```
Running with dbt=0.14.0
Found 1 model, 5 tests, 2 snapshots, 0 analyses, 230 macros, 0 operations, 1 seed file, 0 sources

12:37:44 | Concurrency: 8 threads (target='dev')
12:37:44 | 
12:37:44 | 1 of 1 START test warn1......................................... [RUN]
12:37:44 | 1 of 1 WARN 2 warn1............................................. [WARN 2 in 0.02s]
12:37:44 | 
12:37:44 | Finished running 1 test in 0.65s.

 Completed with 1 warning:

 Warning in test warn1 (tests/warn1.sql)
  Got 2 results, expected 0.

  compiled SQL at target/compiled/my_new_package/data_test/warn1.sql

Done. PASS=0 WARN=1 ERROR=0 SKIP=0 TOTAL=1
```

<img width="1105" alt="Screen Shot 2019-08-03 at 12 41 39 PM" src="https://user-images.githubusercontent.com/1541139/62414631-158d4580-b5ec-11e9-850d-1dd8775a9600.png">
