### PR TITLE
Fix typo: "IternalException" -> "InternalException"

### DIFF
--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -97,7 +97,7 @@ class ListTask(GraphRunnableTask):
         elif output == 'path':
             generator = self.generate_paths
         else:
-            raise dbt.exceptions.IternalException(
+            raise dbt.exceptions.InternalException(
                 'Invalid output {}'.format(output)
             )
         for result in generator():


### PR DESCRIPTION
I reported the bug (#1640), so I guess I should be the one to fix it!