### PR TITLE
More packaging fixes

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -22,7 +22,7 @@ setup(
     author="Fishtown Analytics",
     author_email="info@fishtownanalytics.com",
     url="https://github.com/fishtown-analytics/dbt",
-    packages=find_namespace_packages(include=['dbt.*']),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data={
         'dbt': [
             'include/index.html',
@@ -60,5 +60,6 @@ setup(
         'logbook>=1.5,<1.6',
         'pytest-logbook>=1.2.0,<1.3',
         'typing-extensions>=3.7.4,<3.8',
-    ]
+    ],
+    zip_safe=False,
 )

--- a/editable_requirements.txt
+++ b/editable_requirements.txt
@@ -1,0 +1,5 @@
+-e ./core
+-e ./plugins/postgres
+-e ./plugins/redshift
+-e ./plugins/snowflake
+-e ./plugins/bigquery

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Fishtown Analytics",
     author_email="info@fishtownanalytics.com",
     url="https://github.com/fishtown-analytics/dbt",
-    packages=find_namespace_packages(include=['dbt.*']),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data={
         'dbt': [
             'include/bigquery/dbt_project.yml',
@@ -31,5 +31,6 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'google-cloud-bigquery>=1.0.0,<2',
-    ]
+    ],
+    zip_safe=False,
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Fishtown Analytics",
     author_email="info@fishtownanalytics.com",
     url="https://github.com/fishtown-analytics/dbt",
-    packages=find_namespace_packages(include=['dbt.*']),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data={
         'dbt': [
             'include/postgres/dbt_project.yml',
@@ -31,5 +31,6 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'psycopg2>=2.7.5,<2.8',
-    ]
+    ],
+    zip_safe=False,
 )

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Fishtown Analytics",
     author_email="info@fishtownanalytics.com",
     url="https://github.com/fishtown-analytics/dbt",
-    packages=find_namespace_packages(include=['dbt.*']),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data={
         'dbt': [
             'include/redshift/dbt_project.yml',
@@ -34,5 +34,6 @@ setup(
         'boto3>=1.6.23,<1.10.0',
         'botocore>=1.9.23,<1.13.0',
         'psycopg2>=2.7.5,<2.8',
-    ]
+    ],
+    zip_safe=False,
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Fishtown Analytics",
     author_email="info@fishtownanalytics.com",
     url="https://github.com/fishtown-analytics/dbt",
-    packages=find_namespace_packages(include=['dbt.*']),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data={
         'dbt': [
             'include/snowflake/dbt_project.yml',
@@ -31,5 +31,6 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'snowflake-connector-python>=1.6.12,<2.1',
-    ]
+    ],
+    zip_safe=False,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
--e ./core
--e ./plugins/postgres
--e ./plugins/redshift
--e ./plugins/snowflake
--e ./plugins/bigquery
+./core
+./plugins/postgres
+./plugins/redshift
+./plugins/snowflake
+./plugins/bigquery

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         'dbt-redshift=={}'.format(package_version),
         'dbt-snowflake=={}'.format(package_version),
         'dbt-bigquery=={}'.format(package_version),
-    ]
+    ],
+    zip_safe=False,
 )

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -793,7 +793,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'original_file_path': helpers_path,
                 'package_name': 'dbt',
                 'root_path': normalize(os.path.join(
-                    self.initial_dir, 'core', 'dbt','include', 'global_project'
+                    self.dbt_core_install_root, 'include', 'global_project'
                 )),
                 'name': 'column_list',
                 'unique_id': 'macro.dbt.column_list',

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from unittest.mock import ANY, patch
 
 from test.integration.base import DBTIntegrationTest, use_profile, AnyFloat, \
-    AnyString, AnyStringWith, normalize
+    AnyString, AnyStringWith, normalize, Normalized
 
 
 def _read_file(path):
@@ -784,23 +784,24 @@ class TestDocsGenerate(DBTIntegrationTest):
         # Don't compare the sql, just make sure it exists
         self.assertTrue(len(macro['raw_sql']) > 10)
         without_sql = {k: v for k, v in macro.items() if k != 'raw_sql'}
