### PR TITLE
Merge dev/0.14.1 into dev/louisa-may-alcott

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## dbt 0.14.1 (Currently unreleased)
+## dbt 0.14.1 (September 3, 2019)
 
 ### Overview
 
@@ -6,7 +6,7 @@ This is primarily a bugfix release which contains a few minor improvements too. 
 
 ### Breaking changes
  - The undocumented `macros` attribute was removed from the `graph` context variable ([#1615](https://github.com/fishtown-analytics/dbt/pull/1615))
- 
+
 ### Features:
  - Summarize warnings at the end of dbt runs ([#1597](https://github.com/fishtown-analytics/dbt/issues/1597), [#1654](https://github.com/fishtown-analytics/dbt/pull/1654))
  - Speed up catalog generation on postgres by using avoiding use of the `information_schema` ([#1540](https://github.com/fishtown-analytics/dbt/pull/1540))
@@ -17,11 +17,12 @@ This is primarily a bugfix release which contains a few minor improvements too. 
  - Add environment variables for macro debugging flags ([#1628](https://github.com/fishtown-analytics/dbt/issues/1628), [#1629](https://github.com/fishtown-analytics/dbt/pull/1629))
  - Speed up node selection by making it linear, rather than quadratic, in complexity ([#1611](https://github.com/fishtown-analytics/dbt/issues/1611), [#1615](https://github.com/fishtown-analytics/dbt/pull/1615))
  - Specify the `application` field in Snowflake connections ([#1622](https://github.com/fishtown-analytics/dbt/issues/1622), [#1623](https://github.com/fishtown-analytics/dbt/pull/1623))
- - Add support for clustering on Snowflake ([#634](https://github.com/fishtown-analytics/dbt/issues/634), [#1591](https://github.com/fishtown-analytics/dbt/pull/1591), [#1689](https://github.com/fishtown-analytics/dbt/pull/1689))
- - Add support for job priority on BigQuery ([#1456](https://github.com/fishtown-analytics/dbt/issues/1456), [#1673](https://github.com/fishtown-analytics/dbt/pull/1673))
+ - Add support for clustering on Snowflake ([#634](https://github.com/fishtown-analytics/dbt/issues/634), [#1591](https://github.com/fishtown-analytics/dbt/pull/1591), [#1689](https://github.com/fishtown-analytics/dbt/pull/1689)) ([docs](https://docs.getdbt.com/docs/snowflake-configs#section-configuring-table-clustering))
+ - Add support for job priority on BigQuery ([#1456](https://github.com/fishtown-analytics/dbt/issues/1456), [#1673](https://github.com/fishtown-analytics/dbt/pull/1673)) ([docs](https://docs.getdbt.com/docs/profile-bigquery#section-priority))
+ - Add `node.config` and `node.tags` to the `generate_schema_name` and `generate_alias_name` macro context ([#1700](https://github.com/fishtown-analytics/dbt/issues/1700), [#1701](https://github.com/fishtown-analytics/dbt/pull/1701))
 
 ### Fixes:
- - Fix for reused `check_cols` values in snapshots ([#1614](https://github.com/fishtown-analytics/dbt/pull/1614))
+ - Fix for reused `check_cols` values in snapshots ([#1614](https://github.com/fishtown-analytics/dbt/pull/1614), [#1709](https://github.com/fishtown-analytics/dbt/pull/1709))
  - Fix for rendering column descriptions in sources ([#1619](https://github.com/fishtown-analytics/dbt/issues/1619), [#1633](https://github.com/fishtown-analytics/dbt/pull/1633))
  - Fix for `is_incremental()` returning True for models that are not materialized as incremental models ([#1249](https://github.com/fishtown-analytics/dbt/issues/1249), [#1608](https://github.com/fishtown-analytics/dbt/pull/1608))
  - Fix for serialization of BigQuery results which contain nested or repeated records ([#1626](https://github.com/fishtown-analytics/dbt/issues/1626), [#1638](https://github.com/fishtown-analytics/dbt/pull/1638))
@@ -50,7 +51,8 @@ Thanks for your contributions to dbt!
 - [@edmundyan](https://github.com/edmundyan) ([#1663](https://github.com/fishtown-analytics/dbt/pull/1663))
 - [@vitorbaptista](https://github.com/vitorbaptista) ([#1664](https://github.com/fishtown-analytics/dbt/pull/1664))
 - [@sjwhitworth](https://github.com/sjwhitworth) ([#1672](https://github.com/fishtown-analytics/dbt/pull/1672), [#1673](https://github.com/fishtown-analytics/dbt/pull/1673))
-- [@mikaelene](https://github.com/mikaelene) ([#1688](https://github.com/fishtown-analytics/dbt/pull/1688))
+- [@mikaelene](https://github.com/mikaelene) ([#1688](https://github.com/fishtown-analytics/dbt/pull/1688), [#1709](https://github.com/fishtown-analytics/dbt/pull/1709))
+- [@bastienboutonnet](https://github.com/bastienboutonnet) ([#1591](https://github.com/fishtown-analytics/dbt/pull/1591), [#1689](https://github.com/fishtown-analytics/dbt/pull/1689))
 
 
 

--- a/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
@@ -107,19 +107,7 @@
         )
     {%- endset %}
 
-    {% if target_exists %}
-        {% set row_version -%}
-            (
-             select count(*) from {{ snapshotted_rel }}
-             where {{ snapshotted_rel }}.dbt_unique_key = {{ primary_key }}
-            )
-        {%- endset %}
-        {% set scd_id_cols = [primary_key, row_version] + (check_cols | list) %}
-    {% else %}
-        {% set scd_id_cols = [primary_key] + (check_cols | list) %}
-    {% endif %}
-
-    {% set scd_id_expr = snapshot_hash_arguments(scd_id_cols) %}
+    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}
 
     {% do return({
         "unique_key": primary_key,

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -357,11 +357,11 @@ class ConfiguredParser(
         # parsed_node.config is what it would be if they did nothing
         self.update_parsed_node_config(parsed_node, config_dict)
 
-        self.update_parsed_node_schema(parsed_node, config_dict)
-        self.update_parsed_node_alias(parsed_node, config_dict)
         parsed_node.database = config_dict.get(
             'database', self.default_database
         ).strip()
+        self.update_parsed_node_schema(parsed_node, config_dict)
+        self.update_parsed_node_alias(parsed_node, config_dict)
 
     def initial_config(self, fqn: List[str]) -> SourceConfig:
         return SourceConfig(self.root_project, self.project, fqn,

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -258,7 +258,6 @@ class ConfiguredParser(
         """
         if name is None:
             name = block.name
-
         dct = {
             'alias': name,
             'schema': self.default_schema,
@@ -275,7 +274,6 @@ class ConfiguredParser(
             'config': self.config_dict(config),
         }
         dct.update(kwargs)
-
         try:
             return self.parse_from_dict(dct)
         except ValidationError as exc:
@@ -364,8 +362,6 @@ class ConfiguredParser(
         parsed_node.database = config_dict.get(
             'database', self.default_database
         ).strip()
-
-        self.update_parsed_node_config(parsed_node, config_dict)
 
     def initial_config(self, fqn: List[str]) -> SourceConfig:
         return SourceConfig(self.root_project, self.project, fqn,

--- a/test/integration/024_custom_schema_test/custom-macros-configs/schema.sql
+++ b/test/integration/024_custom_schema_test/custom-macros-configs/schema.sql
@@ -1,0 +1,6 @@
+
+{% macro generate_schema_name(schema_name, node) %}
+
+    {{ node.config['schema'] }}_{{ target.schema }}_macro
+
+{% endmacro %}

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -171,3 +171,30 @@ class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
         self.assertTablesEqual("seed", "view_1", schema, v1_schema)
         self.assertTablesEqual("seed", "view_2", schema, v2_schema)
         self.assertTablesEqual("agg", "view_3", schema, xf_schema)
+
+
+class TestCustomSchemaWithCustomMacroConfigs(TestCustomSchemaWithCustomMacro):
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['custom-macros-configs'],
+            'models': {
+                'schema': 'dbt_test'
+            }
+        }
+
+    @use_profile('postgres')
+    def test__postgres__custom_schema_from_macro(self):
+        self.run_sql_file("seed.sql")
+        results = self.run_dbt()
+        self.assertEqual(len(results), 3)
+
+        schema = self.unique_schema()
+        v1_schema = "dbt_test_{}_macro".format(schema)
+        v2_schema = "custom_{}_macro".format(schema)
+        xf_schema = "test_{}_macro".format(schema)
+
+        self.assertTablesEqual("seed", "view_1", schema, v1_schema)
+        self.assertTablesEqual("seed", "view_2", schema, v2_schema)
+        self.assertTablesEqual("agg", "view_3", schema, xf_schema)

--- a/test/integration/043_custom_aliases_test/macros-configs/macros.sql
+++ b/test/integration/043_custom_aliases_test/macros-configs/macros.sql
@@ -1,0 +1,21 @@
+
+{#-- Verify that the config['alias'] key is present #}
+{% macro generate_alias_name(custom_alias_name, node) -%}
+    {%- if custom_alias_name is none -%}
+        {{ node.name }}
+    {%- else -%}
+        custom_{{ node.config['alias'] | trim }}
+    {%- endif -%}
+{%- endmacro %}
+
+{% macro string_literal(s) -%}
+  {{ adapter_macro('test.string_literal', s) }}
+{%- endmacro %}
+
+{% macro default__string_literal(s) %}
+    '{{ s }}'::text
+{% endmacro %}
+
+{% macro bigquery__string_literal(s) %}
+    cast('{{ s }}' as string)
+{% endmacro %}

--- a/test/integration/043_custom_aliases_test/test_custom_aliases.py
+++ b/test/integration/043_custom_aliases_test/test_custom_aliases.py
@@ -21,3 +21,17 @@ class TestAliases(DBTIntegrationTest):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 2)
         self.run_dbt(['test'])
+
+
+class TestAliasesWithConfig(TestAliases):
+    @property
+    def project_config(self):
+        return {
+            "macro-paths": ['macros-configs'],
+        }
+
+    @use_profile('postgres')
+    def test_postgres_customer_alias_name(self):
+        results = self.run_dbt(['run'])
+        self.assertEqual(len(results), 2)
+        self.run_dbt(['test'])


### PR DESCRIPTION
- Checked out dev/louisa-may-alcott
- Merged dev/0.14.1 in
- Reverted versions back to 0.15.0a1

This merge got a little involved. `node.config` isn't really a dict anymore at parse time in 0.15.x, but I am pretty sure we don't want to break that syntax. So instead, this implements `MutableMapping` for `NodeConfig`, and treating `node.config` as a dict behaves mostly as you'd expect.