### PR TITLE
Use the restrict hologram metadata field instead of multiple enum types

### DIFF
--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -11,16 +11,7 @@ from dbt.contracts.graph.parsed import (
     TestConfig,
     PARSED_TYPES,
 )
-from dbt.node_types import (
-    NodeType,
-    AnalysisType,
-    ModelType,
-    OperationType,
-    RPCCallType,
-    SeedType,
-    SnapshotType,
-    TestType,
-)
+from dbt.node_types import NodeType
 from dbt.contracts.util import Replaceable
 
 from hologram import JsonSchemaMixin
@@ -72,28 +63,30 @@ class CompiledNode(ParsedNode):
 
 @dataclass
 class CompiledAnalysisNode(CompiledNode):
-    resource_type: AnalysisType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Analysis]})
 
 
 @dataclass
 class CompiledHookNode(CompiledNode):
-    resource_type: OperationType
+    resource_type: NodeType = field(
+        metadata={'restrict': [NodeType.Operation]}
+    )
     index: Optional[int] = None
 
 
 @dataclass
 class CompiledModelNode(CompiledNode):
-    resource_type: ModelType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Model]})
 
 
 @dataclass
 class CompiledRPCNode(CompiledNode):
-    resource_type: RPCCallType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.RPCCall]})
 
 
 @dataclass
 class CompiledSeedNode(CompiledNode):
-    resource_type: SeedType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Seed]})
 
     @property
     def empty(self):
@@ -103,12 +96,12 @@ class CompiledSeedNode(CompiledNode):
 
 @dataclass
 class CompiledSnapshotNode(CompiledNode):
-    resource_type: SnapshotType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Snapshot]})
 
 
 @dataclass
 class CompiledTestNode(CompiledNode):
-    resource_type: TestType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -1,4 +1,4 @@
-from dbt.node_types import UnparsedNodeType, NodeType, OperationType, MacroType
+from dbt.node_types import NodeType
 from dbt.contracts.util import Replaceable, Mergeable
 
 from hologram import JsonSchemaMixin
@@ -28,18 +28,28 @@ class HasSQL:
 
 @dataclass
 class UnparsedMacro(UnparsedBaseNode, HasSQL):
-    resource_type: MacroType
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Macro]})
 
 
 @dataclass
 class UnparsedNode(UnparsedBaseNode, HasSQL):
     name: str
-    resource_type: UnparsedNodeType
+    resource_type: NodeType = field(metadata={'restrict': [
+        NodeType.Model,
+        NodeType.Analysis,
+        NodeType.Test,
+        NodeType.Snapshot,
+        NodeType.Operation,
+        NodeType.Seed,
+        NodeType.RPCCall,
+    ]})
 
 
 @dataclass
 class UnparsedRunHook(UnparsedNode):
-    resource_type: OperationType
+    resource_type: NodeType = field(
+        metadata={'restrict': [NodeType.Operation]}
+    )
     index: Optional[int] = None
 
 

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -35,59 +35,6 @@ class NodeType(StrEnum):
         ]]
 
 
-class UnparsedNodeType(StrEnum):
-    Model = str(NodeType.Model)
-    Analysis = str(NodeType.Analysis)
-    Test = str(NodeType.Test)
-    Snapshot = str(NodeType.Snapshot)
-    Operation = str(NodeType.Operation)
-    Seed = str(NodeType.Seed)
-    RPCCall = str(NodeType.RPCCall)
-
-
 class RunHookType(StrEnum):
     Start = 'on-run-start'
     End = 'on-run-end'
