### PR TITLE
fix for serialization issue around node timing

### DIFF
--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -46,7 +46,7 @@ def track_model_run(index, num_nodes, run_model_result):
         "hashed_contents": dbt.utils.get_hashed_contents(
             run_model_result.node
         ),
-        "timing": run_model_result.timing,
+        "timing": [t.to_dict() for t in run_model_result.timing],
     })
 
 


### PR DESCRIPTION
dbt was unable to track anonymous usage events because the TimingInfo class is not json serializable. I fixed this by calling `to_dict` on the TimingInfo objects, but we could probably alternatively just make that class json serializable. If there's a better way to do this, please let me know!