### PR TITLE
Test python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,45 @@ jobs:
           command: tox -e integration-bigquery-py36
       - store_artifacts:
           path: ./logs
+  integration-postgres-py38:
+    docker: *test_and_postgres
+    steps:
+      - checkout
+      - run: *setupdb
+      - run:
+          name: Run tests
+          command: tox -e integration-postgres-py38
+      - store_artifacts:
+          path: ./logs
+  integration-snowflake-py38:
+    docker: &test_only
+      - image: fishtownjacob/test-container
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: tox -e integration-snowflake-py38
+          no_output_timeout: 1h
+      - store_artifacts:
+          path: ./logs
+  integration-redshift-py38:
+    docker: *test_only
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: tox -e integration-redshift-py38
+      - store_artifacts:
+          path: ./logs
+  integration-bigquery-py38:
+    docker: *test_only
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: tox -e integration-bigquery-py38
+      - store_artifacts:
+          path: ./logs
 
 workflows:
   version: 2
@@ -77,3 +116,15 @@ workflows:
       - integration-snowflake-py36:
           requires:
             - integration-postgres-py36
+      - integration-postgres-py38:
+          requires:
+            - unit
+      - integration-redshift-py38:
+          requires:
+            - integration-postgres-py38
+      - integration-bigquery-py38:
+          requires:
+            - integration-postgres-py38
+      - integration-snowflake-py38:
+          requires:
+            - integration-postgres-py38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit:
     docker: &test_and_postgres
-      - image: fishtownjacob/test-container
+      - image: fishtownjacob/test-container:2
       - image: postgres
         name: database
         environment: &pgenv
@@ -19,7 +19,7 @@ jobs:
             PGUSER: root
             PGPASSWORD: password
             PGDATABASE: postgres
-      - run: tox -e flake8,mypy,unit-py36
+      - run: tox -e flake8,mypy,unit-py36,unit-py38
   integration-postgres-py36:
     docker: *test_and_postgres
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: ./logs
   integration-snowflake-py36:
     docker: &test_only
-      - image: fishtownjacob/test-container
+      - image: fishtownjacob/test-container:2
     steps:
       - checkout
       - run:
@@ -70,8 +70,7 @@ jobs:
       - store_artifacts:
           path: ./logs
   integration-snowflake-py38:
-    docker: &test_only
-      - image: fishtownjacob/test-container
+    docker: *test_only
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,52 +3,44 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y  --no-install-recommends \
-        netcat postgresql make build-essential libssl-dev zlib1g-dev \
-        libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
-        xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev git ca-certificates \
-        curl git ssh && \
+        netcat postgresql curl git ssh  software-properties-common \
+        make build-essential ca-certificates libpq-dev && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get install -y \
+        python python-dev python-pip \
+        python3.6 python3.6-dev python3-pip python3.6-venv \
+        python3.7 python3.7-dev python3.7-venv \
+        python3.8 python3.8-dev python3.8-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -mU dbt_test_user
 RUN mkdir /usr/app && chown dbt_test_user /usr/app
 RUN mkdir /home/tox && chown dbt_test_user /home/tox
-USER dbt_test_user
 
 WORKDIR /usr/app
 VOLUME /usr/app
 
-RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+RUN pip3 install tox wheel
 
-ENV PYENV_ROOT="/home/dbt_test_user/.pyenv" \
-    PATH="/home/dbt_test_user/.pyenv/bin:/home/dbt_test_user/.pyenv/shims:$PATH"
+RUN python2.7 -m pip install virtualenv wheel && \
+    python2.7 -m virtualenv /home/tox/venv2.7 && \
+    /home/tox/venv2.7/bin/python -m pip install -U pip tox
 
-RUN pyenv update && \
-    echo "2.7.16 3.6.8 3.7.3" | xargs -P 4 -n 1 pyenv install && \
-    pyenv global $(pyenv versions --bare)
+RUN python3.6 -m pip install -U pip wheel && \
+    python3.6 -m venv /home/tox/venv3.6 && \
+    /home/tox/venv3.6/bin/python -m pip install -U pip tox
 
-RUN pyenv virtualenv 3.6.8 dbt36 && \
-    pyenv virtualenv 3.7.3 dbt37 && \
-    pyenv virtualenv 2.7.16 dbt27
+RUN python3.7 -m pip install -U pip wheel && \
+    python3.7 -m venv /home/tox/venv3.7 && \
+    /home/tox/venv3.7/bin/python -m pip install -U pip tox
 
