### PR TITLE
Make run-operation a ManifestTask

### DIFF
--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -18,6 +18,7 @@ class RPCServerTask(ConfiguredTask):
         super(RPCServerTask, self).__init__(args, config)
         # compile locally
         self.manifest = self._compile_manifest()
+        self.manifest.build_flat_graph()
         self.task_manager = rpc.TaskManager()
         tasks = tasks or [RemoteCompileTask, RemoteRunTask]
         for cls in tasks:

--- a/test/integration/044_run_operations_test/macros/happy_macros.sql
+++ b/test/integration/044_run_operations_test/macros/happy_macros.sql
@@ -42,3 +42,10 @@
   {% endset %}
   {% do run_query(query) %}
 {% endmacro %}
+
+
+{% macro log_graph() %}
+  {% for node in graph.nodes.values() %}
+    {{ log((node | string), info=True)}}
+  {% endfor %}
+{% endmacro %}

--- a/test/integration/044_run_operations_test/test_run_operations.py
+++ b/test/integration/044_run_operations_test/test_run_operations.py
@@ -64,3 +64,7 @@ class TestOperations(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres_select(self):
         self.run_operation('select_something', name='world')
+
+    @use_profile('postgres')
+    def test__postgres_access_graph(self):
+        self.run_operation('log_graph')


### PR DESCRIPTION
This fixes an issue introduced in #1750 where if you accessed the `graph` context member via `run-operation` or the RPC server it was `None`, but it was correct elsewhere. Pretty silly!