### PR TITLE
Rename integration test methods to conform to standard

### DIFF
--- a/test/integration/005_simple_seed_test/test_seed_type_override.py
+++ b/test/integration/005_simple_seed_test/test_seed_type_override.py
@@ -40,7 +40,7 @@ class TestSimpleSeedColumnOverridePostgres(TestSimpleSeedColumnOverride):
         }
 
     @use_profile('postgres')
-    def test_simple_seed_with_column_override_postgres(self):
+    def test_postgres_simple_seed_with_column_override_postgres(self):
         results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
@@ -63,7 +63,7 @@ class TestSimpleSeedColumnOverrideRedshift(TestSimpleSeedColumnOverride):
         }
 
     @use_profile('redshift')
-    def test_simple_seed_with_column_override_redshift(self):
+    def test_redshift_simple_seed_with_column_override_redshift(self):
         results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
@@ -86,7 +86,7 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
         return self.snowflake_profile()
 
     @use_profile('snowflake')
-    def test_simple_seed_with_column_override_snowflake(self):
+    def test_snowflake_simple_seed_with_column_override_snowflake(self):
         results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])
@@ -109,7 +109,7 @@ class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
         return self.bigquery_profile()
 
     @use_profile('bigquery')
-    def test_simple_seed_with_column_override_bigquery(self):
+    def test_bigquery_simple_seed_with_column_override_bigquery(self):
         results = self.run_dbt(["seed", "--show"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt(["test"])

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -27,7 +27,7 @@ class TestSimpleSeed(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_simple_seed(self):
+    def test_postgres_simple_seed(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         self.assertTablesEqual("seed_actual","seed_expected")
@@ -39,7 +39,7 @@ class TestSimpleSeed(DBTIntegrationTest):
 
 
     @use_profile('postgres')
-    def test_simple_seed_with_drop(self):
+    def test_postgres_simple_seed_with_drop(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         self.assertTablesEqual("seed_actual","seed_expected")
@@ -74,7 +74,7 @@ class TestSimpleSeedCustomSchema(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_simple_seed_with_schema(self):
+    def test_postgres_simple_seed_with_schema(self):
         schema_name = "{}_{}".format(self.unique_schema(), 'custom_schema')
 
         results = self.run_dbt(["seed"])
@@ -88,7 +88,7 @@ class TestSimpleSeedCustomSchema(DBTIntegrationTest):
 
 
     @use_profile('postgres')
-    def test_simple_seed_with_drop_and_schema(self):
+    def test_postgres_simple_seed_with_drop_and_schema(self):
         schema_name = "{}_{}".format(self.unique_schema(), 'custom_schema')
 
         results = self.run_dbt(["seed"])
@@ -128,7 +128,7 @@ class TestSimpleSeedDisabled(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_simple_seed_with_disabled(self):
+    def test_postgres_simple_seed_with_disabled(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         self.assertTableDoesExist('seed_enabled')
@@ -184,7 +184,7 @@ class TestSimpleSeedWithBOM(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_simple_seed(self):
+    def test_postgres_simple_seed(self):
         # first make sure nobody "fixed" the file by accident
         seed_path = os.path.join(self.config.data_paths[0], 'seed_bom.csv')
         # 'data-bom/seed_bom.csv'
@@ -212,6 +212,6 @@ class TestSimpleSeedWithUnicode(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_simple_seed(self):
+    def test_postgres_simple_seed(self):
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)

--- a/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
@@ -40,7 +40,7 @@ class TestSimpleDependencyWithConfigs(BaseTestSimpleDependencyWithConfigs):
         }
 
     @use_profile('postgres')
-    def test_simple_dependency(self):
+    def test_postgres_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
         self.assertEqual(len(results),  5)
@@ -83,7 +83,7 @@ class TestSimpleDependencyWithOverriddenConfigs(BaseTestSimpleDependencyWithConf
 
 
     @use_profile('postgres')
-    def test_simple_dependency(self):
+    def test_postgres_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
         self.assertEqual(len(results),  5)
@@ -127,7 +127,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigs(BaseTestSimpleDepen
 
 
     @use_profile('postgres')
-    def test_simple_dependency(self):
+    def test_postgres_simple_dependency(self):
         self.use_default_project()
 
         self.run_dbt(["deps"])
@@ -183,7 +183,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigsAndMaterializations(
 
 
     @use_profile('postgres')
-    def test_simple_dependency(self):
+    def test_postgres_simple_dependency(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
         self.assertEqual(len(results),  3)

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -27,7 +27,7 @@ class TestSchemaTests(DBTIntegrationTest):
         return test_task.run()
 
     @use_profile('postgres')
-    def test_schema_tests(self):
+    def test_postgres_schema_tests(self):
         results = self.run_dbt()
         self.assertEqual(len(results), 5)
         test_results = self.run_schema_validations()
@@ -77,7 +77,7 @@ class TestMalformedSchemaTests(DBTIntegrationTest):
         return test_task.run()
 
     @use_profile('postgres')
-    def test_malformed_schema_strict_will_break_run(self):
+    def test_postgres_malformed_schema_strict_will_break_run(self):
         with self.assertRaises(CompilationException):
             self.run_dbt(strict=True)
         # even if strict = False!
@@ -104,7 +104,7 @@ class TestHooksInTests(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_hooks_dont_run_for_tests(self):
+    def test_postgres_hooks_dont_run_for_tests(self):
         # This would fail if the hooks ran
         results = self.run_dbt(['test', '--model', 'ephemeral'])
         self.assertEqual(len(results), 1)
@@ -162,7 +162,7 @@ class TestCustomSchemaTests(DBTIntegrationTest):
         return test_task.run()
 
     @use_profile('postgres')
-    def test_schema_tests(self):
+    def test_postgres_schema_tests(self):
         self.run_dbt(["deps"])
         results = self.run_dbt()
         self.assertEqual(len(results), 4)

--- a/test/integration/010_permission_tests/test_permissions.py
+++ b/test/integration/010_permission_tests/test_permissions.py
@@ -26,14 +26,14 @@ class TestPermissions(DBTIntegrationTest):
         return "models"
 
     @use_profile('postgres')
-    def test_no_create_schema_permissions(self):
+    def test_postgres_no_create_schema_permissions(self):
         # the noaccess user does not have permissions to create a schema -- this should fail
         self.run_sql('drop schema if exists "{}" cascade'.format(self.unique_schema()))
         with self.assertRaises(RuntimeError):
             self.run_dbt(['run', '--target', 'noaccess'], expect_pass=False)
 
     @use_profile('postgres')
-    def test_create_schema_permissions(self):
+    def test_postgres_create_schema_permissions(self):
         # now it should work!
         self.run_sql('grant create on database {} to noaccess'.format(self.default_database))
         self.run_sql('grant usage, create on schema "{}" to noaccess'.format(self.unique_schema()))

--- a/test/integration/011_invalid_model_tests/test_invalid_models.py
+++ b/test/integration/011_invalid_model_tests/test_invalid_models.py
@@ -17,7 +17,7 @@ class TestInvalidDisabledModels(DBTIntegrationTest):
         return "models-2"
 
     @use_profile('postgres')
-    def test_view_with_incremental_attributes(self):
+    def test_postgres_view_with_incremental_attributes(self):
         with self.assertRaises(RuntimeError) as exc:
             self.run_dbt()
 
@@ -40,7 +40,7 @@ class TestInvalidModelReference(DBTIntegrationTest):
         return "models-3"
 
     @use_profile('postgres')
-    def test_view_with_incremental_attributes(self):
+    def test_postgres_view_with_incremental_attributes(self):
         with self.assertRaises(RuntimeError) as exc:
             self.run_dbt()
 

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -84,7 +84,7 @@ class TestContextVars(DBTIntegrationTest):
         return ctx
 
     @use_profile('postgres')
-    def test_env_vars_dev(self):
+    def test_postgres_env_vars_dev(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)
         ctx = self.get_ctx_vars()
@@ -110,7 +110,7 @@ class TestContextVars(DBTIntegrationTest):
         self.assertEqual(ctx['env_var'], '1')
 
     @use_profile('postgres')
-    def test_env_vars_prod(self):
+    def test_postgres_env_vars_prod(self):
         results = self.run_dbt(['run', '--target', 'prod'])
         self.assertEqual(len(results), 1)
         ctx = self.get_ctx_vars()

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -31,13 +31,13 @@ class TestCLIInvocation(ModelCopyingIntegrationTest):
         return "models"
 
     @use_profile('postgres')
-    def test_toplevel_dbt_run(self):
+    def test_postgres_toplevel_dbt_run(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)
         self.assertTablesEqual("seed", "model")
 
     @use_profile('postgres')
-    def test_subdir_dbt_run(self):
+    def test_postgres_subdir_dbt_run(self):
         os.chdir(os.path.join(self.models, "subdir1"))
 
         results = self.run_dbt(['run'])
@@ -97,7 +97,7 @@ class TestCLIInvocationWithProfilesDir(ModelCopyingIntegrationTest):
         return "models"
 
     @use_profile('postgres')
-    def test_toplevel_dbt_run_with_profile_dir_arg(self):
+    def test_postgres_toplevel_dbt_run_with_profile_dir_arg(self):
         results = self.run_dbt(['run', '--profiles-dir', 'dbt-profile'], profiles_dir=False)
         self.assertEqual(len(results), 1)
 

--- a/test/integration/016_macro_tests/test_macros.py
+++ b/test/integration/016_macro_tests/test_macros.py
@@ -35,7 +35,7 @@ class TestMacros(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_working_macros(self):
+    def test_postgres_working_macros(self):
         self.run_dbt(["deps"])
         results = self.run_dbt(["run"])
         self.assertEqual(len(results), 6)
@@ -64,7 +64,7 @@ class TestInvalidMacros(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_invalid_macro(self):
+    def test_postgres_invalid_macro(self):
 
         try:
             self.run_dbt(["run"], expect_pass=False)

--- a/test/integration/019_analysis_tests/test_analyses.py
+++ b/test/integration/019_analysis_tests/test_analyses.py
@@ -26,7 +26,7 @@ class TestAnalyses(DBTIntegrationTest):
             self.assertEqual(fp.read().strip(), expected)
 
     @use_profile('postgres')
-    def test_analyses(self):
+    def test_postgres_analyses(self):
         compiled_analysis_path = os.path.normpath('target/compiled/test/analysis')
         path_1 = os.path.join(compiled_analysis_path, 'analysis.sql')
         path_2 = os.path.join(compiled_analysis_path, 'raw_stuff.sql')

--- a/test/integration/023_exit_codes_test/test_exit_codes.py
+++ b/test/integration/023_exit_codes_test/test_exit_codes.py
@@ -13,7 +13,6 @@ class TestExitCodes(DBTIntegrationTest):
     def models(self):
         return "models"
 
-
     @property
     def project_config(self):
         return {
@@ -66,6 +65,7 @@ class TestExitCodes(DBTIntegrationTest):
         self.assertTableDoesExist('good_snapshot')
         self.assertTrue(success)
 
+
 class TestExitCodesSnapshotFail(DBTIntegrationTest):
 
     @property
@@ -83,7 +83,7 @@ class TestExitCodesSnapshotFail(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test___snapshot_fail(self):
+    def test__postgres_snapshot_fail(self):
         results, success = self.run_dbt_and_check(['run', '--model', 'good'])
         self.assertTrue(success)
         self.assertEqual(len(results.results), 1)
@@ -112,7 +112,7 @@ class TestExitCodesDeps(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_deps(self):
+    def test_postgres_deps(self):
         _, success = self.run_dbt_and_check(['deps'])
         self.assertTrue(success)
 
@@ -138,7 +138,7 @@ class TestExitCodesDepsFail(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_deps(self):
+    def test_postgres_deps(self):
         with self.assertRaises(dbt.exceptions.InternalException):
             # this should fail
             self.run_dbt_and_check(['deps'])
@@ -160,7 +160,7 @@ class TestExitCodesSeed(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_seed(self):
+    def test_postgres_seed(self):
         results, success = self.run_dbt_and_check(['seed'])
         self.assertEqual(len(results.results), 1)
         self.assertTrue(success)
@@ -182,6 +182,6 @@ class TestExitCodesSeedFail(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_seed(self):
+    def test_postgres_seed(self):
         _, success = self.run_dbt_and_check(['seed'])
         self.assertFalse(success)

--- a/test/integration/025_duplicate_model_test/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_model.py
@@ -33,7 +33,7 @@ class TestDuplicateModelEnabled(DBTIntegrationTest):
         }
 
     @use_profile("postgres")
-    def test_duplicate_model_enabled(self):
+    def test_postgres_duplicate_model_enabled(self):
         message = "dbt found two resources with the name"
         try:
             self.run_dbt(["run"])
@@ -73,7 +73,7 @@ class TestDuplicateModelDisabled(DBTIntegrationTest):
         }
 
     @use_profile("postgres")
-    def test_duplicate_model_disabled(self):
+    def test_postgres_duplicate_model_disabled(self):
         try:
             results = self.run_dbt(["run"])
         except CompilationException:
@@ -109,7 +109,7 @@ class TestDuplicateModelEnabledAcrossPackages(DBTIntegrationTest):
         }
 
     @use_profile("postgres")
-    def test_duplicate_model_enabled_across_packages(self):
+    def test_postgres_duplicate_model_enabled_across_packages(self):
         self.run_dbt(["deps"])
         message = "dbt found two resources with the name"
         try:
@@ -146,7 +146,7 @@ class TestDuplicateModelDisabledAcrossPackages(DBTIntegrationTest):
         }
 
     @use_profile("postgres")
-    def test_duplicate_model_disabled_across_packages(self):
+    def test_postgres_duplicate_model_disabled_across_packages(self):
         self.run_dbt(["deps"])
         try:
             self.run_dbt(["run"])

--- a/test/integration/025_timezones_test/test_timezones.py
+++ b/test/integration/025_timezones_test/test_timezones.py
@@ -43,7 +43,7 @@ class TestTimezones(DBTIntegrationTest):
 
     @freeze_time("2017-01-01 03:00:00", tz_offset=0)
     @use_profile('postgres')
-    def test_run_started_at(self):
+    def test_postgres_run_started_at(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 1)
         result = self.run_sql(self.query, fetch='all')[0]

--- a/test/integration/026_aliases_test/test_aliases.py
+++ b/test/integration/026_aliases_test/test_aliases.py
@@ -27,7 +27,7 @@ class TestAliases(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test__alias_model_name(self):
+    def test__alias_model_name_postgres(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 4)
         self.run_dbt(['test'])
@@ -43,6 +43,7 @@ class TestAliases(DBTIntegrationTest):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 4)
         self.run_dbt(['test'])
+
 
 class TestAliasErrors(DBTIntegrationTest):
     @property
@@ -60,10 +61,11 @@ class TestAliasErrors(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test__alias_dupe_throws_exception(self):
+    def test__postgres_alias_dupe_throws_exception(self):
         message = ".*identical database representation.*"
-        with self.assertRaisesRegexp(Exception, message):
+        with self.assertRaisesRegex(Exception, message):
             self.run_dbt(['run'])
+
 
 class TestSameAliasDifferentSchemas(DBTIntegrationTest):
     @property
@@ -81,7 +83,7 @@ class TestSameAliasDifferentSchemas(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test__same_alias_succeeds_in_different_schemas(self):
+    def test__postgres_same_alias_succeeds_in_different_schemas(self):
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 3)
         res = self.run_dbt(['test'])

--- a/test/integration/027_cycle_test/test_cycles.py
+++ b/test/integration/027_cycle_test/test_cycles.py
@@ -14,7 +14,7 @@ class TestSimpleCycle(DBTIntegrationTest):
 
     @property
     @use_profile('postgres')
-    def test_simple_cycle(self):
+    def test_postgres_simple_cycle(self):
         message = "Found a cycle.*"
         with self.assertRaisesRegexp(Exception, message):
             self.run_dbt(["run"])
@@ -31,7 +31,7 @@ class TestComplexCycle(DBTIntegrationTest):
 
     @property
     @use_profile('postgres')
-    def test_simple_cycle(self):
+    def test_postgres_simple_cycle(self):
         message = "Found a cycle.*"
         with self.assertRaisesRegexp(Exception, message):
             self.run_dbt(["run"])

--- a/test/integration/028_cli_vars/test_cli_var_override.py
+++ b/test/integration/028_cli_vars/test_cli_var_override.py
@@ -22,7 +22,7 @@ class TestCLIVarOverride(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test__overriden_vars_global(self):
+    def test__postgres_overriden_vars_global(self):
         self.use_default_project()
         self.use_profile('postgres')
 
@@ -53,7 +53,7 @@ class TestCLIVarOverridePorject(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test__overriden_vars_project_level(self):
+    def test__postgres_overriden_vars_project_level(self):
 
         # This should be "override"
         self.run_dbt(["run", "--vars", "{required: override}"])

--- a/test/integration/028_cli_vars/test_cli_vars.py
+++ b/test/integration/028_cli_vars/test_cli_vars.py
@@ -12,7 +12,7 @@ class TestCLIVars(DBTIntegrationTest):
         return "models_complex"
 
     @use_profile('postgres')
-    def test__cli_vars_longform(self):
+    def test__postgres_cli_vars_longform(self):
         self.use_profile('postgres')
         self.use_default_project()
 
@@ -39,7 +39,7 @@ class TestCLIVarsSimple(DBTIntegrationTest):
         return "models_simple"
 
     @use_profile('postgres')
-    def test__cli_vars_shorthand(self):
+    def test__postgres_cli_vars_shorthand(self):
         self.use_profile('postgres')
         self.use_default_project()
 
@@ -49,7 +49,7 @@ class TestCLIVarsSimple(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
 
     @use_profile('postgres')
-    def test__cli_vars_longer(self):
+    def test__postgres_cli_vars_longer(self):
         self.use_profile('postgres')
         self.use_default_project()
 

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -190,7 +190,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         }
 
     @use_profile("postgres")
-    def test__event_tracking_compile(self):
+    def test__postgres_event_tracking_compile(self):
         expected_calls = [
             call(
                 category='dbt',
@@ -218,7 +218,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         )
 
     @use_profile("postgres")
-    def test__event_tracking_deps(self):
+    def test__postgres_event_tracking_deps(self):
         package_context = [
             {
                 'schema': 'iglu:com.dbt/package_install/jsonschema/1-0-0',
@@ -261,7 +261,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         self.run_event_test(["deps"], expected_calls, expected_contexts)
 
     @use_profile("postgres")
-    def test__event_tracking_seed(self):
+    def test__postgres_event_tracking_seed(self):
         def seed_context(project_id, user_id, invocation_id, version):
             return [{
                 'schema': 'iglu:com.dbt/run_model/jsonschema/1-0-1',
@@ -315,7 +315,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         self.run_event_test(["seed"], expected_calls, expected_contexts)
 
     @use_profile("postgres")
-    def test__event_tracking_models(self):
+    def test__postgres_event_tracking_models(self):
         expected_calls = [
             call(
                 category='dbt',
@@ -377,7 +377,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         )
 
     @use_profile("postgres")
-    def test__event_tracking_model_error(self):
+    def test__postgres_event_tracking_model_error(self):
         # cmd = ["run", "--model", "model_error"]
         # self.run_event_test(cmd, event_run_model_error, expect_pass=False)
 
@@ -423,7 +423,7 @@ class TestEventTrackingSuccess(TestEventTracking):
         )
 
     @use_profile("postgres")
-    def test__event_tracking_tests(self):
+    def test__postgres_event_tracking_tests(self):
         # TODO: dbt does not track events for tests, but it should!
         self.run_dbt(["run", "--model", "example", "example_2"])
 
@@ -463,7 +463,7 @@ class TestEventTrackingCompilationError(TestEventTracking):
         }
 
     @use_profile("postgres")
-    def test__event_tracking_with_compilation_error(self):
+    def test__postgres_event_tracking_with_compilation_error(self):
         expected_calls = [
             call(
                 category='dbt',
@@ -529,7 +529,7 @@ class TestEventTrackingUnableToConnect(TestEventTracking):
         }
 
     @use_profile("postgres")
-    def test__event_tracking_unable_to_connect(self):
+    def test__postgres_event_tracking_unable_to_connect(self):
         expected_calls = [
             call(
                 category='dbt',
@@ -566,7 +566,7 @@ class TestEventTrackingSnapshot(TestEventTracking):
         }
 
     @use_profile("postgres")
-    def test__event_tracking_snapshot(self):
+    def test__postgres_event_tracking_snapshot(self):
         self.run_dbt(["run", "--models", "snapshottable"])
 
         expected_calls = [
@@ -613,7 +613,7 @@ class TestEventTrackingSnapshot(TestEventTracking):
 
 class TestEventTrackingCatalogGenerate(TestEventTracking):
     @use_profile("postgres")
-    def test__event_tracking_catalog_generate(self):
+    def test__postgres_event_tracking_catalog_generate(self):
         # create a model for the catalog
         self.run_dbt(["run", "--models", "example"])
 

--- a/test/integration/035_docs_blocks/test_docs_blocks.py
+++ b/test/integration/035_docs_blocks/test_docs_blocks.py
@@ -20,7 +20,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
 
 
     @use_profile('postgres')
-    def test_valid_doc_ref(self):
+    def test_postgres_valid_doc_ref(self):
         self.assertEqual(len(self.run_dbt()), 1)
 
         self.assertTrue(os.path.exists('./target/manifest.json'))
@@ -58,7 +58,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
         self.assertEqual(len(model_data['columns']), 3)
 
     @use_profile('postgres')
-    def test_alternative_docs_path(self):
+    def test_postgres_alternative_docs_path(self):
         self.use_default_project({"docs-paths": [self.dir("docs")]})
         self.assertEqual(len(self.run_dbt()), 1)
 
@@ -97,7 +97,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
         self.assertEqual(len(model_data['columns']), 3)
 
     @use_profile('postgres')
-    def test_alternative_docs_path_missing(self):
+    def test_postgres_alternative_docs_path_missing(self):
         self.use_default_project({"docs-paths": [self.dir("not-docs")]})
         with self.assertRaises(dbt.exceptions.CompilationException):
             self.run_dbt()
@@ -116,7 +116,7 @@ class TestMissingDocsBlocks(DBTIntegrationTest):
         return self.dir("missing_docs_models")
 
     @use_profile('postgres')
-    def test_missing_doc_ref(self):
+    def test_postgres_missing_doc_ref(self):
         # The run should fail since we could not find the docs reference.
         with self.assertRaises(dbt.exceptions.CompilationException):
             self.run_dbt()
@@ -135,7 +135,7 @@ class TestBadDocsBlocks(DBTIntegrationTest):
         return self.dir("invalid_name_models")
 
     @use_profile('postgres')
-    def test_invalid_doc_ref(self):
+    def test_postgres_invalid_doc_ref(self):
         # The run should fail since we could not find the docs reference.
         with self.assertRaises(dbt.exceptions.CompilationException):
             self.run_dbt(expect_pass=False)

--- a/test/integration/039_config_test/test_configs.py
+++ b/test/integration/039_config_test/test_configs.py
@@ -77,7 +77,7 @@ class TestTargetConfigs(DBTIntegrationTest):
         }
 
     @use_profile('postgres')
-    def test_alternative_target_paths(self):
+    def test_postgres_alternative_target_paths(self):
         self.run_dbt(['seed'])
         dirs = list(self.new_dirs())
         self.assertEqual(len(dirs), 1)

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -886,7 +886,7 @@ class TestRPCServer(HasRPCServer):
         self.assertEqual(len(result['rows']), 0)
 
     @use_profile('postgres')
-    def test_gc_change_interval(self):
+    def test_postgres_gc_change_interval(self):
         num_requests = 10
         self._make_any_requests(num_requests)
 

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -61,18 +61,20 @@ class TestArgs:
 
 def _profile_from_test_name(test_name):
     adapter_names = ('postgres', 'snowflake', 'redshift', 'bigquery', 'presto')
-    adapters_in_name =  sum(x in test_name for x in adapter_names)
-    if adapters_in_name > 1:
-        raise ValueError('test names must only have 1 profile choice embedded')
+    adapters_in_name = sum(x in test_name for x in adapter_names)
+    if adapters_in_name != 1:
+        raise ValueError(
+            'test names must have exactly 1 profile choice embedded, {} has {}'
+            .format(test_name, adapters_in_name)
+        )
 
     for adapter_name in adapter_names:
         if adapter_name in test_name:
             return adapter_name
 
-    warnings.warn(
+    raise ValueError(
         'could not find adapter name in test name {}'.format(test_name)
     )
-    return 'postgres'
 
 
 def _pytest_test_name():


### PR DESCRIPTION
I'm very tired of seeing the warning about this and it turns out the regex is not that hard to write.

- make all tests have the adapter in the name
- enforce that restriction by raising an exception instead of just warning about it
- fix a call to suppress a unittest warning too (`assertRaisesRegexp` is deprecated)