### PR TITLE
Feature: poll timing information, status -> state

### DIFF
--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -28,7 +28,7 @@ from dbt.rpc.error import (
     RPCException,
     timeout_error,
 )
-from dbt.rpc.gc import Collectible
+from dbt.rpc.task_handler_protocol import TaskHandlerProtocol
 from dbt.rpc.logger import (
     QueueSubscriber,
     QueueLogHandler,
@@ -253,7 +253,7 @@ class SetArgsStateHandler(StateHandler):
         pass
 
 
-class RequestTaskHandler(threading.Thread, Collectible):
+class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
     """Handler for the single task triggered by a given jsonrpc request."""
     def __init__(
         self,

--- a/core/dbt/rpc/task_handler_protocol.py
+++ b/core/dbt/rpc/task_handler_protocol.py
@@ -1,0 +1,97 @@
+import multiprocessing
+from datetime import datetime
+from typing import Optional, Union, MutableMapping
+from typing_extensions import Protocol
+
+import dbt.exceptions
+import dbt.flags
+from dbt.contracts.rpc import (
+    TaskHandlerState,
+    TaskID,
+    TaskTags,
+    TaskTiming,
+    TaskRow,
+)
+
+
+class TaskHandlerProtocol(Protocol):
+    started: Optional[datetime]
+    ended: Optional[datetime]
+    state: TaskHandlerState
+    task_id: TaskID
+    process: Optional[multiprocessing.Process]
+
+    @property
+    def request_id(self) -> Union[str, int]:
+        pass
+
+    @property
+    def request_source(self) -> str:
+        pass
+
+    @property
+    def timeout(self) -> Optional[float]:
+        pass
+
+    @property
+    def method(self) -> str:
+        pass
+
+    @property
+    def tags(self) -> Optional[TaskTags]:
+        pass
+
+    def _assert_started(self) -> datetime:
+        if self.started is None:
+            raise dbt.exceptions.InternalException(
+                'task handler started but start time is not set'
+            )
+        return self.started
+
+    def _assert_ended(self) -> datetime:
+        if self.ended is None:
+            raise dbt.exceptions.InternalException(
+                'task handler finished but end time is not set'
+            )
+        return self.ended
+
+    def make_task_timing(
+        self, now_time: datetime
+    ) -> TaskTiming:
+        # get information about the task in a way that should not provide any
+        # conflicting information. Calculate elapsed time based on `now_time`
+        state = self.state
+        # store end/start so 'ps' output always makes sense:
+        # not started -> no start time/elapsed, running -> no end time, etc
+        end = None
+        start = None
+        elapsed = None
+        if state > TaskHandlerState.NotStarted:
+            start = self._assert_started()
+            elapsed_end = now_time
+
+            if state.finished:
+                elapsed_end = self._assert_ended()
+                end = elapsed_end
+
+            elapsed = (elapsed_end - start).total_seconds()
+        return TaskTiming(state=state, start=start, end=end, elapsed=elapsed)
+
+    def make_task_row(self, now_time: datetime) -> TaskRow:
+        timing = self.make_task_timing(now_time)
+
+        return TaskRow(
+            task_id=self.task_id,
+            request_id=self.request_id,
+            request_source=self.request_source,
+            method=self.method,
+            state=timing.state,
+            start=timing.start,
+            end=timing.end,
+            elapsed=timing.elapsed,
+            timeout=self.timeout,
+            tags=self.tags,
+        )
+
+
+TaskHandlerMap = MutableMapping[TaskID, TaskHandlerProtocol]

--- a/test/rpc/fixtures.py
+++ b/test/rpc/fixtures.py
@@ -63,7 +63,7 @@ class ServerProcess(dbt.flags.MP_CONTEXT.Process):
         return True
 
     def _compare_result(self, result):
-        return result['result']['status'] in self.criteria
+        return result['result']['state'] in self.criteria
 
     def status_ok(self):
         result = self.query(
@@ -308,7 +308,7 @@ class Querier:
         assert 'error' in data
         return data['error']
 
-    def async_wait(self, token: str, timeout: int = 60, status='success') -> Dict[str, Any]:
+    def async_wait(self, token: str, timeout: int = 60, state='success') -> Dict[str, Any]:
         start = time.time()
         while True:
             time.sleep(0.5)
@@ -316,12 +316,12 @@ class Querier:
             if 'error' in response:
                 return response
             result = self.is_result(response)
-            assert 'status' in result
-            if result['status'] == status:
+            assert 'state' in result
+            if result['state'] == state:
                 return response
             delta = (time.time() - start)
             assert timeout > delta, \
-                f'At time {delta}, never saw {status}.\nLast response: {result}'
+                f'At time {delta}, never saw {state}.\nLast response: {result}'
 
 
 def _first_server(cwd, cli_vars, profiles_dir, criteria):


### PR DESCRIPTION
Make `poll` and `ps` provide the same timing information.

Also rename other method `status` fields to `state`. for consistency, and fix all the tests 
accordingly

I had to rearrange things quite a bit to get this to merge ok with louisa-may-alcott post-review, but it's really all type changes.