### PR TITLE
add threads to commands (#1897)

### DIFF
--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -41,12 +41,14 @@ class RPCExecParameters(RPCParameters):
 
 @dataclass
 class RPCCompileParameters(RPCParameters):
+    threads: Optional[int] = None
     models: Union[None, str, List[str]] = None
     exclude: Union[None, str, List[str]] = None
 
 
 @dataclass
 class RPCSnapshotParameters(RPCParameters):
+    threads: Optional[int] = None
     select: Union[None, str, List[str]] = None
     exclude: Union[None, str, List[str]] = None
 
@@ -59,6 +61,7 @@ class RPCTestParameters(RPCCompileParameters):
 
 @dataclass
 class RPCSeedParameters(RPCParameters):
+    threads: Optional[int] = None
     show: bool = False
 
 

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -86,6 +86,10 @@ class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
         handler = QueueLogHandler(self.queue)
         with handler.applicationbound():
             self._spawn_setup()
+            # copy threads over into our credentials, if it exists and is set.
+            # some commands, like 'debug', won't have a threads value at all.
+            if getattr(self.task.args, 'threads', None) is not None:
+                self.task.config.threads = self.task.args.threads
             rpc_exception = None
             result = None
             try:

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -55,6 +55,8 @@ class RemoteCompileProjectTask(
     def set_args(self, params: RPCCompileParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
+        if params.threads is not None:
+            self.args.threads = params.threads
 
 
 class RemoteRunProjectTask(RPCCommandTask[RPCCompileParameters], RunTask):
@@ -63,12 +65,16 @@ class RemoteRunProjectTask(RPCCommandTask[RPCCompileParameters], RunTask):
     def set_args(self, params: RPCCompileParameters) -> None:
         self.args.models = self._listify(params.models)
         self.args.exclude = self._listify(params.exclude)
+        if params.threads is not None:
+            self.args.threads = params.threads
 
 
 class RemoteSeedProjectTask(RPCCommandTask[RPCSeedParameters], SeedTask):
     METHOD_NAME = 'seed'
 
     def set_args(self, params: RPCSeedParameters) -> None:
+        if params.threads is not None:
+            self.args.threads = params.threads
         self.args.show = params.show
 
 
@@ -80,6 +86,8 @@ class RemoteTestProjectTask(RPCCommandTask[RPCTestParameters], TestTask):
         self.args.exclude = self._listify(params.exclude)
         self.args.data = params.data
         self.args.schema = params.schema
+        if params.threads is not None:
+            self.args.threads = params.threads
 
 
 class RemoteDocsGenerateProjectTask(
@@ -140,3 +148,5 @@ class RemoteSnapshotTask(RPCCommandTask[RPCSnapshotParameters], SnapshotTask):
         # select has an argparse `dest` value of `models`.
         self.args.models = self._listify(params.select)
         self.args.exclude = self._listify(params.exclude)
+        if params.threads is not None:
+            self.args.threads = params.threads

--- a/core/dbt/task/rpc/server.py
+++ b/core/dbt/task/rpc/server.py
@@ -123,8 +123,7 @@ class RPCServerTask(ConfiguredTask):
             'Send requests to http://{}:{}/jsonrpc'.format(display_host, port)
         )
 
-        app = self.handle_request
-        app = DispatcherMiddleware(app, {
+        app = DispatcherMiddleware(self.handle_request, {
             '/jsonrpc': self.handle_jsonrpc_request,
         })
 

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -193,6 +193,7 @@ class Querier:
         self,
         models: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
+        threads: Optional[int] = None,
         request_id: int = 1,
     ):
         params = {}
@@ -200,6 +201,8 @@ class Querier:
             params['models'] = models
         if exclude is not None:
             params['exclude'] = exclude
+        if threads is not None:
+            params['threads'] = threads
         return self.request(
             method='compile', params=params, request_id=request_id
         )
@@ -208,6 +211,7 @@ class Querier:
         self,
         models: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
+        threads: Optional[int] = None,
         request_id: int = 1,
     ):
         params = {}
@@ -215,6 +219,8 @@ class Querier:
             params['models'] = models
         if exclude is not None:
             params['exclude'] = exclude
+        if threads is not None:
+            params['threads'] = threads
         return self.request(
             method='run', params=params, request_id=request_id
         )
@@ -232,10 +238,17 @@ class Querier:
             method='run-operation', params=params, request_id=request_id
         )
 
-    def seed(self, show: bool = None, request_id: int = 1):
+    def seed(
+        self,
+        show: bool = None,
+        threads: Optional[int] = None,
+        request_id: int = 1,
+    ):
         params = {}
         if show is not None:
             params['show'] = show
+        if threads is not None:
+            params['threads'] = threads
         return self.request(
             method='seed', params=params, request_id=request_id
         )
@@ -244,6 +257,7 @@ class Querier:
         self,
         select: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
+        threads: Optional[int] = None,
         request_id: int = 1,
     ):
         params = {}
@@ -251,6 +265,8 @@ class Querier:
             params['select'] = select
         if exclude is not None:
             params['exclude'] = exclude
+        if threads is not None:
+            params['threads'] = threads
         return self.request(
             method='snapshot', params=params, request_id=request_id
         )
@@ -259,6 +275,7 @@ class Querier:
         self,
         models: Optional[Union[str, List[str]]] = None,
         exclude: Optional[Union[str, List[str]]] = None,
+        threads: Optional[int] = None,
         data: bool = None,
         schema: bool = None,
         request_id: int = 1,
@@ -272,6 +289,8 @@ class Querier:
             params['data'] = data
         if schema is not None:
             params['schema'] = schema
+        if threads is not None:
+            params['threads'] = threads
         return self.request(
             method='test', params=params, request_id=request_id
         )
@@ -406,6 +425,7 @@ class ProjectDefinition:
         models=None,
         macros=None,
         snapshots=None,
+        seeds=None,
     ):
         self.project = {
             'name': name,
@@ -418,10 +438,11 @@ class ProjectDefinition:
         self.models = models
         self.macros = macros
         self.snapshots = snapshots
+        self.seeds = seeds
 
     def _write_recursive(self, path, inputs):
         for name, value in inputs.items():
-            if name.endswith('.sql'):
+            if name.endswith('.sql') or name.endswith('.csv'):
                 path.join(name).write(value)
             elif name.endswith('.yml'):
                 if isinstance(value, str):
@@ -464,6 +485,9 @@ class ProjectDefinition:
     def write_snapshots(self, project_dir, remove=False):
         self._write_values(project_dir, remove, 'snapshots', self.snapshots)
 
+    def write_seeds(self, project_dir, remove=False):
+        self._write_values(project_dir, remove, 'data', self.seeds)
+
     def write_to(self, project_dir, remove=False):
         if remove:
             project_dir.remove()
@@ -473,6 +497,7 @@ class ProjectDefinition:
         self.write_models(project_dir)
         self.write_macros(project_dir)
         self.write_snapshots(project_dir)
+        self.write_seeds(project_dir)
 
 
 class TestArgs:


### PR DESCRIPTION
Fixes #1897 

I added the `--threads` parameter to the RPC server's `test`, `run`, `compile`, and `seed` tasks as well because it was easy.

The tests assume the `Concurrency: X threads` log is accurate, so... don't break that.
