### PR TITLE
Fix credential validation on iam auth (#1925)

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -16,10 +16,10 @@ from typing import Optional
 class PostgresCredentials(Credentials):
     host: str
     user: str
-    password: str
     port: Port
-    search_path: Optional[str]
-    keepalives_idle: Optional[int] = 0  # 0 means to use the default value
+    password: str  # on postgres the password is mandatory
+    search_path: Optional[str] = None
+    keepalives_idle: int = 0  # 0 means to use the default value
 
     _ALIASES = {
         'dbname': 'database',

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -83,6 +83,26 @@ class TestRedshiftAdapter(unittest.TestCase):
         expected_creds = self.config.credentials.replace(password='tmp_password')
         self.assertEqual(creds, expected_creds)
 
+    def test_iam_conn_optionals(self):
+
+        profile_cfg = {
+            'outputs': {
+                'test': {
+                    'type': 'redshift',
+                    'dbname': 'redshift',
+                    'user': 'root',
+                    'host': 'thishostshouldnotexist',
+                    'port': 5439,
+                    'schema': 'public',
+                    'method': 'iam',
+                    'cluster_id': 'my_redshift',
+                }
+            },
+            'target': 'test'
+        }
+
+        config_from_parts_or_dicts(self.config, profile_cfg)
+
     def test_invalid_auth_method(self):
         # we have to set method this way, otherwise it won't validate
         self.config.credentials.method = 'badmethod'
@@ -199,7 +219,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password='password',
             port=5439,
             connect_timeout=10)
-    
+
     def test_dbname_verification_is_case_insensitive(self):
         # Override adapter settings from setUp()
         profile_cfg = {
@@ -229,5 +249,5 @@ class TestRedshiftAdapter(unittest.TestCase):
         }
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
         self.adapter.cleanup_connections()
-        self._adapter = RedshiftAdapter(self.config) 
+        self._adapter = RedshiftAdapter(self.config)
         self.adapter.verify_database('redshift')


### PR DESCRIPTION
Fixes #1925 

Redshift: Make iam_duration_seconds and password optional again for "iam"

I moved the password field to be the last postgres non-optional
  - now redshift can override it to be optional
Added a check for redshift "database" method that password is set
Fixed up some optional/default behavior
Added a unit test to make sure we don't regress

I don't have actual IAM credentials so I can't test this, but the unit test passes so I think it's fine. Please make sure I didn't break actual IAM!

We should add integration tests to exercise IAM if that's feasible (though that's probably best for a future PR)