### PR TITLE
Fix for run and docs generate on Panoply Redshift

### DIFF
--- a/plugins/postgres/dbt/include/postgres/macros/relations.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/relations.sql
@@ -1,10 +1,12 @@
 {% macro postgres_get_relations () -%}
+
+  {#
+      -- in pg_depend, objid is the dependent, refobjid is the referenced object
+      --  > a pg_depend entry indicates that the referenced object cannot be
+      --  > dropped without also dropping the dependent object.
+  #}
+
   {%- call statement('relations', fetch_result=True) -%}
-    -- {#
-    -- in pg_depend, objid is the dependent, refobjid is the referenced object
-    -- "a pg_depend entry indicates that the referenced object cannot be dropped without also dropping the dependent object."
-    -- #}
-    -- {# this only works with the current database #}
     with relation as (
         select
             pg_rewrite.ev_class as class,

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -80,7 +80,7 @@
           numeric_precision,
           numeric_scale
 
-        from {{ relation.information_schema('columns') }}
+        from information_schema."columns"
         where table_name = '{{ relation.identifier }}'
     ),
 

--- a/plugins/redshift/dbt/include/redshift/macros/catalog.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/catalog.sql
@@ -60,7 +60,7 @@
 
     ),
 
-    columns as (
+    table_columns as (
 
         select
             '{{ database }}'::varchar as table_database,
@@ -74,7 +74,7 @@
             null::varchar as column_comment
 
 
-        from information_schema.columns
+        from information_schema."columns"
 
     ),
 
@@ -82,7 +82,7 @@
 
         select *
         from tables
-        join columns using (table_database, table_schema, table_name)
+        join table_columns using (table_database, table_schema, table_name)
 
         union all
 


### PR DESCRIPTION
Thanks @gautam-ndk for your help in debugging this!

Panoply has two sql rewriting bugs:
 - whitespace before the query begins can cause queries to fail 💀 
 - identifiers named `columns` cause problems; I am quoting or renaming them here

fixes #1479