### PR TITLE
postgres: gracefully handle materialized views (#1698)

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -389,17 +389,21 @@ class BaseRelation(FakeAPIObject, Hashable):
         return self.type == RelationType.View
 
     @classproperty
-    def Table(self) -> str:
+    def Table(cls) -> str:
         return str(RelationType.Table)
 
     @classproperty
-    def CTE(self) -> str:
+    def CTE(cls) -> str:
         return str(RelationType.CTE)
 
     @classproperty
-    def View(self) -> str:
+    def View(cls) -> str:
         return str(RelationType.View)
 
     @classproperty
-    def External(self) -> str:
+    def External(cls) -> str:
         return str(RelationType.External)
+
+    @classproperty
+    def RelationType(cls) -> Type[RelationType]:
+        return RelationType

--- a/core/dbt/adapters/cache.py
+++ b/core/dbt/adapters/cache.py
@@ -253,6 +253,8 @@ class RelationsCache:
         """
         referenced = self.relations.get(referenced_key)
         if referenced is None:
+            return
+        if referenced is None:
             dbt.exceptions.raise_cache_inconsistent(
                 'in add_link, referenced link key {} not in cache!'
                 .format(referenced_key)
@@ -268,8 +270,8 @@ class RelationsCache:
         referenced.add_reference(dependent)
 
     def add_link(self, referenced, dependent):
-        """Add a link between two relations to the database. Both the old and
-        new entries must already exist in the database.
+        """Add a link between two relations to the database. If either relation
+        does not exist, it will be added as an "external" relation.
 
         The dependent model refers _to_ the referenced model. So, given
         arguments of (jake_test, bar, jake_test, foo):
@@ -281,23 +283,36 @@ class RelationsCache:
         :param BaseRelation dependent: The dependent model.
         :raises InternalError: If either entry does not exist.
         """
-        referenced = _make_key(referenced)
-        if (referenced.database, referenced.schema) not in self:
+        ref_key = _make_key(referenced)
+        if (ref_key.database, ref_key.schema) not in self:
             # if we have not cached the referenced schema at all, we must be
             # referring to a table outside our control. There's no need to make
             # a link - we will never drop the referenced relation during a run.
             logger.debug(
                 '{dep!s} references {ref!s} but {ref.database}.{ref.schema} '
                 'is not in the cache, skipping assumed external relation'
-                .format(dep=dependent, ref=referenced)
+                .format(dep=dependent, ref=ref_key)
             )
             return
-        dependent = _make_key(dependent)
+        if ref_key not in self.relations:
+            # Insert a dummy "external" relation.
+            referenced = referenced.replace(
+                type=referenced.RelationType.External
+            )
+            self.add(referenced)
+
+        dep_key = _make_key(dependent)
+        if dep_key not in self.relations:
+            # Insert a dummy "external" relation.
+            dependent = dependent.replace(
+                type=referenced.RelationType.External
+            )
+            self.add(dependent)
         logger.debug(
-            'adding link, {!s} references {!s}'.format(dependent, referenced)
+            'adding link, {!s} references {!s}'.format(dep_key, ref_key)
         )
         with self.lock:
-            self._add_link(referenced, dependent)
+            self._add_link(ref_key, dep_key)
 
     def add(self, relation):
         """Add the relation inner to the cache, under the schema schema and

--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -43,22 +43,22 @@ class PostgresAdapter(SQLAdapter):
         database = self.config.credentials.database
         table = self.execute_macro(GET_RELATIONS_MACRO_NAME)
 
-        for (refed_schema, refed_name, dep_schema, dep_name) in table:
-            referenced = self.Relation.create(
-                database=database,
-                schema=refed_schema,
-                identifier=refed_name
-            )
+        for (dep_schema, dep_name, refed_schema, refed_name) in table:
             dependent = self.Relation.create(
                 database=database,
                 schema=dep_schema,
                 identifier=dep_name
             )
+            referenced = self.Relation.create(
+                database=database,
+                schema=refed_schema,
+                identifier=refed_name
+            )
 
             # don't record in cache if this relation isn't in a relevant
             # schema
             if refed_schema.lower() in schemas:
-                self.cache.add_link(dependent, referenced)
+                self.cache.add_link(referenced, dependent)
 
     def _get_cache_schemas(self, manifest, exec_only=False):
         # postgres/redshift only allow one database (the main one)

--- a/test/integration/003_simple_reference_test/test_simple_reference.py
+++ b/test/integration/003_simple_reference_test/test_simple_reference.py
@@ -19,10 +19,13 @@ class TestSimpleReference(DBTIntegrationTest):
             }
         }
 
+    def setUp(self):
+        super().setUp()
+        # self.use_default_config()
+        self.run_sql_file("seed.sql")
+
     @use_profile('postgres')
     def test__postgres__simple_reference(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         results = self.run_dbt()
         # ephemeral_copy doesn't show up in results
@@ -59,8 +62,6 @@ class TestSimpleReference(DBTIntegrationTest):
 
     @use_profile('snowflake')
     def test__snowflake__simple_reference(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         results = self.run_dbt()
         self.assertEqual(len(results),  8)
@@ -83,8 +84,6 @@ class TestSimpleReference(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__simple_reference_with_models(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         # Run materialized_copy, ephemeral_copy, and their dependents
         # ephemeral_copy should not actually be materialized b/c it is ephemeral
@@ -101,8 +100,6 @@ class TestSimpleReference(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__simple_reference_with_models_and_children(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         # Run materialized_copy, ephemeral_copy, and their dependents
         # ephemeral_copy should not actually be materialized b/c it is ephemeral
@@ -139,8 +136,6 @@ class TestSimpleReference(DBTIntegrationTest):
 
     @use_profile('snowflake')
     def test__snowflake__simple_reference_with_models(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         # Run materialized_copy & ephemeral_copy
         # ephemeral_copy should not actually be materialized b/c it is ephemeral
@@ -157,8 +152,6 @@ class TestSimpleReference(DBTIntegrationTest):
 
     @use_profile('snowflake')
     def test__snowflake__simple_reference_with_models_and_children(self):
-        self.use_default_project()
-        self.run_sql_file("seed.sql")
 
         # Run materialized_copy, ephemeral_copy, and their dependents
         # ephemeral_copy should not actually be materialized b/c it is ephemeral

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -82,16 +82,22 @@ class TestAddLink(TestCache):
         self.cache.add(make_relation('dbt', 'schema_2', 'bar'))
 
     def test_no_src(self):
-        # src does not exist (but similar names do)
-        with self.assertRaises(dbt.exceptions.InternalException):
-            self.cache.add_link(make_relation('dbt', 'schema', 'bar'),
-                                make_relation('dbt', 'schema', 'foo'))
+        self.assert_relations_exist('dbt', 'schema', 'foo')
+        self.assert_relations_do_not_exist('dbt', 'schema', 'bar')
+
+        self.cache.add_link(make_relation('dbt', 'schema', 'bar'),
+                            make_relation('dbt', 'schema', 'foo'))
+
+        self.assert_relations_exist('dbt', 'schema', 'foo', 'bar')
 
     def test_no_dst(self):
-        # dst does not exist (but similar names do)
-        with self.assertRaises(dbt.exceptions.InternalException):
-            self.cache.add_link(make_relation('dbt', 'schema', 'foo'),
-                                make_relation('dbt', 'schema', 'bar'))
+        self.assert_relations_exist('dbt', 'schema', 'foo')
+        self.assert_relations_do_not_exist('dbt', 'schema', 'bar')
+
+        self.cache.add_link(make_relation('dbt', 'schema', 'foo'),
+                            make_relation('dbt', 'schema', 'bar'))
+
+        self.assert_relations_exist('dbt', 'schema', 'foo', 'bar')
 
 
 class TestRename(TestCache):


### PR DESCRIPTION
Fixes #1698 

When the cache is told to add a link between relations that don't exist, create the missing ones with `type=RelationType.External`. Previously dbt failed with a cache inconsistency error, but the cache is really just incomplete rather than inconsistent.