### PR TITLE
(#1645) fix for errant cookie generation

### DIFF
--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -13,8 +13,6 @@ import requests
 import yaml
 import os
 
-import dbt.clients.system
-
 sp_logger.setLevel(100)
 
 COLLECTOR_URL = "fishtownanalytics.sinter-collect.com"
@@ -91,12 +89,22 @@ class User(object):
         tracker.set_subject(subject)
 
     def set_cookie(self):
+        # If the user points dbt to a profile directory which exists AND
+        # contains a profiles.yml file, then we can set a cookie. If the
+        # specified folder does not exist, or if there is not a profiles.yml
+        # file in this folder, then an inconsistent cookie can be used. This
+        # will change in every dbt invocation until the user points to a
+        # profile dir file which contains a valid profiles.yml file.
+        #
+        # See: https://github.com/fishtown-analytics/dbt/issues/1645
+
         user = {"id": str(uuid.uuid4())}
 
-        dbt.clients.system.make_directory(self.cookie_dir)
-
-        with open(self.cookie_path, "w") as fh:
-            yaml.dump(user, fh)
+        cookie_path = os.path.abspath(self.cookie_dir)
+        profiles_file = os.path.join(cookie_path, 'profiles.yml')
+        if os.path.exists(cookie_path) and os.path.exists(profiles_file):
+            with open(self.cookie_path, "w") as fh:
+                yaml.dump(user, fh)
 
         return user
 


### PR DESCRIPTION
closes #1645

This PR fixes an issue where dbt generated a `profiles/.user.yml` file if the `--profiles-dir` flag (or `$DBT_PROFILES_DIR` env var) was set to a path which did not contain a profiles.yml file. There remains an inconsistency between how `--profiles-dir` and `$DBT_PROFILES_DIR` operate when users run dbt from a subdirectory of the project. We should resolve this issue in a future PR, potentially by deferring the loading of the user config until dbt understands more of the project structure. See #1645 for more information on this approach.

Ultimately, if a user points dbt to a profile dir which does not contain a profile, dbt is going to fail pretty hard. This PR fixes a symptom of that problem -- dbt will no longer create user cookies in directories which are _not_ already identified by `profiles.yml` files. Note: this means that the user cookie id may be inconsistent for the first couple of runs for a user, or between runs when the profile dir is being changed dynamically with `--profiles-dir` or `$DBT_PROFILES_DIR`. I am happy to trade a little bit of noise in the anonymous event data to prevent these cookies from being errantly littered across the users' filesystems.