### PR TITLE
Fix for drop statement which was not namespaced to a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Improve CLI output when running snapshots ([#1768](https://github.com/fishtown-analytics/dbt/issues/1768), [#1769](https://github.com/fishtown-analytics/dbt/pull/1769))
 
 #### Fixes
+- Fix for lingering backup tables when incremental models are full-refreshed ([#1933](https://github.com/fishtown-analytics/dbt/issues/1933), [#1931](https://github.com/fishtown-analytics/dbt/pull/1931))
 - Fix for confusing error message when errors are encountered during compilation ([#1807](https://github.com/fishtown-analytics/dbt/issues/1807), [#1839](https://github.com/fishtown-analytics/dbt/pull/1839))
 - Fix for logic error affecting the two-argument flavor of the `ref` function ([#1504](https://github.com/fishtown-analytics/dbt/issues/1504), [#1515](https://github.com/fishtown-analytics/dbt/pull/1515))
 - Fix for invalid reference to dbt.exceptions ([#1569](https://github.com/fishtown-analytics/dbt/issues/1569), [#1609](https://github.com/fishtown-analytics/dbt/pull/1609))

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -8,10 +8,6 @@
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
 
-  {# -- set the type so our rename / drop uses the correct syntax #}
-  {% set backup_type = existing_relation.type | default("table") %}
-  {% set backup_relation = make_temp_relation(this, "__dbt_backup").incorporate(type=backup_type) %}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -21,6 +17,11 @@
   {% if existing_relation is none %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% elif existing_relation.is_view or full_refresh_mode %}
+      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
+      {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
+      {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
+      {% do adapter.drop_relation(backup_relation) %}
+
       {% do adapter.rename_relation(target_relation, backup_relation) %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
       {% do to_drop.append(backup_relation) %}
@@ -43,7 +44,7 @@
   {% do adapter.commit() %}
 
   {% for rel in to_drop %}
-      {% do drop_relation(rel) %}
+      {% do adapter.drop_relation(rel) %}
   {% endfor %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}


### PR DESCRIPTION
The `backup_relation` was previously created without a schema. This results in a (correct) rename query which looked like:
```
alter table schema.table rename to table__dbt_backup_20191118
```

The corresponding drop however also looked like:
```
drop table if exists table__dbt_backup_20191118
```

This was _incorrect_, as it this query is looking for a table called `table__dbt_backup_20191118` in the _public_ schema! As a result, full refresh builds on postgres + redshift may have been leaving backup tables in dbt schemas since at least 0.14.3, though possibly earlier.