### PR TITLE
Updated injected_node.wrapped_sql for data tests

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -134,7 +134,8 @@ class Compiler(object):
             if 'data' in injected_node.tags and \
                is_type(injected_node, NodeType.Test):
                 injected_node.wrapped_sql = (
-                    "select count(*) from (\n{test_sql}\n) sbq").format(
+                    "select count(*) as errors "
+                    "from (\n{test_sql}\n) sbq").format(
                         test_sql=injected_node.injected_sql)
             else:
                 # don't wrap schema tests or analyses.


### PR DESCRIPTION
The data tests feature uses in-code-sql that does not support all databases. This is a fix for supporting more databases and custom adapters. 

This should not effect currently supported databases in any way.

ref conversation on dbt slack: https://getdbt.slack.com/archives/C50NEBJGG/p1565962661033700