-        # Windows means we can't hard-code this.
-        helpers_path = normalize('macros/materializations/helpers.sql')
+        # Windows means we can't hard-code these.
+        helpers_path = Normalized('macros/materializations/helpers.sql')
+        root_path = Normalized(os.path.join(
+            self.dbt_core_install_root, 'include', 'global_project'
+        ))
         self.assertEqual(
-            without_sql,
             {
                 'path': helpers_path,
                 'original_file_path': helpers_path,
                 'package_name': 'dbt',
-                'root_path': normalize(os.path.join(
-                    self.dbt_core_install_root, 'include', 'global_project'
-                )),
+                'root_path': root_path,
                 'name': 'column_list',
                 'unique_id': 'macro.dbt.column_list',
                 'tags': [],
                 'resource_type': 'macro',
                 'depends_on': {'macros': []},
-            }
+            },
+            without_sql,
         )
 
     def expected_seeded_manifest(self, model_database=None):
@@ -830,7 +831,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         return {
             'nodes': {
                 'model.test.model': {
-                    'build_path': os.path.normpath('target/compiled/test/model.sql'),
+                    'build_path': Normalized('target/compiled/test/model.sql'),
                     'name': 'model',
                     'root_path': self.test_root_dir,
                     'resource_type': 'model',
@@ -904,7 +905,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
+                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'resource_type': 'seed',
                     'raw_sql': '',
                     'package_name': 'test',
@@ -931,7 +932,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.not_null_model_id': {
                     'alias': 'not_null_model_id',
-                    'build_path': os.path.normpath('target/compiled/test/schema_test/not_null_model_id.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/not_null_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'config': {
@@ -954,7 +955,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
-                    'path': normalize('schema_test/not_null_model_id.sql'),
+                    'path': Normalized('schema_test/not_null_model_id.sql'),
                     'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(model=ref('model'), column_name='id') }}",
                     'refs': [['model']],
                     'resource_type': 'test',
@@ -978,7 +979,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.test_nothing_model_': {
                     'alias': 'test_nothing_model_',
-                    'build_path': os.path.normpath('target/compiled/test/schema_test/test_nothing_model_.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/test_nothing_model_.sql'),
                     'column_name': None,
                     'columns': {},
                     'config': {
@@ -1025,7 +1026,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.unique_model_id': {
                     'alias': 'unique_model_id',
-                    'build_path': os.path.normpath('target/compiled/test/schema_test/unique_model_id.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/unique_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'config': {
@@ -1179,7 +1180,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'nodes': {
                 'model.test.ephemeral_copy': {
                     'alias': 'ephemeral_copy',
-                    'build_path': os.path.normpath('target/compiled/test/ephemeral_copy.sql'),
+                    'build_path': Normalized('target/compiled/test/ephemeral_copy.sql'),
                     'columns': {},
                     'config': {
                         'column_types': {},
@@ -1225,7 +1226,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.ephemeral_summary': {
                     'alias': 'ephemeral_summary',
-                    'build_path': os.path.normpath('target/compiled/test/ephemeral_summary.sql'),
+                    'build_path': Normalized('target/compiled/test/ephemeral_summary.sql'),
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1300,7 +1301,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.view_summary': {
                     'alias': 'view_summary',
-                    'build_path': os.path.normpath('target/compiled/test/view_summary.sql'),
+                    'build_path': Normalized('target/compiled/test/view_summary.sql'),
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1670,7 +1671,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
                     'fqn': ['test', 'clustered'],
-                    'build_path': os.path.normpath('target/compiled/test/clustered.sql'),
+                    'build_path': Normalized('target/compiled/test/clustered.sql'),
                     'name': 'clustered',
                     'original_file_path': clustered_sql_path,
                     'package_name': 'test',
@@ -1722,7 +1723,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.multi_clustered': {
                     'alias': 'multi_clustered',
-                    'build_path': os.path.normpath('target/compiled/test/multi_clustered.sql'),
+                    'build_path': Normalized('target/compiled/test/multi_clustered.sql'),
                     'config': {
                         'cluster_by': ['first_name', 'email'],
                         'column_types': {},
@@ -1790,7 +1791,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.nested_view': {
                     'alias': 'nested_view',
-                    'build_path': os.path.normpath('target/compiled/test/nested_view.sql'),
+                    'build_path': Normalized('target/compiled/test/nested_view.sql'),
                     'config': {
                         'column_types': {},
                         'enabled': True,
@@ -1859,7 +1860,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.nested_table': {
                     'alias': 'nested_table',
-                    'build_path': os.path.normpath('target/compiled/test/nested_table.sql'),
+                    'build_path': Normalized('target/compiled/test/nested_table.sql'),
                     'config': {
                         'column_types': {},
                         'enabled': True,
@@ -2071,7 +2072,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         return {
             'nodes': {
                 'model.test.model': {
-                    'build_path': os.path.normpath('target/compiled/test/model.sql'),
+                    'build_path': Normalized('target/compiled/test/model.sql'),
                     'name': 'model',
                     'root_path': self.test_root_dir,
                     'resource_type': 'model',
@@ -2146,7 +2147,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
+                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'resource_type': 'seed',
                     'raw_sql': '',
                     'package_name': 'test',
@@ -2338,7 +2339,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'model',
-                    'build_path': normalize(
+                    'build_path': Normalized(
                         'target/compiled/test/model.sql'
                     ),
                     'columns': {
@@ -2422,7 +2423,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'refs': [],
                     'resource_type': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
+                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'schema': schema,
                     'database': self.default_database,
                     'tags': [],
@@ -2441,7 +2442,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'not_null_model_id',
-                    'build_path': normalize('target/compiled/test/schema_test/not_null_model_id.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/not_null_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'compiled': True,
@@ -2470,7 +2471,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
-                    'path': normalize('schema_test/not_null_model_id.sql'),
+                    'path': Normalized('schema_test/not_null_model_id.sql'),
                     'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(model=ref('model'), column_name='id') }}",
                     'refs': [['model']],
                     'resource_type': 'test',
@@ -2498,7 +2499,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'test_nothing_model_',
-                    'build_path': normalize('target/compiled/test/schema_test/test_nothing_model_.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/test_nothing_model_.sql'),
                     'column_name': None,
                     'columns': {},
                     'compiled': True,
@@ -2527,7 +2528,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
-                    'path': normalize('schema_test/test_nothing_model_.sql'),
+                    'path': Normalized('schema_test/test_nothing_model_.sql'),
                     'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(model=ref('model'), ) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
@@ -2555,7 +2556,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'unique_model_id',
-                    'build_path': normalize('target/compiled/test/schema_test/unique_model_id.sql'),
+                    'build_path': Normalized('target/compiled/test/schema_test/unique_model_id.sql'),
                     'column_name': 'id',
                     'columns': {},
                     'compiled': True,
@@ -2584,7 +2585,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'original_file_path': schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
-                    'path': normalize('schema_test/unique_model_id.sql'),
+                    'path': Normalized('schema_test/unique_model_id.sql'),
                     'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(model=ref('model'), column_name='id') }}",
                     'refs': [['model']],
                     'resource_type': 'test',
@@ -2639,7 +2640,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'ephemeral_summary',
-                    'build_path': normalize(
+                    'build_path': Normalized(
                         'target/compiled/test/ephemeral_summary.sql'
                     ),
                     'columns': {
@@ -2730,7 +2731,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'warn': None,
                 'node': {
                     'alias': 'view_summary',
-                    'build_path': normalize(
+                    'build_path': Normalized(
                         'target/compiled/test/view_summary.sql'
                     ),
                     'alias': 'view_summary',
@@ -2852,7 +2853,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'refs': [],
                     'resource_type': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
+                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'tags': [],

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -304,6 +304,7 @@ class DBTIntegrationTest(unittest.TestCase):
         os.symlink(self._logs_dir, os.path.join(self.test_root_dir, 'logs'))
 
     def setUp(self):
+        self.dbt_core_install_root = os.path.dirname(dbt.__file__)
         log_manager.reset_handlers()
         self.initial_dir = INITIAL_ROOT
         os.chdir(self.initial_dir)

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -39,6 +39,20 @@ def normalize(path):
     return os.path.normcase(os.path.normpath(path))
 
 
+class Normalized:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return f'Normalized({self.value!r})'
+
+    def __str__(self):
+        return f'Normalized({self.value!s})'
+
+    def __eq__(self, other):
+        return normalize(self.value) == normalize(other)
+
+
 class FakeArgs:
     def __init__(self):
         self.threads = 1

--- a/tox.ini
+++ b/tox.ini
@@ -7,21 +7,21 @@ envlist = unit-py36, integration-postgres-py36, integration-redshift-py36, integ
 basepython = python3.6
 commands = /bin/bash -c '$(which flake8) --select=E,W,F --ignore=W504 core/dbt plugins/*/dbt'
 deps =
-     -r{toxinidir}/dev_requirements.txt
+     -r ./dev_requirements.txt
 
 [testenv:mypy]
 basepython = python3.6
 commands = /bin/bash -c '$(which mypy) core/dbt'
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
 
 [testenv:unit-py36]
 basepython = python3.6
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/unit'
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
 
 
 [testenv:integration-postgres-py36]
@@ -31,9 +31,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    -r ./dev_requirements.txt
 
 [testenv:integration-snowflake-py36]
 basepython = python3.6
@@ -42,9 +42,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/snowflake
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/snowflake
+    -r ./dev_requirements.txt
 
 [testenv:integration-bigquery-py36]
 basepython = python3.6
@@ -53,9 +53,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_bigquery {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/bigquery
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/bigquery
+    -r ./dev_requirements.txt
 
 [testenv:integration-redshift-py36]
 basepython = python3.6
@@ -64,10 +64,10 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_redshift {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -e {toxinidir}/plugins/redshift
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    ./plugins/redshift
+    -r ./dev_requirements.txt
 
 [testenv:integration-presto-py36]
 basepython = python3.6
@@ -76,9 +76,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_presto {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/presto
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/presto
+    -r ./dev_requirements.txt
 
 [testenv:explicit-py36]
 basepython = python3.6
@@ -87,15 +87,15 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs}'
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./editable_requirements.txt
+    -r ./dev_requirements.txt
 
 [testenv:unit-py37]
 basepython = python3.7
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/unit'
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
 
 [testenv:integration-postgres-py37]
 basepython = python3.7
@@ -104,9 +104,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    -r ./dev_requirements.txt
 
 [testenv:integration-snowflake-py37]
 basepython = python3.7
@@ -115,9 +115,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/snowflake
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/snowflake
+    -r ./dev_requirements.txt
 
 [testenv:integration-bigquery-py37]
 basepython = python3.7
@@ -126,9 +126,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_bigquery {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/bigquery
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/bigquery
+    -r ./dev_requirements.txt
 
 [testenv:integration-redshift-py37]
 basepython = python3.7
@@ -137,10 +137,10 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_redshift {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -e {toxinidir}/plugins/redshift
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    ./plugins/redshift
+    -r ./dev_requirements.txt
 
 [testenv:integration-presto-py37]
 basepython = python3.7
@@ -149,9 +149,9 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_presto {posargs} -n4 test/integration/*'
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/presto
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/presto
+    -r ./dev_requirements.txt
 
 
 [testenv:explicit-py37]
@@ -161,8 +161,8 @@ setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs}'
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./editable_requirements.txt
+    -r ./dev_requirements.txt
 
 [testenv:pywin]
 basepython = {env:PYTHON:}\python.exe
@@ -172,8 +172,8 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = pytest --durations 0 -v -m 'profile_postgres or profile_snowflake or profile_bigquery or profile_redshift' -n4 test/integration test/unit
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
 
 [testenv:pywin-unit]
 basepython = python.exe
@@ -183,8 +183,8 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = python -m pytest --durations 0 -v {posargs} -n4 test/unit
 deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev_requirements.txt
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
 
 
 [testenv:pywin-postgres]
@@ -195,9 +195,9 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = python -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    -r ./dev_requirements.txt
 
 
 [testenv:pywin-snowflake]
@@ -208,9 +208,9 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = python -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/snowflake
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/snowflake
+    -r ./dev_requirements.txt
 
 
 [testenv:pywin-bigquery]
@@ -221,9 +221,9 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = python -m pytest --durations 0 -v -m profile_bigquery {posargs} -n4 test/integration
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/bigquery
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/bigquery
+    -r ./dev_requirements.txt
 
 
 [testenv:pywin-redshift]
@@ -234,7 +234,7 @@ setenv =
     DBT_INVOCATION_ENV = ci-appveyor
 commands = python -m pytest --durations 0 -v -m profile_redshift {posargs} -n4 test/integration
 deps =
-    -e {toxinidir}/core
-    -e {toxinidir}/plugins/postgres
-    -e {toxinidir}/plugins/redshift
-    -r{toxinidir}/dev_requirements.txt
+    ./core
+    ./plugins/postgres
+    ./plugins/redshift
+    -r ./dev_requirements.txt


### PR DESCRIPTION
- Add both 'dbt' and 'dbt.*' to the namespace package search path
- set zip_safe=False, because I think zipping breaks macros
- Make CI tests use non-editable installs
- make tox use editable mode for explicit-* so development is still possible without rebuilding tox
- remove {toxinidir} stuff that breaks core installation
  - as of tox 1.6.1, requirements executes within toxinidir.
- fix paths to account for installing things

When I fixed this on Friday in #1841, I actually broke everything in the base dbt namespace that wasn't a package. Installing in editable mode masks the issue so our tests passed.

Now tests should fail if the package doesn't install during editable mode. For local testing convenience, the `explicit-py*` tox envs both use editable mode and CI uses non-editable mode.

There might be some remaining issues with tests/paths to sort out, but the actual code should be doing the right thing now.