### PR TITLE
Add cli execution support (#1811)

### DIFF
--- a/core/dbt/rpc/task.py
+++ b/core/dbt/rpc/task.py
@@ -21,19 +21,19 @@ class RemoteCallable(metaclass=ABCMeta):
         annotations = argspec.annotations
         if 'params' not in annotations:
             raise TypeError(
-                'handle_request must have parameter named params with a valid '
+                'set_args must have parameter named params with a valid '
                 'JsonSchemaMixin type definition (no params annotation found)'
             )
         params_type = annotations['params']
         if not issubclass(params_type, JsonSchemaMixin):
             raise TypeError(
-                'handle_request must have parameter named params with a valid '
+                'set_args must have parameter named params with a valid '
                 'JsonSchemaMixin type definition (got {}, expected '
                 'JsonSchemaMixin subclass)'.format(params_type)
             )
         if params_type is JsonSchemaMixin:
             raise TypeError(
-                'handle_request must have parameter named params with a valid '
+                'set_args must have parameter named params with a valid '
                 'JsonSchemaMixin type definition (got JsonSchemaMixin itself!)'
             )
         return params_type

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -104,7 +104,8 @@ def _task_bootstrap(
         rpc_exception = None
         result = None
         try:
-            result = task.handle_request(params=params)
+            task.set_args(params=params)
+            result = task.handle_request()
         except RPCException as exc:
             rpc_exception = exc
         except dbt.exceptions.RPCKilledException as exc:
@@ -306,6 +307,10 @@ class RequestTaskHandler(threading.Thread):
             # raise a TypeError to indicate invalid parameters
             self.state = TaskHandlerState.Error
             raise TypeError(exc)
+        except TypeError:
+            # we got this from our argument parser, already a nice TypeError
+            self.state = TaskHandlerState.Error
+            raise
         self.subscriber = QueueSubscriber()
         self.process = multiprocessing.Process(
             target=_task_bootstrap,

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import signal
+import sys
 import threading
 import uuid
 from contextlib import contextmanager
@@ -11,7 +12,9 @@ from hologram.helpers import StrEnum
 
 import dbt.exceptions
 from dbt.adapters.factory import cleanup_connections
-from dbt.logger import GLOBAL_LOGGER as logger, list_handler, LogMessage
+from dbt.logger import (
+    GLOBAL_LOGGER as logger, list_handler, LogMessage, OutputHandler
+)
 from dbt.rpc.error import (
     dbt_error,
     server_error,
@@ -116,7 +119,8 @@ def _task_bootstrap(
             logger.debug('dbt runtime exception', exc_info=True)
             rpc_exception = dbt_error(exc)
         except Exception as exc:
-            logger.debug('uncaught python exception', exc_info=True)
+            with OutputHandler(sys.stderr).applicationbound():
+                logger.error('uncaught python exception', exc_info=True)
             rpc_exception = server_error(exc)
 
         # put whatever result we got onto the queue as well.

--- a/core/dbt/task/remote.py
+++ b/core/dbt/task/remote.py
@@ -190,56 +190,44 @@ class RemoteRunTask(_RPCExecTask, RunTask):
         return RPCExecuteRunner
 
 
-class RemoteCompileProjectTask(RPCTask):
+class _RPCCommandTask(RPCTask):
+    def __init__(self, args, config, manifest):
+        super().__init__(args, config, manifest)
+        self.manifest = self._base_manifest
+
+    def load_manifest(self):
+        # we started out with a manifest!
+        pass
+
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
+
+
+class RemoteCompileProjectTask(_RPCCommandTask):
     METHOD_NAME = 'compile'
 
-    def load_manifest(self):
-        # we started out with a manifest!
-        pass
-
     def set_args(self, params: RPCCompileProjectParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
 
-    def handle_request(self) -> RemoteCallableResult:
-        return self.run()
 
-
-class RemoteRunProjectTask(RPCTask, RunTask):
+class RemoteRunProjectTask(_RPCCommandTask, RunTask):
     METHOD_NAME = 'run'
 
-    def load_manifest(self):
-        # we started out with a manifest!
-        pass
-
     def set_args(self, params: RPCCompileProjectParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
 
-    def handle_request(self) -> RemoteCallableResult:
-        return self.run()
 
-
-class RemoteSeedProjectTask(RPCTask, SeedTask):
+class RemoteSeedProjectTask(_RPCCommandTask, SeedTask):
     METHOD_NAME = 'seed'
-
-    def load_manifest(self):
-        # we started out with a manifest!
-        pass
 
     def set_args(self, params: RPCSeedProjectParameters) -> None:
         self.args.show = params.show
 
-    def handle_request(self) -> RemoteCallableResult:
-        return self.run()
 
-
-class RemoteTestProjectTask(RPCTask, TestTask):
+class RemoteTestProjectTask(_RPCCommandTask, TestTask):
     METHOD_NAME = 'test'
-
-    def load_manifest(self):
-        # we started out with a manifest!
-        pass
 
     def set_args(self, params: RPCTestProjectParameters) -> None:
         self.args.models = self._listify(params.models)
@@ -247,24 +235,14 @@ class RemoteTestProjectTask(RPCTask, TestTask):
         self.args.data = params.data
         self.args.schema = params.schema
 
-    def handle_request(self) -> RemoteCallableResult:
-        return self.run()
 
-
-class RemoteDocsGenerateProjectTask(RPCTask, GenerateTask):
+class RemoteDocsGenerateProjectTask(_RPCCommandTask, GenerateTask):
     METHOD_NAME = 'docs.generate'
-
-    def load_manifest(self):
-        # we started out with a manifest!
-        pass
 
     def set_args(self, params: RPCDocsGenerateProjectParameters) -> None:
         self.args.models = None
         self.args.exclude = None
         self.args.compile = params.compile
-
-    def handle_request(self) -> RemoteCallableResult:
-        return self.run()
 
     def get_catalog_results(
         self, nodes, generated_at, compile_results
@@ -277,7 +255,7 @@ class RemoteDocsGenerateProjectTask(RPCTask, GenerateTask):
         )
 
 
-class RemoteRPCParameters(RPCTask):
+class RemoteRPCParameters(_RPCCommandTask):
     METHOD_NAME = 'cli_args'
 
     def set_args(self, params: RPCCliParameters) -> None:

--- a/core/dbt/task/remote.py
+++ b/core/dbt/task/remote.py
@@ -1,3 +1,4 @@
+import shlex
 import signal
 import threading
 from dataclasses import dataclass
@@ -6,6 +7,8 @@ from typing import Union, List, Optional
 
 from hologram import JsonSchemaMixin
 
+import dbt.exceptions
+import dbt.ui.printer
 from dbt.adapters.factory import get_adapter
 from dbt.clients.jinja import extract_toplevel_blocks
 from dbt.compilation import compile_manifest
@@ -13,7 +16,6 @@ from dbt.contracts.results import RemoteCatalogResults
 from dbt.parser.results import ParseResult
 from dbt.parser.rpc import RPCCallParser, RPCMacroParser
 from dbt.parser.util import ParserUtils
-import dbt.ui.printer
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.rpc.node_runners import RPCCompileRunner, RPCExecuteRunner
 from dbt.rpc.task import RemoteCallableResult, RPCTask
@@ -53,11 +55,12 @@ class RPCDocsGenerateProjectParameters(JsonSchemaMixin):
     compile: bool = True
 
 
-class _RPCExecTask(RPCTask):
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self._base_manifest = manifest.deepcopy(config=config)
+@dataclass
+class RPCCliParameters(JsonSchemaMixin):
+    cli: str
 
+
+class _RPCExecTask(RPCTask):
     def runtime_cleanup(self, selected_uids):
         """Do some pre-run cleanup that is usually performed in Task __init__.
         """
@@ -81,10 +84,11 @@ class _RPCExecTask(RPCTask):
         sql = ''.join(data_chunks)
         return sql, macros
 
-    def _get_exec_node(self, name, sql, macros):
+    def _get_exec_node(self):
         results = ParseResult.rpc()
         macro_overrides = {}
-        sql, macros = self._extract_request_data(sql)
+        macros = self.args.macros
+        sql, macros = self._extract_request_data(self.args.sql)
 
         if macros:
             macro_parser = RPCMacroParser(results, self.config)
@@ -98,7 +102,7 @@ class _RPCExecTask(RPCTask):
             root_project=self.config,
             macro_manifest=self._base_manifest,
         )
-        node = rpc_parser.parse_remote(sql, name)
+        node = rpc_parser.parse_remote(sql, self.args.name)
         self.manifest = ParserUtils.add_new_refs(
             manifest=self._base_manifest,
             current_project=self.config,
@@ -124,14 +128,17 @@ class _RPCExecTask(RPCTask):
         finally:
             thread_done.set()
 
-    def handle_request(
-        self, params: RPCExecParameters
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCExecParameters):
+        self.args.name = params.name
+        self.args.sql = params.sql
+        self.args.macros = params.macros
+
+    def handle_request(self) -> RemoteCallableResult:
         # we could get a ctrl+c at any time, including during parsing.
         thread = None
         started = datetime.utcnow()
         try:
-            node = self._get_exec_node(params.name, params.sql, params.macros)
+            node = self._get_exec_node()
 
             selected_uids = [node.unique_id]
             self.runtime_cleanup(selected_uids)
@@ -186,109 +193,78 @@ class RemoteRunTask(_RPCExecTask, RunTask):
 class RemoteCompileProjectTask(RPCTask):
     METHOD_NAME = 'compile'
 
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self.manifest = manifest.deepcopy(config=config)
-
     def load_manifest(self):
         # we started out with a manifest!
         pass
 
-    def handle_request(
-        self, params: RPCCompileProjectParameters
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCCompileProjectParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
 
-        results = self.run()
-        return results
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
 
 
 class RemoteRunProjectTask(RPCTask, RunTask):
     METHOD_NAME = 'run'
 
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self.manifest = manifest.deepcopy(config=config)
-
     def load_manifest(self):
         # we started out with a manifest!
         pass
 
-    def handle_request(
-        self, params: RPCCompileProjectParameters
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCCompileProjectParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
 
-        results = self.run()
-        return results
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
 
 
 class RemoteSeedProjectTask(RPCTask, SeedTask):
     METHOD_NAME = 'seed'
 
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self.manifest = manifest.deepcopy(config=config)
-
     def load_manifest(self):
         # we started out with a manifest!
         pass
 
-    def handle_request(
-        self, params: RPCSeedProjectParameters
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCSeedProjectParameters) -> None:
         self.args.show = params.show
 
-        results = self.run()
-        return results
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
 
 
 class RemoteTestProjectTask(RPCTask, TestTask):
     METHOD_NAME = 'test'
 
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self.manifest = manifest.deepcopy(config=config)
-
     def load_manifest(self):
         # we started out with a manifest!
         pass
 
-    def handle_request(
-        self, params: RPCTestProjectParameters,
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCTestProjectParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
         self.args.data = params.data
         self.args.schema = params.schema
 
-        results = self.run()
-        return results
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
 
 
 class RemoteDocsGenerateProjectTask(RPCTask, GenerateTask):
     METHOD_NAME = 'docs.generate'
 
-    def __init__(self, args, config, manifest):
-        super().__init__(args, config)
-        self.manifest = manifest.deepcopy(config=config)
-
     def load_manifest(self):
         # we started out with a manifest!
         pass
 
-    def handle_request(
-        self, params: RPCDocsGenerateProjectParameters,
-    ) -> RemoteCallableResult:
+    def set_args(self, params: RPCDocsGenerateProjectParameters) -> None:
         self.args.models = None
         self.args.exclude = None
         self.args.compile = params.compile
 
-        results = self.run()
-        assert isinstance(results, RemoteCatalogResults)
-        return results
+    def handle_request(self) -> RemoteCallableResult:
+        return self.run()
 
     def get_catalog_results(
         self, nodes, generated_at, compile_results
@@ -299,3 +275,32 @@ class RemoteDocsGenerateProjectTask(RPCTask, GenerateTask):
             _compile_results=compile_results,
             logs=[],
         )
+
+
+class RemoteRPCParameters(RPCTask):
+    METHOD_NAME = 'cli_args'
+
+    def set_args(self, params: RPCCliParameters) -> None:
+        # more import cycles :(
+        from dbt.main import parse_args, RPCArgumentParser
+        split = shlex.split(params.cli)
+        self.args = parse_args(split, RPCArgumentParser)
+
+    def get_rpc_task_cls(self):
+        # This is obnoxious, but we don't have actual access to the TaskManager
+        # so instead we get to dig through all the subclasses of RPCTask
+        # (recursively!) looking for a matching METHOD_NAME
+        for candidate in RPCTask.recursive_subclasses():
+            if candidate.METHOD_NAME == self.args.rpc_method:
+                return candidate
+        # this shouldn't happen
+        raise dbt.exceptions.InternalException(
+            'No matching handler found for rpc method {} (which={})'
+            .format(self.args.rpc_method, self.args.which)
+        )
+
+    def handle_request(self) -> JsonSchemaMixin:
+        cls = self.get_rpc_task_cls()
+        # we parsed args from the cli, so we're set on that front
+        task = cls(self.args, self.config, self.manifest)
+        return task.handle_request()

--- a/core/dbt/task/rpc_server.py
+++ b/core/dbt/task/rpc_server.py
@@ -17,13 +17,7 @@ from dbt.logger import (
 )
 from dbt.task.base import ConfiguredTask
 from dbt.task.compile import CompileTask
-from dbt.task.remote import (
-    RemoteCompileTask, RemoteCompileProjectTask,
-    RemoteRunTask, RemoteRunProjectTask,
-    RemoteSeedProjectTask,
-    RemoteTestProjectTask,
-    RemoteDocsGenerateProjectTask,
-)
+from dbt.task.remote import RPCTask
 from dbt.utils import ForgivingJSONEncoder, env_set_truthy
 from dbt import rpc
 from dbt.rpc.logger import ServerContext, HTTPRequest, RPCResponse
@@ -147,12 +141,7 @@ class RPCServerTask(ConfiguredTask):
 
     @staticmethod
     def _default_tasks():
-        return [
-            RemoteCompileTask, RemoteCompileProjectTask,
-            RemoteRunTask, RemoteRunProjectTask,
-            RemoteSeedProjectTask, RemoteTestProjectTask,
-            RemoteDocsGenerateProjectTask
-        ]
+        return RPCTask.recursive_subclasses(named_only=True)
 
     def single_threaded(self):
         return SINGLE_THREADED_WEBSERVER or self.args.single_threaded


### PR DESCRIPTION
Fixes #1811 

Also, changed explicitly listing RPC tasks out to instead use the same discovery technique as this code does.

You can call it like:
```
{
  "method": "cli_args",
  "params": {
    "cli": "docs generate --no-compile",
    "timeout": 1000,
  }
}
```

The argument to `cli` should exactly match the cli arguments you would pass to dbt (so, note `docs generate` instead of `docs.generate`).
