### PR TITLE
Feature/query headers

### DIFF
--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -146,7 +146,7 @@ class Project(object):
                  analysis_paths, docs_paths, target_path, snapshot_paths,
                  clean_targets, log_path, modules_path, quoting, models,
                  on_run_start, on_run_end, archive, seeds, dbt_version,
-                 packages):
+                 packages, query_header):
         self.project_name = project_name
         self.version = version
         self.project_root = project_root
@@ -170,6 +170,7 @@ class Project(object):
         self.seeds = seeds
         self.dbt_version = dbt_version
         self.packages = packages
+        self.query_header = query_header
 
     @staticmethod
     def _preprocess(project_dict):
@@ -248,6 +249,7 @@ class Project(object):
         modules_path = project_dict.get('modules-path', 'dbt_modules')
         # in the default case we'll populate this once we know the adapter type
         quoting = project_dict.get('quoting', {})
+        query_header = project_dict.get('query_header')
 
         models = project_dict.get('models', {})
         on_run_start = project_dict.get('on-run-start', [])
@@ -286,7 +288,8 @@ class Project(object):
             archive=archive,
             seeds=seeds,
             dbt_version=dbt_version,
-            packages=packages
+            packages=packages,
+            query_header=query_header,
         )
         # sanity check - this means an internal issue
         project.validate()
@@ -335,6 +338,7 @@ class Project(object):
             'require-dbt-version': [
                 v.to_version_string() for v in self.dbt_version
             ],
+            'query_header': self.query_header,
         })
         if with_packages:
             result.update(self.packages.serialize())

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -21,7 +21,7 @@ class ConfigRenderer(object):
 
         first = keypath[0]
         # run hooks
-        if first in {'on-run-start', 'on-run-end'}:
+        if first in {'on-run-start', 'on-run-end', 'query_header'}:
             return True
         # models have two things to avoid
         if first in {'seeds', 'models'}:

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -30,7 +30,8 @@ class RuntimeConfig(Project, Profile):
                  docs_paths, target_path, snapshot_paths, clean_targets,
                  log_path, modules_path, quoting, models, on_run_start,
                  on_run_end, archive, seeds, dbt_version, profile_name,
-                 target_name, config, threads, credentials, packages, args):
+                 target_name, config, threads, credentials, packages,
+                 query_header, args):
         # 'vars'
         self.args = args
         self.cli_vars = parse_cli_vars(getattr(args, 'vars', '{}'))
@@ -59,7 +60,8 @@ class RuntimeConfig(Project, Profile):
             archive=archive,
             seeds=seeds,
             dbt_version=dbt_version,
-            packages=packages
+            packages=packages,
+            query_header=query_header
         )
         # 'profile'
         Profile.__init__(
@@ -115,12 +117,13 @@ class RuntimeConfig(Project, Profile):
             seeds=project.seeds,
             dbt_version=project.dbt_version,
             packages=project.packages,
+            query_header=project.query_header,
             profile_name=profile.profile_name,
             target_name=profile.target_name,
             config=profile.config,
             threads=profile.threads,
             credentials=profile.credentials,
-            args=args
+            args=args,
         )
 
     def new_project(self, project_root):

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -14,6 +14,7 @@ import dbt.flags
 import dbt.tracking
 import dbt.writer
 import dbt.utils
+import dbt.version
 
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
@@ -22,6 +23,7 @@ from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 # approaches which will extend well to potentially many modules
 import pytz
 import datetime
+import base64
 
 
 class RelationProxy(object):
@@ -352,10 +354,22 @@ def get_datetime_module_context():
     }
 
 
+def get_base64_module_context():
+    context_exports = [
+        'b64encode',
+        'b64decode',
+    ]
+
+    return {
+        name: getattr(base64, name) for name in context_exports
+    }
+
+
 def get_context_modules():
     return {
         'pytz': get_pytz_module_context(),
         'datetime': get_datetime_module_context(),
+        'base64': get_base64_module_context()
     }
 
 
@@ -420,7 +434,8 @@ def generate_base(model, model_dict, config, manifest, source_config,
         "fromjson": fromjson,
         "tojson": tojson,
         "target": target,
-        "try_or_compiler_error": try_or_compiler_error(model)
+        "try_or_compiler_error": try_or_compiler_error(model),
+        "dbt_version": dbt.version.__version__,
     })
     if os.environ.get('DBT_MACRO_DEBUGGING'):
         context['debug'] = _debug_here

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -459,7 +459,7 @@ class ParsedNode(APIObject):
     def query_header(self):
         return self._contents['query_header']
 
-    @alias.setter
+    @query_header.setter
     def query_header(self, value):
         self._contents['query_header'] = value
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -340,6 +340,13 @@ PARSED_NODE_CONTRACT = deep_merge(
                     'In seeds, the path to the source file used during build.'
                 ),
             },
