### PR TITLE
wip: support docs configs in schema.yml files

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -6,7 +6,7 @@ import dbt.clients.jinja
 
 from dbt.contracts.graph.unparsed import UNPARSED_NODE_CONTRACT, \
     UNPARSED_MACRO_CONTRACT, UNPARSED_DOCUMENTATION_FILE_CONTRACT, \
-    UNPARSED_BASE_CONTRACT, TIME_CONTRACT
+    UNPARSED_BASE_CONTRACT, TIME_CONTRACT, UNPARSED_NODE_DOCS_DATA_CONTRACT
 
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
@@ -308,6 +308,7 @@ PARSED_NODE_CONTRACT = deep_merge(
     HAS_CONFIG_CONTRACT,
     COLUMN_TEST_CONTRACT,
     HAS_RELATION_METADATA_CONTRACT,
+    UNPARSED_NODE_DOCS_DATA_CONTRACT,
     {
         'properties': {
             'alias': {
@@ -401,6 +402,7 @@ class ParsedNode(APIObject):
             'description': patch.description,
             'columns': patch.columns,
             'docrefs': patch.docrefs,
+            'docs': patch.docs,
         })
         # patches always trigger re-validation
         self.validate()
@@ -554,10 +556,13 @@ PARSED_NODE_PATCH_CONTRACT = {
         'docrefs': {
             'type': 'array',
             'items': DOCREF_CONTRACT,
+        },
+        'docs': {
+            'type': 'object'
         }
     },
     'required': [
-        'name', 'original_file_path', 'description', 'columns', 'docrefs'
+        'name', 'original_file_path', 'description', 'columns', 'docrefs', 'docs'
     ],
 }
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -161,9 +161,23 @@ UNPARSED_NODE_DESCRIPTION_CONTRACT = {
 }
 
 
+UNPARSED_NODE_DOCS_DATA_CONTRACT = {
+    'properties': {
+        'docs': {
+            'type': 'object',
+            'description': (
+                'A dictionary of key-value pairs which configure attributes '
+                'of the dbt Documentation'
+            ),
+        },
+    },
+}
+
+
 UNPARSED_NODE_UPDATE_CONTRACT = deep_merge(
     UNPARSED_NODE_DESCRIPTION_CONTRACT,
     UNPARSED_COLUMN_DESCRIPTION_CONTRACT,
+    UNPARSED_NODE_DOCS_DATA_CONTRACT,
     {
         'type': 'object',
         'additionalProperties': False,

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -351,6 +351,7 @@ class SchemaModelParser(SchemaBaseTestParser):
 
     def parse_models_entry(self, model_dict, path, package_name, root_dir):
         model_name = model_dict['name']
+        docs_data = model_dict['docs']
         refs = ParserRef()
         for column in model_dict.get('columns', []):
             column_tests = self._parse_column(model_dict, column, package_name,
@@ -379,7 +380,8 @@ class SchemaModelParser(SchemaBaseTestParser):
             original_file_path=path,
             description=description,
             columns=refs.column_info,
-            docrefs=refs.docrefs
+            docrefs=refs.docrefs,
+            docs=docs_data,
         )
         yield 'patch', patch
 


### PR DESCRIPTION
Work in progress / for exploratory use!

This PR is intended to pull through an arbitrary dictionary of docs configs from the dbt project into the compiled artifacts, eg:
```

version: 2

models:
    - name: my_model
      docs:
          color: "blue"
          hidden: true

    - name: my_other_model
      docs:
          color: "red"
          hidden: false
```

When compiled, the manifest contains a `docs` dictionary for each node with the values shown here.

TODO : 
 - should this interoperate with a `docs:` config in `dbt_project.yml`?
 - I'm sure all of the tests are broken
 - We probably want to target this for 0.15.x, not 0.14.1, so a rebase will be required