### PR TITLE
(#1576) use the information schema on BigQuery

### DIFF
--- a/plugins/bigquery/dbt/adapters/bigquery/relation.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/relation.py
@@ -5,6 +5,10 @@ from dbt.adapters.base.relation import (
     BaseRelation, ComponentName
 )
 from dbt.utils import filter_null_values
+from typing import TypeVar
+
+
+Self = TypeVar('Self', bound='BigQueryRelation')
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -40,3 +44,33 @@ class BigQueryRelation(BaseRelation):
     @property
     def dataset(self):
         return self.schema
+
+    def information_schema(self: Self, identifier=None) -> Self:
+        # BigQuery (usually) addresses information schemas at the dataset
+        # level. This method overrides the BaseRelation method to return an
+        # Information Schema relation as project.dataset.information_schem
+
+        include_policy = self.include_policy.replace(
+            database=self.database is not None,
+            schema=self.schema is not None,
+            identifier=True
+        )
+
+        # Quote everything on BigQuery -- identifiers are case-sensitive,
+        # even when quoted.
+        quote_policy = self.quote_policy.replace(
+            database=True,
+            schema=True,
+            identifier=True,
+        )
+
+        path = self.path.replace(
+            schema=self.schema,
+            identifier='INFORMATION_SCHEMA'
+        )
+
+        return self.replace(
+            quote_policy=quote_policy,
+            include_policy=include_policy,
+            path=path,
+        )

--- a/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
@@ -1,0 +1,202 @@
+
+{% macro bigquery__get_catalog(information_schemas) -%}
+
+  {%- call statement('catalog', fetch_result=True) -%}
+    {% for information_schema in information_schemas %}
+      (
+        with tables as (
+            select
+                project_id as table_database,
+                dataset_id as table_schema,
+                table_id as original_table_name,
+
+                concat(project_id, '.', dataset_id, '.', table_id) as relation_id,
+
+                row_count,
+                size_bytes as size_bytes,
+                case
+                    when type = 1 then 'table'
+                    when type = 2 then 'view'
+                    else concat('unknown (', cast(type as string), ')')
+                end as table_type,
+
+                REGEXP_CONTAINS(table_id, '^.+[0-9]{8}$') and type = 1 as is_date_shard,
+                REGEXP_EXTRACT(table_id, '^(.+)[0-9]{8}$') as shard_base_name,
+                REGEXP_EXTRACT(table_id, '^.+([0-9]{8})$') as shard_name
+
+            from {{ information_schema }}.__TABLES__
+
+        ),
+
+        extracted as (
+
+            select *,
+                case
+                    when is_date_shard then shard_base_name
+                    else original_table_name
+                end as table_name
+
+            from tables
+
+        ),
+
+        unsharded_tables as (
+
+            select
+                table_database,
+                table_schema,
+                table_name,
+                table_type,
+                is_date_shard,
+
+                struct(
+                    min(shard_name) as shard_min,
+                    max(shard_name) as shard_max,
+                    count(*) as shard_count
+                ) as table_shards,
+
+                sum(size_bytes) as size_bytes,
+                sum(row_count) as row_count,
+
+                max(relation_id) as relation_id
+
+            from extracted
+            group by 1,2,3,4,5
+
+        ),
+
+        info_schema_columns as (
+
+            select
+                concat(table_catalog, '.', table_schema, '.', table_name) as relation_id,
+                table_catalog as table_database,
+                table_schema,
+                table_name,
+
+                -- use the "real" column name from the paths query below
+                column_name as base_column_name,
+                ordinal_position as column_index,
+                cast(null as string) as column_comment,
+
+                is_partitioning_column,
+                clustering_ordinal_position
+
+            from {{ information_schema }}.INFORMATION_SCHEMA.COLUMNS
+            where ordinal_position is not null
+
+        ),
+
+        info_schema_column_paths as (
+
+            select
+                concat(table_catalog, '.', table_schema, '.', table_name) as relation_id,
+                field_path as column_name,
+                data_type as column_type,
+                column_name as base_column_name
+
+            from {{ information_schema }}.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+            where data_type not like 'STRUCT%'
+
+        ),
+
+        columns as (
+
+            select * except (base_column_name)
+            from info_schema_columns 
+            join info_schema_column_paths using (relation_id, base_column_name)
+
+        ),
+
+        column_stats as (
+
+            select
+                table_database,
+                table_schema,
+                table_name,
+                max(relation_id) as relation_id,
+                max(case when is_partitioning_column = 'YES' then 1 else 0 end) = 1 as is_partitioned,
+                max(case when is_partitioning_column = 'YES' then column_name else null end) as partition_column,
+                max(case when clustering_ordinal_position is not null then 1 else 0 end) = 1 as is_clustered,
+                array_to_string(
+                    array_agg(
+                        case
+                            when clustering_ordinal_position is not null then column_name
+                            else null
+                        end ignore nulls
+                        order by clustering_ordinal_position
+                    ), ', '
+                ) as clustering_columns
+
+            from columns
+            group by 1,2,3
+
+        )
+
+        select
+            unsharded_tables.table_database,
+            unsharded_tables.table_schema,
+            case
+                when is_date_shard then concat(unsharded_tables.table_name, '*')
+                else unsharded_tables.table_name
+            end as table_name,
+            unsharded_tables.table_type,
+
+            columns.column_name,
+            -- invent a row number to account for nested fields -- BQ does
+            -- not treat these nested properties as independent fields
+            row_number() over (
+                partition by relation_id
+                order by columns.column_index, columns.column_name
+            ) as column_index,
+            columns.column_type,
+            columns.column_comment,
+
+            'Shard count' as `stats__date_shards__label`,
+            table_shards.shard_count as `stats__date_shards__value`,
+            'The number of date shards in this table' as `stats__date_shards__description`,
+            is_date_shard as `stats__date_shards__include`,
+
+            'Shard (min)' as `stats__date_shard_min__label`,
+            table_shards.shard_min as `stats__date_shard_min__value`,
+            'The first date shard in this table' as `stats__date_shard_min__description`,
+            is_date_shard as `stats__date_shard_min__include`,
+
+            'Shard (max)' as `stats__date_shard_max__label`,
+            table_shards.shard_max as `stats__date_shard_max__value`,
+            'The last date shard in this table' as `stats__date_shard_max__description`,
+            is_date_shard as `stats__date_shard_max__include`,
+
+            '# Rows' as `stats__num_rows__label`,
+            row_count as `stats__num_rows__value`,
+            'Approximate count of rows in this table' as `stats__num_rows__description`,
+            (unsharded_tables.table_type = 'table') as `stats__num_rows__include`,
+
+            'Approximate Size' as `stats__num_bytes__label`,
+            size_bytes as `stats__num_bytes__value`,
+            'Approximate size of table as reported by BigQuery' as `stats__num_bytes__description`,
+            (unsharded_tables.table_type = 'table') as `stats__num_bytes__include`,
+
+            'Partitioned By' as `stats__partitioning_type__label`,
+            partition_column as `stats__partitioning_type__value`,
+            'The partitioning column for this table' as `stats__partitioning_type__description`,
+            is_partitioned as `stats__partitioning_type__include`,
+
+            'Clustered By' as `stats__clustering_fields__label`,
+            clustering_columns as `stats__clustering_fields__value`,
+            'The clustering columns for this table' as `stats__clustering_fields__description`,
+            is_clustered as `stats__clustering_fields__include`
+
+        -- join using relation_id (an actual relation, not a shard prefix) to make
+        -- sure that column metadata is picked up through the join. This will only
+        -- return the column information for the "max" table in a date-sharded table set
+        from unsharded_tables
+        left join columns using (relation_id)
+        left join column_stats using (relation_id)
+      )
+
+      {% if not loop.last %} union all {% endif %}
+    {% endfor %}
+  {%- endcall -%}
+  {{ return(load_result('catalog').table) }}
+
+{% endmacro %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
@@ -11,7 +11,7 @@
               schema_name as table_schema,
               location
 
-            from `{{ information_schema.database }}`.INFORMATION_SCHEMA.SCHEMATA
+            from {{ information_schema.include(schema=False) }}.SCHEMATA
 
         ),
 
@@ -35,7 +35,7 @@
                 REGEXP_EXTRACT(table_id, '^(.+)[0-9]{8}$') as shard_base_name,
                 REGEXP_EXTRACT(table_id, '^.+([0-9]{8})$') as shard_name
 
-            from {{ information_schema }}.__TABLES__
+            from {{ information_schema.include(identifier=False) }}.__TABLES__
 
         ),
 
