### PR TITLE
Set a much more strict version upper bound for jsonschema

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -51,7 +51,7 @@ setup(
         'requests>=2.18.0,<3',
         'colorama==0.3.9',
         'agate>=1.6,<2',
-        'jsonschema>=3.0.1,<4',
+        'jsonschema>=3.0.1,<3.1.2,!=3.1.0',
         'json-rpc>=1.12,<2',
         'werkzeug>=0.14.1,<0.15',
     ]


### PR DESCRIPTION
See #1817 - the "real" fix will be in another set of PRs.

For 0.14.3, disallow jsonschema 3.1.x, except for 3.1.1 which works fine

We can probably sneak this straight into 0.14.3 without cutting an rc2 if we want, it's just a dependency lockdown