### PR TITLE
remove case sensitivity from postgres/redshift dbname verification

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -23,10 +23,8 @@ class PostgresAdapter(SQLAdapter):
     def verify_database(self, database):
         if database.startswith('"'):
             database = database.strip('"')
-        else:
-            database = database.lower()
         expected = self.config.credentials.database
-        if database != expected:
+        if database.lower() != expected.lower():
             raise dbt.exceptions.NotImplementedException(
                 'Cross-db references not allowed in {} ({} vs {})'
                 .format(self.type(), database, expected)

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -199,3 +199,35 @@ class TestRedshiftAdapter(unittest.TestCase):
             password='password',
             port=5439,
             connect_timeout=10)
+    
+    def test_dbname_verification_is_case_insensitive(self):
+        # Override adapter settings from setUp()
+        profile_cfg = {
+            'outputs': {
+                'test': {
+                    'type': 'redshift',
+                    'dbname': 'Redshift',
+                    'user': 'root',
+                    'host': 'thishostshouldnotexist',
+                    'pass': 'password',
+                    'port': 5439,
+                    'schema': 'public'
+                }
+            },
+            'target': 'test'
+        }
+
+        project_cfg = {
+            'name': 'X',
+            'version': '0.1',
+            'profile': 'test',
+            'project-root': '/tmp/dbt/does-not-exist',
+            'quoting': {
+                'identifier': False,
+                'schema': True,
+            },
+        }
+        self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+        self.adapter.cleanup_connections()
+        self._adapter = RedshiftAdapter(self.config) 
+        self.adapter.verify_database('redshift')


### PR DESCRIPTION
This PR addresses [1800](https://github.com/fishtown-analytics/dbt/issues/1800) and may also resolve  [1914](https://github.com/fishtown-analytics/dbt/issues/1914). It appears to fix the case sensitivity issue for database verification against both postgres and redshift.

### Code Changes
* modified the `verify_database` function in `impl.py` for the postgres adapter. This change appears to fix redshift without any additional code changes.
### Test Changes
I made two changes to the unit tests:
* modified `test_postgres_adapter.py` and added a test function called `test_dbname_verification_is_case_insensitive`. I also noticed that `test_connection_fail_select` appeared to be indented incorrectly so I moved it up by a level. Unit tests still pass so I'm guessing its nesting was a typo. If not I'll revert.
* modified `test_redshift_adapter.py` and added a test function called `test_dbname_verification_is_case_insensitive`
### Verification of fix
Revert `impl.py` and run tests. Unit tests will fail with an error matching the aforementioned issues.
#### Final thoughts
The tests I put together are clunkier than I'd like. I'm having to modify the adapter even though it's already created in `setUp` and is a protected property. To avoid refactoring all of the other tests, I ended up mirroring the steps performed in `setUp` in each test. 

Long term it might make sense to break these into their own classes so that setting up the conditions for failure are easier.

Let me know if there's anything you want me to refactor, and thanks for reading. :)