-
-# It would be nice to use hologram.StrLiteral for these, but it results in
-# un-pickleable types :(
-
-
-class AnalysisType(StrEnum):
-    Analysis = str(NodeType.Analysis)
-
-
-class DocumentationType(StrEnum):
-    Documentation = str(NodeType.Documentation)
-
-
-class MacroType(StrEnum):
-    Macro = str(NodeType.Macro)
-
-
-class ModelType(StrEnum):
-    Model = str(NodeType.Model)
-
-
-class OperationType(StrEnum):
-    Operation = str(NodeType.Operation)
-
-
-class RPCCallType(StrEnum):
-    RPCCall = str(NodeType.RPCCall)
-
-
-class SeedType(StrEnum):
-    Seed = str(NodeType.Seed)
-
-
-class SnapshotType(StrEnum):
-    Snapshot = str(NodeType.Snapshot)
-
-
-class SourceType(StrEnum):
-    Source = str(NodeType.Source)
-
-
-class TestType(StrEnum):
-    Test = str(NodeType.Test)

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -21,7 +21,7 @@ from dbt.exceptions import (
     CompilationException, validator_error_message
 )
 from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
-from dbt.node_types import NodeType, UnparsedNodeType
+from dbt.node_types import NodeType
 from dbt.source_config import SourceConfig
 from dbt.parser.results import ParseResult, ManifestNodes
 from dbt.parser.search import FileBlock
@@ -236,7 +236,7 @@ class ConfiguredParser(
         # message reasons
         return UnparsedNode(
             name=name,
-            resource_type=UnparsedNodeType(self.resource_type),
+            resource_type=self.resource_type,
             path=path,
             original_file_path=original_file_path,
             root_path=self.project.project_root,

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -7,7 +7,7 @@ from dbt.contracts.graph.unparsed import UnparsedMacro
 from dbt.contracts.graph.parsed import ParsedMacro
 from dbt.exceptions import CompilationException
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.node_types import NodeType, MacroType
+from dbt.node_types import NodeType
 from dbt.parser.base import BaseParser
 from dbt.parser.search import FileBlock, FilesystemSearcher
 from dbt.utils import MACRO_PREFIX
@@ -78,7 +78,7 @@ class MacroParser(BaseParser[ParsedMacro]):
             package_name=self.project.project_name,
             raw_sql=source_file.contents,
             root_path=self.project.project_root,
-            resource_type=MacroType(NodeType.Macro),
+            resource_type=NodeType.Macro,
         )
 
         for node in self.parse_unparsed_macros(base_node):

--- a/core/dbt/parser/rpc.py
+++ b/core/dbt/parser/rpc.py
@@ -6,7 +6,7 @@ from dbt.contracts.graph.manifest import SourceFile
 from dbt.contracts.graph.parsed import ParsedRPCNode, ParsedMacro
 from dbt.contracts.graph.unparsed import UnparsedMacro
 from dbt.exceptions import InternalException
-from dbt.node_types import NodeType, MacroType
+from dbt.node_types import NodeType
 from dbt.parser.base import SimpleSQLParser
 from dbt.parser.macros import MacroParser
 from dbt.parser.search import FileBlock
@@ -56,7 +56,7 @@ class RPCMacroParser(MacroParser):
             package_name=self.project.project_name,
             raw_sql=contents,
             root_path=self.project.project_root,
-            resource_type=MacroType(NodeType.Macro),
+            resource_type=NodeType.Macro,
         )
         for node in self.parse_unparsed_macros(base):
             yield node

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -21,7 +21,7 @@ from dbt.exceptions import (
     validator_error_message, JSONValidationException,
     raise_invalid_schema_yml_version, ValidationException, CompilationException
 )
