### PR TITLE
rm jsonschema requirement from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 - Drop support for `networkx 1.x` ([#1577](https://github.com/fishtown-analytics/dbt/issues/1577), [#1814](https://github.com/fishtown-analytics/dbt/pull/1814))
 - Upgrade `werkzeug` to 0.15.6 ([#1697](https://github.com/fishtown-analytics/dbt/issues/1697), [#1814](https://github.com/fishtown-analytics/dbt/pull/1814))
 - Pin `psycopg2` dependency to 2.8.x to prevent segfaults ([#1221](https://github.com/fishtown-analytics/dbt/issues/1221), [#1898](https://github.com/fishtown-analytics/dbt/pull/1898))
-- Set a strict upper bound for `jsonschema` dependency ([#1817](https://github.com/fishtown-analytics/dbt/issues/1817), [#1821](https://github.com/fishtown-analytics/dbt/pull/1821))
+- Set a strict upper bound for `jsonschema` dependency ([#1817](https://github.com/fishtown-analytics/dbt/issues/1817), [#1821](https://github.com/fishtown-analytics/dbt/pull/1821), [#1932](https://github.com/fishtown-analytics/dbt/pull/1932))
 #### Everything else
 - Provide test names and kwargs in the manifest ([#1154](https://github.com/fishtown-analytics/dbt/issues/1154), [#1816](https://github.com/fishtown-analytics/dbt/pull/1816))
 - Replace JSON Schemas with data classes ([#1447](https://github.com/fishtown-analytics/dbt/issues/1447), [#1589](https://github.com/fishtown-analytics/dbt/pull/1589))

--- a/core/setup.py
+++ b/core/setup.py
@@ -52,7 +52,6 @@ setup(
         'requests>=2.18.0,<3',
         'colorama>=0.3.9,<0.5',
         'agate>=1.6,<2',
-        'jsonschema>=3.0.1,<4',
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<0.17',
         'dataclasses==0.6;python_version<"3.7"',


### PR DESCRIPTION
This dependency is set by `hologram` - we don't need to restate it in dbt-core.

As it stands, installations of dbt-0.15.0rc1 result in:
```
ERROR: hologram 0.0.5 has requirement jsonschema<3.2, but you'll have jsonschema 3.2.0 which is incompatible.
```