### PR TITLE
fix the `metadata` behavior for dbt-utils (#1857)

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -43,7 +43,6 @@ class FakeAPIObject(JsonSchemaMixin, Replaceable, Mapping):
         return True
 
     def __getitem__(self, key):
-        # deprecations.warn('not-a-dictionary', obj=self)
         try:
             return getattr(self, key)
         except AttributeError:
@@ -155,6 +154,16 @@ class BaseRelation(FakeAPIObject, Hashable):
     @classmethod
     def get_relation_type_class(cls: Type[Self]) -> Type[RelationType]:
         return cls._get_field_named('type')
+
+    def get(self, key, default=None):
+        """Override `.get` to return a metadata object so we don't break
+        dbt_utils.
+        """
+        if key == 'metadata':
+            return {
+                'type': self.__class__.__name__
+            }
+        return super().get(key, default)
 
     def matches(
         self,

--- a/test/integration/001_simple_copy_test/models/materialized.sql
+++ b/test/integration/001_simple_copy_test/models/materialized.sql
@@ -3,6 +3,10 @@
     materialized = "table"
   )
 }}
-
+-- ensure that dbt_utils' relation check will work
+{% set relation = ref('seed') %}
+{%- if not (relation is mapping and relation.get('metadata', {}).get('type', '').endswith('Relation')) -%}
+    {%- do exceptions.raise_compiler_error("Macro " ~ macro ~ " expected a Relation but received the value: " ~ relation) -%}
+{%- endif -%}
 -- this is a unicode character: å
-select * from {{ ref('seed') }}
+select * from {{ relation }}


### PR DESCRIPTION
Fixes #1857

In 0.15.x, I removed the `metadata` field. It turns out `dbt_utils` uses it, so expose it through the `get` method.

I modified an existing test to expose this bug if it regresses.