### PR TITLE
populate the cache on compile, too (#1705)

### DIFF
--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -9,6 +9,10 @@ class CompileTask(GraphRunnableTask):
     def raise_on_first_error(self):
         return True
 
+    def before_run(self, adapter, selected_uids):
+        with adapter.connection_named('master'):
+            self.populate_adapter_cache(adapter)
+
     def build_query(self):
         return {
             "include": self.args.models,

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -56,9 +56,6 @@ class RunTask(CompileTask):
     def raise_on_first_error(self):
         return False
 
-    def populate_adapter_cache(self, adapter):
-        adapter.set_relations_cache(self.manifest)
-
     def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context):
         compiled = compile_node(adapter, self.config, hook, self.manifest,
                                 extra_context)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -52,6 +52,9 @@ class ManifestTask(ConfiguredTask):
         self.load_manifest()
         self.compile_manifest()
 
+    def populate_adapter_cache(self, adapter):
+        adapter.set_relations_cache(self.manifest)
+
 
 class GraphRunnableTask(ManifestTask):
     def __init__(self, args, config):


### PR DESCRIPTION
Fixes #1705 

`dbt compile` will now populate the cache before the run, but after the manifest has been built, just like `dbt run`/`dbt test` already do.

I don't think `dbt ls` will need this as it doesn't compile nodes, it just compiles a manifest.

I didn't implement lazy-loading, though we could definitely also choose to lazy-load the cache on a per-schema basis. That would help if you had a project with many schemas and only a couple `get_relation`/`is_incremental`/similar calls.