### PR TITLE
Standardize snapshot CLI output

### DIFF
--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -480,11 +480,14 @@ class TestRunner(CompileRunner):
 
 class SnapshotRunner(ModelRunner):
     def describe_node(self):
-        return "snapshot {}".format(self.node.name)
+        return "snapshot {}".format(self.get_node_representation())
 
     def print_result_line(self, result):
-        dbt.ui.printer.print_snapshot_result_line(result, self.node_index,
-                                                  self.num_nodes)
+        dbt.ui.printer.print_snapshot_result_line(
+            result,
+            self.get_node_representation(),
+            self.node_index,
+            self.num_nodes)
 
 
 class SeedRunner(ModelRunner):

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -192,14 +192,16 @@ def print_model_result_line(
         result.execution_time)
 
 
-def print_snapshot_result_line(result, index: int, total: int):
+def print_snapshot_result_line(
+    result, description: str, index: int, total: int
+) -> None:
     model = result.node
 
     info, status = get_printable_result(result, 'snapshotted', 'snapshotting')
     cfg = model.config.to_dict()
 
-    msg = "{info} {name}".format(
-        info=info, name=model.name, **cfg)
+    msg = "{info} {description}".format(
+        info=info, description=description, **cfg)
     print_fancy_output_line(
         msg,
         status,


### PR DESCRIPTION
Fixes #1768 

Output:
```
$ dbt snapshot
Running with dbt=0.15.0-a1
Found 2 models, 5 tests, 1 snapshot, 0 analyses, 130 macros, 0 operations, 2 seed files, 1 source

22:36:19 | Concurrency: 8 threads (target='dev')
22:36:19 |
22:36:19 | 1 of 1 START snapshot snapshots.my_snapshot... [RUN]
22:36:19 | 1 of 1 OK snapshotted snapshots.my_snapshot... [INSERT 0 0 in 0.20s]
22:36:19 |
22:36:19 | Finished running 1 snapshot in 0.40s.
```