### PR TITLE
fix for manifest reload logic

### DIFF
--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -179,7 +179,7 @@ def get_results_context(
 
     with manifest_blocking:
         yield
-        if RemoteMethodFlags.RequiresManifestReloadAfter:
+        if RemoteMethodFlags.RequiresManifestReloadAfter in flags:
             manager.parse_manifest()
 
 


### PR DESCRIPTION
This PR adjusts the way that we check the `RequiresManifestReloadAfter` flag. I think previously we were checking the value of the flag itself (which is something like `5`) so it was always truthy. As a result, the dbt server was reloading the manifest after calls to `run_sql` and `compile_sql` which wasn't necessary.