### PR TITLE
Updated hologram to handle parallel json_schema

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -56,7 +56,7 @@ setup(
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<0.17',
         'dataclasses==0.6;python_version<"3.7"',
-        'hologram==0.0.4',
+        'hologram==0.0.5',
         'logbook>=1.5,<1.6',
         'pytest-logbook>=1.2.0,<1.3',
         'typing-extensions>=3.7.4,<3.8',


### PR DESCRIPTION
Fixes #1866 

Use fishtown-analytics/hologram#25 in dbt.

This should fix a concurrency issue in hologram's json schema generation, in the sense that after isnaalling this version of hologram I can no longer reproduce the bug.