### PR TITLE
add GitHub stale issue plugin

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions to dbt!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to inactivity. Please feel
+  free to comment on this issue if you believe that it should be reopened.
+
+  I am a bot. Beep boop.


### PR DESCRIPTION
- mark issues as `stale` after 90 days
- close them after 7 days of inactivity
- we don't currently use the exempt labels, but we should

TODO:
 - manually go through old issues, tagging ones that should be exempt from the stale bot and closing ones that are #wontfix with our current thinking