@@ -92,7 +92,7 @@
                 is_partitioning_column,
                 clustering_ordinal_position
 
-            from {{ information_schema }}.INFORMATION_SCHEMA.COLUMNS
+            from {{ information_schema }}.COLUMNS
             where ordinal_position is not null
 
         ),
@@ -105,7 +105,7 @@
                 data_type as column_type,
                 column_name as base_column_name
 
-            from {{ information_schema }}.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+            from {{ information_schema }}.COLUMN_FIELD_PATHS
             where data_type not like 'STRUCT%'
 
         ),

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from unittest.mock import ANY, patch
 
 from test.integration.base import DBTIntegrationTest, use_profile, AnyFloat, \
-    AnyStringWith, normalize
+    AnyString, AnyStringWith, normalize
 
 
 def _read_file(path):
@@ -215,49 +215,51 @@ class TestDocsGenerate(DBTIntegrationTest):
             'has_stats': {
                 'id': 'has_stats',
                 'label': 'Has Stats?',
-                'value': True,
+                'value': (is_table or partition is not None or cluster is not None),
                 'description': 'Indicates whether there are statistics for this table',
                 'include': False,
-            },
-            'location': {
-                'id': 'location',
-                'label': 'Location',
-                'value': 'US',
-                'description': 'The geographic location of this table',
-                'include': True,
-            },
+            }
         }
         if is_table:
             stats.update({
                 'num_bytes': {
                     'id': 'num_bytes',
-                    'label': 'Number of bytes',
+                    'label': AnyString(),
                     'value': AnyFloat(),
-                    'description': 'The number of bytes this table consumes',
+                    'description': AnyString(),
                     'include': True,
                 },
                 'num_rows': {
                     'id': 'num_rows',
-                    'label': 'Number of rows',
+                    'label': AnyString(),
                     'value': AnyFloat(),
-                    'description': 'The number of rows in this table',
+                    'description': AnyString(),
                     'include': True,
-                },
+                }
+            })
+
+        if partition is not None:
+            stats.update({
                 'partitioning_type': {
                     'id': 'partitioning_type',
-                    'label': 'Partitioning Type',
+                    'label': AnyString(),
                     'value': partition,
-                    'description': 'The partitioning type used for this table',
-                    'include': True,
-                },
+                    'description': AnyString(),
+                    'include': True
+                }
+            })
+
+        if cluster is not None:
+            stats.update({
                 'clustering_fields': {
                     'id': 'clustering_fields',
-                    'label': 'Clustering Fields',
+                    'label': AnyString(),
                     'value': cluster,
-                    'description': 'The clustering fields for this table',
-                    'include': True,
-                },
+                    'description': AnyString(),
+                    'include': True
+                }
             })
