### PR TITLE
Superconductive feature/specify docs in schema yml

### DIFF
--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -84,6 +84,10 @@ CONFIG_CONTRACT = {
                 }
             ]
         },
+        'docs': {
+            'type': 'object',
+            'additionalProperties': True,
+            },
         'severity': {
             'type': 'string',
             'pattern': '([eE][rR][rR][oO][rR]|[wW][aA][rR][nN])',

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -379,7 +379,7 @@ class SchemaModelParser(SchemaBaseTestParser):
             original_file_path=path,
             description=description,
             columns=refs.column_info,
-            docrefs=refs.docrefs
+            docrefs=refs.docrefs,
         )
         yield 'patch', patch
 

--- a/core/dbt/parser/source_config.py
+++ b/core/dbt/parser/source_config.py
@@ -16,7 +16,7 @@ class SourceConfig(object):
         'unique_key',
         'database',
         'severity',
-
+        'docs',
         'incremental_strategy'
     }
 


### PR DESCRIPTION
This PR was a collaboration between @Aylr and @talagluck in conjunction with [this PR in dbt-docs](https://github.com/fishtown-analytics/dbt-docs/pull/46) in response to @drewbanin 's awesome work [here](https://github.com/fishtown-analytics/dbt/pull/1692).

We've gone in a slightly different direction, adjusting colors either:
* on project directories in the `dbt_project.yml`
* on individual models in the `{{ config() }}` tag at the top of the model

The primary use that we'd been imagining for this feature was visually distinguishing between different stages of the dag, comparable to the way that dbt currently distinguishes sources.

Because of this, and because of the way that we have used dbt (we typically have separate .yml files for each model), adjusting through the `dbt_project.yml` seemed like a more natural approach than using the `schema.yml, but this is meant to be an ongoing discussion.

Adding the capability to specify color in individual model configs seemed like a natural extension, but we're imagining this will be used more sparingly, as otherwise the colors will quickly become difficult to look at.

dbt_project.yml snippet:
```
models:
  dbt_colors:
      # Applies to all files under models/example/
      example:
          materialized: view
          docs:
            color: black
      second_example:
          materialized: table
          docs:
            color: blue
```

individual model color config snippet:
```
{{ config(materialized='table',docs={'color':'magenta'}) }}
```
![Screen Shot 2019-08-29 at 11 55 06 AM](https://user-images.githubusercontent.com/15267635/63957780-16808e00-ca57-11e9-8a7e-eb52de50e520.png)
![Screen Shot 2019-08-29 at 11 48 55 AM](https://user-images.githubusercontent.com/15267635/63957799-1ed8c900-ca57-11e9-881e-57a6f3874392.png)  


