### PR TITLE
docs generate RPC task (#1781)

### DIFF
--- a/core/dbt/rpc/logger.py
+++ b/core/dbt/rpc/logger.py
@@ -9,12 +9,18 @@ from datetime import datetime, timedelta
 from queue import Empty
 from typing import Optional, Any, Union
 
-from dbt.contracts.results import RemoteCompileResult, RemoteExecutionResult
+from dbt.contracts.results import (
+    RemoteCompileResult, RemoteExecutionResult, RemoteCatalogResults
+)
 from dbt.exceptions import InternalException
 from dbt.utils import restrict_to
 
 
-RemoteCallableResult = Union[RemoteCompileResult, RemoteExecutionResult]
+RemoteCallableResult = Union[
+    RemoteCompileResult,
+    RemoteExecutionResult,
+    RemoteCatalogResults,
+]
 
 
 class QueueMessageType(StrEnum):

--- a/core/dbt/rpc/response_manager.py
+++ b/core/dbt/rpc/response_manager.py
@@ -88,7 +88,7 @@ class ResponseManager(JSONRPCResponseManager):
             # to_dict
             if hasattr(output, 'result'):
                 if isinstance(output.result, JsonSchemaMixin):
-                    output.result = output.result.to_dict(omit_empty=False)
+                    output.result = output.result.to_dict(omit_none=False)
             yield output
 
     @classmethod

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -1,15 +1,17 @@
 import os
 import shutil
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Union, Dict, List, Optional, Any, NamedTuple
+from typing import Dict, List, Any
 
-from hologram import JsonSchemaMixin, ValidationError
+from hologram import ValidationError
 
 from dbt.adapters.factory import get_adapter
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.util import Writable, Replaceable
+from dbt.contracts.results import (
+    TableMetadata, CatalogTable, CatalogResults, Primitive, CatalogKey,
+    StatsItem, StatsDict, ColumnMetadata
+)
 from dbt.include.global_project import DOCS_INDEX_FILE_PATH
 import dbt.ui.printer
 import dbt.utils
@@ -33,87 +35,31 @@ def get_stripped_prefix(source: Dict[str, Any], prefix: str) -> Dict[str, Any]:
     }
 
 
-Primitive = Union[bool, str, float, None]
 PrimitiveDict = Dict[str, Primitive]
 
 
-Key = NamedTuple(
-    'Key',
-    [('database', str), ('schema', str), ('name', str)]
-)
+def build_catalog_table(data) -> CatalogTable:
+    # build the new table's metadata + stats
+    metadata = TableMetadata.from_dict(get_stripped_prefix(data, 'table_'))
+    stats = format_stats(get_stripped_prefix(data, 'stats:'))
 
-
-@dataclass
-class StatsItem(JsonSchemaMixin):
-    id: str
-    label: str
-    value: Primitive
-    description: str
-    include: bool
-
-
-StatsDict = Dict[str, StatsItem]
-
-
-@dataclass
-class ColumnMetadata(JsonSchemaMixin):
-    type: str
-    comment: Optional[str]
-    index: int
-    name: str
-
-
-ColumnMap = Dict[str, ColumnMetadata]
-
-
-@dataclass
-class TableMetadata(JsonSchemaMixin):
-    type: str
-    database: str
-    schema: str
-    name: str
-    comment: Optional[str]
-    owner: Optional[str]
-
-
-@dataclass
-class Table(JsonSchemaMixin, Replaceable):
-    metadata: TableMetadata
-    columns: ColumnMap
-    stats: StatsDict
-    # the same table with two unique IDs will just be listed two times
-    unique_id: Optional[str] = None
-
-    @classmethod
-    def from_query_result(cls, data) -> 'Table':
-        # build the new table's metadata + stats
-        metadata = TableMetadata.from_dict(get_stripped_prefix(data, 'table_'))
-        stats = format_stats(get_stripped_prefix(data, 'stats:'))
-
-        return cls(
-            metadata=metadata,
-            stats=stats,
-            columns={},
-        )
-
-    def key(self) -> Key:
-        return Key(
-            self.metadata.database.lower(),
-            self.metadata.schema.lower(),
-            self.metadata.name.lower(),
-        )
+    return CatalogTable(
+        metadata=metadata,
+        stats=stats,
+        columns={},
+    )
 
 
 # keys are database name, schema name, table name
-class Catalog(Dict[Key, Table]):
+class Catalog(Dict[CatalogKey, CatalogTable]):
     def __init__(self, columns: List[PrimitiveDict]):
         super().__init__()
         for col in columns:
             self.add_column(col)
 
