### PR TITLE
Implement Clustering for Snowflake

### DIFF
--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -10,11 +10,13 @@ class SnowflakeAdapter(SQLAdapter):
     Relation = SnowflakeRelation
     ConnectionManager = SnowflakeConnectionManager
 
-    AdapterSpecificConfigs = frozenset({"transient"})
+    AdapterSpecificConfigs = frozenset(
+        {"transient", "cluster_by", "automatic_clustering"}
+    )
 
     @classmethod
     def date_function(cls):
-        return 'CURRENT_TIMESTAMP()'
+        return "CURRENT_TIMESTAMP()"
 
     @classmethod
     def _catalog_filter_table(cls, table, manifest):
@@ -23,20 +25,21 @@ class SnowflakeAdapter(SQLAdapter):
         lowered = table.rename(
             column_names=[c.lower() for c in table.column_names]
         )
-        return super(SnowflakeAdapter, cls)._catalog_filter_table(lowered,
-                                                                  manifest)
+        return super(SnowflakeAdapter, cls)._catalog_filter_table(
+            lowered, manifest
+        )
 
     def _make_match_kwargs(self, database, schema, identifier):
         quoting = self.config.quoting
-        if identifier is not None and quoting['identifier'] is False:
+        if identifier is not None and quoting["identifier"] is False:
             identifier = identifier.upper()
 
-        if schema is not None and quoting['schema'] is False:
+        if schema is not None and quoting["schema"] is False:
             schema = schema.upper()
 
-        if database is not None and quoting['database'] is False:
+        if database is not None and quoting["database"] is False:
             database = database.upper()
 
-        return filter_null_values({'identifier': identifier,
-                                   'schema': schema,
-                                   'database': database})
+        return filter_null_values(
+            {"identifier": identifier, "schema": schema, "database": database}
+        )

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -4,8 +4,8 @@
   {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
   {%- if cluster_by_keys is not none and cluster_by_keys is string -%}
     {%-  set cluster_by_keys = [cluster_by_keys] -%}
-    {%- set cluster_by_string = cluster_by_keys|join(", ")-%}
   {%- endif -%}
+  {%- set cluster_by_string = cluster_by_keys|join(", ")-%}
 
       create or replace {% if temporary -%}
         temporary

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -25,10 +25,10 @@
           {{ sql }}
         {%- endif %}
       );
-    {% if cluster_by_string is not none -%}
+    {% if cluster_by_string is not none and not temporary -%}
       alter table {{relation}} cluster by ({{cluster_by_string}});
     {%- endif -%}
-    {% if enable_automatic_clustering and cluster_by_string is not none  -%}
+    {% if enable_automatic_clustering and cluster_by_string is not none and not temporary  -%}
       alter table {{relation}} resume recluster;
     {%- endif -%}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -28,7 +28,7 @@
     {% if cluster_by_string is not none -%}
       alter table {{relation}} cluster by ({{cluster_by_string}});
     {%- endif -%}
-    {% if enable_automatic_clustering  -%}
+    {% if enable_automatic_clustering and cluster_by_string is not none  -%}
       alter table {{relation}} resume recluster;
     {%- endif -%}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -42,6 +42,7 @@
 
     {%- call statement('main') -%}
       {{ create_table_as(false, target_relation, sql) }}
+
     {%- endcall -%}
 
   {%- else -%}


### PR DESCRIPTION
## Aim
Brings clustering to snowflake.

Table materialisations will leverage an order by via wrapping the SQL in a `select * from ( {{sql}} ) order by ( {{cluster_by_keys}}`
Incremental materialisation will create table as above and followed by an alter statement `alter table {{relation}} cluster by ({{cluster_by_keys}})` to leverage Snowflake's automatic clustering.
This approach was discussed in #634

This is a duplicate of PR #1591  that I had to re open due to killing my fork in the meantime... All discussion can be found there though.