### PR TITLE
inject query comments (#1643)

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -11,7 +11,7 @@ import agate
 import dbt.exceptions
 import dbt.flags
 from dbt.contracts.connection import (
-    Connection, Identifier, ConnectionState, HasCredentials
+    Connection, Identifier, ConnectionState, AdapterRequiredConfig
 )
 from dbt.adapters.base.query_headers import QueryStringSetter
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -32,7 +32,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     """
     TYPE: str = NotImplemented
 
-    def __init__(self, profile: HasCredentials):
+    def __init__(self, profile: AdapterRequiredConfig):
         self.profile = profile
         self.thread_connections: Dict[Hashable, Connection] = {}
         self.lock: RLock = dbt.flags.MP_CONTEXT.RLock()

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -1,6 +1,6 @@
 import abc
-from multiprocessing import RLock
 import os
+from multiprocessing import RLock
 from threading import get_ident
 from typing import (
     Dict, Tuple, Hashable, Optional, ContextManager, List
@@ -13,6 +13,7 @@ import dbt.flags
 from dbt.contracts.connection import (
     Connection, Identifier, ConnectionState, HasCredentials
 )
+from dbt.adapters.base.query_headers import QueryStringSetter
 from dbt.logger import GLOBAL_LOGGER as logger
 
 
@@ -35,6 +36,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         self.profile = profile
         self.thread_connections: Dict[Hashable, Connection] = {}
         self.lock: RLock = dbt.flags.MP_CONTEXT.RLock()
+        self.query_header = QueryStringSetter(profile)
 
     @staticmethod
     def get_thread_identifier() -> Hashable:
@@ -91,6 +93,10 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             # named 'master'
             conn_name = 'master'
         else:
+            if not isinstance(name, str):
+                raise dbt.exceptions.CompilerException(
+                    f'For connection name, got {name} - not a string!'
+                )
             assert isinstance(name, str)
             conn_name = name
 
@@ -221,7 +227,10 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     def _rollback(cls, connection: Connection) -> None:
         """Roll back the given connection."""
         if dbt.flags.STRICT_MODE:
-            assert isinstance(connection, Connection)
+            if not isinstance(connection, Connection):
+                raise dbt.exceptions.CompilerException(
+                    f'In _rollback, got {connection} - not a Connection!'
+                )
 
         if connection.transaction_open is False:
             raise dbt.exceptions.InternalException(
@@ -236,7 +245,10 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
     @classmethod
     def close(cls, connection: Connection) -> Connection:
         if dbt.flags.STRICT_MODE:
-            assert isinstance(connection, Connection)
+            if not isinstance(connection, Connection):
+                raise dbt.exceptions.CompilerException(
+                    f'In close, got {connection} - not a Connection!'
+                )
 
         # if the connection is in closed or init, there's nothing to do
         if connection.state in {ConnectionState.CLOSED, ConnectionState.INIT}:
@@ -256,6 +268,9 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         connection = self.get_if_exists()
         if connection:
             self.commit()
+
+    def _add_query_comment(self, sql: str) -> str:
+        return self.query_header.add(sql)
 
     @abc.abstractmethod
     def execute(

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -9,9 +9,10 @@ from dbt.contracts.connection import AdapterRequiredConfig
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import RuntimeException
+from dbt.helper_types import NoValue
 
 
-default_query_comment = '''
+DEFAULT_QUERY_COMMENT = '''
 {%- set comment_dict = {} -%}
 {%- do comment_dict.update(
     app='dbt',
@@ -46,12 +47,15 @@ class _QueryComment(local):
         - a source_name indicating what set the current thread's query comment
     """
     def __init__(self, initial):
-        self.query_comment: str = initial
+        self.query_comment: Optional[str] = initial
 
     def add(self, sql: str) -> str:
-        return '/* {} */\n{}'.format(self.query_comment.strip(), sql)
+        if not self.query_comment:
+            return sql
+        else:
+            return '/* {} */\n{}'.format(self.query_comment.strip(), sql)
 
-    def set(self, comment: str):
+    def set(self, comment: Optional[str]):
         if '*/' in comment:
             # tell the user "no" so they don't hurt themselves by writing
             # garbage
@@ -68,23 +72,31 @@ class QueryStringSetter:
     """The base query string setter. This is only used once."""
     def __init__(self, config: AdapterRequiredConfig):
         self.config = config
-        macro = '\n'.join((
-            '{%- macro query_comment_macro(connection_name, node) -%}',
-            self._get_comment_macro(),
-            '{% endmacro %}'
-        ))
 
-        ctx = self._get_context()
-
-        self.generator: QueryStringFunc = QueryStringGenerator(macro, ctx)
-        self.comment = _QueryComment('')
+        comment_macro = self._get_comment_macro()
+        self.generator: QueryStringFunc = lambda name, model: ''
+        # if the comment value was None or the empty string, just skip it
+        if comment_macro:
+            macro = '\n'.join((
+                '{%- macro query_comment_macro(connection_name, node) -%}',
+                self._get_comment_macro(),
+                '{% endmacro %}'
+            ))
+            ctx = self._get_context()
+            self.generator: QueryStringFunc = QueryStringGenerator(macro, ctx)
+        self.comment = _QueryComment(None)
         self.reset()
 
     def _get_context(self):
         return QueryHeaderContext(self.config).to_dict()
 
-    def _get_comment_macro(self):
-        return default_query_comment
+    def _get_comment_macro(self) -> Optional[str]:
+        # if the query comment is null/empty string, there is no comment at all
+        if not self.config.query_comment:
+            return None
+        else:
+            # else, the default
+            return DEFAULT_QUERY_COMMENT
 
     def add(self, sql: str) -> str:
         return self.comment.add(sql)
@@ -107,7 +119,10 @@ class MacroQueryStringSetter(QueryStringSetter):
         super().__init__(config)
 
     def _get_comment_macro(self):
-        if self.config.query_comment is not None:
+        if (
+            self.config.query_comment != NoValue() and
+            self.config.query_comment
+        ):
             return self.config.query_comment
         else:
             return super()._get_comment_macro()

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -1,0 +1,101 @@
+from threading import local
+from typing import Optional, Callable
+
+from dbt.clients.jinja import QueryStringGenerator
+
+from dbt.contracts.connection import HasCredentials
+# this generates an import cycle, as usual
+from dbt.context.base import QueryHeaderContext
+from dbt.contracts.graph.compiled import CompileResultNode
+
+
+default_query_comment = '''
+{%- set comment_dict = {} -%}
+{%- do comment_dict.update(target) -%}
+{%- do comment_dict.update(
+    app='dbt',
+    dbt_version=dbt_version,
+) -%}
+{%- if node is not none -%}
+  {%- do comment_dict.update(
+    file=node.original_file_path,
+    node_id=node.unique_id,
+    node_name=node.name,
+    resource_type=node.resource_type,
+    package_name=node.package_name,
+    tags=node.tags,
+    identifier=node.identifier,
+    schema=node.schema,
+    database=node.database,
+  ) -%}
+{% else %}
+  {# in the node context, the connection name is the node_id #}
+  {%- do comment_dict.update(connection_name=connection_name) -%}
+{%- endif -%}
+{{ return(tojson(comment_dict)) }}
+'''
+
+
+class NodeWrapper:
+    def __init__(self, node):
+        self._inner_node = node
+
+    def __getattr__(self, name):
+        return getattr(self._inner_node, name, '')
+
+
+class _QueryComment(local):
+    """A thread-local class storing thread-specific state information for
+    connection management, namely:
+        - the current thread's query comment.
+        - a source_name indicating what set the current thread's query comment
+    """
+    def __init__(self, initial):
+        self.query_comment: str = initial
+
+    def add(self, sql: str) -> str:
+        # Make sure there are no trailing newlines.
+        # For every newline, add a comment after it in case query_comment
+        # is multiple lines.
+        # Then add a comment to the first line of the query comment, and
+        # put the sql on a fresh line.
+        comment_split = self.query_comment.strip().replace('\n', '\n-- ')
+        return '-- {}\n{}'.format(comment_split, sql)
+
+    def set(self, comment: str):
+        self.query_comment = comment
+
+
+QueryStringFunc = Callable[[str, Optional[CompileResultNode]], str]
+
+
+class QueryStringSetter:
+    def __init__(self, config: HasCredentials):
+        if config.config.query_comment is not None:
+            comment = config.config.query_comment
+        else:
+            comment = default_query_comment
+        macro = '\n'.join((
+            '{%- macro query_comment_macro(connection_name, node) -%}',
+            comment,
+            '{% endmacro %}'
+        ))
+
+        ctx = QueryHeaderContext(config).to_dict()
+        self.generator: QueryStringFunc = QueryStringGenerator(macro, ctx)
+        self.comment = _QueryComment('')
+        self.reset()
+
+    def add(self, sql: str) -> str:
+        return self.comment.add(sql)
+
+    def reset(self):
+        self.set('master', None)
+
+    def set(self, name: str, node: Optional[CompileResultNode]):
+        if node is not None:
+            wrapped = NodeWrapper(node)
+        else:
+            wrapped = None
+        comment_str = self.generator(name, wrapped)
+        self.comment.set(comment_str)

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -11,22 +11,15 @@ from dbt.contracts.graph.compiled import CompileResultNode
 
 default_query_comment = '''
 {%- set comment_dict = {} -%}
-{%- do comment_dict.update(target) -%}
 {%- do comment_dict.update(
     app='dbt',
     dbt_version=dbt_version,
+    profile_name=target.get('profile_name'),
+    target_name=target.get('target_name'),
 ) -%}
 {%- if node is not none -%}
   {%- do comment_dict.update(
-    file=node.original_file_path,
     node_id=node.unique_id,
-    node_name=node.name,
-    resource_type=node.resource_type,
-    package_name=node.package_name,
-    tags=node.tags,
-    identifier=node.identifier,
-    schema=node.schema,
-    database=node.database,
   ) -%}
 {% else %}
   {# in the node context, the connection name is the node_id #}

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -47,13 +47,7 @@ class _QueryComment(local):
         self.query_comment: str = initial
 
     def add(self, sql: str) -> str:
-        # Make sure there are no trailing newlines.
-        # For every newline, add a comment after it in case query_comment
-        # is multiple lines.
-        # Then add a comment to the first line of the query comment, and
-        # put the sql on a fresh line.
-        comment_split = self.query_comment.strip().replace('\n', '\n-- ')
-        return '-- {}\n{}'.format(comment_split, sql)
+        return '/* {} */\n{}'.format(self.query_comment.strip(), sql)
 
     def set(self, comment: str):
         self.query_comment = comment

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -3,9 +3,9 @@ from typing import Optional, Callable
 
 from dbt.clients.jinja import QueryStringGenerator
 
-from dbt.contracts.connection import HasCredentials
 # this generates an import cycle, as usual
 from dbt.context.base import QueryHeaderContext
+from dbt.contracts.connection import AdapterRequiredConfig
 from dbt.contracts.graph.compiled import CompileResultNode
 
 
@@ -70,9 +70,9 @@ QueryStringFunc = Callable[[str, Optional[CompileResultNode]], str]
 
 
 class QueryStringSetter:
-    def __init__(self, config: HasCredentials):
-        if config.config.query_comment is not None:
-            comment = config.config.query_comment
+    def __init__(self, config: AdapterRequiredConfig):
+        if config.query_comment is not None:
+            comment = config.query_comment
         else:
             comment = default_query_comment
         macro = '\n'.join((

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -16,6 +16,7 @@ from hologram.helpers import StrEnum
 from dbt.contracts.util import Replaceable
 from dbt.contracts.graph.compiled import CompiledNode
 from dbt.contracts.graph.parsed import ParsedSourceDefinition, ParsedNode
+from dbt.exceptions import InternalException
 from dbt import deprecations
 
 
@@ -322,10 +323,18 @@ class BaseRelation(FakeAPIObject, Hashable):
         **kwargs: Any,
     ) -> Self:
         if node.resource_type == NodeType.Source:
-            assert isinstance(node, ParsedSourceDefinition)
+            if not isinstance(node, ParsedSourceDefinition):
+                raise InternalException(
+                    'type mismatch, expected ParsedSourceDefinition but got {}'
+                    .format(type(node))
+                )
             return cls.create_from_source(node, **kwargs)
         else:
-            assert isinstance(node, (ParsedNode, CompiledNode))
+            if not isinstance(node, (ParsedNode, CompiledNode)):
+                raise InternalException(
+                    'type mismatch, expected ParsedNode or CompiledNode but '
+                    'got {}'.format(type(node))
+                )
             return cls.create_from_node(config, node, **kwargs)
 
     @classmethod

--- a/core/dbt/adapters/factory.py
+++ b/core/dbt/adapters/factory.py
@@ -5,10 +5,11 @@ from typing import Type, Dict, Any
 from dbt.exceptions import RuntimeException
 from dbt.include.global_project import PACKAGES
 from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.contracts.connection import Credentials, HasCredentials
+from dbt.contracts.connection import Credentials, AdapterRequiredConfig
 
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.base.plugin import AdapterPlugin
+
 
 # TODO: we can't import these because they cause an import cycle.
 # Profile has to call into load_plugin to get credentials, so adapter/relation
@@ -74,7 +75,7 @@ class AdpaterContainer:
 
         return plugin.credentials
 
-    def register_adapter(self, config: HasCredentials) -> None:
+    def register_adapter(self, config: AdapterRequiredConfig) -> None:
         adapter_name = config.credentials.type
         adapter_type = self.get_adapter_class_by_name(adapter_name)
 
@@ -109,11 +110,11 @@ class AdpaterContainer:
 FACTORY: AdpaterContainer = AdpaterContainer()
 
 
-def register_adapter(config: HasCredentials) -> None:
+def register_adapter(config: AdapterRequiredConfig) -> None:
     FACTORY.register_adapter(config)
 
 
-def get_adapter(config: HasCredentials):
+def get_adapter(config: AdapterRequiredConfig):
     return FACTORY.lookup_adapter(config.credentials.type)
 
 

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -76,8 +76,10 @@ def recursively_prepend_ctes(model, manifest):
         return (model, model.extra_ctes, manifest)
 
     if dbt.flags.STRICT_MODE:
-        assert isinstance(model, tuple(COMPILED_TYPES.values())), \
-            'Bad model type: {}'.format(type(model))
+        if not isinstance(model, tuple(COMPILED_TYPES.values())):
+            raise dbt.exceptions.InternalException(
+                'Bad model type: {}'.format(type(model))
+            )
 
     prepended_ctes = []
 

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -255,7 +255,10 @@ class Profile:
             target could not be found
         :returns Profile: The new Profile object.
         """
-        # user_cfg is not rendered since it only contains booleans.
+        # user_cfg is not rendered.
+        if user_cfg is None:
+            user_cfg = raw_profile.get('config')
+
         # TODO: should it be, and the values coerced to bool?
         target_name, profile_data = cls.render_profile(
             raw_profile, profile_name, target_override, cli_vars

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -11,6 +11,7 @@ from dbt.exceptions import RecursionException
 from dbt.exceptions import SemverException
 from dbt.exceptions import validator_error_message
 from dbt.exceptions import warn_or_error
+from dbt.helper_types import NoValue
 from dbt.semver import VersionSpecifier
 from dbt.semver import versions_compatible
 from dbt.version import get_installed_version
@@ -258,7 +259,7 @@ class Project:
         seeds = project_dict.get('seeds', {})
         snapshots = project_dict.get('snapshots', {})
         dbt_raw_version = project_dict.get('require-dbt-version', '>=0.0.0')
-        query_comment = project_dict.get('query-comment')
+        query_comment = project_dict.get('query-comment', NoValue())
 
         try:
             dbt_version = _parse_versions(dbt_raw_version)
@@ -343,10 +344,12 @@ class Project:
             'require-dbt-version': [
                 v.to_version_string() for v in self.dbt_version
             ],
-            'query-comment': self.query_comment,
         })
         if with_packages:
             result.update(self.packages.to_dict())
+        if self.query_comment != NoValue():
+            result['query-comment'] = self.query_comment
+
         return result
 
     def validate(self):

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -149,7 +149,7 @@ class Project:
                  analysis_paths, docs_paths, target_path, snapshot_paths,
                  clean_targets, log_path, modules_path, quoting, models,
                  on_run_start, on_run_end, seeds, snapshots, dbt_version,
-                 packages):
+                 packages, query_comment):
         self.project_name = project_name
         self.version = version
         self.project_root = project_root
@@ -173,6 +173,7 @@ class Project:
         self.snapshots = snapshots
         self.dbt_version = dbt_version
         self.packages = packages
+        self.query_comment = query_comment
 
     @staticmethod
     def _preprocess(project_dict):
@@ -257,6 +258,7 @@ class Project:
         seeds = project_dict.get('seeds', {})
         snapshots = project_dict.get('snapshots', {})
         dbt_raw_version = project_dict.get('require-dbt-version', '>=0.0.0')
+        query_comment = project_dict.get('query-comment')
 
         try:
             dbt_version = _parse_versions(dbt_raw_version)
@@ -291,7 +293,8 @@ class Project:
             seeds=seeds,
             snapshots=snapshots,
             dbt_version=dbt_version,
-            packages=packages
+            packages=packages,
+            query_comment=query_comment,
         )
         # sanity check - this means an internal issue
         project.validate()
@@ -340,6 +343,7 @@ class Project:
             'require-dbt-version': [
                 v.to_version_string() for v in self.dbt_version
             ],
+            'query-comment': self.query_comment,
         })
         if with_packages:
             result.update(self.packages.to_dict())

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -14,13 +14,13 @@ class ConfigRenderer:
         self.context = ConfigRenderContext(cli_vars).to_dict()
 
     @staticmethod
-    def _is_hook_or_model_vars_path(keypath):
+    def _is_deferred_render(keypath):
         if not keypath:
             return False
 
         first = keypath[0]
         # run hooks
-        if first in {'on-run-start', 'on-run-end'}:
+        if first in {'on-run-start', 'on-run-end', 'query-comment'}:
             return True
         # models have two things to avoid
         if first in {'seeds', 'models', 'snapshots'}:
@@ -45,9 +45,10 @@ class ConfigRenderer:
         :param key str: The key to convert on.
         :return Any: The rendered entry.
         """
-        # hooks should be treated as raw sql, they'll get rendered later.
-        # Same goes for 'vars' declarations inside 'models'/'seeds'.
-        if self._is_hook_or_model_vars_path(keypath):
+        # query comments and hooks should be treated as raw sql, they'll get
+        # rendered later.
+        # Same goes for 'vars' declarations inside 'models'/'seeds'
+        if self._is_deferred_render(keypath):
             return value
 
         return self.render_value(value)

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -1,5 +1,5 @@
 from dbt.clients.jinja import get_rendered
-from dbt.context.base import generate_config_context
+from dbt.context.base import ConfigRenderContext
 from dbt.exceptions import DbtProfileError
 from dbt.exceptions import DbtProjectError
 from dbt.exceptions import RecursionException
@@ -11,7 +11,7 @@ class ConfigRenderer:
     variables and a render type.
     """
     def __init__(self, cli_vars):
-        self.context = generate_config_context(cli_vars)
+        self.context = ConfigRenderContext(cli_vars).to_dict()
 
     @staticmethod
     def _is_hook_or_model_vars_path(keypath):

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -21,7 +21,8 @@ class RuntimeConfig(Project, Profile):
                  docs_paths, target_path, snapshot_paths, clean_targets,
                  log_path, modules_path, quoting, models, on_run_start,
                  on_run_end, seeds, snapshots, dbt_version, profile_name,
-                 target_name, config, threads, credentials, packages, args):
+                 target_name, config, threads, credentials, packages,
+                 query_comment, args):
         # 'vars'
         self.args = args
         self.cli_vars = parse_cli_vars(getattr(args, 'vars', '{}'))
@@ -50,7 +51,8 @@ class RuntimeConfig(Project, Profile):
             seeds=seeds,
             snapshots=snapshots,
             dbt_version=dbt_version,
-            packages=packages
+            packages=packages,
+            query_comment=query_comment,
         )
         # 'profile'
         Profile.__init__(
@@ -101,6 +103,7 @@ class RuntimeConfig(Project, Profile):
             snapshots=project.snapshots,
             dbt_version=project.dbt_version,
             packages=project.packages,
+            query_comment=project.query_comment,
             profile_name=profile.profile_name,
             target_name=profile.target_name,
             config=profile.config,

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -1,30 +1,18 @@
 import json
 import os
+from typing import Dict, Any
 
 import dbt.tracking
 from dbt.clients.jinja import undefined_error
-from dbt.utils import merge
+from dbt.exceptions import MacroReturn, raise_compiler_error
+from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.version import __version__ as dbt_version
 
 
 # These modules are added to the context. Consider alternative
 # approaches which will extend well to potentially many modules
 import pytz
 import datetime
-
-
-def add_tracking(context):
-    if dbt.tracking.active_user is not None:
-        context = merge(context, {
-            "run_started_at": dbt.tracking.active_user.run_started_at,
-            "invocation_id": dbt.tracking.active_user.invocation_id,
-        })
-    else:
-        context = merge(context, {
-            "run_started_at": None,
-            "invocation_id": None
-        })
-
-    return context
 
 
 def env_var(var, default=None):
@@ -75,7 +63,7 @@ class Var:
         msg = self.UndefinedVarError.format(
             var_name, self.model_name, pretty_vars
         )
-        dbt.exceptions.raise_compiler_error(msg, self.model)
+        raise_compiler_error(msg, self.model)
 
     def assert_var_defined(self, var_name, default):
         if var_name not in self.local_vars and default is self._VAR_NOTSET:
@@ -127,12 +115,109 @@ def get_context_modules():
     }
 
 
-def generate_config_context(cli_vars):
-    context = {
-        'env_var': env_var,
-        'modules': get_context_modules(),
-    }
-    context['var'] = Var(None, context, cli_vars)
-    if os.environ.get('DBT_MACRO_DEBUGGING'):
-        context['debug'] = debug_here
-    return add_tracking(context)
+def _return(value):
+    raise MacroReturn(value)
+
+
+def fromjson(string, default=None):
+    try:
+        return json.loads(string)
+    except ValueError:
+        return default
+
+
+def tojson(value, default=None):
+    try:
+        return json.dumps(value)
+    except ValueError:
+        return default
+
+
+def log(msg, info=False):
+    if info:
+        logger.info(msg)
+    else:
+        logger.debug(msg)
+    return ''
+
+
+class BaseContext:
+    def get_context_modules(self):
+        return {
+            'pytz': get_pytz_module_context(),
+            'datetime': get_datetime_module_context(),
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        run_started_at = None
+        invocation_id = None
+
+        if dbt.tracking.active_user is not None:
+            run_started_at = dbt.tracking.active_user.run_started_at
+            invocation_id = dbt.tracking.active_user.invocation_id
+
+        context: Dict[str, Any] = {
+            'env_var': env_var,
+            'modules': self.get_context_modules(),
+            'run_started_at': run_started_at,
+            'invocation_id': invocation_id,
+            'return': _return,
+            'fromjson': fromjson,
+            'tojson': tojson,
+            'log': log,
+        }
+        if os.environ.get('DBT_MACRO_DEBUGGING'):
+            context['debug'] = debug_here
+        return context
+
+
+class ConfigRenderContext(BaseContext):
+    def __init__(self, cli_vars):
+        self.cli_vars = cli_vars
+
+    def make_var(self, context) -> Var:
+        return Var(None, context, self.cli_vars)
+
+    def to_dict(self) -> Dict[str, Any]:
+        context = super().to_dict()
+        context['var'] = self.make_var(context)
+        return context
+
+
+class HasCredentialsContext(ConfigRenderContext):
+    def __init__(self, config):
+        # sometimes we only have a profile object and end up here. In those
+        # cases, we never want the actual cli vars passed, so we can do this.
+        cli_vars = getattr(config, 'cli_vars', {})
+        super().__init__(cli_vars=cli_vars)
+        self.config = config
+
+    def get_target(self) -> Dict[str, Any]:
+        target = dict(
+            self.config.credentials.connection_info(with_aliases=True)
+        )
+        target.update({
+            'type': self.config.credentials.type,
+            'threads': self.config.threads,
+            'name': self.config.target_name,
+            # not specified, but present for compatibility
+            'target_name': self.config.target_name,
+            'profile_name': self.config.profile_name,
+            'config': self.config.config.to_dict(),
+        })
+        return target
+
+    @property
+    def search_package_name(self):
+        return self.config.package_name
+
+
+class QueryHeaderContext(HasCredentialsContext):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def to_dict(self):
+        context = super().to_dict()
+        context['target'] = self.get_target()
+        context['dbt_version'] = dbt_version
+        return context

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -1,7 +1,7 @@
 import agate
 import os
 from typing_extensions import Protocol
-from typing import Union, Callable, Any, Dict, List, TypeVar, Type
+from typing import Union, Callable, Any, Dict, TypeVar, Type
 
 import dbt.clients.agate_helper
 from dbt.contracts.graph.compiled import CompiledSeedNode
@@ -13,8 +13,6 @@ import dbt.utils
 import dbt.writer
 from dbt.adapters.factory import get_adapter
 from dbt.node_types import NodeType
-from dbt.include.global_project import PACKAGES
-from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
 from dbt.clients.jinja import get_rendered
 from dbt.context.base import Var, HasCredentialsContext
 from dbt.contracts.graph.manifest import Manifest

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -135,9 +135,9 @@ def generate(model, runtime_config, manifest, source_config):
     # have to acquire it.
     # In the future, it would be nice to lazily open the connection, as in some
     # projects it would be possible to parse without connecting to the db
-    with get_adapter(runtime_config).connection_named(model.name):
+    with get_adapter(runtime_config).connection_for(model):
         return dbt.context.common.generate(
-            model, runtime_config, manifest, source_config, Provider()
+            model, runtime_config, manifest, Provider(), source_config
         )
 
 

--- a/core/dbt/context/runtime.py
+++ b/core/dbt/context/runtime.py
@@ -158,4 +158,5 @@ class Provider(dbt.context.common.Provider):
 
 def generate(model, runtime_config, manifest):
     return dbt.context.common.generate(
-        model, runtime_config, manifest, None, Provider())
+        model, runtime_config, manifest, Provider(), None
+    )

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -1,7 +1,8 @@
 import abc
+import itertools
 from dataclasses import dataclass, field
 from typing import (
-    Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType
+    Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType, List
 )
 from typing_extensions import Protocol
 
@@ -88,11 +89,19 @@ class Credentials(
             'type not implemented for base credentials class'
         )
 
-    def connection_info(self) -> Iterable[Tuple[str, Any]]:
+    def connection_info(
+        self, *, with_aliases: bool = False
+    ) -> Iterable[Tuple[str, Any]]:
         """Return an ordered iterator of key/value pairs for pretty-printing.
         """
-        as_dict = self.to_dict()
-        for key in self._connection_keys():
+        as_dict = self.to_dict(omit_none=False, with_aliases=with_aliases)
+        connection_keys = set(self._connection_keys())
+        aliases: List[str] = []
+        if with_aliases:
+            aliases = [
+                k for k, v in self._ALIASES.items() if v in connection_keys
+            ]
+        for key in itertools.chain(self._connection_keys(), aliases):
             if key in as_dict:
                 yield key, as_dict[key]
 
@@ -109,7 +118,7 @@ class Credentials(
     def translate_aliases(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return translate_aliases(kwargs, cls._ALIASES)
 
-    def to_dict(self, omit_none=True, validate=False, with_aliases=False):
+    def to_dict(self, omit_none=True, validate=False, *, with_aliases=False):
         serialized = super().to_dict(omit_none=omit_none, validate=validate)
         if with_aliases:
             serialized.update({

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -131,3 +131,7 @@ class Credentials(
 
 class HasCredentials(Protocol):
     credentials: Credentials
+
+
+class AdapterRequiredConfig(HasCredentials):
+    query_comment: Optional[str]

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -1,6 +1,15 @@
 from dataclasses import dataclass, field, Field
 from typing import (
-    Optional, Union, List, Dict, Any, Type, Tuple, NewType, MutableMapping
+    Optional,
+    Union,
+    List,
+    Dict,
+    Any,
+    Type,
+    Tuple,
+    NewType,
+    MutableMapping,
+    Callable,
 )
 
 from hologram import JsonSchemaMixin
@@ -8,7 +17,7 @@ from hologram.helpers import (
     StrEnum, register_pattern
 )
 
-import dbt.clients.jinja
+from dbt.clients.jinja import MacroGenerator
 import dbt.flags
 from dbt.contracts.graph.unparsed import (
     UnparsedNode, UnparsedMacro, UnparsedDocumentationFile, Quoting,
@@ -461,11 +470,11 @@ class ParsedMacro(UnparsedMacro, HasUniqueID):
         return {}
 
     @property
-    def generator(self):
+    def generator(self) -> Callable[[Dict[str, Any]], Callable]:
         """
         Returns a function that can be called to render the macro results.
         """
-        return dbt.clients.jinja.macro_generator(self)
+        return MacroGenerator(self)
 
 
 @dataclass

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -2,6 +2,7 @@ from dbt.contracts.util import Replaceable, Mergeable, list_str
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt import tracking
 from dbt.ui import printer
+from dbt.helper_types import NoValue
 
 from hologram import JsonSchemaMixin, ValidationError
 from hologram.helpers import HyphenatedJsonSchemaMixin, register_pattern, \
@@ -158,7 +159,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Optional[str] = None
+    query_comment: Optional[Union[str, NoValue]] = NoValue()
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -158,6 +158,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
+    query_comment: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data, validate=True):
@@ -176,7 +177,6 @@ class UserConfig(ExtensibleJsonSchemaMixin, Replaceable):
     use_colors: bool = DEFAULT_USE_COLORS
     partial_parse: Optional[bool] = None
     printer_width: Optional[int] = None
-    query_comment: Optional[str] = None
 
     def set_values(self, cookie_dir):
         if self.send_anonymous_usage_stats:

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -176,6 +176,7 @@ class UserConfig(ExtensibleJsonSchemaMixin, Replaceable):
     use_colors: bool = DEFAULT_USE_COLORS
     partial_parse: Optional[bool] = None
     printer_width: Optional[int] = None
+    query_comment: Optional[str] = None
 
     def set_values(self, cookie_dir):
         if self.send_anonymous_usage_stats:

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -510,13 +510,13 @@ class LogManager(logbook.NestedSetup):
         if error is None:
             error = stream
 
-        if self._output_handler.stream is self.stdout_stream:
+        if self._output_handler.stream is self.stdout:
             self._output_handler.stream = stream
-        elif self._output_handler.stream is self.stderr_stream:
+        elif self._output_handler.stream is self.stderr:
             self._output_handler.stream = error
 
-        self.stdout_stream = stream
-        self.stderr_stream = error
+        self.stdout = stream
+        self.stderr = error
 
 
 log_manager = LogManager()

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -147,21 +147,21 @@ class BaseRunner:
 
     def compile_and_execute(self, manifest, ctx):
         result = None
-        self.adapter.acquire_connection(self.node.name)
-        with collect_timing_info('compile') as timing_info:
-            # if we fail here, we still have a compiled node to return
-            # this has the benefit of showing a build path for the errant
-            # model
-            ctx.node = self.compile(manifest)
-        ctx.timing.append(timing_info)
-
-        # for ephemeral nodes, we only want to compile, not run
-        if not ctx.node.is_ephemeral_model:
-            with collect_timing_info('execute') as timing_info:
-                result = self.run(ctx.node, manifest)
-                ctx.node = result.node
-
+        with self.adapter.connection_for(self.node):
+            with collect_timing_info('compile') as timing_info:
+                # if we fail here, we still have a compiled node to return
+                # this has the benefit of showing a build path for the errant
+                # model
+                ctx.node = self.compile(manifest)
             ctx.timing.append(timing_info)
+
+            # for ephemeral nodes, we only want to compile, not run
+            if not ctx.node.is_ephemeral_model:
+                with collect_timing_info('execute') as timing_info:
+                    result = self.run(ctx.node, manifest)
+                    ctx.node = result.node
+
+                ctx.timing.append(timing_info)
 
         return result
 
@@ -496,7 +496,7 @@ class FreshnessRunner(BaseRunner):
 
         relation = self.adapter.Relation.create_from_source(compiled_node)
         # given a Source, calculate its fresnhess.
-        with self.adapter.connection_named(compiled_node.unique_id):
+        with self.adapter.connection_for(compiled_node):
             self.adapter.clear_transaction()
             freshness = self.adapter.calculate_freshness(
                 relation,

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -88,11 +88,15 @@ class ManifestLoader:
         self,
         root_project: RuntimeConfig,
         all_projects: Mapping[str, Project],
-        macro_hook: Callable[[Manifest], Any],
+        macro_hook: Optional[Callable[[Manifest], Any]] = None,
     ) -> None:
         self.root_project: RuntimeConfig = root_project
         self.all_projects: Mapping[str, Project] = all_projects
-        self.macro_hook: Callable[[Manifest], Any] = macro_hook
+        self.macro_hook: Callable[[Manifest], Any]
+        if macro_hook is None:
+            self.macro_hook = lambda m: None
+        else:
+            self.macro_hook = macro_hook
 
         self.results: ParseResult = make_parse_result(
             root_project, all_projects,
@@ -189,6 +193,7 @@ class ManifestLoader:
             macros=self.results.macros,
             files=self.results.files
         )
+        self.macro_hook(macro_manifest)
 
         for project in self.all_projects.values():
             # parse a single project

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -3,7 +3,7 @@ from typing import Iterable, Dict, Any, Union, List, Optional
 
 from hologram import ValidationError
 
-from dbt.context.base import generate_config_context
+from dbt.context.base import ConfigRenderContext
 
 from dbt.clients.jinja import get_rendered
 from dbt.clients.yaml_helper import load_yaml_text
@@ -237,7 +237,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
         builds the initial node to be parsed, but rendering is basically the
         same
         """
-        render_ctx = generate_config_context(self.root_project.cli_vars)
+        render_ctx = ConfigRenderContext(self.root_project.cli_vars).to_dict()
         builder = TestBuilder[Target](
             test=block.test,
             target=block.target,

--- a/core/dbt/perf_utils.py
+++ b/core/dbt/perf_utils.py
@@ -16,4 +16,8 @@ def get_full_manifest(config: RuntimeConfig) -> Manifest:
     """
     adapter = get_adapter(config)  # type: ignore
     internal: Manifest = adapter.load_internal_manifest()
-    return load_manifest(config, internal)
+
+    def set_header(manifest):
+        adapter.connections.set_query_header(manifest)
+
+    return load_manifest(config, internal, set_header)

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -57,6 +57,12 @@ documentation:
 FILE_NOT_FOUND = 'file not found'
 
 
+class QueryCommentedProfile(Profile):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.query_comment = None
+
+
 class DebugTask(BaseTask):
     def __init__(self, args, config):
         super().__init__(args, config)
@@ -209,7 +215,9 @@ class DebugTask(BaseTask):
         self.profile_name = self._choose_profile_name()
         self.target_name = self._choose_target_name()
         try:
-            self.profile = Profile.from_args(self.args, self.profile_name)
+            self.profile = QueryCommentedProfile.from_args(
+                self.args, self.profile_name
+            )
         except dbt.exceptions.DbtConfigError as exc:
             self.profile_fail_details = str(exc)
             return red('ERROR invalid')

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -45,7 +45,8 @@ class BigQueryCredentials(Credentials):
         return 'bigquery'
 
     def _connection_keys(self):
-        return ('method', 'database', 'schema', 'location')
+        return ('method', 'database', 'schema', 'location', 'priority',
+                'timeout_seconds')
 
 
 class BigQueryConnectionManager(BaseConnectionManager):
@@ -200,6 +201,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         return query_job, iterator
 
     def execute(self, sql, auto_begin=False, fetch=None):
+        sql = self._add_query_comment(sql)
         # auto_begin is ignored on bigquery, and only included for consistency
         query_job, iterator = self.raw_execute(sql, fetch=fetch)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -334,8 +334,16 @@ class BigQueryAdapter(BaseAdapter):
 
         if flags.STRICT_MODE:
             connection = self.connections.get_thread_connection()
-            assert isinstance(connection, Connection)
-            assert(connection.name == model.get('name'))
+            if not isinstance(connection, Connection):
+                raise dbt.exceptions.CompilerException(
+                    f'Got {connection} - not a Connection!'
+                )
+            model_uid = model.get('unique_id')
+            if connection.name != model_uid:
+                raise dbt.exceptions.InternalException(
+                    f'Connection had name "{connection.name}", expected model '
+                    f'unique id of "{model_uid}"'
+                )
 
         if materialization == 'view':
             res = self._materialize_as_view(model)

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -31,7 +31,8 @@ class PostgresCredentials(Credentials):
         return 'postgres'
 
     def _connection_keys(self):
-        return ('host', 'port', 'user', 'database', 'schema', 'search_path')
+        return ('host', 'port', 'user', 'database', 'schema', 'search_path',
+                'keepalives_idle')
 
 
 class PostgresConnectionManager(SQLConnectionManager):

--- a/plugins/redshift/dbt/adapters/redshift/connections.py
+++ b/plugins/redshift/dbt/adapters/redshift/connections.py
@@ -52,9 +52,8 @@ class RedshiftCredentials(PostgresCredentials):
         return 'redshift'
 
     def _connection_keys(self):
-        return (
-            'host', 'port', 'user', 'database', 'schema', 'method',
-            'search_path')
+        keys = super()._connection_keys()
+        return keys + ('method', 'cluster_id', 'iam_duration_seconds')
 
 
 class RedshiftConnectionManager(PostgresConnectionManager):

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -35,7 +35,8 @@ class SnowflakeCredentials(Credentials):
         return 'snowflake'
 
     def _connection_keys(self):
-        return ('account', 'user', 'database', 'schema', 'warehouse', 'role')
+        return ('account', 'user', 'database', 'schema', 'warehouse', 'role',
+                'client_session_keep_alive')
 
     def auth_args(self):
         # Pull all of the optional authentication args for the connector,

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -33,7 +33,8 @@ setup(
         'snowflake-connector-python>=1.6.12,<2.1',
         'azure-storage-blob~=2.1',
         'azure-storage-common~=2.1',
-
+        # hoist this to here so pip's silly dependency resolver sees it
+        'urllib3<1.25.0',
     ],
     zip_safe=False,
 )

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -723,7 +723,7 @@ class TestRPCServerCompileRun(HasRPCServer):
         ).json()
         error_data = self.assertIsErrorWith(data, 10003, 'Database Error', {
             'type': 'DatabaseException',
-            'message': 'Database Error in rpc foo (from remote system)\n  syntax error at or near "hi"\n  LINE 1: hi this is not sql\n          ^',
+            'message': 'Database Error in rpc foo (from remote system)\n  syntax error at or near "hi"\n  LINE 2: hi this is not sql\n          ^',
             'compiled_sql': 'hi this is not sql',
             'raw_sql': 'hi this is not sql',
         })

--- a/test/integration/051_query_comments_test/macros/macro.sql
+++ b/test/integration/051_query_comments_test/macros/macro.sql
@@ -1,0 +1,25 @@
+{%- macro query_header_no_args() -%}
+{%- set x = "are pretty cool" -%}
+{{ "dbt macros" }}
+{{ x }}
+{%- endmacro -%}
+
+
+{%- macro query_header_args(message) -%}
+  {%- set comment_dict = dict(
+    app='dbt++',
+    macro_version='0.1.0',
+    dbt_version=dbt_version,
+    message='blah: '~ message) -%}
+  {{ return(comment_dict) }}
+{%- endmacro -%}
+
+
+{%- macro ordered_to_json(dct) -%}
+{{ tojson(dct, sort_keys=True) }}
+{%- endmacro %}
+
+
+{% macro invalid_query_header() -%}
+{{ "Here is an invalid character for you: */" }}
+{% endmacro %}

--- a/test/integration/051_query_comments_test/models/x.sql
+++ b/test/integration/051_query_comments_test/models/x.sql
@@ -1,0 +1,33 @@
+{% set blacklist = ['pass', 'password', 'keyfile', 'keyfile.json', 'password', 'private_key_passphrase'] %}
+{% for key in blacklist %}
+  {% if key in blacklist and blacklist[key] %}
+  	{% do exceptions.raise_compiler_error('invalid target, found banned key "' ~ key ~ '"') %}
+  {% endif %}
+{% endfor %}
+
+{% if 'type' not in target %}
+  {% do exceptions.raise_compiler_error('invalid target, missing "type"') %}
+{% endif %}
+
+{% set required = ['name', 'schema', 'type', 'threads'] %}
+
+{# Require what we docuement at https://docs.getdbt.com/docs/target #}
+{% if target.type == 'postgres' or target.type == 'redshift' %}
+	{% do required.extend(['dbname', 'host', 'user', 'port']) %}
+{% elif target.type == 'snowflake' %}
+	{% do required.extend(['database', 'warehouse', 'user', 'role', 'account']) %}
+{% elif target.type == 'bigquery' %}
+	{% do required.extend(['project']) %}
+{% else %}
+  {% do exceptions.raise_compiler_error('invalid target, got unknown type "' ~ target.type ~ '"') %}
+
+{% endif %}
+
+{% for value in required %}
+	{% if value not in target %}
+  		{% do exceptions.raise_compiler_error('invalid target, missing "' ~ value ~ '"') %}
+	{% endif %}
+{% endfor %}
+
+{% do run_query('select 2 as inner_id') %}
+select 1 as outer_id

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -161,3 +161,31 @@ class TestMacroInvalidQueryComments(TestDefaultQueryComments):
     def run_assert_comments(self):
         with self.assertRaises(dbt.exceptions.RuntimeException):
             self.run_get_json(expect_pass=False)
+
+
+class TestNullQueryComments(TestDefaultQueryComments):
+    @property
+    def project_config(self):
+        cfg = super().project_config
+        cfg.update({'query-comment': None})
+        return cfg
+
+    def matches_comment(self, msg) -> bool:
+        self.assertFalse(
+            '/*' in msg or '*/' in msg,
+            f"'{msg}' contained a query comment"
+        )
+
+
+class TestEmptyQueryComments(TestDefaultQueryComments):
+    @property
+    def project_config(self):
+        cfg = super().project_config
+        cfg.update({'query-comment': ''})
+        return cfg
+
+    def matches_comment(self, msg) -> bool:
+        self.assertFalse(
+            '/*' in msg or '*/' in msg,
+            f"'{msg}' contained a query comment"
+        )

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -79,7 +79,7 @@ class TestQueryComments(QueryComments):
 
     def matches_comment(self, msg) -> bool:
         self.assertTrue(
-            msg.startswith('-- dbt\n-- rules!\n'),
+            msg.startswith('/* dbt\nrules! */\n'),
             f'{msg} did not start with query comment'
         )
 
@@ -102,10 +102,10 @@ class TestQueryComments(QueryComments):
 
 class TestDefaultQueryComments(QueryComments):
     def matches_comment(self, msg):
-        if not msg.startswith('-- '):
+        if not msg.startswith('/* '):
             return False
-        # our blob is the first line of the query comments, minus the '-- '
-        json_str = msg.split('\n')[0][3:]
+        # our blob is the first line of the query comments, minus the comment
+        json_str = msg.split('\n')[0][3:-3]
         data = json.loads(json_str)
         self.assertEqual(data['app'], 'dbt')
         self.assertEqual(data['dbt_version'], dbt_version)

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -1,0 +1,128 @@
+from test.integration.base import DBTIntegrationTest,  use_profile
+import io
+import json
+import os
+import sys
+from dbt.version import __version__ as dbt_version
+from dbt.logger import log_manager
+
+
+class QueryComments(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return 'dbt_query_comments_051'
+
+    @staticmethod
+    def dir(value):
+        return os.path.normpath(value)
+
+    @property
+    def models(self):
+        return self.dir('models')
+
+    def setUp(self):
+        super().setUp()
+        self.initial_stdout = log_manager.stdout
+        self.initial_stderr = log_manager.stderr
+        self.stringbuf = io.StringIO()
+        log_manager.set_output_stream(self.stringbuf)
+
+    def tearDown(self):
+        log_manager.set_output_stream(self.initial_stdout, self.initial_stderr)
+        super().tearDown()
+
+    def run_get_json(self):
+        self.run_dbt(['--debug', '--log-format=json', 'run'])
+        logs = []
+        for line in self.stringbuf.getvalue().split('\n'):
+            try:
+                log = json.loads(line)
+            except ValueError:
+                continue
+
+            if log['extra'].get('run_state') != 'running':
+                continue
+            logs.append(log)
+        self.assertGreater(len(logs), 0)
+        return logs
+
+    def query_comment(self, model_name, log):
+        prefix = 'On {}: '.format(model_name)
+
+        if log['message'].startswith(prefix):
+            msg = log['message'][len(prefix):]
+            if msg in {'COMMIT', 'BEGIN', 'ROLLBACK'}:
+                return None
+            return msg
+        return None
+
+    def matches_comment(self, msg) -> bool:
+        raise NotImplementedError
+
+    def run_assert_comments(self):
+        logs = self.run_get_json()
+
+        seen = False
+        for log in logs:
+            msg = self.query_comment('model.test.x', log)
+            if msg is not None:
+                self.matches_comment(msg)
+                seen = True
+
+        self.assertTrue(seen, 'Never saw a matching log message! Logs:\n{}'.format('\n'.join(l['message'] for l in logs)))
+
+
+class TestQueryComments(QueryComments):
+    @property
+    def profile_config(self):
+        return {'config': {'query_comment': 'dbt\nrules!\n'}}
+
+    def matches_comment(self, msg) -> bool:
+        self.assertTrue(
+            msg.startswith('-- dbt\n-- rules!\n'),
+            f'{msg} did not start with query comment'
+        )
+
+    @use_profile('postgres')
+    def test_postgres_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('redshift')
+    def test_redshift_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('snowflake')
+    def test_snowflake_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('bigquery')
+    def test_bigquery_comments(self):
+        self.run_assert_comments()
+
+
+class TestDefaultQueryComments(QueryComments):
+    def matches_comment(self, msg):
+        if not msg.startswith('-- '):
+            return False
+        # our blob is the first line of the query comments, minus the '-- '
+        json_str = msg.split('\n')[0][3:]
+        data = json.loads(json_str)
+        self.assertEqual(data['app'], 'dbt')
+        self.assertEqual(data['dbt_version'], dbt_version)
+        self.assertEqual(data['node_id'], 'model.test.x')
+
+    @use_profile('postgres')
+    def test_postgres_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('redshift')
+    def test_redshift_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('snowflake')
+    def test_snowflake_comments(self):
+        self.run_assert_comments()
+
+    @use_profile('bigquery')
+    def test_bigquery_comments(self):
+        self.run_assert_comments()

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -74,8 +74,8 @@ class QueryComments(DBTIntegrationTest):
 
 class TestQueryComments(QueryComments):
     @property
-    def profile_config(self):
-        return {'config': {'query_comment': 'dbt\nrules!\n'}}
+    def project_config(self):
+        return {'query-comment': 'dbt\nrules!\n'}
 
     def matches_comment(self, msg) -> bool:
         self.assertTrue(

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -324,12 +324,9 @@ class DBTIntegrationTest(unittest.TestCase):
         os.chdir(self.initial_dir)
         # before we go anywhere, collect the initial path info
         self._logs_dir = os.path.join(self.initial_dir, 'logs', self.prefix)
-        print('initial_dir={}'.format(self.initial_dir))
         _really_makedirs(self._logs_dir)
         self.test_original_source_path = _pytest_get_test_root()
-        print('test_original_source_path={}'.format(self.test_original_source_path))
         self.test_root_dir = normalize(tempfile.mkdtemp(prefix='dbt-int-test-'))
-        print('test_root_dir={}'.format(self.test_root_dir))
         os.chdir(self.test_root_dir)
         try:
             self._symlink_test_folders()
@@ -396,9 +393,6 @@ class DBTIntegrationTest(unittest.TestCase):
         if self.packages_config is not None:
             with open('packages.yml', 'w') as f:
                 yaml.safe_dump(self.packages_config, f, default_flow_style=True)
-
-    def test_only_config(self):
-        return None
 
     def load_config(self):
         # we've written our profile and project. Now we want to instantiate a

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -397,6 +397,9 @@ class DBTIntegrationTest(unittest.TestCase):
             with open('packages.yml', 'w') as f:
                 yaml.safe_dump(self.packages_config, f, default_flow_style=True)
 
+    def test_only_config(self):
+        return None
+
     def load_config(self):
         # we've written our profile and project. Now we want to instantiate a
         # fresh adapter for the tests.

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -25,6 +25,9 @@ class BaseTestBigQueryAdapter(unittest.TestCase):
         flags.STRICT_MODE = True
 
         self.raw_profile = {
+            'config': {
+                'query_comment': 'dbt'
+            },
             'outputs': {
                 'oauth': {
                     'type': 'bigquery',

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -25,9 +25,6 @@ class BaseTestBigQueryAdapter(unittest.TestCase):
         flags.STRICT_MODE = True
 
         self.raw_profile = {
-            'config': {
-                'query_comment': 'dbt'
-            },
             'outputs': {
                 'oauth': {
                     'type': 'bigquery',
@@ -62,6 +59,7 @@ class BaseTestBigQueryAdapter(unittest.TestCase):
             'version': '0.1',
             'project-root': '/tmp/dbt/does-not-exist',
             'profile': 'default',
+            'query-comment': 'dbt',
         }
 
     def get_adapter(self, target):

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -25,11 +25,9 @@ class TestPostgresAdapter(unittest.TestCase):
             'version': '0.1',
             'profile': 'test',
             'project-root': '/tmp/dbt/does-not-exist',
+            'query-comment': 'dbt',
         }
         profile_cfg = {
-            'config': {
-                'query_comment': 'dbt'
-            },
             'outputs': {
                 'test': {
                     'type': 'postgres',
@@ -207,9 +205,6 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         }
 
         profile_cfg = {
-            'config': {
-                'query_comment': 'dbt'
-            },
             'outputs': {
                 'test': self.target_dict,
             },
@@ -223,7 +218,8 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
             'quoting': {
                 'identifier': False,
                 'schema': True,
-            }
+            },
+            'query-comment': 'dbt',
         }
 
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -252,7 +252,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         self.adapter.drop_schema(database='postgres', schema='test_schema')
 
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\ndrop schema if exists "test_schema" cascade', None)
+            mock.call('/* dbt */\ndrop schema if exists "test_schema" cascade', None)
         ])
 
     def test_quoting_on_drop(self):
@@ -265,7 +265,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         )
         self.adapter.drop_relation(relation)
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\ndrop table if exists "postgres"."test_schema".test_table cascade', None)
+            mock.call('/* dbt */\ndrop table if exists "postgres"."test_schema".test_table cascade', None)
         ])
 
     def test_quoting_on_truncate(self):
@@ -278,7 +278,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         )
         self.adapter.truncate_relation(relation)
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\ntruncate table "postgres"."test_schema".test_table', None)
+            mock.call('/* dbt */\ntruncate table "postgres"."test_schema".test_table', None)
         ])
 
     def test_quoting_on_rename(self):
@@ -302,13 +302,13 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
             to_relation=to_relation
         )
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\nalter table "postgres"."test_schema".table_a rename to table_b', None)
+            mock.call('/* dbt */\nalter table "postgres"."test_schema".table_a rename to table_b', None)
         ])
 
     def test_debug_connection_ok(self):
         DebugTask.validate_connection(self.target_dict)
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\nselect 1 as id', None)
+            mock.call('/* dbt */\nselect 1 as id', None)
         ])
 
     def test_debug_connection_fail_nopass(self):
@@ -321,6 +321,6 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
             with self.assertRaises(DbtConfigError):
                 DebugTask.validate_connection(self.target_dict)
             self.mock_execute.assert_has_calls([
-                mock.call('-- dbt\nselect 1 as id', None)
+                mock.call('/* dbt */\nselect 1 as id', None)
             ])
 

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -27,6 +27,9 @@ class TestPostgresAdapter(unittest.TestCase):
             'project-root': '/tmp/dbt/does-not-exist',
         }
         profile_cfg = {
+            'config': {
+                'query_comment': 'dbt'
+            },
             'outputs': {
                 'test': {
                     'type': 'postgres',
@@ -204,6 +207,9 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         }
 
         profile_cfg = {
+            'config': {
+                'query_comment': 'dbt'
+            },
             'outputs': {
                 'test': self.target_dict,
             },
@@ -250,7 +256,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         self.adapter.drop_schema(database='postgres', schema='test_schema')
 
         self.mock_execute.assert_has_calls([
-            mock.call('drop schema if exists "test_schema" cascade', None)
+            mock.call('-- dbt\ndrop schema if exists "test_schema" cascade', None)
         ])
 
     def test_quoting_on_drop(self):
@@ -263,7 +269,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         )
         self.adapter.drop_relation(relation)
         self.mock_execute.assert_has_calls([
-            mock.call('drop table if exists "postgres"."test_schema".test_table cascade', None)
+            mock.call('-- dbt\ndrop table if exists "postgres"."test_schema".test_table cascade', None)
         ])
 
     def test_quoting_on_truncate(self):
@@ -276,7 +282,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         )
         self.adapter.truncate_relation(relation)
         self.mock_execute.assert_has_calls([
-            mock.call('truncate table "postgres"."test_schema".test_table', None)
+            mock.call('-- dbt\ntruncate table "postgres"."test_schema".test_table', None)
         ])
 
     def test_quoting_on_rename(self):
@@ -300,13 +306,13 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
             to_relation=to_relation
         )
         self.mock_execute.assert_has_calls([
-            mock.call('alter table "postgres"."test_schema".table_a rename to table_b', None)
+            mock.call('-- dbt\nalter table "postgres"."test_schema".table_a rename to table_b', None)
         ])
 
     def test_debug_connection_ok(self):
         DebugTask.validate_connection(self.target_dict)
         self.mock_execute.assert_has_calls([
-            mock.call('select 1 as id', None)
+            mock.call('-- dbt\nselect 1 as id', None)
         ])
 
     def test_debug_connection_fail_nopass(self):
@@ -319,6 +325,6 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
             with self.assertRaises(DbtConfigError):
                 DebugTask.validate_connection(self.target_dict)
             self.mock_execute.assert_has_calls([
-                mock.call('select 1 as id', None)
+                mock.call('-- dbt\nselect 1 as id', None)
             ])
 

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -49,7 +49,6 @@ class TestRedshiftAdapter(unittest.TestCase):
                 'identifier': False,
                 'schema': True,
             },
-            'query-comment': 'dbt',
         }
 
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -26,9 +26,6 @@ class TestRedshiftAdapter(unittest.TestCase):
         flags.STRICT_MODE = True
 
         profile_cfg = {
-            'config': {
-                'query_comment': 'dbt'
-            },
             'outputs': {
                 'test': {
                     'type': 'redshift',
@@ -51,7 +48,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             'quoting': {
                 'identifier': False,
                 'schema': True,
-            }
+            },
+            'query-comment': 'dbt',
         }
 
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -26,6 +26,9 @@ class TestRedshiftAdapter(unittest.TestCase):
         flags.STRICT_MODE = True
 
         profile_cfg = {
+            'config': {
+                'query_comment': 'dbt'
+            },
             'outputs': {
                 'test': {
                     'type': 'redshift',

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -77,7 +77,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
 
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\ndrop schema if exists test_database."test_schema" cascade', None)
+            mock.call('/* dbt */\ndrop schema if exists test_database."test_schema" cascade', None)
         ])
 
     def test_quoting_on_drop(self):
@@ -92,7 +92,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
         self.mock_execute.assert_has_calls([
             mock.call(
-                '-- dbt\ndrop table if exists test_database."test_schema".test_table cascade',
+                '/* dbt */\ndrop table if exists test_database."test_schema".test_table cascade',
                 None
             )
         ])
@@ -108,7 +108,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.adapter.truncate_relation(relation)
 
         self.mock_execute.assert_has_calls([
-            mock.call('-- dbt\ntruncate table test_database."test_schema".test_table', None)
+            mock.call('/* dbt */\ntruncate table test_database."test_schema".test_table', None)
         ])
 
     def test_quoting_on_rename(self):
@@ -133,7 +133,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
         self.mock_execute.assert_has_calls([
             mock.call(
-                '-- dbt\nalter table test_database."test_schema".table_a rename to test_database."test_schema".table_b',
+                '/* dbt */\nalter table test_database."test_schema".table_a rename to test_database."test_schema".table_b',
                 None
             )
         ])
@@ -145,7 +145,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         execute_side_effect = self.mock_execute.side_effect
 
         def execute_effect(sql, *args, **kwargs):
-            if sql == '-- dbt\nselect current_warehouse() as warehouse':
+            if sql == '/* dbt */\nselect current_warehouse() as warehouse':
                 self.cursor.description = [['name']]
                 self.cursor.fetchall.return_value = [[response]]
             else:
@@ -180,12 +180,12 @@ class TestSnowflakeAdapter(unittest.TestCase):
             result = self.adapter.pre_model_hook(config)
             self.assertIsNotNone(result)
             calls = [
-                mock.call('-- dbt\nselect current_warehouse() as warehouse', None),
-                mock.call('-- dbt\nuse warehouse other_warehouse', None)
+                mock.call('/* dbt */\nselect current_warehouse() as warehouse', None),
+                mock.call('/* dbt */\nuse warehouse other_warehouse', None)
             ]
             self.mock_execute.assert_has_calls(calls)
             self.adapter.post_model_hook(config, result)
-            calls.append(mock.call('-- dbt\nuse warehouse warehouse', None))
+            calls.append(mock.call('/* dbt */\nuse warehouse warehouse', None))
             self.mock_execute.assert_has_calls(calls)
 
     def test_pre_post_hooks_no_warehouse(self):

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -18,9 +18,6 @@ class TestSnowflakeAdapter(unittest.TestCase):
         flags.STRICT_MODE = False
 
         profile_cfg = {
-            'config': {
-                'query_comment': 'dbt'
-            },
             'outputs': {
                 'test': {
                     'type': 'snowflake',
@@ -42,10 +39,11 @@ class TestSnowflakeAdapter(unittest.TestCase):
             'quoting': {
                 'identifier': False,
                 'schema': True,
-            }
+            },
+            'query-comment': 'dbt',
         }
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
-        self.assertEqual(self.config.config.query_comment, 'dbt')
+        self.assertEqual(self.config.query_comment, 'dbt')
 
         self.handle = mock.MagicMock(
             spec=snowflake_connector.SnowflakeConnection)

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -61,12 +61,17 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.snowflake.return_value = self.handle
         self.adapter = SnowflakeAdapter(self.config)
 
+        self.qh_patch = mock.patch.object(self.adapter.connections.query_header, 'add')
+        self.mock_query_header_add = self.qh_patch.start()
+        self.mock_query_header_add.side_effect = lambda q: '/* dbt */\n{}'.format(q)
+
         self.adapter.acquire_connection()
         inject_adapter(self.adapter)
 
     def tearDown(self):
         # we want a unique self.handle every time.
         self.adapter.cleanup_connections()
+        self.qh_patch.stop()
         self.patcher.stop()
         self.load_patch.stop()
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,17 @@ deps =
 basepython = python3.6
 commands = /bin/bash -c '$(which mypy) core/dbt'
 deps =
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
+
+
+[testenv:mypy-dev]
+basepython = python3.6
+commands = /bin/bash -c '$(which mypy) core/dbt'
+deps =
     -r ./editable_requirements.txt
     -r ./dev_requirements.txt
+
 
 [testenv:unit-py36]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 basepython = python3.6
 commands = /bin/bash -c '$(which mypy) core/dbt'
 deps =
-    -r ./requirements.txt
+    -r ./editable_requirements.txt
     -r ./dev_requirements.txt
 
 [testenv:unit-py36]


### PR DESCRIPTION
Fixes #1643 

In a user's dbt_project.yml, a new string field is accepted: `query-comment`. The string is used as the body of a macro that is evaluated with the following context:
  - `dbt_version`
  - `env_var`
  - `modules`
  - `run_started_at`
  - `invocation_id`
  - `return`
  - `fromjson`
  - `tojson`
  - `log`
  - `var`
  - `target`
  - all the macros that would be available in a model (even ones that will not work with the given context)!

It will be provided with two arguments:
  - `connection_name`, a string
  - `node`, which will either be `null` or a compiled/parsed node object.


The parsed macro is not available in any other context, and has no access to any macros.

Cleaned up contexts so things have a sensible inheritance pattern
 - it's probably not perfect but at least it's defined

query generator is an attribute on the connection manager
 - has a thread-local comment str
 - when acquiring a connection, set the comment str appropriately
new 'connection_for' context manager: like `connection_named`, except also use the node to set the query string
`connection_named` sets the query string using the connection name only.
 - has a special context