### PR TITLE
Partial parse updates (#1835)

### DIFF
--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -174,6 +174,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
 class UserConfig(ExtensibleJsonSchemaMixin, Replaceable):
     send_anonymous_usage_stats: bool = DEFAULT_SEND_ANONYMOUS_USAGE_STATS
     use_colors: bool = DEFAULT_USE_COLORS
+    partial_parse: Optional[bool] = None
     printer_width: Optional[int] = None
 
     def set_values(self, cookie_dir):

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -53,7 +53,7 @@ def set_from_args(args):
 
     TEST_NEW_PARSER = getattr(args, 'test_new_parser', TEST_NEW_PARSER)
     WRITE_JSON = getattr(args, 'write_json', WRITE_JSON)
-    PARTIAL_PARSE = getattr(args, 'partial_parse', PARTIAL_PARSE)
+    PARTIAL_PARSE = getattr(args, 'partial_parse', None)
     MP_CONTEXT = _get_context()
 
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -789,14 +789,29 @@ def parse_args(args, cls=DBTArgumentParser):
         '''
     )
 
-    p.add_argument(
+    partial_flag = p.add_mutually_exclusive_group()
+    partial_flag.add_argument(
         '--partial-parse',
-        action='store_true',
+        action='store_const',
+        const=True,
+        dest='partial_parse',
+        default=None,
         help='''
         Allow for partial parsing by looking for and writing to a pickle file
-        in the target directory.
+        in the target directory. This overrides the user configuration file.
 
         WARNING: This can result in unexpected behavior if you use env_var()!
+        '''
+    )
+
+    partial_flag.add_argument(
+        '--no-partial-parse',
+        action='store_const',
+        const=False,
+        default=None,
+        dest='partial_parse',
+        help='''
+        Disallow partial parsing. This overrides the user configuration file.
         '''
     )
 

--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -9,11 +9,12 @@ from dbt.contracts.graph.parsed import (
     ParsedSourceDefinition, ParsedAnalysisNode, ParsedHookNode, ParsedRPCNode,
     ParsedModelNode, ParsedSeedNode, ParsedTestNode, ParsedSnapshotNode,
 )
-from dbt.contracts.util import Writable
+from dbt.contracts.util import Writable, Replaceable
 from dbt.exceptions import (
     raise_duplicate_resource_name, raise_duplicate_patch_name,
     CompilationException, InternalException
 )
+from dbt.version import __version__
 
 
 # Parsers can return anything as long as it's a unique ID
@@ -43,7 +44,7 @@ def dict_field():
 
 
 @dataclass
-class ParseResult(JsonSchemaMixin, Writable):
+class ParseResult(JsonSchemaMixin, Writable, Replaceable):
     vars_hash: FileHash
     profile_hash: FileHash
     project_hashes: MutableMapping[str, FileHash]
@@ -54,6 +55,7 @@ class ParseResult(JsonSchemaMixin, Writable):
     patches: MutableMapping[str, ParsedNodePatch] = dict_field()
     files: MutableMapping[str, SourceFile] = dict_field()
     disabled: MutableMapping[str, List[ParsedNode]] = dict_field()
+    dbt_version: str = __version__
 
     def get_file(self, source_file: SourceFile) -> SourceFile:
         key = source_file.search_key


### PR DESCRIPTION
Fixes #1835


- Use the user's profile config and the CLI arguments to determine whether to try partial parsing
  - defaults to False
  - CLI wins, then config
  - added `--no-partial-parse` so I don't have to keep flipping my config around
- Check the dbt version number as part of deciding if a cached result is ok