### PR TITLE
Agate fixes (#999) (#1639)

### DIFF
--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -1,21 +1,58 @@
 from codecs import BOM_UTF8
 
 import agate
+import datetime
+import isodate
 import json
+from typing import Iterable
 
 
 BOM = BOM_UTF8.decode('utf-8')  # '\ufeff'
 
-DEFAULT_TYPE_TESTER = agate.TypeTester(types=[
-    agate.data_types.Number(null_values=('null', '')),
-    agate.data_types.TimeDelta(null_values=('null', '')),
-    agate.data_types.Date(null_values=('null', '')),
-    agate.data_types.DateTime(null_values=('null', '')),
-    agate.data_types.Boolean(true_values=('true',),
-                             false_values=('false',),
-                             null_values=('null', '')),
-    agate.data_types.Text(null_values=('null', ''))
-])
+
+class ISODateTime(agate.data_types.DateTime):
+    def cast(self, d):
+        # this is agate.data_types.DateTime.cast with the "clever" bits removed
+        # so we only handle ISO8601 stuff
+        if isinstance(d, datetime.datetime) or d is None:
+            return d
+        elif isinstance(d, datetime.date):
+            return datetime.datetime.combine(d, datetime.time(0, 0, 0))
+        elif isinstance(d, str):
+            d = d.strip()
+            if d.lower() in self.null_values:
+                return None
+        try:
+            return isodate.parse_datetime(d)
+        except:  # noqa
+            pass
+
+        raise agate.exceptions.CastError(
+            'Can not parse value "%s" as datetime.' % d
+        )
+
+
+def build_type_tester(text_columns: Iterable[str]):
+    types = [
+        agate.data_types.Number(null_values=('null', '')),
+        agate.data_types.Date(null_values=('null', ''),
+                              date_format='%Y-%m-%d'),
+        agate.data_types.DateTime(null_values=('null', ''),
+                                  datetime_format='%Y-%m-%d %H:%M:%S'),
+        ISODateTime(null_values=('null', '')),
+        agate.data_types.Boolean(true_values=('true',),
+                                 false_values=('false',),
+                                 null_values=('null', '')),
+        agate.data_types.Text(null_values=('null', ''))
+    ]
+    force = {
+        k: agate.data_types.Text(null_values=('null', ''))
+        for k in text_columns
+    }
+    return agate.TypeTester(force=force, types=types)
+
+
+DEFAULT_TYPE_TESTER = build_type_tester(())
 
 
 def table_from_data(data, column_names):
@@ -61,8 +98,9 @@ def as_matrix(table):
     return [r.values() for r in table.rows.values()]
 
 
-def from_csv(abspath):
+def from_csv(abspath, text_columns):
+    type_tester = build_type_tester(text_columns=text_columns)
     with open(abspath, encoding='utf-8') as fp:
         if fp.read(1) != BOM:
             fp.seek(0)
-        return agate.Table.from_csv(fp, column_types=DEFAULT_TYPE_TESTER)
+        return agate.Table.from_csv(fp, column_types=type_tester)

--- a/core/dbt/context/common.py
+++ b/core/dbt/context/common.py
@@ -3,7 +3,7 @@ import os
 from typing_extensions import Protocol
 from typing import Union, Callable, Any, Dict, TypeVar, Type
 
-import dbt.clients.agate_helper
+from dbt.clients import agate_helper
 from dbt.contracts.graph.compiled import CompiledSeedNode
 from dbt.contracts.graph.parsed import ParsedSeedNode
 import dbt.exceptions
@@ -105,11 +105,11 @@ class ManifestParsedContext(HasCredentialsContext):
 def _store_result(sql_results):
     def call(name, status, agate_table=None):
         if agate_table is None:
-            agate_table = dbt.clients.agate_helper.empty_table()
+            agate_table = agate_helper.empty_table()
 
         sql_results[name] = dbt.utils.AttrDict({
             'status': status,
-            'data': dbt.clients.agate_helper.as_matrix(agate_table),
+            'data': agate_helper.as_matrix(agate_table),
             'table': agate_table
         })
         return ''
@@ -185,8 +185,9 @@ def _build_load_agate_table(
 ) -> Callable[[], agate.Table]:
     def load_agate_table():
         path = model.seed_file_path
+        column_types = model.config.column_types
         try:
-            table = dbt.clients.agate_helper.from_csv(path)
+            table = agate_helper.from_csv(path, text_columns=column_types)
         except ValueError as e:
             dbt.exceptions.raise_compiler_error(str(e))
         table.original_abspath = os.path.abspath(path)

--- a/core/setup.py
+++ b/core/setup.py
@@ -52,6 +52,7 @@ setup(
         'requests>=2.18.0,<3',
         'colorama>=0.3.9,<0.5',
         'agate>=1.6,<2',
+        'isodate>=0.6,<0.7',
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<0.17',
         'dataclasses==0.6;python_version<"3.7"',

--- a/test/integration/005_simple_seed_test/data-config/seed_tricky.csv
+++ b/test/integration/005_simple_seed_test/data-config/seed_tricky.csv
@@ -1,0 +1,7 @@
+id,id_str,a_bool,looks_like_a_bool,a_date,looks_like_a_date,relative,weekday
+1,1,true,true,2019-01-01 12:32:30,2019-01-01 12:32:30,tomorrow,Saturday
+2,2,True,True,2019-01-01 12:32:31,2019-01-01 12:32:31,today,Sunday
+3,3,TRUE,TRUE,2019-01-01 12:32:32,2019-01-01 12:32:32,yesterday,Monday
+4,4,false,false,2019-01-01 01:32:32,2019-01-01 01:32:32,tomorrow,Saturday
+5,5,False,False,2019-01-01 01:32:32,2019-01-01 01:32:32,today,Sunday
+6,6,FALSE,FALSE,2019-01-01 01:32:32,2019-01-01 01:32:32,yesterday,Monday

--- a/test/integration/005_simple_seed_test/macros/schema_test.sql
+++ b/test/integration/005_simple_seed_test/macros/schema_test.sql
@@ -9,6 +9,10 @@
     {% endfor %}
 
     {% set val = 0 if col_types.get(column_name) == type else 1 %}
+    {% if val == 1 and execute %}
+        {# I'm so tired of guessing what's wrong, let's just log it #}
+        {{ log('Got a column type of ' ~ col_types.get(column_name) ~ ', expected ' ~ type, info=True) }}
+    {% endif %}
 
     select {{ val }} as pass_fail
 

--- a/test/integration/005_simple_seed_test/models-bq/schema.yml
+++ b/test/integration/005_simple_seed_test/models-bq/schema.yml
@@ -10,3 +10,38 @@ models:
     tests:
     - column_type:
         type: FLOAT64
+
+- name: seed_tricky
+  columns:
+  - name: id
+    tests:
+    - column_type:
+        type: INT64
+  - name: id_str
+    tests:
+    - column_type:
+        type: STRING
+  - name: a_bool
+    tests:
+    - column_type:
+        type: BOOLEAN
+  - name: looks_like_a_bool
+    tests:
+    - column_type:
+        type: STRING
+  - name: a_date
+    tests:
+    - column_type:
+        type: DATETIME
+  - name: looks_like_a_date
+    tests:
+    - column_type:
+        type: STRING
+  - name: relative
+    tests:
+    - column_type:
+        type: STRING
+  - name: weekday
+    tests:
+    - column_type:
+        type: STRING

--- a/test/integration/005_simple_seed_test/models-pg/schema.yml
+++ b/test/integration/005_simple_seed_test/models-pg/schema.yml
@@ -10,3 +10,38 @@ models:
     tests:
     - column_type:
         type: text
+
+- name: seed_tricky
+  columns:
+  - name: id
+    tests:
+    - column_type:
+        type: integer
+  - name: id_str
+    tests:
+    - column_type:
+        type: text
+  - name: a_bool
+    tests:
+    - column_type:
+        type: boolean
+  - name: looks_like_a_bool
+    tests:
+    - column_type:
+        type: text
+  - name: a_date
+    tests:
+    - column_type:
+        type: timestamp without time zone
+  - name: looks_like_a_date
+    tests:
+    - column_type:
+        type: text
+  - name: relative
+    tests:
+    - column_type:
+        type: text
+  - name: weekday
+    tests:
+    - column_type:
+        type: text

--- a/test/integration/005_simple_seed_test/models-rs/schema.yml
+++ b/test/integration/005_simple_seed_test/models-rs/schema.yml
@@ -10,3 +10,38 @@ models:
     tests:
     - column_type:
         type: character varying(256)
+
+- name: seed_tricky
+  columns:
+  - name: id
+    tests:
+    - column_type:
+        type: integer
+  - name: id_str
+    tests:
+    - column_type:
+        type: character varying(256)
+  - name: a_bool
+    tests:
+    - column_type:
+        type: boolean
+  - name: looks_like_a_bool
+    tests:
+    - column_type:
+        type: character varying(256)
+  - name: a_date
+    tests:
+    - column_type:
+        type: timestamp without time zone
+  - name: looks_like_a_date
+    tests:
+    - column_type:
+        type: character varying(256)
+  - name: relative
+    tests:
+    - column_type:
+        type: character varying(9)
+  - name: weekday
+    tests:
+    - column_type:
+        type: character varying(8)

--- a/test/integration/005_simple_seed_test/models-snowflake/schema.yml
+++ b/test/integration/005_simple_seed_test/models-snowflake/schema.yml
@@ -2,11 +2,46 @@ version: 2
 models:
 - name: seed_enabled
   columns:
-  - name: BIRTHDAY
+  - name: birthday
     tests:
     - column_type:
         type: character varying(16777216)
-  - name: ID
+  - name: id
     tests:
     - column_type:
         type: FLOAT
+
+- name: seed_tricky
+  columns:
+  - name: id
+    tests:
+    - column_type:
+        type: NUMBER(38,0)
+  - name: id_str
+    tests:
+    - column_type:
+        type: character varying(16777216)
+  - name: a_bool
+    tests:
+    - column_type:
+        type: BOOLEAN
+  - name: looks_like_a_bool
+    tests:
+    - column_type:
+        type: character varying(16777216)
+  - name: a_date
+    tests:
+    - column_type:
+        type: TIMESTAMP_NTZ
+  - name: looks_like_a_date
+    tests:
+    - column_type:
+        type: character varying(16777216)
+  - name: relative
+    tests:
+    - column_type:
+        type: character varying(16777216)
+  - name: weekday
+    tests:
+    - column_type:
+        type: character varying(16777216)

--- a/test/integration/005_simple_seed_test/test_seed_type_override.py
+++ b/test/integration/005_simple_seed_test/test_seed_type_override.py
@@ -24,7 +24,7 @@ class TestSimpleSeedColumnOverride(DBTIntegrationTest):
                         'column_types': self.seed_tricky_types(),
                     }
                 },
-                'quote_columns': False,
+                'quote_columns': True,
             }
         }
 
