### PR TITLE
log hook info in json logs (#1890)

### DIFF
--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -265,9 +265,9 @@ class NodeCount(logbook.Processor):
         record.extra['node_count'] = self.node_count
 
 
-class ModelMetadata(logbook.Processor):
-    def __init__(self, model, index):
-        self.model = model
+class NodeMetadata(logbook.Processor):
+    def __init__(self, node, index):
+        self.node = node
         self.index = index
         super().__init__()
 
@@ -276,7 +276,7 @@ class ModelMetadata(logbook.Processor):
 
     def process_keys(self, record):
         for attr, key in self.mapping_keys():
-            value = getattr(self.model, attr, None)
+            value = getattr(self.node, attr, None)
             if value is not None:
                 record.extra[key] = value
 
@@ -285,7 +285,7 @@ class ModelMetadata(logbook.Processor):
         record.extra['node_index'] = self.index
 
 
-class NodeMetadata(ModelMetadata):
+class ModelMetadata(NodeMetadata):
     def mapping_keys(self):
         return [
             ('alias', 'node_alias'),
@@ -297,8 +297,8 @@ class NodeMetadata(ModelMetadata):
         ]
 
     def process_config(self, record):
-        if hasattr(self.model, 'config'):
-            materialized = getattr(self.model.config, 'materialized', None)
+        if hasattr(self.node, 'config'):
+            materialized = getattr(self.node.config, 'materialized', None)
             if materialized is not None:
                 record.extra['node_materialized'] = materialized
 
@@ -307,7 +307,7 @@ class NodeMetadata(ModelMetadata):
         self.process_config(record)
 
 
-class HookMetadata(ModelMetadata):
+class HookMetadata(NodeMetadata):
     def mapping_keys(self):
         return [
             ('name', 'node_name'),

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -12,7 +12,7 @@ from dbt.logger import (
     UniqueID,
     TimestampNamed,
     DbtModelState,
-    NodeMetadata,
+    ModelMetadata,
     NodeCount,
 )
 from dbt.compilation import compile_manifest
@@ -124,7 +124,7 @@ class GraphRunnableTask(ManifestTask):
         with RUNNING_STATE, uid_context:
             startctx = TimestampNamed('node_started_at')
             index = self.index_offset(runner.node_index)
-            extended_metadata = NodeMetadata(runner.node, index)
+            extended_metadata = ModelMetadata(runner.node, index)
             with startctx, extended_metadata:
                 logger.debug('Began running node {}'.format(
                     runner.node.unique_id))

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -67,6 +67,9 @@ class GraphRunnableTask(ManifestTask):
         self._skipped_children = {}
         self._raise_next_tick = None
 
+    def index_offset(self, value: int) -> int:
+        return value
+
     def select_nodes(self):
         selector = dbt.graph.selector.NodeSelector(
             self.linker.graph, self.manifest
@@ -120,7 +123,8 @@ class GraphRunnableTask(ManifestTask):
         uid_context = UniqueID(runner.node.unique_id)
         with RUNNING_STATE, uid_context:
             startctx = TimestampNamed('node_started_at')
-            extended_metadata = NodeMetadata(runner.node, runner.node_index)
+            index = self.index_offset(runner.node_index)
+            extended_metadata = NodeMetadata(runner.node, index)
             with startctx, extended_metadata:
                 logger.debug('Began running node {}'.format(
                     runner.node.unique_id))

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -8,7 +8,10 @@ import itertools
 import json
 import os
 from enum import Enum
-from typing import Tuple, Type, Any, Optional, TypeVar, Dict
+from typing import (
+    Tuple, Type, Any, Optional, TypeVar, Dict, Iterable, Set, List
+)
+from typing_extensions import Protocol
 
 import dbt.exceptions
 
@@ -314,7 +317,16 @@ def get_pseudo_hook_path(hook_name):
     return os.path.join(*path_parts)
 
 
-def get_nodes_by_tags(nodes, match_tags, resource_type):
+class _Tagged(Protocol):
+    tags: Iterable[str]
+
+
+Tagged = TypeVar('Tagged', bound=_Tagged)
+
+
+def get_nodes_by_tags(
+    nodes: Iterable[Tagged], match_tags: Set[str], resource_type: NodeType
+) -> List[Tagged]:
     matched_nodes = []
     for node in nodes:
         node_tags = node.tags


### PR DESCRIPTION
Fixes #1890 

```json
{
  "json_only": true,
  "node_started_at": "2019-11-07T18:30:21.727439",
  "node_name": "minimal-on-run-start-1",
  "resource_type": "operation",
  "node_index": 2,
  "unique_id": "operation.minimal.minimal-on-run-start-1",
  "run_state": "internal"
}
```

completion:
```json
{
  "node_status": "SELECT 1",
  "json_only": true,
  "node_finished_at": "2019-11-07T18:30:21.731011",
  "unique_id": "operation.minimal.minimal-on-run-start-1",
  "run_state": "internal"
}
```

On errors in hooks we fail entirely, so currently this only logs completion on success. We can make it do so though, It's just some extra work to catch+log+reraise exceptions.