### PR TITLE
Add task tags parameter (#1822)

### DIFF
--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -3,7 +3,6 @@ from dbt.contracts.graph.unparsed import Time, FreshnessStatus
 from dbt.contracts.graph.parsed import ParsedSourceDefinition
 from dbt.contracts.util import Writable, Replaceable
 from dbt.logger import (
-    LogMessage,
     TimingProcessor,
     JsonOnly,
     GLOBAL_LOGGER as logger,
@@ -207,35 +206,6 @@ class FreshnessRunOutput(JsonSchemaMixin, Writable):
     sources: Dict[str, SourceFreshnessRunResult]
 
 
-@dataclass
-class RemoteCompileResult(JsonSchemaMixin):
-    raw_sql: str
-    compiled_sql: str
-    node: CompileResultNode
-    timing: List[TimingInfo]
-    logs: List[LogMessage]
-
-    @property
-    def error(self):
-        return None
-
-
-@dataclass
-class RemoteExecutionResult(ExecutionResult):
-    logs: List[LogMessage]
-
-
-@dataclass
-class ResultTable(JsonSchemaMixin):
-    column_names: List[str]
-    rows: List[Any]
-
-
-@dataclass
-class RemoteRunResult(RemoteCompileResult):
-    table: ResultTable
-
-
 Primitive = Union[bool, str, float, None]
 
 CatalogKey = NamedTuple(
@@ -298,8 +268,3 @@ class CatalogResults(JsonSchemaMixin, Writable):
     nodes: Dict[str, CatalogTable]
     generated_at: datetime
     _compile_results: Optional[Any] = None
-
-
-@dataclass
-class RemoteCatalogResults(CatalogResults):
-    logs: List[LogMessage] = field(default_factory=list)

--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass, field
+from numbers import Real
+from typing import Optional, Union, List, Any, Dict
+
+from hologram import JsonSchemaMixin
+
+from dbt.contracts.graph.compiled import CompileResultNode
+from dbt.contracts.results import (
+    TimingInfo,
+    CatalogResults,
+    ExecutionResult,
+)
+from dbt.logger import LogMessage
+
+# Inputs
+
+
+@dataclass
+class RPCParameters(JsonSchemaMixin):
+    timeout: Optional[Real]
+    task_tags: Optional[Dict[str, Any]]
+
+
+@dataclass
+class RPCExecParameters(RPCParameters):
+    name: str
+    sql: str
+    macros: Optional[str]
+
+
+@dataclass
+class RPCCompileParameters(RPCParameters):
+    models: Union[None, str, List[str]] = None
+    exclude: Union[None, str, List[str]] = None
+
+
+@dataclass
+class RPCTestParameters(RPCCompileParameters):
+    data: bool = False
+    schema: bool = False
+
+
+@dataclass
+class RPCSeedParameters(RPCParameters):
+    show: bool = False
+
+
+@dataclass
+class RPCDocsGenerateParameters(RPCParameters):
+    compile: bool = True
+
+
+@dataclass
+class RPCCliParameters(RPCParameters):
+    cli: str
+
+
+# Outputs
+
+
+@dataclass
+class RemoteCatalogResults(CatalogResults):
+    logs: List[LogMessage] = field(default_factory=list)
+
+
+@dataclass
+class RemoteCompileResult(JsonSchemaMixin):
+    raw_sql: str
+    compiled_sql: str
+    node: CompileResultNode
+    timing: List[TimingInfo]
+    logs: List[LogMessage]
+
+    @property
+    def error(self):
+        return None
+
+
+@dataclass
+class RemoteExecutionResult(ExecutionResult):
+    logs: List[LogMessage]
+
+
+@dataclass
+class ResultTable(JsonSchemaMixin):
+    column_names: List[str]
+    rows: List[Any]
+
+
+@dataclass
+class RemoteRunResult(RemoteCompileResult):
+    table: ResultTable

--- a/core/dbt/helper_types.py
+++ b/core/dbt/helper_types.py
@@ -1,5 +1,6 @@
 # never name this package "types", or mypy will crash in ugly ways
 from datetime import timedelta
+from numbers import Real
 from typing import NewType
 
 from hologram import (
@@ -37,7 +38,14 @@ class TimeDeltaFieldEncoder(FieldEncoder[timedelta]):
         return {'type': 'number'}
 
 
+class RealEncoder(FieldEncoder):
+    @property
+    def json_schema(self):
+        return {'type': 'number'}
+
+
 JsonSchemaMixin.register_field_encoders({
     Port: PortEncoder(),
     timedelta: TimeDeltaFieldEncoder(),
+    Real: RealEncoder(),
 })

--- a/core/dbt/rpc/logger.py
+++ b/core/dbt/rpc/logger.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from queue import Empty
 from typing import Optional, Any, Union
 
-from dbt.contracts.results import (
+from dbt.contracts.rpc import (
     RemoteCompileResult, RemoteExecutionResult, RemoteCatalogResults
 )
 from dbt.exceptions import InternalException

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands = /bin/bash -c '$(which mypy) \
     core/dbt/adapters/cache.py \
     core/dbt/clients \
     core/dbt/config \
+    core/dbt/contracts/rpc.py \
     core/dbt/deprecations.py \
     core/dbt/exceptions.py \
     core/dbt/flags.py \
@@ -42,6 +43,7 @@ commands = /bin/bash -c '$(which mypy) \
     core/dbt/task/generate.py \
     core/dbt/task/init.py \
     core/dbt/task/list.py \
+    core/dbt/task/remote.py \
     core/dbt/task/run_operation.py \
     core/dbt/task/runnable.py \
     core/dbt/task/seed.py \


### PR DESCRIPTION
Fixes #1822 

- Created a base class for parameter types
   - include arbitrary "task_tags" parameter
   - include "timeout" so we can extract/document full/valid json schemas

- Added output to ps and poll results (including errors)
- Fixed a number of type annotation issues along the way
- Refactored/moved some contracts that were scattered all over the place into `contracts/rpc.py`
- Added an encoder for `number.Real`
  - this avoids an issue with values that can be floats or ints and are therefore valid under multiple encodings.


