### PR TITLE
Add trailing comma when creating BQ options to each list item

### DIFF
--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -38,7 +38,7 @@
   {% endif %}
 
   OPTIONS({% for opt_key, opt_val in opts.items() %}
-    {{ opt_key }}={{ opt_val }}
+    {{ opt_key }}={{ opt_val }}{{ "," if not loop.last }}
   {% endfor %})
 {%- endmacro -%}
 


### PR DESCRIPTION
- This is a bug in the existing code, BQ needs commas between option items.
Discovered it when creating a temp table using dbt_utils

This fixes #1786 