+
         return stats
 
     def _expected_catalog(self, id_type, text_type, time_type, view_type,
@@ -535,10 +537,10 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
         role = self.get_role()
         table_stats = self._bigquery_stats(True)
-        clustering_stats = self._bigquery_stats(True, partition='DAY',
+        clustering_stats = self._bigquery_stats(True, partition='updated_at',
                                                 cluster='first_name')
-        multi_clustering_stats = self._bigquery_stats(True, partition='DAY',
-                                                      cluster='first_name,email')
+        multi_clustering_stats = self._bigquery_stats(True, partition='updated_at',
+                                                      cluster='first_name, email')
         nesting_columns = {
             'field_1': {
                 'name': 'field_1',

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -215,9 +215,16 @@ class TestDocsGenerate(DBTIntegrationTest):
             'has_stats': {
                 'id': 'has_stats',
                 'label': 'Has Stats?',
-                'value': (is_table or partition is not None or cluster is not None),
+                'value': True,
                 'description': 'Indicates whether there are statistics for this table',
                 'include': False,
+            },
+            'location': {
+                'id': 'location',
+                'label': 'Location',
+                'value': 'US',
+                'description': 'The geographic location of this table',
+                'include': True,
             }
         }
         if is_table:

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1157,6 +1157,13 @@ class AnyFloat:
         return isinstance(other, float)
 
 
+class AnyString:
+    """Any string. Use this in assertEqual() calls to assert that it is a float.
+    """
+    def __eq__(self, other):
+        return isinstance(other, str)
+
+
 class AnyStringWith:
     def __init__(self, contains=None):
         self.contains = contains

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1158,7 +1158,7 @@ class AnyFloat:
 
 
 class AnyString:
-    """Any string. Use this in assertEqual() calls to assert that it is a float.
+    """Any string. Use this in assertEqual() calls to assert that it is a string.
     """
     def __eq__(self, other):
         return isinstance(other, str)


### PR DESCRIPTION
Fixes #1576 

Work in progress. Use the BigQuery `INFORMATION_SCHEMA` to fetch the catalog. I actually cheat here and use `__TABLES__` (not `INFORMATION_SCHEMA.TABLES`) because the information in `__TABLES__` is a superset of the data in `TABLES` (ie. `row_count` and `size_bytes`).

Couple of things to verify here:
 - do we need to worry about quoting/casing here? I just want to preserve the existing behavior
 - it's hard to find good docs on `__TABLES__` -- is that appropriate for us to use?
 - make sure this fix actually addresses #1576 -- how does this hold up for datasets with many date-sharded tables?

To document:

Date sharded tables can be addressed using dbt sources by replacing the date shard suffix with a `*` in the source specification. When this source is referenced from a model, dbt will expand the wildcard to match all date shards in the table. Additionally, the auto-generated dbt documentation website will correctly collect statistics about _all_ of the date shards in this table.

```
sources:
    - name: source_schema
      tables:
          - name: events_*
```