### PR TITLE
Fix for broken catalog generation on pg/redshift

### DIFF
--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -246,7 +246,10 @@ class BaseRelation(FakeAPIObject, Hashable):
         if not isinstance(view_name, str):
             view_name = None
 
-        return InformationSchema.from_relation(self, view_name)
+        # Kick the user-supplied schema out of the information schema relation
+        # Instead address this as <database>.information_schema by default
+        info_schema = InformationSchema.from_relation(self, view_name)
+        return info_schema.incorporate(path={"schema": None})
 
     def information_schema_only(self) -> 'InformationSchema':
         return self.information_schema()

--- a/plugins/redshift/dbt/include/redshift/macros/catalog.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/catalog.sql
@@ -1,6 +1,7 @@
 
 {% macro redshift__get_base_catalog(information_schemas) -%}
   {%- call statement('base_catalog', fetch_result=True) -%}
+    {{ log(information_schemas, info=true) }}
     {% if (information_schemas | length) != 1 %}
         {{ exceptions.raise_compiler_error('redshift get_catalog requires exactly one database') }}
     {% endif %}

--- a/plugins/redshift/dbt/include/redshift/macros/catalog.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/catalog.sql
@@ -1,7 +1,6 @@
 
 {% macro redshift__get_base_catalog(information_schemas) -%}
   {%- call statement('base_catalog', fetch_result=True) -%}
-    {{ log(information_schemas, info=true) }}
     {% if (information_schemas | length) != 1 %}
         {{ exceptions.raise_compiler_error('redshift get_catalog requires exactly one database') }}
     {% endif %}


### PR DESCRIPTION
Fixes #1926 

Some recent updates to how the BigQuery information schema is handled changed the corresponding logic for Postgres & Redshift. dbt previously generated multiple `information schema` objects, _one for each pair of schema and database_, then used them to generate a catalog. Since pg/redshift do not allow cross-database queries, this was caught by an internal exception raised by dbt.

This PR pops the schema name out of the information schema Relation before returning it to the schema cache. This is the correct behavior for normal databases - the only one that should work different is BigQuery (which sometimes namespaces the information schema behind a dataset). Both of those changes should be addressed here.