### PR TITLE
Adds `quote` parameter to accepted_values test

### DIFF
--- a/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
@@ -2,6 +2,7 @@
 {% macro test_accepted_values(model, values) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('field')) %}
+{% set quote_values = kwargs.get('quote', True) %}
 
 with all_values as (
 
@@ -20,9 +21,12 @@ validation_errors as (
     from all_values
     where value_field not in (
         {% for value in values -%}
-
-            '{{ value }}' {% if not loop.last -%} , {%- endif %}
-
+            {% if quote_values -%}
+            '{{ value }}'
+            {%- else -%}
+            {{ val }}
+            {%- endif -%}
+            {%- if not loop.last -%},{%- endif %}
         {%- endfor %}
     )
 )

--- a/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
@@ -24,7 +24,7 @@ validation_errors as (
             {% if quote_values -%}
             '{{ value }}'
             {%- else -%}
-            {{ val }}
+            {{ value }}
             {%- endif -%}
             {%- if not loop.last -%},{%- endif %}
         {%- endfor %}

--- a/test/integration/008_schema_tests_test/models-v2/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/models/schema.yml
@@ -31,8 +31,7 @@ models:
         - name: favorite_color
           description: "The user's favorite color"
           tests:
-            - accepted_values: { values: ['blue', 'green'] }
-                quote: true
+            - accepted_values: { values: ['blue', 'green'], quote: trues }
 
     - name: table_summary
       description: "The summary table"

--- a/test/integration/008_schema_tests_test/models-v2/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/models/schema.yml
@@ -33,8 +33,8 @@ models:
           description: "The user's favorite number"
           tests:
               - accepted_values:
-                values: [3.14159265]
-                quote: false
+                  values: [3.14159265]
+                  quote: false
 
 
     - name: table_summary

--- a/test/integration/008_schema_tests_test/models-v2/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/models/schema.yml
@@ -9,6 +9,9 @@ models:
           tests:
             - not_null
             - unique
+            - accepted_values:
+                values: [1, 2, 99, 100]
+                quote: false
         - name: first_name
           description: "The user's first name"
           tests:
@@ -29,6 +32,7 @@ models:
           description: "The user's favorite color"
           tests:
             - accepted_values: { values: ['blue', 'green'] }
+                quote: true
 
     - name: table_summary
       description: "The summary table"

--- a/test/integration/008_schema_tests_test/models-v2/models/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/models/schema.yml
@@ -9,9 +9,6 @@ models:
           tests:
             - not_null
             - unique
-            - accepted_values:
-                values: [1, 2, 99, 100]
-                quote: false
         - name: first_name
           description: "The user's first name"
           tests:
@@ -31,7 +28,14 @@ models:
         - name: favorite_color
           description: "The user's favorite color"
           tests:
-            - accepted_values: { values: ['blue', 'green'], quote: trues }
+            - accepted_values: { values: ['blue', 'green'], quote: true }
+        - name: fav_number
+          description: "The user's favorite number"
+          tests:
+              - accepted_values:
+                values: [3.14159265]
+                quote: false
+
 
     - name: table_summary
       description: "The summary table"

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -32,7 +32,7 @@ class TestSchemaTests(DBTIntegrationTest):
         self.assertEqual(len(results), 5)
         test_results = self.run_schema_validations()
         # If the disabled model's tests ran, there would be 19 of these.
-        self.assertEqual(len(test_results), 18)
+        self.assertEqual(len(test_results), 19)
 
         for result in test_results:
             # assert that all deliberately failing tests actually fail


### PR DESCRIPTION
Adds `quote` parameter to `accepted_values` test. Closes #1873.

Users can now test for acceptable integer values by opting not to quote these values.
```yaml
...
         - name: day_of_week
            description: 
            tests:
              - not_null
              - accepted_values:
                  values: [1, 2, 3, 4, 5, 6, 7]
                  quote: false
...
 ```  
Results in:
```sql
with all_values as (
    select distinct
        day_of_week as value_field
    from dw.dim_date
),
validation_errors as (
    select
        value_field
    from 
        all_values
    where
        value_field not in (
            1,
            2,
            3,
            4,
            5,
            6,
            7
            )
)

select count(*)
from validation_errors
```
While the default behavior is to quote, e.g.
```yaml
...
         - name: day_of_week_name
            description: 
            tests:
              - not_null
              - accepted_values:
                  values: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
...
```  

```sql
with all_values as (
    select distinct
        day_of_week_name as value_field
    from dw.dim_date
),
validation_errors as (
    select
        value_field
    from 
        all_values
    where
        value_field not in (
            'Sunday',
            'Monday',
            'Tuesday',
            'Wednesday',
            'Thursday',
            'Friday',
            'Saturday'
            )
)

select count(*)
from validation_errors
```