### PR TITLE
pin psycopg2 (#1221)

### DIFF
--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -2,6 +2,24 @@
 from setuptools import find_namespace_packages
 from setuptools import setup
 import os
+import sys
+
+
+def _dbt_psycopg2_name():
+    # if the user chose something, use that
+    package_name = os.getenv('DBT_PSYCOPG2_NAME', '')
+    if package_name:
+        return package_name
+
+    binary_only_versions = [(3, 8)]
+
+    # binary wheels don't exist for all versions. Require psycopg2-binary for
+    # them and wait for psycopg2.
+    if sys.version_info[:2] in binary_only_versions:
+        return 'psycopg2-binary'
+    else:
+        return 'psycopg2'
+
 
 package_name = "dbt-postgres"
 package_version = "0.15.0b2"
@@ -10,6 +28,8 @@ description = """The postgres adpter plugin for dbt (data build tool)"""
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
+
+DBT_PSYCOPG2_NAME = _dbt_psycopg2_name()
 
 setup(
     name=package_name,
@@ -30,7 +50,7 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'psycopg2>=2.8.4,<2.9',
+        '{}~=2.8'.format(DBT_PSYCOPG2_NAME),
     ],
     zip_safe=False,
     classifiers=[

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_namespace_packages
 from setuptools import setup
 import os
 
+
 package_name = "dbt-redshift"
 package_version = "0.15.0b2"
 description = """The redshift adapter plugin for dbt (data build tool)"""
@@ -33,7 +34,6 @@ setup(
         'dbt-postgres=={}'.format(package_version),
         'boto3>=1.6.23,<1.10.0',
         'botocore>=1.9.23,<1.13.0',
-        'psycopg2>=2.7.5,<2.8',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Fixes #1221 
See [this comment](https://github.com/fishtown-analytics/dbt/issues/1221#issuecomment-551122553) for the reasoning here.

Rev psycopg2 to 2.8.x
Remove `psycopg2` from redshift's dependencies since it's inherited from postgres anyway
Install `psycopg2-binary` by default on 3.8, `psycopg2` otherwise

If the `DBT_PSYCOPG2_NAME` environment variable is present during installation, dbt will require that name instead (even if it is a stupid request like a `-binary` on an unsupported platform).
We don't restrict this to only `psycopg2-binary` and `psycopg2`, but we could.
This flag doesn't change the package version.
