### PR TITLE
Added Copy Grants to Snowflake Adapter

### DIFF
--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -9,7 +9,8 @@ class SnowflakeAdapter(SQLAdapter):
     ConnectionManager = SnowflakeConnectionManager
 
     AdapterSpecificConfigs = frozenset(
-        {"transient", "cluster_by", "automatic_clustering", "secure"}
+        {"transient", "cluster_by", "automatic_clustering", "secure",
+         "copy_grants"}
     )
 
     @classmethod

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -2,6 +2,7 @@
   {%- set transient = config.get('transient', default=true) -%}
   {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
   {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
+  {%- set copy_grants = config.get('copy_grants', default=false) -%}
   {%- if cluster_by_keys is not none and cluster_by_keys is string -%}
     {%- set cluster_by_keys = [cluster_by_keys] -%}
   {%- endif -%}
@@ -15,8 +16,8 @@
         temporary
       {%- elif transient -%}
         transient
-      {%- endif %} table {{ relation }}
-      as (
+      {%- endif %} table {{ relation }} {% if copy_grants and not temporary -%} copy grants {%- endif %} as 
+      (
         {%- if cluster_by_string is not none -%}
           select * from(
             {{ sql }}
@@ -36,9 +37,10 @@
 
 {% macro snowflake__create_view_as(relation, sql) -%}
   {%- set secure = config.get('secure', default=false) -%}
+  {%- set copy_grants = config.get('copy_grants', default=false) -%}
   create or replace {% if secure -%}
     secure
-  {%- endif %} view {{ relation }} as (
+  {%- endif %} view {{ relation }} {% if copy_grants -%} copy grants {%- endif %} as (
     {{ sql }}
   );
 {% endmacro %}


### PR DESCRIPTION
Added Copy Grants to Snowflake Adapter for both Views and Tables, excluding temporary tables.
**Usage**
`{{ config(materialized='table',copy_grants=true) }}`

Files Updated:  adapters.sql and impl.py for Snowflake Plugin.