### PR TITLE
Improve Error Messaging for Invalid Source Arguments

### DIFF
--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -115,7 +115,7 @@ class SourceResolver(dbt.context.common.BaseResolver):
 
         else:
             dbt.exceptions.raise_compiler_error(
-                "source() takes at exactly two arguments ({} given)".format(len(args)),
+                "source() takes exactly two arguments ({} given)".format(len(args)),
                 self.model)
 
         return self.Relation.create_from(self.config, self.model)

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -115,8 +115,8 @@ class SourceResolver(dbt.context.common.BaseResolver):
 
         else:
             dbt.exceptions.raise_compiler_error(
-                "source() takes exactly two arguments ({} given)".format(len(args)),
-                self.model)
+                "source() takes exactly two arguments ({} given)"
+                .format(len(args)), self.model)
 
         return self.Relation.create_from(self.config, self.model)
 

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -111,14 +111,13 @@ class SourceResolver(dbt.context.common.BaseResolver):
     def __call__(self, *args):
         # When you call source(), this is what happens at parse time
         if len(args) == 2:
-            source_name = args[0]
-            table_name = args[1]
+            self.model.sources.append(list(args))
+
         else:
             dbt.exceptions.raise_compiler_error(
-                "Source requires exactly two arguments",
+                "source() takes at exactly two arguments ({} given)".format(len(args)),
                 self.model)
 
-        self.model.sources.append([source_name, table_name])
         return self.Relation.create_from(self.config, self.model)
 
 

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -108,8 +108,16 @@ class RefResolver(dbt.context.common.BaseResolver):
 
 
 class SourceResolver(dbt.context.common.BaseResolver):
-    def __call__(self, source_name, table_name):
+    def __call__(self, *args):
         # When you call source(), this is what happens at parse time
+        if len(args) == 2:
+            source_name = args[0]
+            table_name = args[1]
+        else:
+            dbt.exceptions.raise_compiler_error(
+                "Source requires exactly two arguments",
+                self.model)
+
         self.model.sources.append([source_name, table_name])
         return self.Relation.create_from(self.config, self.model)
 


### PR DESCRIPTION
This pull request fixes #1660

This pull request enforces that exactly two arguments are provided to `source()` during compilation. If anything other than 2 arguments are given, a compiler error is now raised. This is an improvement over the current state described in #1660, where the error messaging is unclear after providing a single argument to `source()`.

#1660 also mentions adding better error messaging in `ref()` but it already seems satisfactory to me: https://github.com/fishtown-analytics/dbt/blob/dev/louisa-may-alcott/core/dbt/context/parser.py#L98-L107

This is my first contribution to dbt so I will need help with the CI environment variables.

Thanks to @emilieschario for helping me with this.