### PR TITLE
Tweak rpc logging settings

### DIFF
--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -88,7 +88,7 @@ class KillParameters(RPCParameters):
 @dataclass
 class PollParameters(RPCParameters):
     request_token: TaskID
-    logs: bool = False
+    logs: bool = True
     logs_start: int = 0
 
 

--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -349,9 +349,10 @@ class PollRemoteEmptyCompleteResult(PollResult, RemoteEmptyResult):
         base: RemoteEmptyResult,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollRemoteEmptyCompleteResult':
         return cls(
-            logs=base.logs,
+            logs=logs,
             tags=tags,
             state=timing.state,
             start=timing.start,
@@ -380,12 +381,13 @@ class PollExecuteCompleteResult(RemoteExecutionResult, PollResult):
         base: RemoteExecutionResult,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollExecuteCompleteResult':
         return cls(
             results=base.results,
             generated_at=base.generated_at,
             elapsed_time=base.elapsed_time,
-            logs=base.logs,
+            logs=logs,
             tags=tags,
             state=timing.state,
             start=timing.start,
@@ -407,13 +409,14 @@ class PollCompileCompleteResult(RemoteCompileResult, PollResult):
         base: RemoteCompileResult,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollCompileCompleteResult':
         return cls(
             raw_sql=base.raw_sql,
             compiled_sql=base.compiled_sql,
             node=base.node,
             timing=base.timing,
-            logs=base.logs,
+            logs=logs,
             tags=tags,
             state=timing.state,
             start=timing.start,
@@ -435,13 +438,14 @@ class PollRunCompleteResult(RemoteRunResult, PollResult):
         base: RemoteRunResult,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollRunCompleteResult':
         return cls(
             raw_sql=base.raw_sql,
             compiled_sql=base.compiled_sql,
             node=base.node,
             timing=base.timing,
-            logs=base.logs,
+            logs=logs,
             table=base.table,
             tags=tags,
             state=timing.state,
@@ -464,10 +468,11 @@ class PollRunOperationCompleteResult(RemoteRunOperationResult, PollResult):
         base: RemoteRunOperationResult,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollRunOperationCompleteResult':
         return cls(
             success=base.success,
-            logs=base.logs,
+            logs=logs,
             tags=tags,
             state=timing.state,
             start=timing.start,
@@ -489,12 +494,13 @@ class PollCatalogCompleteResult(RemoteCatalogResults, PollResult):
         base: RemoteCatalogResults,
         tags: TaskTags,
         timing: TaskTiming,
+        logs: List[LogMessage],
     ) -> 'PollCatalogCompleteResult':
         return cls(
             nodes=base.nodes,
             generated_at=base.generated_at,
             _compile_results=base._compile_results,
-            logs=base.logs,
+            logs=logs,
             tags=tags,
             state=timing.state,
             start=timing.start,

--- a/core/dbt/rpc/builtins.py
+++ b/core/dbt/rpc/builtins.py
@@ -130,7 +130,7 @@ class PS(RemoteBuiltinMethod[PSParameters, PSResult]):
 
 
 def poll_complete(
-    timing: TaskTiming, result: Any, tags: TaskTags
+    timing: TaskTiming, result: Any, tags: TaskTags, logs: List[LogMessage]
 ) -> PollResult:
     if timing.state not in (TaskHandlerState.Success, TaskHandlerState.Failed):
         raise dbt.exceptions.InternalException(
@@ -163,7 +163,7 @@ def poll_complete(
         raise dbt.exceptions.InternalException(
             'got invalid result in poll_complete: {}'.format(result)
         )
-    return cls.from_result(result, tags, timing)
+    return cls.from_result(result, tags, timing, logs)
 
 
 class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
@@ -224,6 +224,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
                 timing=timing,
                 result=task.result,
                 tags=task.tags,
+                logs=task_logs
             )
         elif state == TaskHandlerState.Killed:
             return PollKilledResult(

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -127,7 +127,8 @@ class RunTask(CompileTask):
                                           hook.index)
             hook_meta_ctx = HookMetadata(hook, self.index_offset(idx))
             uid_ctx = UniqueID(hook.unique_id)
-            with uid_ctx, hook_meta_ctx, startctx, DbtModelState({'node_status': 'running'}):
+            running_ctx = DbtModelState({'node_status': 'running'})
+            with uid_ctx, hook_meta_ctx, startctx, running_ctx:
                 print_hook_start_line(hook_text, idx, num_hooks)
 
             status = 'OK'

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -126,9 +126,8 @@ class RunTask(CompileTask):
             hook_text = '{}.{}.{}'.format(hook.package_name, hook_type,
                                           hook.index)
             hook_meta_ctx = HookMetadata(hook, self.index_offset(idx))
-            running_ctx = DbtModelState({'node_status': 'running'})
             with UniqueID(hook.unique_id):
-                with hook_meta_ctx, startctx, running_ctx:
+                with hook_meta_ctx, startctx:
                     print_hook_start_line(hook_text, idx, num_hooks)
 
                 status = 'OK'

--- a/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
+++ b/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
@@ -19,7 +19,7 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
             'macro-paths': ['macros'],
         }
 
-    def test_pickle(self, agate_table):
+    def do_test_pickle(self, agate_table):
         table = {
             'column_names': list(agate_table.column_names),
             'rows': [list(row) for row in agate_table]
@@ -36,7 +36,7 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
         self.assertTrue(len(table.columns) > 0, "agate table had no columns")
         self.assertTrue(len(table.rows) > 0, "agate table had no rows")
 
-        self.test_pickle(table)
+        self.do_test_pickle(table)
 
     @use_profile('bigquery')
     def test__bigquery_fetch_and_serialize(self):

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -148,8 +148,8 @@ class Querier:
     def poll(
         self,
         request_token: str,
-        logs: bool = False,
-        logs_start: int = 0,
+        logs: Optional[bool] = None,
+        logs_start: Optional[int] = None,
         request_id: int = 1,
     ):
         params = {
@@ -374,6 +374,14 @@ class Querier:
             delta = (time.time() - start)
             assert timeout > delta, \
                 f'At time {delta}, never saw {state}.\nLast response: {result}'
+
+    def async_wait_for_result(self, data: Dict[str, Any], state='success'):
+        token = self.is_async_result(data)
+        return self.is_result(self.async_wait(token, state=state))
+
+    def async_wait_for_error(self, data: Dict[str, Any], state='success'):
+        token = self.is_async_result(data)
+        return self.is_error(self.async_wait(token, state=state))
 
 
 def _first_server(cwd, cli_vars, profiles_dir, criteria):


### PR DESCRIPTION
- respect logs_start parameter even when tasks have completed
- fix for incorrect hook index for on-run-end hooks
- clean up on-run hook log messages
- include SQL run in the context of a hook in the hook log messages