-    def get_table(self, data: PrimitiveDict) -> Table:
+    def get_table(self, data: PrimitiveDict) -> CatalogTable:
         try:
-            key = Key(
+            key = CatalogKey(
                 str(data['table_database']),
                 str(data['table_schema']),
                 str(data['table_name']),
@@ -123,10 +69,11 @@ class Catalog(Dict[Key, Table]):
                 'Catalog information missing required key {} (got {})'
                 .format(exc, data)
             )
+        table: CatalogTable
         if key in self:
             table = self[key]
         else:
-            table = Table.from_query_result(data)
+            table = build_catalog_table(data)
             self[key] = table
         return table
 
@@ -140,8 +87,10 @@ class Catalog(Dict[Key, Table]):
         column = ColumnMetadata.from_dict(column_data)
         table.columns[column.name] = column
 
-    def make_unique_id_map(self, manifest: Manifest) -> Dict[str, Table]:
-        nodes: Dict[str, Table] = {}
+    def make_unique_id_map(
+        self, manifest: Manifest
+    ) -> Dict[str, CatalogTable]:
+        nodes: Dict[str, CatalogTable] = {}
 
         manifest_mapping = get_unique_id_mapping(manifest)
         for table in self.values():
@@ -201,16 +150,16 @@ def format_stats(stats: PrimitiveDict) -> StatsDict:
     return stats_collector
 
 
-def mapping_key(node: CompileResultNode) -> Key:
-    return Key(
+def mapping_key(node: CompileResultNode) -> CatalogKey:
+    return CatalogKey(
         node.database.lower(), node.schema.lower(), node.identifier.lower()
     )
 
 
-def get_unique_id_mapping(manifest: Manifest) -> Dict[Key, List[str]]:
+def get_unique_id_mapping(manifest: Manifest) -> Dict[CatalogKey, List[str]]:
     # A single relation could have multiple unique IDs pointing to it if a
     # source were also a node.
-    ident_map: Dict[Key, List[str]] = {}
+    ident_map: Dict[CatalogKey, List[str]] = {}
     for unique_id, node in manifest.nodes.items():
         key = mapping_key(node)
 
@@ -219,13 +168,6 @@ def get_unique_id_mapping(manifest: Manifest) -> Dict[Key, List[str]]:
 
         ident_map[key].append(unique_id)
     return ident_map
-
-
-@dataclass
-class CatalogResults(JsonSchemaMixin, Writable):
-    nodes: Dict[str, Table]
-    generated_at: datetime
-    _compile_results: Optional[Any] = None
 
 
 def _coerce_decimal(value):
@@ -242,7 +184,7 @@ class GenerateTask(CompileTask):
     def run(self):
         compile_results = None
         if self.args.compile:
-            compile_results = super().run()
+            compile_results = CompileTask.run(self)
             if any(r.error is not None for r in compile_results):
                 dbt.ui.printer.print_timestamped_line(
                     'compile failed, cannot generate docs'
@@ -266,10 +208,10 @@ class GenerateTask(CompileTask):
         ]
 
         catalog = Catalog(catalog_data)
-        results = CatalogResults(
+        results = self.get_catalog_results(
             nodes=catalog.make_unique_id_map(manifest),
             generated_at=datetime.utcnow(),
-            _compile_results=compile_results,
+            compile_results=compile_results,
         )
 
         path = os.path.join(self.config.target_path, CATALOG_FILENAME)
@@ -279,6 +221,15 @@ class GenerateTask(CompileTask):
             'Catalog written to {}'.format(os.path.abspath(path))
         )
         return results
+
+    def get_catalog_results(
+        self, nodes, generated_at, compile_results
+    ) -> CatalogResults:
+        return CatalogResults(
+            nodes=nodes,
+            generated_at=datetime.utcnow(),
+            _compile_results=compile_results,
+        )
 
     def interpret_results(self, results):
         compile_results = results._compile_results

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -22,6 +22,7 @@ from dbt.task.remote import (
     RemoteRunTask, RemoteRunProjectTask,
     RemoteSeedProjectTask,
     RemoteTestProjectTask,
+    RemoteDocsGenerateProjectTask,
 )
 from dbt.utils import ForgivingJSONEncoder, env_set_truthy
 from dbt import rpc
@@ -149,7 +150,8 @@ class RPCServerTask(ConfiguredTask):
         return [
             RemoteCompileTask, RemoteCompileProjectTask,
             RemoteRunTask, RemoteRunProjectTask,
-            RemoteSeedProjectTask, RemoteTestProjectTask
+            RemoteSeedProjectTask, RemoteTestProjectTask,
+            RemoteDocsGenerateProjectTask
         ]
 
     def single_threaded(self):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -21,6 +21,11 @@ RESULT_FILE_NAME = 'run_results.json'
 MANIFEST_FILE_NAME = 'manifest.json'
 
 
+def write_manifest(manifest, config):
+    if dbt.flags.WRITE_JSON:
+        manifest.write(os.path.join(config.target_path, MANIFEST_FILE_NAME))
+
+
 def load_manifest(config):
     # performance trick: if the adapter has a manifest loaded, use that to
     # avoid parsing internal macros twice. Also, when loading the adapter's
@@ -31,8 +36,7 @@ def load_manifest(config):
     internal = adapter.load_internal_manifest()
     manifest = GraphLoader.load_all(config, internal_manifest=internal)
 
-    if dbt.flags.WRITE_JSON:
-        manifest.write(os.path.join(config.target_path, MANIFEST_FILE_NAME))
+    write_manifest(manifest, config)
     return manifest
 
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -821,7 +821,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         return {
             'nodes': {
                 'model.test.model': {
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/model.sql'),
                     'name': 'model',
                     'root_path': self.test_root_dir,
                     'resource_type': 'model',
@@ -869,9 +869,17 @@ class TestDocsGenerate(DBTIntegrationTest):
                     },
                     'patch_path': schema_yml_path,
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'seed.test.seed': {
                     'build_path': None,
+                    'compiled': True,
+                    'compiled_sql': '',
                     'config': {
                         'enabled': True,
                         'materialized': 'seed',
@@ -905,10 +913,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'columns': {},
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': '',
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': '',
+                    'wrapped_sql': 'None',
                 },
                 'test.test.not_null_model_id': {
                     'alias': 'not_null_model_id',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/schema_test/not_null_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'config': {
@@ -941,10 +955,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': ['schema'],
                     'unique_id': 'test.test.not_null_model_id',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': AnyStringWith('count(*)'),
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': AnyStringWith('count(*)'),
+                    'wrapped_sql': AnyStringWith('count(*)'),
                 },
                 'test.test.test_nothing_model_': {
                     'alias': 'test_nothing_model_',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/schema_test/test_nothing_model_.sql'),
                     'column_name': None,
                     'columns': {},
                     'config': {
@@ -977,10 +997,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': ['schema'],
                     'unique_id': 'test.test.test_nothing_model_',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': AnyStringWith('select 0'),
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': AnyStringWith('select 0'),
+                    'wrapped_sql': AnyStringWith('select 0'),
                 },
                 'test.test.unique_model_id': {
                     'alias': 'unique_model_id',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/schema_test/unique_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'config': {
@@ -1013,6 +1039,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': ['schema'],
                     'unique_id': 'test.test.unique_model_id',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': AnyStringWith('count(*)'),
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': AnyStringWith('count(*)'),
+                    'wrapped_sql': AnyStringWith('count(*)'),
                 },
             },
             'parent_map': {
@@ -1123,7 +1155,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'nodes': {
                 'model.test.ephemeral_copy': {
                     'alias': 'ephemeral_copy',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/ephemeral_copy.sql'),
                     'columns': {},
                     'config': {
                         'column_types': {},
@@ -1160,10 +1192,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': [],
                     'unique_id': 'model.test.ephemeral_copy',
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'model.test.ephemeral_summary': {
                     'alias': 'ephemeral_summary',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/ephemeral_summary.sql'),
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1228,10 +1266,17 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'tags': [],
-                    'unique_id': 'model.test.ephemeral_summary'},
+                    'unique_id': 'model.test.ephemeral_summary',
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [ANY],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
+                },
                 'model.test.view_summary': {
                     'alias': 'view_summary',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/view_summary.sql'),
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1295,7 +1340,13 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'sources': [],
                     'tags': [],
-                    'unique_id': 'model.test.view_summary'
+                    'unique_id': 'model.test.view_summary',
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'seed.test.seed': {
                     'alias': 'seed',
@@ -1330,7 +1381,13 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'tags': [],
-                    'unique_id': 'seed.test.seed'
+                    'unique_id': 'seed.test.seed',
+                    'compiled': True,
+                    'compiled_sql': '',
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': '',
+                    'wrapped_sql': 'None',
                 },
                 'source.test.my_source.my_table': {
                     'columns': {
@@ -1365,7 +1422,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                         },
                     ],
                     'external': {
-                        'file_format': None, 'location': None, 'partitions': None, 
+                        'file_format': None, 'location': None, 'partitions': None,
                         'row_format': None, 'tbl_properties': None
                     },
                     'freshness': {'error_after': None, 'warn_after': None, 'filter': None},
@@ -1589,7 +1646,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
                     'fqn': ['test', 'clustered'],
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/clustered.sql'),
                     'name': 'clustered',
                     'original_file_path': clustered_sql_path,
                     'package_name': 'test',
@@ -1632,10 +1689,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'A clustered and partitioned copy of the test model',
                     'patch_path': self.dir('bq_models/schema.yml'),
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'model.test.multi_clustered': {
                     'alias': 'multi_clustered',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/multi_clustered.sql'),
                     'config': {
                         'cluster_by': ['first_name', 'email'],
                         'column_types': {},
@@ -1694,10 +1757,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'A clustered and partitioned copy of the test model, clustered on multiple columns',
                     'patch_path': self.dir('bq_models/schema.yml'),
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'model.test.nested_view': {
                     'alias': 'nested_view',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/nested_view.sql'),
                     'config': {
                         'column_types': {},
                         'enabled': True,
@@ -1757,10 +1826,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'The test model',
                     'patch_path': self.dir('bq_models/schema.yml'),
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'model.test.nested_table': {
                     'alias': 'nested_table',
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/nested_table.sql'),
                     'config': {
                         'column_types': {},
                         'enabled': True,
@@ -1794,6 +1869,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'columns': {},
                     'description': '',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'seed.test.seed': {
                     'build_path': None,
@@ -1832,6 +1913,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'columns': {},
                     'description': '',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': '',
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': '',
+                    'wrapped_sql': 'None',
                 },
             },
             'child_map': {
@@ -1960,7 +2047,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         return {
             'nodes': {
                 'model.test.model': {
-                    'build_path': None,
+                    'build_path': os.path.normpath('target/compiled/test/model.sql'),
                     'name': 'model',
                     'root_path': self.test_root_dir,
                     'resource_type': 'model',
@@ -2022,6 +2109,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     },
                     'patch_path': self.dir('rs_models/schema.yml'),
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
                 'seed.test.seed': {
                     'build_path': None,
@@ -2060,6 +2153,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'columns': {},
                     'description': '',
                     'docrefs': [],
+                    'compiled': True,
+                    'compiled_sql': ANY,
+                    'extra_ctes_injected': True,
+                    'extra_ctes': [],
+                    'injected_sql': ANY,
+                    'wrapped_sql': 'None',
                 },
             },
             'parent_map': {

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -927,6 +927,8 @@ class TestRPCServer(HasRPCServer):
         self.run_dbt_with_vars(['seed'])
         self.run_dbt_with_vars(['run'])
         self.assertFalse(os.path.exists('target/catalog.json'))
+        if os.path.exists('target/manifest.json'):
+            os.remove('target/manifest.json')
         result = self.async_query('docs.generate').json()
         dct = self.assertIsResult(result)
         self.assertTrue(os.path.exists('target/catalog.json'))
@@ -949,6 +951,11 @@ class TestRPCServer(HasRPCServer):
         }
         for uid in expected:
             self.assertIn(uid, nodes)
+        self.assertTrue(os.path.exists('target/manifest.json'))
+        with open('target/manifest.json') as fp:
+            manifest = json.load(fp)
+        self.assertIn('nodes', manifest)
+        self.assertEqual(len(manifest['nodes']), 17)
 
 
 class FailedServerProcess(ServerProcess):

--- a/test/unit/test_docs_generate.py
+++ b/test/unit/test_docs_generate.py
@@ -20,7 +20,7 @@ class GenerateTest(unittest.TestCase):
 
     def map_uids(self, effects):
         results = {
-            generate.Key(db, sch, tbl): [uid]
+            generate.CatalogKey(db, sch, tbl): [uid]
             for db, sch, tbl, uid in effects
         }
         self.mock_get_unique_id_mapping.return_value = results


### PR DESCRIPTION
Fixes #1781 

Implement docs generate for the RPC task. I went with `docs.generate` for the RPC call name, since `.` is allowed and it seems like a nice namespace separator. That way we can do `dbt source snapshot-freshness` -> `source.snapshot-freshness` in the future, and the mapping is reasonably straightforward.