### PR TITLE
Fail on parse errors (#1493)

### DIFF
--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -77,20 +77,12 @@ class TestMalformedSchemaTests(DBTIntegrationTest):
         return test_task.run()
 
     @use_profile('postgres')
-    def test_malformed_schema_test_wont_brick_run(self):
-        # dbt run should work (Despite broken schema test)
-        results = self.run_dbt(strict=False)
-        self.assertEqual(len(results), 2)
-
-        # in v2, we skip the entire model
-        ran_tests = self.run_schema_validations()
-        self.assertEqual(len(ran_tests), 5)
-        self.assertEqual(sum(x.status for x in ran_tests), 0)
-
-    @use_profile('postgres')
     def test_malformed_schema_strict_will_break_run(self):
         with self.assertRaises(CompilationException):
             self.run_dbt(strict=True)
+        # even if strict = False!
+        with self.assertRaises(CompilationException):
+            self.run_dbt(strict=False)
 
 
 class TestHooksInTests(DBTIntegrationTest):

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -958,7 +958,7 @@ class TestRPCServerFailed(HasRPCServer):
             'RPC server failed to compile project, call the "status" method for compile status',
             None)
         self.assertIn('message', data)
-        self.assertIn('Compilation warning: Invalid test config', str(data['message']))
+        self.assertIn('Invalid test config', str(data['message']))
 
     def tearDown(self):
         # prevent an OperationalError where the server closes on us in the


### PR DESCRIPTION
Fix #1493 

- Raise exceptions where we used to (usually) just warn, kind of `--strict` all the time
- Fix some error messages to be a bit more informative (though you still kind of have to piece stuff together on large, deeply nested validation errors)
- Hoisted logging about those errors up into the GraphLoader itself, which then re-raises exceptions to ensure dbt actually stops. This is a bit more useful, I think, given that we are failing immediately in all those cases now.
- We had some tests that asserted the opposite of what this PR accomplishes, so I've reversed those accordingly