### PR TITLE
fix for unpickleable datetime tzs set by snowflake

### DIFF
--- a/core/dbt/adapters/factory.py
+++ b/core/dbt/adapters/factory.py
@@ -1,6 +1,7 @@
 import dbt.exceptions
 from importlib import import_module
 from dbt.include.global_project import PACKAGES
+from dbt.logger import GLOBAL_LOGGER as logger
 
 import threading
 
@@ -29,7 +30,8 @@ def get_relation_class_by_name(adapter_name):
 def load_plugin(adapter_name):
     try:
         mod = import_module('.' + adapter_name, 'dbt.adapters')
-    except ImportError:
+    except ImportError as e:
+        logger.info("Error importing adapter: {}".format(e))
         raise dbt.exceptions.RuntimeException(
             "Could not find adapter type {}!".format(adapter_name)
         )

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -77,15 +77,18 @@ class SQLConnectionManager(BaseConnectionManager):
         )
 
     @classmethod
+    def process_results(cls, column_names, rows):
+        return [dict(zip(column_names, row)) for row in rows]
+
+    @classmethod
     def get_result_from_cursor(cls, cursor):
         data = []
         column_names = []
 
         if cursor.description is not None:
             column_names = [col[0] for col in cursor.description]
-            raw_results = cursor.fetchall()
-            data = [dict(zip(column_names, row))
-                    for row in raw_results]
+            rows = cursor.fetchall()
+            data = cls.process_results(column_names, rows)
 
         return dbt.clients.agate_helper.table_from_data(data, column_names)
 

--- a/test/integration/048_rpc_test/sql/bigquery.sql
+++ b/test/integration/048_rpc_test/sql/bigquery.sql
@@ -1,0 +1,26 @@
+
+select
+    cast(1 as int64) as test_int64,
+    cast(1 as numeric) as test_numeric,
+    cast(1 as float64) as test_float64,
+        cast('inf' as float64) as test_float64_inf,
+        cast('+inf' as float64) as test_float64_pos_inf,
+        cast('-inf' as float64) as test_float64_neg_inf,
+        cast('NaN' as float64) as test_float64_nan,
+    cast(true as boolean) as test_boolean,
+    cast('abc123' as string) as test_string,
+    cast('abc123' as bytes) as test_bytes,
+    cast('2019-01-01' as date) as test_date,
+    cast('12:00:00' as time) as test_time,
+    cast('2019-01-01 12:00:00' as timestamp) as test_timestamp,
+        timestamp('2019-01-01T12:00:00+04:00') as test_timestamp_tz,
+    st_geogfromgeojson('{ "type": "LineString", "coordinates": [ [1, 1], [3, 2] ] }') as test_geo,
+    [
+        struct(1 as val_1, 2 as val_2),
+        struct(3 as val_1, 4 as val_2)
+    ] as test_array,
+    struct(
+        cast('Fname' as string) as fname,
+        cast('Lname' as string) as lname
+    ) as test_struct,
+    cast(null as int64) as test_null

--- a/test/integration/048_rpc_test/sql/redshift.sql
+++ b/test/integration/048_rpc_test/sql/redshift.sql
@@ -1,0 +1,15 @@
+
+select
+    cast(1 as smallint) as test_smallint,
+    cast(1 as int) as test_int,
+    cast(1 as bigint) as test_bigint,
+    cast(1 as decimal) as test_decimal,
+    cast(1 as numeric(12,2)) as test_numeric,
+    cast(true as boolean) as test_boolean,
+    cast('abc123' as char) as test_char,
+    cast('abc123' as varchar) as test_varchar,
+    cast('abc123' as text) as test_text,
+    cast('2019-01-01' as date) as test_date,
+    cast('2019-01-01 12:00:00' as timestamp) as test_timestamp,
+    cast('2019-01-01 12:00:00+04:00' as timestamptz) as test_timestamptz,
+    cast(null as int) as test_null

--- a/test/integration/048_rpc_test/sql/snowflake.sql
+++ b/test/integration/048_rpc_test/sql/snowflake.sql
@@ -1,0 +1,19 @@
+
+select
+    cast(1 as number(12, 2)) as test_number,
+    cast(1 as int) as test_int,
+    cast(1 as float) as test_float,
+    cast('abc123' as varchar) as test_varchar,
+    cast('abc123' as char(6)) as test_char,
+    cast('2019-01-01' as date) as test_date,
+    cast('2019-01-01 12:00:00' as datetime) as test_datetime,
+    cast('12:00:00' as time) as test_time,
+    cast('2019-01-01 12:00:00' as timestamp_ltz) as test_timestamp_ltz,
+    cast('2019-01-01 12:00:00' as timestamp_ntz) as test_timestamp_ntz,
+    cast('2019-01-01 12:00:00' as timestamp_tz) as test_timestamp_tz,
+    cast(parse_json('{"a": 1, "b": 2}') as variant) as test_variant,
+    cast(parse_json('{"a": 1, "b": 2}') as object) as test_object,
+    cast(parse_json('[{"a": 1, "b": 2}]') as array) as test_array
+
+    -- This fails inside of Agate on Py2
+    --cast('C0FF33' as binary) as test_binary,

--- a/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
+++ b/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
@@ -1,0 +1,50 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+import pickle
+import os
+
+class TestRpcExecuteReturnsResults(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "rpc_test_048"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['macros'],
+        }
+
+    def test_pickle(self, agate_table):
+        table = {
+            'column_names': list(agate_table.column_names),
+            'rows': [list(row) for row in agate_table]
+        }
+
+        pickle.dumps(table)
+
+    def test_file(self, filename):
+        file_path = os.path.join("sql", filename)
+        with open(file_path) as fh:
+            query = fh.read()
+
+        status, table = self.adapter.execute(query, auto_begin=False, fetch=True)
+        self.assertTrue(len(table.columns) > 0, "agate table had no columns")
+        self.assertTrue(len(table.rows) > 0, "agate table had no rows")
+
+        self.test_pickle(table)
+
+    @use_profile('bigquery')
+    def test__bigquery_fetch_and_serialize(self):
+        self.test_file('bigquery.sql')
+
+    @use_profile('snowflake')
+    def test__snowflake_fetch_and_serialize(self):
+        self.test_file('snowflake.sql')
+
+    @use_profile('redshift')
+    def test__redshift_fetch_and_serialize(self):
+        self.test_file('redshift.sql')


### PR DESCRIPTION
The `snowflake-connector-python` library does something... surprising... when handling timezones. It dynamically generates its own timezone objects which are not pickleable. As a result, simple queries like:
```sql
select current_timestamp::TIMESTAMP_TZ as oops
```

will fail if run on the rpc server. This happens specifically when data is passed between subprocesses over a queue.

Relevant issue: https://github.com/snowflakedb/snowflake-connector-python/issues/81
Relevant code: [converter.py#L140](https://github.com/snowflakedb/snowflake-connector-python/blob/6c3e666ef6c388a3bde2b190256f88a615259196/converter.py#L140-L167)

I'm unsure if the approach I took here is a good one. I think I'd prefer for this code to live closer to the RPC server, but wasn't exactly sure if we had a good place to put this today. Very open to feedback / insight here.