### PR TITLE
Handle a number of bad failure-path behaviors (#1807)

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -46,9 +46,8 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         key = self.get_thread_identifier()
         with self.lock:
             if key not in self.thread_connections:
-                raise RuntimeError(
-                    'connection never acquired for thread {}, have {}'
-                    .format(key, list(self.thread_connections))
+                raise dbt.exceptions.InvalidConnectionException(
+                    key, list(self.thread_connections)
                 )
             return self.thread_connections[key]
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -219,7 +219,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         return self.connections.commit_if_has_connection()
 
     def nice_connection_name(self):
-        conn = self.connections.get_thread_connection()
+        conn = self.connections.get_if_exists()
         if conn is None or conn.name is None:
             return '<None>'
         return conn.name

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -338,6 +338,16 @@ class CommandResultError(CommandError):
         return '{} running: {}'.format(self.msg, self.cmd)
 
 
+class InvalidConnectionException(RuntimeException):
+    def __init__(self, thread_id, known, node=None):
+        self.thread_id = thread_id
+        self.known = known
+        super().__init__(
+            msg='connection never acquired for thread {}, have {}'
+            .format(self.thread_id, self.known)
+        )
+
+
 def raise_compiler_error(msg, node=None) -> NoReturn:
     raise CompilationException(msg, node)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -64,7 +64,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         error_msg = "\n".join(
             [item['message'] for item in error.errors])
 
-        raise dbt.exceptions.DatabaseException(error_msg)
+        raise dbt.exceptions.DatabaseException(error_msg) from error
 
     def clear_transaction(self):
         pass
@@ -90,7 +90,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
-            raise dbt.exceptions.RuntimeException(str(e))
+            raise dbt.exceptions.RuntimeException(str(e)) from e
 
     def cancel_open(self) -> None:
         pass

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -52,7 +52,7 @@ class PostgresConnectionManager(SQLConnectionManager):
                 logger.debug("Failed to release connection!")
                 pass
 
-            raise dbt.exceptions.DatabaseException(str(e).strip())
+            raise dbt.exceptions.DatabaseException(str(e).strip()) from e
 
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
@@ -64,7 +64,7 @@ class PostgresConnectionManager(SQLConnectionManager):
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.RuntimeException(e)
+            raise dbt.exceptions.RuntimeException(e) from e
 
     @classmethod
     def open(cls, connection):

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -99,7 +99,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
-            raise dbt.exceptions.RuntimeException(e.msg)
+            raise dbt.exceptions.RuntimeException(str(e)) from e
 
     @classmethod
     def open(cls, connection):


### PR DESCRIPTION
Fixes #1807 

This is one of those bugs where I don't see the bad behavior anymore so I assume it's ok. This was hard to write tests for, I had to use our internal analytics project with 8 threads to reproduce the issue: I assume it needs a large and complex test case to trigger. And I don't know where I'd even pull debugging information from.

Anyway, my attempts at fixing the issue described:

- When a connection is missing, raise a special exception
   - instead of RuntimeError, this derives from our RuntimeException, so we catch/suppress it better
- Be graceful if a connection does not exist during nice_connection_name
- Handle the case where exceptions caught by the Snowflake exception handler do not have a 'msg' attr
- Re-raise exceptions in the adapter exception handlers "from" the originating error so we don't get big double stack traces about "during handling... another exception was raised"