### PR TITLE
Lock many dependencies/sub-dependencies (#1892)

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -46,7 +46,7 @@ setup(
         'Jinja2>=2.10',
         'PyYAML>=3.11',
         'sqlparse==0.2.3',
-        'networkx>=1.11,<3',
+        'networkx>=1.11,<2.4',
         'minimal-snowplow-tracker==0.0.2',
         'requests>=2.18.0,<3',
         'colorama==0.3.9',

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -30,6 +30,6 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'psycopg2>=2.7.5,<2.8',
+        'psycopg2>=2.7,<2.8',
     ]
 )

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -26,13 +26,13 @@ setup(
             'include/redshift/dbt_project.yml',
             'include/redshift/macros/*.sql',
             'include/redshift/macros/**/*.sql',
-        ]
+        ],
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'dbt-postgres=={}'.format(package_version),
-        'boto3>=1.6.23,<1.10.0',
-        'botocore>=1.9.23,<1.13.0',
-        'psycopg2>=2.7.5,<2.8',
-    ]
+        'psycopg2>=2.7,<2.8',
+        'boto3>=1.4.4,<1.11.0',
+        'botocore>=1.5.0,<1.14.0',
+    ],
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -30,6 +30,17 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'snowflake-connector-python>=1.6.12',
+        'snowflake-connector-python==2.0.3',
+        'requests<2.23',
+        'urllib3<1.25',
+        'azure-common<2',
+        'azure-storage-blob<3',
+        'pycryptodomex>=3.2,!=3.5.0,<4',
+        'pyOpenSSL>=16.2.0',
+        'cffi>=1.9,<2',
+        'cryptography>2,<3',
+        'pyjwt<2',
+        'idna<3',
+        'ijson<2.6',
     ]
 )


### PR DESCRIPTION
Fixes #1892 

Pin all sorts of troublesome things:
 networkx 2.4 breaks python 3.6
 pinned snowflake adapter
 expanded boto/botocore to match new snowflake
 pinned many snowflake dependencies
 set a cap on a lot of sub-dependencies that didn't have them before to hopefully avoid any more issues with deps in 0.14.x