### PR TITLE
add test metadata for schema tests, add test tests (#1154)

### DIFF
--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -9,6 +9,7 @@ from dbt.contracts.graph.parsed import (
     ParsedSourceDefinition,
     ParsedTestNode,
     TestConfig,
+    TestMetadata,
     PARSED_TYPES,
 )
 from dbt.node_types import NodeType
@@ -112,6 +113,7 @@ class CompiledTestNode(CompiledNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
+    test_metadata: Optional[TestMetadata] = None
 
 
 def _inject_ctes_into_sql(sql: str, ctes: List[InjectedCTE]) -> str:

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -261,10 +261,18 @@ class TestConfig(NodeConfig):
 
 
 @dataclass
+class TestMetadata(JsonSchemaMixin):
+    namespace: Optional[str]
+    name: str
+    kwargs: Dict[str, Any]
+
+
+@dataclass
 class ParsedTestNode(ParsedNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
+    test_metadata: Optional[TestMetadata] = None
 
 
 @dataclass(init=False)

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -10,7 +10,11 @@ from dbt.clients.yaml_helper import load_yaml_text
 from dbt.config.renderer import ConfigRenderer
 from dbt.contracts.graph.manifest import SourceFile
 from dbt.contracts.graph.parsed import (
-    ParsedNodePatch, ParsedTestNode, ParsedSourceDefinition, ColumnInfo, Docref
+    ParsedNodePatch,
+    ParsedSourceDefinition,
+    ColumnInfo,
+    Docref,
+    ParsedTestNode,
 )
 from dbt.contracts.graph.unparsed import (
     UnparsedSourceDefinition, UnparsedNodeUpdate, NamedTested,
@@ -255,6 +259,12 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
 
         config = self.initial_config(fqn)
 
+        metadata = {
+            'namespace': builder.namespace,
+            'name': builder.name,
+            'kwargs': builder.args,
+        }
+
         node = self._create_parsetime_node(
             block=block,
             path=compiled_path,
@@ -263,6 +273,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
             name=builder.fqn_name,
             raw_sql=builder.build_raw_sql(),
             column_name=block.column_name,
+            test_metadata=metadata,
         )
         self.render_update(node, config)
         self.add_result_node(block, node)

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -961,6 +961,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('count(*)'),
                     'wrapped_sql': AnyStringWith('count(*)'),
+                    'test_metadata': {
+                        'namespace': None,
+                        'name': 'not_null',
+                        'kwargs': {'column_name': 'id'},
+                    },
                 },
                 'test.test.test_nothing_model_': {
                     'alias': 'test_nothing_model_',
@@ -1003,6 +1008,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('select 0'),
                     'wrapped_sql': AnyStringWith('select 0'),
+                    'test_metadata': {
+                        'namespace': 'test',
+                        'name': 'nothing',
+                        'kwargs': {},
+                    },
                 },
                 'test.test.unique_model_id': {
                     'alias': 'unique_model_id',
@@ -1045,6 +1055,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('count(*)'),
                     'wrapped_sql': AnyStringWith('count(*)'),
+                    'test_metadata': {
+                        'namespace': None,
+                        'name': 'unique',
+                        'kwargs': {'column_name': 'id'},
+                    },
                 },
             },
             'parent_map': {
@@ -2455,7 +2470,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': ['schema'],
                     'unique_id': 'test.test.not_null_model_id',
-                    'wrapped_sql': AnyStringWith('id is null')
+                    'wrapped_sql': AnyStringWith('id is null'),
+                    'test_metadata': {
+                        'namespace': None,
+                        'name': 'not_null',
+                        'kwargs': {'column_name': 'id'},
+                    },
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -2508,6 +2528,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': ['schema'],
                     'unique_id': 'test.test.test_nothing_model_',
                     'wrapped_sql': AnyStringWith('select 0'),
+                    'test_metadata': {
+                        'namespace': 'test',
+                        'name': 'nothing',
+                        'kwargs': {},
+                    },
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -2559,7 +2584,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'tags': ['schema'],
                     'unique_id': 'test.test.unique_model_id',
-                    'wrapped_sql': AnyStringWith('count(*)')
+                    'wrapped_sql': AnyStringWith('count(*)'),
+                    'test_metadata': {
+                        'namespace': None,
+                        'name': 'unique',
+                        'kwargs': {'column_name': 'id'},
+                    },
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -306,6 +306,15 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assertTrue(tests[0].name.startswith('accepted_values_'))
         self.assertEqual(tests[0].fqn, ['snowplow', 'schema_test', tests[0].name])
         self.assertEqual(tests[0].unique_id.split('.'), ['test', 'snowplow', tests[0].name])
+        self.assertEqual(tests[0].test_metadata.name, 'accepted_values')
+        self.assertIsNone(tests[0].test_metadata.namespace)
+        self.assertEqual(
+            tests[0].test_metadata.kwargs,
+            {
+                'column_name': 'color',
+                'values': ['red', 'blue', 'green'],
+            }
+        )
 
         # foreign packages are a bit weird, they include the macro package
         # name in the test name
@@ -318,6 +327,15 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assertTrue(tests[1].name.startswith('foreign_package_test_case_'))
         self.assertEqual(tests[1].package_name, 'snowplow')
         self.assertEqual(tests[1].unique_id.split('.'), ['test', 'snowplow', tests[1].name])
+        self.assertEqual(tests[1].test_metadata.name, 'test_case')
+        self.assertEqual(tests[1].test_metadata.namespace, 'foreign_package')
+        self.assertEqual(
+            tests[1].test_metadata.kwargs,
+            {
+                'column_name': 'color',
+                'arg': 100,
+            },
+        )
 
         self.assertEqual(tests[2].config.severity, 'WARN')
         self.assertEqual(tests[2].tags, ['schema'])
@@ -327,6 +345,14 @@ class SchemaParserModelsTest(SchemaParserTest):
         self.assertTrue(tests[2].name.startswith('not_null_'))
         self.assertEqual(tests[2].fqn, ['snowplow', 'schema_test', tests[2].name])
         self.assertEqual(tests[2].unique_id.split('.'), ['test', 'snowplow', tests[2].name])
+        self.assertEqual(tests[2].test_metadata.name, 'not_null')
+        self.assertIsNone(tests[2].test_metadata.namespace)
+        self.assertEqual(
+            tests[2].test_metadata.kwargs,
+            {
+                'column_name': 'color',
+            },
+        )
 
         path = get_abs_os_path('./dbt_modules/snowplow/models/test_one.yml')
         self.assertIn(path, self.parser.results.files)


### PR DESCRIPTION
Fixes #1154 

Add a new optional metadata field to the ParsedTestNode. On data tests it's None, but on schema tests it's a dict with 3 entries:
- (optional) the namespace, if you had a dotted test name
- The test name, without the namespace if it was dotted
- The test arguments, including the column name if it was a column test
