### PR TITLE
Fix for issues with some Mojave installs

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -1,5 +1,5 @@
 import abc
-import multiprocessing
+from multiprocessing import RLock
 import os
 from threading import get_ident
 from typing import (
@@ -34,7 +34,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     def __init__(self, profile: HasCredentials):
         self.profile = profile
         self.thread_connections: Dict[Hashable, Connection] = {}
-        self.lock = multiprocessing.RLock()
+        self.lock: RLock = dbt.flags.MP_CONTEXT.RLock()
 
     @staticmethod
     def get_thread_identifier() -> Hashable:

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -1,3 +1,5 @@
+import os
+import multiprocessing
 # initially all flags are set to None, the on-load call of reset() will set
 # them for their first time.
 STRICT_MODE = None
@@ -9,9 +11,22 @@ WRITE_JSON = None
 PARTIAL_PARSE = None
 
 
+def _get_context():
+    if os.name == 'posix' and os.uname().sysname.lower() != 'darwin':
+        # on linux fork is available and it's fast
+        return multiprocessing.get_context('fork')
+    else:
+        # on windows, spawn is the only choice.
+        # On osx, fork is buggy: https://bugs.python.org/issue33725
+        return multiprocessing.get_context('spawn')
+
+
+MP_CONTEXT = _get_context()
+
+
 def reset():
     global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER, \
-        WRITE_JSON, PARTIAL_PARSE
+        WRITE_JSON, PARTIAL_PARSE, MP_CONTEXT
 
     STRICT_MODE = False
     FULL_REFRESH = False
@@ -20,11 +35,13 @@ def reset():
     TEST_NEW_PARSER = False
     WRITE_JSON = True
     PARTIAL_PARSE = False
+    MP_CONTEXT = _get_context()
 
 
 def set_from_args(args):
     global STRICT_MODE, FULL_REFRESH, USE_CACHE, WARN_ERROR, TEST_NEW_PARSER, \
-        WRITE_JSON, PARTIAL_PARSE
+        WRITE_JSON, PARTIAL_PARSE, MP_CONTEXT
+
     USE_CACHE = getattr(args, 'use_cache', USE_CACHE)
 
     FULL_REFRESH = getattr(args, 'full_refresh', FULL_REFRESH)
@@ -37,6 +54,7 @@ def set_from_args(args):
     TEST_NEW_PARSER = getattr(args, 'test_new_parser', TEST_NEW_PARSER)
     WRITE_JSON = getattr(args, 'write_json', WRITE_JSON)
     PARTIAL_PARSE = getattr(args, 'partial_parse', PARTIAL_PARSE)
+    MP_CONTEXT = _get_context()
 
 
 # initialize everything to the defaults on module load

--- a/core/dbt/rpc/task_manager.py
+++ b/core/dbt/rpc/task_manager.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import operator
 import os
 import signal
@@ -14,6 +13,7 @@ from hologram import JsonSchemaMixin, ValidationError
 from hologram.helpers import StrEnum
 
 import dbt.exceptions
+import dbt.flags
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.rpc import (
     RemoteCompileResult,
@@ -333,7 +333,7 @@ class TaskManager:
         self._rpc_task_map: Dict[str, RemoteMethod] = {}
         self._builtins: Dict[str, UnmanagedHandler] = {}
         self.last_compile = LastCompile(status=ManifestStatus.Init)
-        self._lock = multiprocessing.Lock()
+        self._lock: dbt.flags.MP_CONTEXT.Lock = dbt.flags.MP_CONTEXT.Lock()
         self._gc_settings = GCSettings(
             maxsize=1000, reapsize=500, auto_reap_age=timedelta(days=30)
         )

--- a/plugins/redshift/dbt/adapters/redshift/connections.py
+++ b/plugins/redshift/dbt/adapters/redshift/connections.py
@@ -1,4 +1,4 @@
-import multiprocessing
+from multiprocessing import Lock
 from contextlib import contextmanager
 from typing import NewType
 
@@ -6,6 +6,7 @@ from dbt.adapters.postgres import PostgresConnectionManager
 from dbt.adapters.postgres import PostgresCredentials
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 import dbt.exceptions
+import dbt.flags
 
 import boto3
 
@@ -15,7 +16,7 @@ from hologram.helpers import StrEnum
 from dataclasses import dataclass, field
 from typing import Optional
 
-drop_lock = multiprocessing.Lock()
+drop_lock: Lock = dbt.flags.MP_CONTEXT.Lock()
 
 
 IAMDuration = NewType('IAMDuration', int)


### PR DESCRIPTION
Use an internal multiprocessing.context in dbt.flags for multiprocessing things
 - On osx, force the use of "spawn" to handle https://bugs.python.org/issue33725
 - Bring _nt_setup back from the dead as _spawn_setup

OSX will probably be a bit slower for RPC startup and SIGHUP handling now, as the manifest has to get pickled/unpickled for each API call. But at least it won't abort!