-RUN cd /usr/app && \
-    python -m pip install -U pip && \
-    python -m pip install tox && \
-    pyenv local dbt37 && \
-    python -m pip install -U pip && \
-    python -m pip install tox && \
-    pyenv local --unset && \
-    pyenv local dbt36 && \
-    python -m pip install -U pip && \
-    python -m pip install tox && \
-    pyenv local --unset && \
-    pyenv local dbt27 && \
-    python -m pip install -U pip && \
-    python -m pip install tox && \
-    pyenv local --unset && \
-    pyenv rehash
+RUN python3.8 -m pip install -U pip wheel && \
+    python3.8 -m venv /home/tox/venv3.8 && \
+    /home/tox/venv3.8/bin/python -m pip install -U pip tox
 
-RUN pyenv local dbt36 dbt37 dbt27
+USER dbt_test_user
 
 ENV PYTHONIOENCODING=utf-8
 ENV LANG C.UTF-8

--- a/core/setup.py
+++ b/core/setup.py
@@ -62,4 +62,17 @@ setup(
         'typing-extensions>=3.7.4,<3.8',
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -33,4 +33,17 @@ setup(
         'google-cloud-bigquery>=1.15.0,<2',
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -30,7 +30,7 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'psycopg2>=2.7.5,<2.8',
+        'psycopg2>=2.8.4,<2.9',
     ],
     zip_safe=False,
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -33,4 +33,17 @@ setup(
         'psycopg2>=2.8.4,<2.9',
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -36,4 +36,17 @@ setup(
         'psycopg2>=2.7.5,<2.8',
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -33,7 +33,6 @@ setup(
         'snowflake-connector-python>=1.6.12,<2.1',
         'azure-storage-blob~=2.1',
         'azure-storage-common~=2.1',
-        # hoist this to here so pip's silly dependency resolver sees it
         'urllib3<1.25.0',
     ],
     zip_safe=False,

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -36,4 +36,17 @@ setup(
         'urllib3<1.25.0',
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,17 @@ setup(
         'dbt-bigquery=={}'.format(package_version),
     ],
     zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 skipsdist = True
 envlist = unit-py36, integration-postgres-py36, integration-redshift-py36, integration-snowflake-py36, flake8, integration-bigquery-py36, mypy
+requires = tox-pip-version
 
 
 [testenv:flake8]
@@ -12,6 +13,7 @@ deps =
 [testenv:mypy]
 basepython = python3.6
 commands = /bin/bash -c '$(which mypy) core/dbt'
+pip_version = pip
 deps =
     -r ./requirements.txt
     -r ./dev_requirements.txt
@@ -168,6 +170,70 @@ deps =
 
 [testenv:explicit-py37]
 basepython = python3.7
+passenv = *
+setenv =
+    HOME=/home/tox
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs}'
+deps =
+    -r ./editable_requirements.txt
+    -r ./dev_requirements.txt
+
+[testenv:unit-py38]
+basepython = python3.8
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/unit'
+deps =
+    -r ./requirements.txt
+    -r ./dev_requirements.txt
+
+
+[testenv:integration-postgres-py38]
+basepython = python3.8
+passenv = *
+setenv =
+    HOME=/home/tox
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*'
+deps =
+    ./core
+    ./plugins/postgres
+    -r ./dev_requirements.txt
+
+[testenv:integration-snowflake-py38]
+basepython = python3.8
+passenv = *
+setenv =
+    HOME=/home/tox
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
+deps =
+    ./core
+    ./plugins/snowflake
+    -r ./dev_requirements.txt
+
+[testenv:integration-bigquery-py38]
+basepython = python3.8
+passenv = *
+setenv =
+    HOME=/home/tox
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_bigquery {posargs} -n4 test/integration/*'
+deps =
+    ./core
+    ./plugins/bigquery
+    -r ./dev_requirements.txt
+
+[testenv:integration-redshift-py38]
+basepython = python3.8
+passenv = *
+setenv =
+    HOME=/home/tox
+commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_redshift {posargs} -n4 test/integration/*'
+deps =
+    ./core
+    ./plugins/postgres
+    ./plugins/redshift
+    -r ./dev_requirements.txt
+
+
+[testenv:explicit-py38]
+basepython = python3.8
 passenv = *
 setenv =
     HOME=/home/tox


### PR DESCRIPTION
Revamp the test docker images to be more multi-version-friendly, build MUCH more quickly, and be smaller.
Add testing for python 3.8, since that's released now.
Bump psycopg to 2.8.4 - they build binary wheels now (this isn't really advertised), and it works properly with python 3.8.