### PR TITLE
Feature/snowflake secure view 4

### DIFF
--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -9,7 +9,7 @@ class SnowflakeAdapter(SQLAdapter):
     ConnectionManager = SnowflakeConnectionManager
 
     AdapterSpecificConfigs = frozenset(
-        {"transient", "cluster_by", "automatic_clustering"}
+        {"transient", "cluster_by", "automatic_clustering","secure"}
     )
 
     @classmethod

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -9,7 +9,7 @@ class SnowflakeAdapter(SQLAdapter):
     ConnectionManager = SnowflakeConnectionManager
 
     AdapterSpecificConfigs = frozenset(
-        {"transient", "cluster_by", "automatic_clustering","secure"}
+        {"transient", "cluster_by", "automatic_clustering"}
     )
 
     @classmethod

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -9,7 +9,7 @@ class SnowflakeAdapter(SQLAdapter):
     ConnectionManager = SnowflakeConnectionManager
 
     AdapterSpecificConfigs = frozenset(
-        {"transient", "cluster_by", "automatic_clustering"}
+        {"transient", "cluster_by", "automatic_clustering", "secure"}
     )
 
     @classmethod

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -35,7 +35,10 @@
 {% endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
-  create or replace view {{ relation }} as (
+  {%- set secure = config.get('secure', default=false) -%}
+  create or replace {% if secure -%}
+    secure
+  {%- endif %} view {{ relation }} as (
     {{ sql }}
   );
 {% endmacro %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -35,10 +35,7 @@
 {% endmacro %}
 
 {% macro snowflake__create_view_as(relation, sql) -%}
-  {%- set secure = config.get('secure', default=false) -%}
-  create or replace {% if secure -%}
-    secure
-  {%- endif %} view {{ relation }} as (
+  create or replace view {{ relation }} as (
     {{ sql }}
   );
 {% endmacro %}


### PR DESCRIPTION
Updated impl.py and adapters.sql to implement a switch to enable secure view syntax in the Snowflake View creation SQL.
{{ config(materialized='view',secure=true) }}

Will output the word SECURE into the View creation code sent to Snowflake.
The Default view is set to false for the secure feature.