### PR TITLE
(#1717) fix for re-rendering in statement calls

### DIFF
--- a/core/dbt/include/global_project/macros/core.sql
+++ b/core/dbt/include/global_project/macros/core.sql
@@ -1,6 +1,6 @@
 {% macro statement(name=None, fetch_result=False, auto_begin=True) -%}
   {%- if execute: -%}
-    {%- set sql = render(caller()) -%}
+    {%- set sql = caller() -%}
 
     {%- if name == 'main' -%}
       {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}
@@ -16,7 +16,7 @@
 {%- endmacro %}
 
 {% macro noop_statement(name=None, status=None, res=None) -%}
-  {%- set sql = render(caller()) -%}
+  {%- set sql = caller() -%}
 
   {%- if name == 'main' -%}
     {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}

--- a/core/dbt/include/global_project/macros/materializations/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/helpers.sql
@@ -5,9 +5,12 @@
         commit;
       {% endcall %}
     {% endif %}
-    {% call statement(auto_begin=inside_transaction) %}
-      {{ hook.get('sql') }}
-    {% endcall %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
   {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
Fixes #1717 
Fixes #1108

This PR removes the call to `render()` in statement blocks. For most applications of dbt, this shouldn't change anything at all. I had to amend the `run_hooks` macro to render hooks, as they previously relied on statement blocks to be rendered. While I was in there, I added a check to skip queries for empty hooks, which should fix #1108.

We should think hard about if there are any other built-in parts of the dbt codebase which rely on statements re-rendering queries - I don't believe there are, but if they do exist, they're probably not explicitly tested. We should also add a note to the release notes / migration guide describing this change in behavior, as it could be _very_ breaking for some dbt projects out there.