### PR TITLE
(#1665) Fix for casting error on old versions of postgres in snapshots

### DIFF
--- a/plugins/postgres/dbt/include/postgres/macros/materializations/snapshot_merge.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/materializations/snapshot_merge.sql
@@ -5,8 +5,8 @@
     update {{ target }}
     set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
     from {{ source }} as DBT_INTERNAL_SOURCE
-    where DBT_INTERNAL_SOURCE.dbt_scd_id = {{ target }}.dbt_scd_id
-      and DBT_INTERNAL_SOURCE.dbt_change_type = 'update'
+    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text
+      and DBT_INTERNAL_SOURCE.dbt_change_type::text = 'update'::text
       and {{ target }}.dbt_valid_to is null;
 
     insert into {{ target }} ({{ insert_cols_csv }})
@@ -14,5 +14,5 @@
         DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}
     {%- endfor %}
     from {{ source }} as DBT_INTERNAL_SOURCE
-    where DBT_INTERNAL_SOURCE.dbt_change_type = 'insert';
+    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;
 {% endmacro %}


### PR DESCRIPTION
closes #1665

The specific change required to fix these queries on pg 9.6 is involves explicitly casting the `dbt_change_type` column when comparing its value in both the `update` and `insert` statements. This PR casts all text columns explicitly to `text` type in these queries just to be extra careful.