### PR TITLE
hologram is on pypi

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -55,6 +55,6 @@ setup(
         'json-rpc>=1.12,<2',
         'werkzeug>=0.14.1,<0.15',
         'dataclasses;python_version<"3.7"',
-        'hologram @ git+https://github.com/fishtown-analytics/hologram.git@master#egg=hologram',
+        'hologram==0.0.1',
     ]
 )


### PR DESCRIPTION
Downloads hologram from pypi instead of locally. This lets us deploy this version of dbt to dbt Cloud.