### PR TITLE
add run-operation + snapshot to the RPC server (#1875)

### DIFF
--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -46,6 +46,12 @@ class RPCCompileParameters(RPCParameters):
 
 
 @dataclass
+class RPCSnapshotParameters(RPCParameters):
+    select: Union[None, str, List[str]] = None
+    exclude: Union[None, str, List[str]] = None
+
+
+@dataclass
 class RPCTestParameters(RPCCompileParameters):
     data: bool = False
     schema: bool = False

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -386,7 +386,7 @@ def _build_snapshot_subparser(subparsers, base_subparser):
         '''
     )
     sub.set_defaults(cls=snapshot_task.SnapshotTask, which='snapshot',
-                     rpc_method=None)
+                     rpc_method='snapshot')
     return sub
 
 
@@ -707,7 +707,7 @@ def _build_run_operation_subparser(subparsers, base_subparser):
         '''
     )
     sub.set_defaults(cls=run_operation_task.RunOperationTask,
-                     which='run-operation', rpc_method=None)
+                     which='run-operation', rpc_method='run-operation')
     return sub
 
 

--- a/core/dbt/rpc/builtins.py
+++ b/core/dbt/rpc/builtins.py
@@ -21,6 +21,7 @@ from dbt.contracts.rpc import (
     RemoteCompileResult,
     RemoteCatalogResults,
     RemoteEmptyResult,
+    RemoteRunOperationResult,
     PollParameters,
     PollResult,
     PollInProgressResult,
@@ -30,6 +31,7 @@ from dbt.contracts.rpc import (
     PollCompileCompleteResult,
     PollCatalogCompleteResult,
     PollRemoteEmptyCompleteResult,
+    PollRunOperationCompleteResult,
     TaskHandlerState,
     TaskTiming,
 )
@@ -141,6 +143,7 @@ def poll_complete(
         PollCompileCompleteResult,
         PollCatalogCompleteResult,
         PollRemoteEmptyCompleteResult,
+        PollRunOperationCompleteResult,
     ]]
 
     if isinstance(result, RemoteExecutionResult):
