### PR TITLE
Fix bigquery snowflake unknown relation types

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -147,14 +147,6 @@ class BaseRelation(FakeAPIObject, Hashable):
     def get_default_quote_policy(cls: Type[Self]) -> Policy:
         return cls._get_field_named('quote_policy').default
 
-    @classmethod
-    def get_default_include_policy(cls: Type[Self]) -> Policy:
-        return cls._get_field_named('include_policy').default
-
-    @classmethod
-    def get_relation_type_class(cls: Type[Self]) -> Type[RelationType]:
-        return cls._get_field_named('type')
-
     def get(self, key, default=None):
         """Override `.get` to return a metadata object so we don't break
         dbt_utils.

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -196,6 +196,10 @@ class SQLAdapter(BaseAdapter):
             'identifier': True
         }
         for _database, name, _schema, _type in results:
+            try:
+                _type = self.Relation.RelationType(_type)
+            except ValueError:
+                _type = self.Relation.RelationType.External
             relations.append(self.Relation.create(
                 database=_database,
                 schema=_schema,

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -294,7 +294,10 @@ class BigQueryAdapter(BaseAdapter):
                 'schema': True,
                 'identifier': True
             },
-            type=self.RELATION_TYPES.get(bq_table.table_type))
+            type=self.RELATION_TYPES.get(
+                bq_table.table_type, RelationType.External
+            ),
+        )
 
     @classmethod
     def warning_on_hooks(hook_type):


### PR DESCRIPTION
These fixes are kind of speculative, I can't come up with a nice way to reproduce them. But they make sense to me as errors and I am reasonably confident in the fixes.

For bigquery, instead of defaulting to `None` if the relation type isn't immediately recognized, we default to `External`.

Similarly, in the SQL adapters no longer pass along whatever the `list_relations_without_caching` macro returns. Instead, check that it's something we support and if it isn't, mark it "external".

Fixes #1868 
Fixes #1869