### PR TITLE
Don't deep copy the manifest unless we're in single threaded mode (#1904)

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -16,6 +16,7 @@ import dbt.exceptions
 import dbt.utils
 
 from dbt.clients._jinja_blocks import BlockIterator, BlockData, BlockTag
+from dbt.flags import MACRO_DEBUGGING
 
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
@@ -79,9 +80,8 @@ class MacroFuzzEnvironment(jinja2.sandbox.SandboxedEnvironment):
         If the value is 'write', also write the files to disk.
         WARNING: This can write a ton of data if you aren't careful.
         """
-        macro_compile = dbt.utils.env_set_truthy('DBT_MACRO_DEBUGGING')
-        if filename == '<template>' and macro_compile:
-            write = macro_compile == 'write'
+        if filename == '<template>' and MACRO_DEBUGGING:
+            write = MACRO_DEBUGGING == 'write'
             filename = _linecache_inject(source, write)
 
         return super()._compile(source, filename)

--- a/core/dbt/flags.py
+++ b/core/dbt/flags.py
@@ -1,5 +1,6 @@
 import os
 import multiprocessing
+from typing import Optional
 # initially all flags are set to None, the on-load call of reset() will set
 # them for their first time.
 STRICT_MODE = None
@@ -9,6 +10,21 @@ WARN_ERROR = None
 TEST_NEW_PARSER = None
 WRITE_JSON = None
 PARTIAL_PARSE = None
+
+
+def env_set_truthy(key: str) -> Optional[str]:
+    """Return the value if it was set to a "truthy" string value, or None
+    otherwise.
+    """
+    value = os.getenv(key)
+    if not value or value.lower() in ('0', 'false', 'f'):
+        return None
+    return value
+
+
+SINGLE_THREADED_WEBSERVER = env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
+SINGLE_THREADED_HANDLER = env_set_truthy('DBT_SINGLE_THREADED_HANDLER')
+MACRO_DEBUGGING = env_set_truthy('DBT_MACRO_DEBUGGING')
 
 
 def _get_context():

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -37,13 +37,11 @@ from dbt.rpc.logger import (
     QueueTimeoutMessage,
 )
 from dbt.rpc.method import RemoteMethod
-from dbt.utils import env_set_truthy
+from dbt.flags import SINGLE_THREADED_HANDLER
+
 
 # we use this in typing only...
 from queue import Queue  # noqa
-
-
-SINGLE_THREADED_HANDLER = env_set_truthy('DBT_SINGLE_THREADED_HANDLER')
 
 
 def sigterm_handler(signum, frame):

--- a/core/dbt/rpc/task_manager.py
+++ b/core/dbt/rpc/task_manager.py
@@ -32,10 +32,7 @@ import dbt.rpc.builtins  # noqa
 
 # import this to make sure our timedelta encoder is registered
 from dbt import helper_types  # noqa
-from dbt.utils import env_set_truthy
-
-
-SINGLE_THREADED_WEBSERVER = env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
+from dbt.flags import SINGLE_THREADED_WEBSERVER
 
 
 WrappedHandler = Callable[..., Dict[str, Any]]

--- a/core/dbt/task/rpc/sql_commands.py
+++ b/core/dbt/task/rpc/sql_commands.py
@@ -110,7 +110,7 @@ class RemoteRunSQLTask(RPCTask[RPCExecParameters]):
         node = rpc_parser.parse_remote(sql, self.args.name)
         self.manifest = ParserUtils.add_new_refs(
             manifest=self.manifest,
-            current_project=self.config,
+            config=self.config,
             node=node,
             macros=macro_overrides
         )

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -518,16 +518,6 @@ def pluralize(count, string):
         return "{} {}s".format(count, string)
 
 
-def env_set_truthy(key: str) -> Optional[str]:
-    """Return the value if it was set to a "truthy" string value, or None
-    otherwise.
-    """
-    value = os.getenv(key)
-    if not value or value.lower() in ('0', 'false', 'f'):
-        return None
-    return value
-
-
 def restrict_to(*restrictions):
     """Create the metadata for a restricted dataclass field"""
     return {'restrict': list(restrictions)}


### PR DESCRIPTION
Fixes #1904 

Also move environment variable handling into dbt.flags so it's easier to check