### PR TITLE
Use setuptools instead of distutils.core

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.0b1
+current_version = 0.15.0b2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -56,5 +56,5 @@ def get_version_information():
                 .format(version_msg))
 
 
-__version__ = '0.15.0b1'
+__version__ = '0.15.0b2'
 installed = get_installed_version()

--- a/core/scripts/create_adapter_plugins.py
+++ b/core/scripts/create_adapter_plugins.py
@@ -21,7 +21,7 @@ __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 SETUP_PY_TEMPLATE = '''
 #!/usr/bin/env python
 from setuptools import find_packages
-from distutils.core import setup
+from setuptools import setup
 
 package_name = "dbt-{adapter}"
 package_version = "{version}"

--- a/core/setup.py
+++ b/core/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 
 package_name = "dbt-core"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """dbt (data build tool) is a command line tool that helps \
 analysts and engineers transform data in their warehouse more effectively"""
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_namespace_packages
-from distutils.core import setup
+from setuptools import setup
 import os
 
 

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 import os
 
 package_name = "dbt-bigquery"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """The bigquery adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_namespace_packages
-from distutils.core import setup
+from setuptools import setup
 import os
 
 package_name = "dbt-bigquery"

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_namespace_packages
-from distutils.core import setup
+from setuptools import setup
 import os
 
 package_name = "dbt-postgres"

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 import os
 
 package_name = "dbt-postgres"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """The postgres adpter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 import os
 
 package_name = "dbt-redshift"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """The redshift adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_namespace_packages
-from distutils.core import setup
+from setuptools import setup
 import os
 
 package_name = "dbt-redshift"

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 import os
 
 package_name = "dbt-snowflake"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """The snowflake adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import find_namespace_packages
-from distutils.core import setup
+from setuptools import setup
 import os
 
 package_name = "dbt-snowflake"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt"
-package_version = "0.15.0b1"
+package_version = "0.15.0b2"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 import os
 
 


### PR DESCRIPTION
When trying to build sdists, I got an error from twine about converting the README.md to reStructuredText. The Python Packaging Guide (https://packaging.python.org/guides/tool-recommendations/) recommends using setuptools in place of distutils.core because distutils.core.setup doesn't support all of the metadata fields, where setuptools.setup does. Switching from distutils.core to setuptools fixes the RST error.