-from dbt.node_types import NodeType, SourceType
+from dbt.node_types import NodeType
 from dbt.parser.base import SimpleParser
 from dbt.parser.search import FileBlock, FilesystemSearcher
 from dbt.parser.schema_test_builders import (
@@ -355,7 +355,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
             loaded_at_field=loaded_at_field,
             freshness=freshness,
             quoting=quoting,
-            resource_type=SourceType(NodeType.Source),
+            resource_type=NodeType.Source,
             fqn=[self.project.project_name, source.name, table.name],
         )
 

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -4,8 +4,8 @@ from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import (
     ParsedModelNode, DependsOn, NodeConfig, ColumnInfo, Hook, ParsedTestNode,
     TestConfig, ParsedSnapshotNode, TimestampSnapshotConfig, All, Docref,
-    GenericSnapshotConfig, CheckSnapshotConfig, TimestampStrategy,
-    CheckStrategy, IntermediateSnapshotNode, ParsedNodePatch, ParsedMacro,
+    GenericSnapshotConfig, CheckSnapshotConfig, SnapshotStrategy,
+    IntermediateSnapshotNode, ParsedNodePatch, ParsedMacro,
     MacroDependsOn, ParsedSourceDefinition, ParsedDocumentation, ParsedHookNode
 )
 from dbt.contracts.graph.unparsed import Quoting, FreshnessThreshold