+            'query_header': {
+                'type': 'string',
+                'description': (
+                    'A header string to prepend to queries executed in the '
+                    'context of this node'
+                )
+            }
         },
         'required': ['empty', 'tags', 'alias'],
     }
@@ -447,6 +454,14 @@ class ParsedNode(APIObject):
     @config.setter
     def config(self, value):
         self._contents['config'] = value
+
+    @property
+    def query_header(self):
+        return self._contents['query_header']
+
+    @alias.setter
+    def query_header(self, value):
+        self._contents['query_header'] = value
 
 
 SNAPSHOT_CONFIG_CONTRACT = {

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -126,6 +126,9 @@ PROJECT_CONTRACT = {
                 }
             },
         },
+        'query_header': {
+            'type': ['null', 'string'],
+        },
         'models': {
             'type': 'object',
             'additionalProperties': True,

--- a/core/dbt/include/global_project/macros/core.sql
+++ b/core/dbt/include/global_project/macros/core.sql
@@ -1,6 +1,12 @@
+
+{% macro preprocess_statement(model, sql) -%}
+{{ model.query_header}}
+{{ sql }}
+{%- endmacro %}
+
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
   {%- if execute: -%}
-    {%- set sql = render(caller()) -%}
+    {%- set sql = preprocess_statement(model, render(caller())) -%}
 
     {%- if name == 'main' -%}
       {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}

--- a/core/dbt/include/global_project/macros/core.sql
+++ b/core/dbt/include/global_project/macros/core.sql
@@ -1,12 +1,15 @@
 
 {% macro preprocess_statement(model, sql) -%}
-{{ model.query_header}}
-{{ sql }}
+    {%- if model.query_header -%}
+        {{ render(model.query_header) }}
+    {%- endif %}
+
+    {{ render(sql) }}
 {%- endmacro %}
 
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
   {%- if execute: -%}
-    {%- set sql = preprocess_statement(model, render(caller())) -%}
+    {%- set sql = preprocess_statement(model, caller()) -%}
 
     {%- if name == 'main' -%}
       {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}

--- a/core/dbt/include/global_project/macros/etc/query_header.sql
+++ b/core/dbt/include/global_project/macros/etc/query_header.sql
@@ -1,6 +1,1 @@
 
-{% macro generate_query_header(node) -%}
-
-    {# This macro is intentionally left blank #}
-
-{%- endmacro %}

--- a/core/dbt/include/global_project/macros/etc/query_header.sql
+++ b/core/dbt/include/global_project/macros/etc/query_header.sql
@@ -1,25 +1,6 @@
 
 {% macro generate_query_header(node) -%}
 
-    {% set payload = {
-        "app": "dbt",
-        "dbt_version": dbt_version,
-        "target_name": target.name,
-        "user": target.user | default("unset"),
-
-        "file": node.original_file_path | default("unset"),
-        "node_id": node.unique_id,
-        "node_name": node.name,
-        "resource_type": node.resource_type,
-        "package_name": node.package_name,
-        "tags": node.config.get('tags'),
-
-        "relation": node.database ~ "." ~ node.schema ~ "." ~ node.alias,
-        "database": node.database,
-        "schema": node.schema,
-        "identifier": node.alias,
-    } %}
-
-    /* dbt query context: {{ tojson(payload) }} */
+    {# This macro is intentionally left blank #}
 
 {%- endmacro %}

--- a/core/dbt/include/global_project/macros/etc/query_header.sql
+++ b/core/dbt/include/global_project/macros/etc/query_header.sql
@@ -1,0 +1,6 @@
+
+{% macro generate_query_header(node) -%}
+
+    {#- This macro is intentionally left blank -#}
+
+{%- endmacro %}

--- a/core/dbt/include/global_project/macros/etc/query_header.sql
+++ b/core/dbt/include/global_project/macros/etc/query_header.sql
@@ -1,6 +1,25 @@
 
 {% macro generate_query_header(node) -%}
 
-    {#- This macro is intentionally left blank -#}
+    {% set payload = {
+        "app": "dbt",
+        "dbt_version": dbt_version,
+        "target_name": target.name,
+        "user": target.user | default("unset"),
+
+        "file": node.original_file_path | default("unset"),
+        "node_id": node.unique_id,
+        "node_name": node.name,
+        "resource_type": node.resource_type,
+        "package_name": node.package_name,
+        "tags": node.config.get('tags'),
+
+        "relation": node.database ~ "." ~ node.schema ~ "." ~ node.alias,
+        "database": node.database,
+        "schema": node.schema,
+        "identifier": node.alias,
+    } %}
+
+    /* dbt query context: {{ tojson(payload) }} */
 
 {%- endmacro %}

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -60,7 +60,6 @@ class MacrosKnownParser(BaseParser):
         self.macro_manifest = macro_manifest
         self._get_schema_func = None
         self._get_alias_func = None
-        self._get_query_header_func = None
 
     def get_schema_func(self):
         """The get_schema function is set by a few different things:
@@ -137,42 +136,6 @@ class MacrosKnownParser(BaseParser):
 
         self._get_alias_func = get_alias
         return self._get_alias_func
-
-    def get_query_header_func(self):
-        """The get_query_header function is set by a few different things:
-            - if there is a 'generate_query_header' macro in the root project,
-                it will be used.
-            - if that does not exist but there is a 'generate_query_header'
-                macro in the 'dbt' internal project, that will be used
-            - if neither of those exist (unit tests?), a function that returns
-                and empty string is used
-        """
-        if self._get_query_header_func is not None:
-            return self._get_query_header_func
-
-        get_query_header_macro = self.macro_manifest.find_macro_by_name(
-            'generate_query_header',
-            self.root_project_config.project_name
-        )
-        if get_query_header_macro is None:
-            get_query_header_macro = self.macro_manifest.find_macro_by_name(
-                'generate_query_header',
-                GLOBAL_PROJECT_NAME
-            )
-
-        # the generate_query_header macro might not exist
-        if get_query_header_macro is None:
-            def get_query_header(node):
-                return ''
-        else:
-            root_context = dbt.context.parser.generate_macro(
-                get_query_header_macro, self.root_project_config,
-                self.macro_manifest
-            )
-            get_query_header = get_query_header_macro.generator(root_context)
-
-        self._get_query_header_func = get_query_header
-        return self._get_query_header_func
 
     def _build_intermediate_node_dict(self, config, node_dict, node_path,
                                       package_project_config, tags, fqn,
@@ -276,9 +239,7 @@ class MacrosKnownParser(BaseParser):
         config_dict = parsed_node.get('config', {})
         config_dict.update(config.config)
         parsed_node.config = config_dict
-
-        get_query_header = self.get_query_header_func()
-        parsed_node.query_header = get_query_header(parsed_node).strip()
+        parsed_node.query_header = config.active_project.query_header
 
         for hook_type in dbt.hooks.ModelHookType.Both:
             parsed_node.config[hook_type] = dbt.hooks.get_hooks(parsed_node,

--- a/test/integration/049_query_header_test/macros/get_unique_id.sql
+++ b/test/integration/049_query_header_test/macros/get_unique_id.sql
@@ -1,0 +1,6 @@
+
+{%- macro get_unique_id() -%}
+
+    {{ model.unique_id }}
+
+{%- endmacro -%}

--- a/test/integration/049_query_header_test/models/incremental.sql
+++ b/test/integration/049_query_header_test/models/incremental.sql
@@ -1,0 +1,5 @@
+
+
+{{ config(materialized='incremental') }}
+
+select 1 as id

--- a/test/integration/049_query_header_test/models/table.sql
+++ b/test/integration/049_query_header_test/models/table.sql
@@ -1,0 +1,5 @@
+
+
+{{ config(materialized='table') }}
+
+select 1 as id

--- a/test/integration/049_query_header_test/models/view.sql
+++ b/test/integration/049_query_header_test/models/view.sql
@@ -1,0 +1,5 @@
+
+
+{{ config(materialized='view') }}
+
+select 1 as id

--- a/test/integration/049_query_header_test/test_query_header.py
+++ b/test/integration/049_query_header_test/test_query_header.py
@@ -1,0 +1,33 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestQueryHeader(DBTIntegrationTest):
+    @property
+    def project_config(self):
+        return {
+            "query_header": "-- debug {{ get_unique_id() }}"
+        }
+
+    @property
+    def schema(self):
+        return "query_header_049"
+
+    @staticmethod
+    def dir(path):
+        return path.lstrip('/')
+
+    @property
+    def models(self):
+        return self.dir("models")
+
+    @use_profile("postgres")
+    def test__postgres__simple_copy(self):
+        results = self.run_dbt(["run"])
+
+        self.assertEquals(len(results), 3)
+
+        for result in results:
+            path = result.node.get('build_path').replace("compiled", "run")
+            with open(path, 'r') as f:
+                run_contents = f.read()
+                self.assertIn('-- debug {}'.format(result.node.get('unique_id')), run_contents)


### PR DESCRIPTION
Adding query headers. Fixes #1643

The big idea: add `query_header: "..."` to your `dbt_project.yml` file. It will show up at the top of (most) of your queries.

TODO:
 - I don't love the way this is implemented, but it's hard to find a better entrypoint than the statement block
 - calls to adapter methods (like `get_columns_in_table`) don't run with the root model's context, so they don't get this header
 - how can we also render this thing for queries run outside the context of a model, like introspective queries in parsing?
