### PR TITLE
fix for stdout logging of on-run- hooks

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -46,8 +46,10 @@ def print_compile_stats(stats):
     results = {k: 0 for k in names.keys()}
     results.update(stats)
 
-    stat_line = ", ".join(
-        [dbt.utils.pluralize(ct, names.get(t)) for t, ct in results.items()])
+    stat_line = ", ".join([
+        dbt.utils.pluralize(ct, names.get(t)) for t, ct in results.items()
+        if t in names
+    ])
 
     logger.info("Found {}".format(stat_line))
 

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -315,7 +315,7 @@ class HookMetadata(NodeMetadata):
         ]
 
 
-class TimestampNamed(JsonOnly):
+class TimestampNamed(logbook.Processor):
     def __init__(self, name: str):
         self.name = name
         super().__init__()


### PR DESCRIPTION
I recently made changes to logging for hooks which _broke_ the CLI output for run-operations. This change appears to work well in both CLI and rpc logs, but I'm uncertain if it's the right approach here. Please advise if not!

The `stat_line` isn't super germane to this issue, but I did see that we were reporting `1 None` in the logs for the rpc server in `compile_sql` and `run_sql` tasks. I fixed this by excluding the RPCCall node types from this log line.