@@ -871,7 +871,7 @@ class TestTimestampSnapshotConfig(ContractTestCase):
             'target_schema': 'some_snapshot_schema',
         }
         cfg = self.ContractType(
-            strategy=TimestampStrategy.Timestamp,
+            strategy=SnapshotStrategy.Timestamp,
             updated_at='last_update',
             unique_key='id',
             target_database='some_snapshot_db',
@@ -902,7 +902,7 @@ class TestTimestampSnapshotConfig(ContractTestCase):
             column_types={'a': 'text'},
             materialized='table',
             post_hook=[Hook(sql='insert into blah(a, b) select "1", 1')],
-            strategy=TimestampStrategy.Timestamp,
+            strategy=SnapshotStrategy.Timestamp,
             target_database='some_snapshot_db',
             target_schema='some_snapshot_schema',
             updated_at='last_update',
@@ -972,7 +972,7 @@ class TestCheckSnapshotConfig(ContractTestCase):
             'check_cols': 'all',
         }
         cfg = self.ContractType(
-            strategy=CheckStrategy.Check,
+            strategy=SnapshotStrategy.Check,
             check_cols=All.All,
             unique_key='id',
             target_database='some_snapshot_db',
@@ -1003,7 +1003,7 @@ class TestCheckSnapshotConfig(ContractTestCase):
             column_types={'a': 'text'},
             materialized='table',
             post_hook=[Hook(sql='insert into blah(a, b) select "1", 1')],
-            strategy=CheckStrategy.Check,
+            strategy=SnapshotStrategy.Check,
             check_cols=['a', 'b'],
             target_database='some_snapshot_db',
             target_schema='some_snapshot_schema',
@@ -1071,37 +1071,6 @@ class TestCheckSnapshotConfig(ContractTestCase):
         self.assert_fails_validation(invalid_check_type)
 
 
-class TestGenericSnapshotConfig(ContractTestCase):
-    ContractType = GenericSnapshotConfig
-
-    def test_ok(self):
-        cfg_dict = {
-            'column_types': {},
-            'enabled': True,
-            'materialized': 'view',
-            'persist_docs': {},
-            'post-hook': [],
-            'pre-hook': [],
-            'quoting': {},
-            'tags': [],
-            'vars': {},
-            'unique_key': 'id',
-            'strategy': 'hello',
-            'target_database': 'some_snapshot_db',
-            'target_schema': 'some_snapshot_schema',
-            'magic_key': 'magic',
-        }
-        cfg = self.ContractType(
-            strategy='hello',
-            unique_key='id',
-            target_database='some_snapshot_db',
-            target_schema='some_snapshot_schema',
-        )
-        cfg._extra.update({'magic_key': 'magic'})
-        self.assert_symmetric(cfg, cfg_dict)
-        pickle.loads(pickle.dumps(cfg))
-
-
 class TestParsedSnapshotNode(ContractTestCase):
     ContractType = ParsedSnapshotNode
 
@@ -1163,7 +1132,7 @@ class TestParsedSnapshotNode(ContractTestCase):
             alias='bar',
             tags=[],
             config=TimestampSnapshotConfig(
-                strategy=TimestampStrategy.Timestamp,
+                strategy=SnapshotStrategy.Timestamp,
                 unique_key='id',
                 updated_at='last_update',
                 target_database='some_snapshot_db',
@@ -1268,7 +1237,7 @@ class TestParsedSnapshotNode(ContractTestCase):
             alias='bar',
             tags=[],
             config=CheckSnapshotConfig(
-                strategy=CheckStrategy.Check,
+                strategy=SnapshotStrategy.Check,
                 unique_key='id',
                 check_cols=All.All,
                 target_database='some_snapshot_db',
@@ -1312,74 +1281,6 @@ class TestParsedSnapshotNode(ContractTestCase):
         )
         self.assertTrue(node.is_refable)
         self.assertFalse(node.is_ephemeral)
-
-    def test_ok_unknown_strategy(self):
-        unknown_strategy = {
-            'name': 'foo',
-            'root_path': '/root/',
-            'resource_type': str(NodeType.Snapshot),
-            'path': '/root/x/path.sql',
-            'original_file_path': '/root/path.sql',
-            'package_name': 'test',
-            'raw_sql': 'select * from wherever',
-            'unique_id': 'model.test.foo',
-            'fqn': ['test', 'models', 'foo'],
-            'refs': [],
-            'sources': [],
-            'depends_on': {'macros': [], 'nodes': []},
-            'database': 'test_db',
-            'description': '',
-            'schema': 'test_schema',
-            'alias': 'bar',
-            'tags': [],
-            'config': {
-                'column_types': {},
-                'enabled': True,
-                'materialized': 'view',
-                'persist_docs': {},
-                'post-hook': [],
-                'pre-hook': [],
-                'quoting': {},
-                'tags': [],
-                'vars': {},
-                'target_database': 'some_snapshot_db',
-                'target_schema': 'some_snapshot_schema',
-                'unique_key': 'id',
-                'strategy': 'unknown',
-                'magic_key': 'something',
-            },
-            'docrefs': [],
-            'columns': {},
-        }
-        config = GenericSnapshotConfig(
-                strategy='unknown',
-                unique_key='id',
-                target_database='some_snapshot_db',
-                target_schema='some_snapshot_schema',
-        )
-        config._extra.update({'magic_key': 'something'})
-
-        node = self.ContractType(
-            package_name='test',
-            root_path='/root/',
-            path='/root/x/path.sql',
-            original_file_path='/root/path.sql',
-            raw_sql='select * from wherever',
-            name='foo',
-            resource_type=NodeType.Snapshot,
-            unique_id='model.test.foo',
-            fqn=['test', 'models', 'foo'],
-            refs=[],
-            sources=[],
-            depends_on=DependsOn(),
-            description='',
-            database='test_db',
-            schema='test_schema',
-            alias='bar',
-            tags=[],
-            config=config,
-        )
-        self.assert_symmetric(node, unknown_strategy)
 
     def test_invalid_bad_resource_type(self):
         bad_resource_type = {

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -14,16 +14,14 @@ from dbt.parser import (
 from dbt.parser.search import FileBlock
 from dbt.parser.schema_test_builders import YamlBlock
 
-from dbt.node_types import (
-    NodeType, SnapshotType, MacroType, SourceType, TestType, AnalysisType
-)
+from dbt.node_types import NodeType
 from dbt.contracts.graph.manifest import (
     Manifest, FilePath, SourceFile, FileHash
 )
 from dbt.contracts.graph.parsed import (
     ParsedModelNode, ParsedMacro, ParsedNodePatch, ParsedSourceDefinition,
     NodeConfig, DependsOn, ColumnInfo, ParsedTestNode, TestConfig,
-    ParsedSnapshotNode, TimestampSnapshotConfig, TimestampStrategy,
+    ParsedSnapshotNode, TimestampSnapshotConfig, SnapshotStrategy,
     ParsedAnalysisNode
 )
 from dbt.contracts.graph.unparsed import FreshnessThreshold
@@ -221,7 +219,7 @@ class SchemaParserSourceTest(SchemaParserTest):
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             path=normalize('models/test_one.yml'),
             original_file_path=normalize('models/test_one.yml'),
-            resource_type=SourceType.Source,
+            resource_type=NodeType.Source,
         )
         self.assertEqual(src, expected)
 
@@ -424,14 +422,14 @@ class SnapshotParserTest(BaseParserTest):
             # the `database` entry is overrridden by the target_database config
             database='dbt',
             schema='analytics',
-            resource_type=SnapshotType.Snapshot,
+            resource_type=NodeType.Snapshot,
             unique_id='snapshot.snowplow.foo',
             fqn=['snowplow', 'nested', 'snap_1', 'foo'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             config=TimestampSnapshotConfig(
-                strategy=TimestampStrategy.Timestamp,
+                strategy=SnapshotStrategy.Timestamp,
                 updated_at='last_update',
                 target_database='dbt',
                 target_schema='analytics',
@@ -476,14 +474,14 @@ class SnapshotParserTest(BaseParserTest):
             name='foo',
             database='dbt',
             schema='analytics',
-            resource_type=SnapshotType.Snapshot,
+            resource_type=NodeType.Snapshot,
             unique_id='snapshot.snowplow.foo',
             fqn=['snowplow', 'nested', 'snap_1', 'foo'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             config=TimestampSnapshotConfig(
-                strategy=TimestampStrategy.Timestamp,
+                strategy=SnapshotStrategy.Timestamp,
                 updated_at='last_update',
                 target_database='dbt',
                 target_schema='analytics',
@@ -498,14 +496,14 @@ class SnapshotParserTest(BaseParserTest):
             name='bar',
             database='dbt',
             schema='analytics',
-            resource_type=SnapshotType.Snapshot,
+            resource_type=NodeType.Snapshot,
             unique_id='snapshot.snowplow.bar',
             fqn=['snowplow', 'nested', 'snap_1', 'bar'],
             package_name='snowplow',
             original_file_path=normalize('snapshots/nested/snap_1.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             config=TimestampSnapshotConfig(
-                strategy=TimestampStrategy.Timestamp,
+                strategy=SnapshotStrategy.Timestamp,
                 updated_at='last_update',
                 target_database='dbt',
                 target_schema='analytics',
@@ -542,7 +540,7 @@ class MacroParserTest(BaseParserTest):
         macro = list(self.parser.results.macros.values())[0]
         expected = ParsedMacro(
             name='foo',
-            resource_type=MacroType.Macro,
+            resource_type=NodeType.Macro,
             unique_id='macro.snowplow.foo',
             package_name='snowplow',
             original_file_path=normalize('macros/macro.sql'),
@@ -580,7 +578,7 @@ class DataTestParserTest(BaseParserTest):
             name='test_1',
             database='test',
             schema='analytics',
-            resource_type=TestType.Test,
+            resource_type=NodeType.Test,
             unique_id='test.snowplow.test_1',
             fqn=['snowplow', 'data_test', 'test_1'],
             package_name='snowplow',
@@ -622,7 +620,7 @@ class AnalysisParserTest(BaseParserTest):
             name='analysis_1',
             database='test',
             schema='analytics',
-            resource_type=AnalysisType.Analysis,
+            resource_type=NodeType.Analysis,
             unique_id='analysis.snowplow.analysis_1',
             fqn=['snowplow', 'analysis', 'nested', 'analysis_1'],
             package_name='snowplow',


### PR DESCRIPTION
I found this sitting around in my git history and realized it never got merged. I've rebased it onto louisa-may-alcott and cleaned it up.

This PR changes dbt to use `hologram` v0.0.3's new `restrict` metadata keyword to accomplish the task of restricting nodes to individual enum values while keeping mypy happy.