### PR TITLE
Fixes the issue running DBT against Panoply

### DIFF
--- a/plugins/postgres/dbt/include/postgres/macros/relations.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/relations.sql
@@ -1,10 +1,11 @@
+-- {#
+-- in pg_depend, objid is the dependent, refobjid is the referenced object
+-- "a pg_depend entry indicates that the referenced object cannot be dropped without also dropping the dependent object."
+-- #}
+-- {# this only works with the current database #}
+
 {% macro postgres_get_relations () -%}
   {%- call statement('relations', fetch_result=True) -%}
-    -- {#
-    -- in pg_depend, objid is the dependent, refobjid is the referenced object
-    -- "a pg_depend entry indicates that the referenced object cannot be dropped without also dropping the dependent object."
-    -- #}
-    -- {# this only works with the current database #}
     with relation as (
         select
             pg_rewrite.ev_class as class,


### PR DESCRIPTION
Panoply cleans up queries before executing. Apparently, they have a bug in the cleansing system which throws a syntax error because of the position of the comment.

Slightly changed the position and now I could `dbt run` against panoply.