@@ -106,12 +106,6 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
             'looks_like_a_bool': 'TEXT',
             'looks_like_a_date': 'TEXT',
         }
-
-    # @property
-    # def project_config(self):
-    #     cfg = super().project_config
-    #     cfg['data-paths'] = ['snowflake-data-config']
-    #     return cfg
 
     @property
     def profile_config(self):

--- a/test/integration/005_simple_seed_test/test_seed_type_override.py
+++ b/test/integration/005_simple_seed_test/test_seed_type_override.py
@@ -10,15 +10,19 @@ class TestSimpleSeedColumnOverride(DBTIntegrationTest):
     @property
     def project_config(self):
         return {
-            "data-paths": ['data-config'],
-            "macro-paths": ['macros'],
-            "seeds": {
-                "test": {
-                    "enabled": False,
-                    "seed_enabled": {
-                        "enabled": True,
-                        "column_types": self.seed_types()
+            'data-paths': ['data-config'],
+            'macro-paths': ['macros'],
+            'seeds': {
+                'test': {
+                    'enabled': False,
+                    'seed_enabled': {
+                        'enabled': True,
+                        'column_types': self.seed_enabled_types()
                     },
+                    'seed_tricky': {
+                        'enabled': True,
+                        'column_types': self.seed_tricky_types(),
+                    }
                 },
                 'quote_columns': False,
             }
@@ -34,18 +38,25 @@ class TestSimpleSeedColumnOverridePostgres(TestSimpleSeedColumnOverride):
     def profile_config(self):
         return self.postgres_profile()
 
-    def seed_types(self):
+    def seed_enabled_types(self):
         return {
             "id": "text",
             "birthday": "date",
         }
 
+    def seed_tricky_types(self):
+        return {
+            'id_str': 'text',
+            'looks_like_a_bool': 'text',
+            'looks_like_a_date': 'text',
+        }
+
     @use_profile('postgres')
     def test_postgres_simple_seed_with_column_override_postgres(self):
         results = self.run_dbt(["seed", "--show"])
-        self.assertEqual(len(results),  1)
-        results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
+        results = self.run_dbt(["test"])
+        self.assertEqual(len(results),  10)
 
 
 class TestSimpleSeedColumnOverrideRedshift(TestSimpleSeedColumnOverride):
@@ -57,18 +68,25 @@ class TestSimpleSeedColumnOverrideRedshift(TestSimpleSeedColumnOverride):
     def profile_config(self):
         return self.redshift_profile()
 
-    def seed_types(self):
+    def seed_enabled_types(self):
         return {
             "id": "text",
             "birthday": "date",
         }
 
+    def seed_tricky_types(self):
+        return {
+            'id_str': 'text',
+            'looks_like_a_bool': 'text',
+            'looks_like_a_date': 'text',
+        }
+
     @use_profile('redshift')
     def test_redshift_simple_seed_with_column_override_redshift(self):
         results = self.run_dbt(["seed", "--show"])
-        self.assertEqual(len(results),  1)
-        results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
+        results = self.run_dbt(["test"])
+        self.assertEqual(len(results),  10)
 
 
 class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
@@ -76,17 +94,24 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
     def models(self):
         return "models-snowflake"
 
-    def seed_types(self):
+    def seed_enabled_types(self):
         return {
-            "ID": "FLOAT",
-            "BIRTHDAY": "TEXT",
+            "id": "FLOAT",
+            "birthday": "TEXT",
         }
 
-    @property
-    def project_config(self):
-        cfg = super().project_config
-        cfg['data-paths'] = ['snowflake-data-config']
-        return cfg
+    def seed_tricky_types(self):
+        return {
+            'id_str': 'TEXT',
+            'looks_like_a_bool': 'TEXT',
+            'looks_like_a_date': 'TEXT',
+        }
+
+    # @property
+    # def project_config(self):
+    #     cfg = super().project_config
+    #     cfg['data-paths'] = ['snowflake-data-config']
+    #     return cfg
 
     @property
     def profile_config(self):
@@ -95,9 +120,9 @@ class TestSimpleSeedColumnOverrideSnowflake(TestSimpleSeedColumnOverride):
     @use_profile('snowflake')
     def test_snowflake_simple_seed_with_column_override_snowflake(self):
         results = self.run_dbt(["seed", "--show"])
-        self.assertEqual(len(results),  1)
-        results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
+        results = self.run_dbt(["test"])
+        self.assertEqual(len(results),  10)
 
 
 class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
@@ -105,10 +130,17 @@ class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
     def models(self):
         return "models-bq"
 
-    def seed_types(self):
+    def seed_enabled_types(self):
         return {
             "id": "FLOAT64",
             "birthday": "STRING",
+        }
+
+    def seed_tricky_types(self):
+        return {
+            'id_str': 'STRING',
+            'looks_like_a_bool': 'STRING',
+            'looks_like_a_date': 'STRING',
         }
 
     @property
@@ -118,6 +150,6 @@ class TestSimpleSeedColumnOverrideBQ(TestSimpleSeedColumnOverride):
     @use_profile('bigquery')
     def test_bigquery_simple_seed_with_column_override_bigquery(self):
         results = self.run_dbt(["seed", "--show"])
-        self.assertEqual(len(results),  1)
-        results = self.run_dbt(["test"])
         self.assertEqual(len(results),  2)
+        results = self.run_dbt(["test"])
+        self.assertEqual(len(results),  10)

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -132,7 +132,7 @@ class TestSimpleSeedDisabled(DBTIntegrationTest):
     @use_profile('postgres')
     def test_postgres_simple_seed_with_disabled(self):
         results = self.run_dbt(["seed"])
-        self.assertEqual(len(results),  1)
+        self.assertEqual(len(results),  2)
         self.assertTableDoesExist('seed_enabled')
         self.assertTableDoesNotExist('seed_disabled')
 

--- a/third-party-stubs/isodate/__init__.pyi
+++ b/third-party-stubs/isodate/__init__.pyi
@@ -1,0 +1,3 @@
+import datetime
+
+def parse_datetime(datetimestring: str): datetime.datetime


### PR DESCRIPTION
Fixes #999 
Closes #1639 (sort of)

"Fix" agate by making its type inference more nuanced:
 - the only date time formats supported are `%Y-%m-%d %H:%M:%S` and ISO 8601 compatible.
 - the only date format supported is `%Y-%m-%d`.
 - removed `timedelta` support as it's pretty much always wrong.
 - When csvs are loaded, all columns that have a column type specified are now loaded as text before they're cast.

Things to think about:
 - should we do even less type inference when reading data from the database? Would it be possible/desirable to do introspection on the database types and use that to determine agate types?

The datetime/date changes mean that agate will no longer try to interpret locale-specific natural language names as dates. This means that `tomorrow`, `Saturday`, `SAT`, and a number of other unexpectedly special values will be treated as strings, which is what I like to imagine any reasonable person would want.