### PR TITLE
add log-format flag (#1237)

### DIFF
--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -236,6 +236,7 @@ class DelayedFileHandler(logbook.TimedRotatingFileHandler, FormatterMixin):
         logbook.Handler.__init__(self, level, filter, bubble)
         if log_dir is not None:
             self.set_path(log_dir)
+        self._text_format_string = None
 
     def reset(self):
         if self.initialized:

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -180,7 +180,7 @@ def run_from_args(parsed):
     log_cache_events(getattr(parsed, 'log_cache_events', False))
     flags.set_from_args(parsed)
 
-    parsed.cls.pre_init_hook()
+    parsed.cls.pre_init_hook(parsed)
     # we can now use the logger for stdout
 
     logger.info("Running with dbt{}".format(dbt.version.installed))
@@ -738,6 +738,13 @@ def parse_args(args):
         Display debug logging during dbt execution. Useful for debugging and
         making bug reports.
         '''
+    )
+
+    p.add_argument(
+        '--log-format',
+        choices=['text', 'json', None],
+        default=None,
+        help='''Specify the log format, overriding the command's default.'''
     )
 
     p.add_argument(

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -742,8 +742,8 @@ def parse_args(args):
 
     p.add_argument(
         '--log-format',
-        choices=['text', 'json', None],
-        default=None,
+        choices=['text', 'json', 'default'],
+        default='default',
         help='''Specify the log format, overriding the command's default.'''
     )
 

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -47,10 +47,10 @@ class BaseTask(metaclass=ABCMeta):
     @classmethod
     def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
-        if args.log_format == 'text' or args.log_format is None:
-            log_manager.format_text()
-        else:
+        if args.log_format == 'json':
             log_manager.format_json()
+        else:
+            log_manager.format_text()
 
     @classmethod
     def from_args(cls, args):

--- a/core/dbt/task/base.py
+++ b/core/dbt/task/base.py
@@ -5,7 +5,7 @@ from typing import Type, Union
 from dbt.config import RuntimeConfig, Project
 from dbt.config.profile import read_profile, PROFILES_DIR
 from dbt import tracking
-from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.logger import GLOBAL_LOGGER as logger, log_manager
 import dbt.exceptions
 
 
@@ -45,8 +45,12 @@ class BaseTask(metaclass=ABCMeta):
         self.config = config
 
     @classmethod
-    def pre_init_hook(cls):
+    def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
+        if args.log_format == 'text' or args.log_format is None:
+            log_manager.format_text()
+        else:
+            log_manager.format_json()
 
     @classmethod
     def from_args(cls, args):

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -43,9 +43,10 @@ class ListTask(GraphRunnableTask):
                 )
 
     @classmethod
-    def pre_init_hook(cls):
+    def pre_init_hook(cls, args):
         """A hook called before the task is initialized."""
         log_manager.stderr_console()
+        super().pre_init_hook(args)
 
     def _iterate_selected_nodes(self):
         nodes = sorted(self.select_nodes())

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -94,6 +94,8 @@ def signhup_replace():
 
 
 class RPCServerTask(ConfiguredTask):
+    DEFAULT_LOG_FORMAT = 'json'
+
     def __init__(self, args, config, tasks=None):
         if os.name == 'nt':
             raise RuntimeException(
@@ -105,6 +107,14 @@ class RPCServerTask(ConfiguredTask):
         self._reloader = None
         self._reload_task_manager()
         signal.signal(signal.SIGHUP, self._sighup_handler)
+
+    @classmethod
+    def pre_init_hook(cls, args):
+        """A hook called before the task is initialized."""
+        if args.log_format == 'text':
+            log_manager.format_text()
+        else:
+            log_manager.format_json()
 
     def _reload_task_manager(self):
         """This function can only be running once at a time, as it runs in the
@@ -144,8 +154,7 @@ class RPCServerTask(ConfiguredTask):
     def single_threaded(self):
         return SINGLE_THREADED_WEBSERVER or self.args.single_threaded
 
-    def run(self):
-        log_manager.format_json()
+    def run_forever(self):
         host = self.args.host
         port = self.args.port
         addr = (host, port)
@@ -154,7 +163,6 @@ class RPCServerTask(ConfiguredTask):
         if host == '0.0.0.0':
             display_host = 'localhost'
 
-        ServerContext().push_application()
         logger.info(
             'Serving RPC server at {}:{}, pid={}'.format(
                 *addr, os.getpid()
@@ -181,6 +189,10 @@ class RPCServerTask(ConfiguredTask):
         # manager to the request  task handler and in general gets messy
         # fast.
         run_simple(host, port, app, threaded=not self.single_threaded)
+
+    def run(self):
+        with ServerContext().applicationbound():
+            self.run_forever()
 
     @Request.application
     def handle_jsonrpc_request(self, request):


### PR DESCRIPTION
Fixes #1237 

Add a `--log-format` flag. It accepts `text` and `json` as valid arguments. All dbt tasks should honor it, it formats the command's output as the specified format instead of the task's default.

Tasks that use `print` (`dbt ls` and `dbt debug`) are mostly not changed by this flag, though messages that go through the logger, such as `dbt ls`'s stderr output, will be transformed.