### PR TITLE
add disallowed project names list to dbt projects (#1696)

### DIFF
--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -282,5 +282,3 @@ class TestSnowflakeIncrementalOverwrite(BaseTestSimpleCopy):
 
         results = self.run_dbt(["run"])
         self.assertEqual(len(results),  1)
-
-

--- a/test/unit/test_contracts_project.py
+++ b/test/unit/test_contracts_project.py
@@ -1,0 +1,33 @@
+from .utils import ContractTestCase
+
+from hologram import ValidationError
+
+from dbt.contracts.project import Project
+
+class TestProject(ContractTestCase):
+    ContractType = Project
+
+    def test_minimal(self):
+        dct = {
+            'name': 'test',
+            'version': '1.0',
+            'profile': 'test',
+            'project-root': '/usr/src/app',
+        }
+        project = Project(
+            name='test',
+            version='1.0',
+            profile='test',
+            project_root='/usr/src/app',
+        )
+        self.assert_from_dict(project, dct)
+
+    def test_invalid_name(self):
+        dct = {
+            'name': 'log',
+            'version': '1.0',
+            'profile': 'test',
+            'project-root': '/usr/src/app',
+        }
+        with self.assertRaises(ValidationError):
+            Project.from_dict(dct)


### PR DESCRIPTION
Fixes #1696

- Raise ValidationErrors on disallowed project names
- Set defaults in project contract to make testing easier (project contracts should probably just be part of the Project class!)
- Add some trivial unit tests
- Removed an empty unit test file, which makes me a bit anxious... what did I do there?