@@ -154,6 +157,8 @@ def poll_complete(
         cls = PollCatalogCompleteResult
     elif isinstance(result, RemoteEmptyResult):
         cls = PollRemoteEmptyCompleteResult
+    elif isinstance(result, RemoteRunOperationResult):
+        cls = PollRunOperationCompleteResult
     else:
         raise dbt.exceptions.InternalException(
             'got invalid result in poll_complete: {}'.format(result)

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -11,6 +11,7 @@ from dbt.contracts.rpc import (
     RemoteCatalogResults,
     RemoteExecutionResult,
     RemoteRunOperationResult,
+    RPCSnapshotParameters,
 )
 from dbt.rpc.method import (
     Parameters,
@@ -132,9 +133,10 @@ class RemoteRunOperationTask(
         return results.success
 
 
-class RemoteSnapshotTask(RPCCommandTask[RPCCompileParameters], SnapshotTask):
+class RemoteSnapshotTask(RPCCommandTask[RPCSnapshotParameters], SnapshotTask):
     METHOD_NAME = 'snapshot'
 
-    def set_args(self, params: RPCCompileParameters) -> None:
-        self.args.models = self._listify(params.models)
+    def set_args(self, params: RPCSnapshotParameters) -> None:
+        # select has an argparse `dest` value of `models`.
+        self.args.models = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -455,6 +455,10 @@ class JSONEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return obj.isoformat()
+        if hasattr(obj, 'to_dict'):
+            # if we have a to_dict we should try to serialize the result of
+            # that!
+            obj = obj.to_dict()
         return super().default(obj)
 
 

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -31,6 +31,9 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'snowflake-connector-python>=1.6.12,<2.1',
+        'azure-storage-blob~=2.1',
+        'azure-storage-common~=2.1',
+
     ],
     zip_safe=False,
 )

--- a/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
+++ b/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
@@ -2,6 +2,7 @@ from test.integration.base import DBTIntegrationTest, use_profile
 import pickle
 import os
 
+
 class TestRpcExecuteReturnsResults(DBTIntegrationTest):
 
     @property
@@ -26,7 +27,7 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
 
         pickle.dumps(table)
 
-    def test_file(self, filename):
+    def do_test_file(self, filename):
         file_path = os.path.join("sql", filename)
         with open(file_path) as fh:
             query = fh.read()
@@ -39,12 +40,12 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
 
     @use_profile('bigquery')
     def test__bigquery_fetch_and_serialize(self):
-        self.test_file('bigquery.sql')
+        self.do_test_file('bigquery.sql')
 
     @use_profile('snowflake')
     def test__snowflake_fetch_and_serialize(self):
-        self.test_file('snowflake.sql')
+        self.do_test_file('snowflake.sql')
 
     @use_profile('redshift')
     def test__redshift_fetch_and_serialize(self):
-        self.test_file('redshift.sql')
+        self.do_test_file('redshift.sql')

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+import random
+import time
+from typing import Dict, Any
+
+import yaml
+
+
+@pytest.fixture
+def unique_schema() -> str:
+    return "test{}{:04}".format(int(time.time()), random.randint(0, 9999))
+
+
+@pytest.fixture
+def profiles_root(tmpdir):
+    return tmpdir.mkdir('profile')
+
+
+@pytest.fixture
+def project_root(tmpdir):
+    return tmpdir.mkdir('project')
+
+
+@pytest.fixture
+def postgres_profile_data(unique_schema):
+    return {
+        'config': {
+            'send_anonymous_usage_stats': False
+        },
+        'test': {
+            'outputs': {
+                'default': {
+                    'type': 'postgres',
+                    'threads': 4,
+                    'host': 'database',
+                    'port': 5432,
+                    'user': 'root',
+                    'pass': 'password',
+                    'dbname': 'dbt',
+                    'schema': unique_schema,
+                },
+            },
+            'target': 'default'
+        }
+    }
+
+
+@pytest.fixture
+def postgres_profile(profiles_root, postgres_profile_data) -> Dict[str, Any]:
+    path = os.path.join(profiles_root, 'profiles.yml')
+    with open(path, 'w') as fp:
+        fp.write(yaml.safe_dump(postgres_profile_data))
+    return postgres_profile_data

--- a/test/rpc/test_base.py
+++ b/test/rpc/test_base.py
@@ -1,23 +1,23 @@
+# flake8: disable=redefined-outer-name
 import time
-from .fixtures import (
-    ProjectDefinition, rpc_server, Querier, project_dir, profiles_dir,
-    postgres_profile, unique_schema, postgres_profile_data, built_schema,
+from .util import (
+    ProjectDefinition, rpc_server, Querier, built_schema, get_querier,
 )
 
 
-def test_rpc_basics(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_rpc_basics(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
 
+    with querier_ctx as querier:
         token = querier.is_async_result(querier.run_sql('select 1 as id'))
         querier.is_result(querier.async_wait(token))
 
@@ -38,15 +38,15 @@ def deps_with_packages(packages, bad_packages, project_dir, profiles_dir, schema
         },
         packages={'packages': packages},
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_dir,
+        profiles_dir=profiles_dir,
+        schema=schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
 
+    with querier_ctx as querier:
         # we should be able to run sql queries at startup
         token = querier.is_async_result(querier.run_sql('select 1 as id'))
         querier.is_result(querier.async_wait(token))
@@ -101,7 +101,7 @@ def deps_with_packages(packages, bad_packages, project_dir, profiles_dir, schema
         querier.is_result(querier.async_wait(tok1))
 
 
-def test_rpc_deps_packages(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_rpc_deps_packages(project_root, profiles_root, postgres_profile, unique_schema):
     packages = [{
         'package': 'fishtown-analytics/dbt_utils',
         'version': '0.2.1',
@@ -110,10 +110,10 @@ def test_rpc_deps_packages(project_dir, profiles_dir, postgres_profile, unique_s
         'package': 'fishtown-analytics/dbt_util',
         'version': '0.2.1',
     }]
-    deps_with_packages(packages, bad_packages, project_dir, profiles_dir, unique_schema)
+    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
 
 
-def test_rpc_deps_git(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_rpc_deps_git(project_root, profiles_root, postgres_profile, unique_schema):
     packages = [{
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
         'revision': '0.2.1'
@@ -123,7 +123,7 @@ def test_rpc_deps_git(project_dir, profiles_dir, postgres_profile, unique_schema
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
         'revision': 'not-a-real-revision'
     }]
-    deps_with_packages(packages, bad_packages, project_dir, profiles_dir, unique_schema)
+    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
 
 
 bad_schema_yml = '''
@@ -155,21 +155,22 @@ sources:
 '''
 
 
-def test_rpc_status_error(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_rpc_status_error(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={
             'descendant_model.sql': 'select * from {{ source("test_source", "test_table") }}',
             'schema.yml': bad_schema_yml,
         }
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, criteria='error',
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
+        criteria='error',
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+    with querier_ctx as querier:
 
         # the status should be an error result
         result = querier.is_result(querier.status())
@@ -184,7 +185,7 @@ def test_rpc_status_error(project_dir, profiles_dir, postgres_profile, unique_sc
         for key in ('message', 'timestamp', 'levelname', 'level'):
             assert key in logs[0]
         assert 'pid' in result
-        assert server.pid == result['pid']
+        assert querier.server.pid == result['pid']
 
         error = querier.is_error(querier.compile_sql('select 1 as id'))
         assert 'code' in error
@@ -210,7 +211,7 @@ def test_rpc_status_error(project_dir, profiles_dir, postgres_profile, unique_sc
         assert error['code'] == 10011
 
         project.models['schema.yml'] = fixed_schema_yml
-        project.write_models(project_dir, remove=True)
+        project.write_models(project_root, remove=True)
 
         # deps should work
         token = querier.is_async_result(querier.deps())
@@ -224,18 +225,19 @@ def test_rpc_status_error(project_dir, profiles_dir, postgres_profile, unique_sc
         querier.is_result(querier.compile_sql('select 1 as id'))
 
 
-def test_gc_change_interval(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_gc_change_interval(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+
+    with querier_ctx as querier:
 
         for _ in range(10):
             token = querier.is_async_result(querier.run())
@@ -271,19 +273,19 @@ def test_gc_change_interval(project_dir, profiles_dir, postgres_profile, unique_
         assert len(result['rows']) == 2
 
 
-def test_ps_poll_output_match(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_ps_poll_output_match(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
-    )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
 
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+    with querier_ctx as querier:
 
         token = querier.is_async_result(querier.run())
         poll_result = querier.is_result(querier.async_wait(token))
@@ -311,21 +313,22 @@ macros_data = '''
 '''
 
 
-def test_run_operation(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_run_operation(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'},
         macros={
             'my_macros.sql': macros_data,
         }
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+
+    with querier_ctx as querier:
         token = querier.is_async_result(querier.run_operation(macro='foo', args={}))
         poll_result = querier.is_result(querier.async_wait(token))
 
@@ -349,21 +352,22 @@ def test_run_operation(project_dir, profiles_dir, postgres_profile, unique_schem
         assert poll_result['success'] is True
 
 
-def test_run_operation_cli(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_run_operation_cli(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'},
         macros={
             'my_macros.sql': macros_data,
         }
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+
+    with querier_ctx as querier:
         token = querier.is_async_result(querier.cli_args(cli='run-operation foo'))
         poll_result = querier.is_result(querier.async_wait(token))
 
@@ -405,39 +409,44 @@ snapshot_data = '''
 '''
 
 
-def test_snapshots(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_snapshots(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         snapshots={'my_snapshots.sql': snapshot_data},
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+
+    with querier_ctx as querier:
         token = querier.is_async_result(querier.snapshot())
         results = querier.is_result(querier.async_wait(token))
         assert len(results['results']) == 1
 
         token = querier.is_async_result(querier.snapshot(exclude=['snapshot_actual']))
         results = querier.is_result(querier.async_wait(token))
-        assert len(results['results']) == 0
+
+        token = querier.is_async_result(querier.snapshot(select=['snapshot_actual']))
+        results = querier.is_result(querier.async_wait(token))
+        assert len(results['results']) == 1
 
 
-def test_snapshots_cli(project_dir, profiles_dir, postgres_profile, unique_schema):
+def test_snapshots_cli(project_root, profiles_root, postgres_profile, unique_schema):
     project = ProjectDefinition(
         snapshots={'my_snapshots.sql': snapshot_data},
     )
-    server_ctx = rpc_server(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
     )
-    schema_ctx = built_schema(
-        project_dir=project_dir, schema=unique_schema, profiles_dir=profiles_dir, test_kwargs={}, project_def=project,
-    )
-    with schema_ctx, server_ctx as server:
-        querier = Querier(server)
+
+    with querier_ctx as querier:
         token = querier.is_async_result(querier.cli_args(cli='snapshot'))
         results = querier.is_result(querier.async_wait(token))
         assert len(results['results']) == 1
@@ -445,3 +454,7 @@ def test_snapshots_cli(project_dir, profiles_dir, postgres_profile, unique_schem
         token = querier.is_async_result(querier.cli_args(cli='snapshot --exclude=snapshot_actual'))
         results = querier.is_result(querier.async_wait(token))
         assert len(results['results']) == 0
+
+        token = querier.is_async_result(querier.cli_args(cli='snapshot --select=snapshot_actual'))
+        results = querier.is_result(querier.async_wait(token))
+        assert len(results['results']) == 1

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -29,7 +29,9 @@ class NoServerException(Exception):
 
 
 class ServerProcess(dbt.flags.MP_CONTEXT.Process):
-    def __init__(self, cwd, port, profiles_dir, cli_vars=None, criteria=('ready',)):
+    def __init__(
+        self, cwd, port, profiles_dir, cli_vars=None, criteria=('ready',)
+    ):
         self.cwd = cwd
         self.port = port
         self.criteria = criteria
@@ -44,7 +46,8 @@ class ServerProcess(dbt.flags.MP_CONTEXT.Process):
         super().__init__(
             target=handle_and_check,
             args=(handle_and_check_args,),
-            name='ServerProcess')
+            name='ServerProcess',
+        )
 
     def run(self):
         os.chdir(self.cwd)
@@ -239,13 +242,13 @@ class Querier:
 
     def snapshot(
         self,
-        models: Optional[Union[str, List[str]]] = None,
+        select: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
         request_id: int = 1,
     ):
         params = {}
-        if models is not None:
-            params['models'] = models
+        if select is not None:
+            params['select'] = select
         if exclude is not None:
             params['exclude'] = exclude
         return self.request(
@@ -336,7 +339,9 @@ class Querier:
         assert 'error' in data
         return data['error']
 
-    def async_wait(self, token: str, timeout: int = 60, state='success') -> Dict[str, Any]:
+    def async_wait(
+        self, token: str, timeout: int = 60, state='success'
+    ) -> Dict[str, Any]:
         start = time.time()
         while True:
             time.sleep(0.5)
@@ -388,53 +393,6 @@ def rpc_server(project_dir, schema, profiles_dir, criteria='ready'):
     if proc.is_alive():
         os.kill(proc.pid, signal.SIGKILL)
         proc.join()
-
-
-@pytest.fixture
-def unique_schema() -> str:
-    return "test{}{:04}".format(int(time.time()), random.randint(0, 9999))
-
-
-@pytest.fixture
-def profiles_dir(tmpdir):
-    return tmpdir.mkdir('profile')
-
-
-@pytest.fixture
-def postgres_profile_data(unique_schema):
-    return {
-        'config': {
-            'send_anonymous_usage_stats': False
-        },
-        'test': {
-            'outputs': {
-                'default': {
-                    'type': 'postgres',
-                    'threads': 4,
-                    'host': 'database',
-                    'port': 5432,
-                    'user': 'root',
-                    'pass': 'password',
-                    'dbname': 'dbt',
-                    'schema': unique_schema,
-                },
-            },
-            'target': 'default'
-        }
-    }
-
-
-@pytest.fixture
-def postgres_profile(profiles_dir, postgres_profile_data) -> Dict[str, Any]:
-    path = os.path.join(profiles_dir, 'profiles.yml')
-    with open(path, 'w') as fp:
-        fp.write(yaml.safe_dump(postgres_profile_data))
-    return postgres_profile_data
-
-
-@pytest.fixture
-def project_dir(tmpdir):
-    return tmpdir.mkdir('project')
 
 
 class ProjectDefinition:
@@ -496,7 +454,6 @@ class ProjectDefinition:
 
         if value is not None:
             self._write_recursive(project_dir.mkdir(name), value)
-
 
     def write_models(self, project_dir, remove=False):
         self._write_values(project_dir, remove, 'models', self.models)
@@ -565,3 +522,24 @@ def built_schema(project_dir, schema, profiles_dir, test_kwargs, project_def):
     adapter = get_adapter(cfg)
     adapter.cleanup_connections()
     execute(adapter, 'drop schema if exists {} cascade'.format(schema))
+
+
+@contextmanager
+def get_querier(
+    project_def,
+    project_dir,
+    profiles_dir,
+    schema,
+    test_kwargs,
+    criteria='ready',
+):
+    server_ctx = rpc_server(
+        project_dir=project_dir, schema=schema, profiles_dir=profiles_dir,
+        criteria=criteria,
+    )
+    schema_ctx = built_schema(
+        project_dir=project_dir, schema=schema, profiles_dir=profiles_dir,
+        test_kwargs={}, project_def=project_def,
+    )
+    with schema_ctx, server_ctx as server:
+        yield Querier(server)


### PR DESCRIPTION
Fixes #1875 

`snapshot` + `run-operation` support. 


`run-operation`:
In addition to the defaults of 'task_tags' and 'timeout' there are 2 parameters:
    - macro: str (required)
    - args: Dict[str, Any] (optional)

As in the CLI version, run operations return a `success` boolean that indicates whether the macro raised an exception or not. They will only return an `error` object if the request itself is somehow wrong. The result returned by the macro is discarded.


`snapshot`:
This has the same arguments as `compile` and `run`. It executes the `dbt snapshot` task.


Both methods work via `cli_args`.