### PR TITLE
lazy-load connections (#1584)

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -234,11 +234,11 @@ class BaseAdapter(metaclass=AdapterMeta):
     @contextmanager
     def connection_named(
         self, name: str, node: Optional[CompileResultNode] = None
-    ):
+    ) -> Iterator[None]:
         try:
             self.connections.query_header.set(name, node)
-            conn = self.acquire_connection(name)
-            yield conn
+            self.acquire_connection(name)
+            yield
         finally:
             self.release_connection()
             self.connections.query_header.reset()
@@ -246,9 +246,9 @@ class BaseAdapter(metaclass=AdapterMeta):
     @contextmanager
     def connection_for(
         self, node: CompileResultNode
-    ) -> Iterator[Connection]:
-        with self.connection_named(node.unique_id, node) as conn:
-            yield conn
+    ) -> Iterator[None]:
+        with self.connection_named(node.unique_id, node):
+            yield
 
     @available.parse(lambda *a, **k: ('', empty_table()))
     def execute(

--- a/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
+++ b/test/integration/032_concurrent_transaction_test/test_concurrent_transaction.py
@@ -41,11 +41,12 @@ class BaseTestConcurrentTransaction(DBTIntegrationTest):
     def run_select_and_check(self, rel, sql):
         connection_name = '__test_{}'.format(id(threading.current_thread()))
         try:
-            with self._secret_adapter.connection_named(connection_name) as conn:
+            with self._secret_adapter.connection_named(connection_name):
+                conn = self._secret_adapter.connections.get_thread_connection()
                 res = self.run_sql_common(self.transform_sql(sql), 'one', conn)
 
             # The result is the output of f_sleep(), which is True
-            if res[0] == True:
+            if res[0]:
                 self.query_state[rel] = 'good'
             else:
                 self.query_state[rel] = 'bad'

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -753,7 +753,8 @@ class DBTIntegrationTest(unittest.TestCase):
         if name is None:
             name = '__test'
         with patch.object(common, 'get_adapter', return_value=self.adapter):
-            with self.adapter.connection_named(name) as conn:
+            with self.adapter.connection_named(name):
+                conn = self.adapter.connections.get_thread_connection()
                 yield conn
 
     def get_relation_columns(self, relation):

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -519,7 +519,8 @@ class TestArgs:
 
 
 def execute(adapter, sql):
-    with adapter.connection_named('rpc-tests') as conn:
+    with adapter.connection_named('rpc-tests'):
+        conn = adapter.connections.get_thread_connection()
         with conn.handle.cursor() as cursor:
             try:
                 cursor.execute(sql)

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -100,6 +100,8 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         except BaseException as e:
             raise
 
+        mock_open_connection.assert_not_called()
+        connection.handle
         mock_open_connection.assert_called_once()
 
     @patch('dbt.adapters.bigquery.BigQueryConnectionManager.open', return_value=_bq_conn())
@@ -115,6 +117,8 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         except BaseException as e:
             raise
 
+        mock_open_connection.assert_not_called()
+        connection.handle
         mock_open_connection.assert_called_once()
 
     @patch('dbt.adapters.bigquery.BigQueryConnectionManager.open', return_value=_bq_conn())
@@ -128,9 +132,8 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         except dbt.exceptions.ValidationException as e:
             self.fail('got ValidationException: {}'.format(str(e)))
 
-        except BaseException as e:
-            raise
-
+        mock_open_connection.assert_not_called()
+        connection.handle
         mock_open_connection.assert_called_once()
 
     def test_cancel_open_connections_empty(self):
@@ -158,8 +161,11 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
         mock_auth_default.return_value = (creds, MagicMock())
         adapter = self.get_adapter('loc')
 
-        adapter.acquire_connection('dummy')
+        connection = adapter.acquire_connection('dummy')
         mock_client = mock_bq.Client
+
+        mock_client.assert_not_called()
+        connection.handle
         mock_client.assert_called_once_with('dbt-unit-000000', creds,
                                             location='Luna Station')
 

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -60,12 +60,17 @@ class TestPostgresAdapter(unittest.TestCase):
             self.fail('acquiring connection failed with unknown exception: {}'
                       .format(str(e)))
         self.assertEqual(connection.type, 'postgres')
+
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once()
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
     def test_acquire_connection(self, psycopg2):
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         self.assertEqual(connection.state, 'open')
         self.assertNotEqual(connection.handle, None)
         psycopg2.connect.assert_called_once()
@@ -101,6 +106,8 @@ class TestPostgresAdapter(unittest.TestCase):
     def test_default_keepalive(self, psycopg2):
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='postgres',
             user='root',
@@ -114,6 +121,8 @@ class TestPostgresAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(keepalives_idle=256)
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='postgres',
             user='root',
@@ -128,6 +137,8 @@ class TestPostgresAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(search_path="test")
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='postgres',
             user='root',
@@ -142,6 +153,8 @@ class TestPostgresAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(search_path="test test")
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='postgres',
             user='root',
@@ -156,6 +169,8 @@ class TestPostgresAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(keepalives_idle=0)
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='postgres',
             user='root',

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -153,6 +153,8 @@ class TestRedshiftAdapter(unittest.TestCase):
     def test_default_keepalive(self, psycopg2):
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='redshift',
             user='root',
@@ -168,6 +170,8 @@ class TestRedshiftAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(keepalives_idle=256)
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='redshift',
             user='root',
@@ -182,6 +186,8 @@ class TestRedshiftAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(search_path="test")
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='redshift',
             user='root',
@@ -197,6 +203,8 @@ class TestRedshiftAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(search_path="test test")
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='redshift',
             user='root',
@@ -212,6 +220,8 @@ class TestRedshiftAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(keepalives_idle=0)
         connection = self.adapter.acquire_connection('dummy')
 
+        psycopg2.connect.assert_not_called()
+        connection.handle
         psycopg2.connect.assert_called_once_with(
             dbname='redshift',
             user='root',

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -230,7 +230,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
             add_query.assert_called_once_with('select system$abort_session(42)')
 
     def test_client_session_keep_alive_false_by_default(self):
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
@@ -243,8 +246,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.config.credentials = self.config.credentials.replace(
                                           client_session_keep_alive=True)
         self.adapter = SnowflakeAdapter(self.config)
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
 
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
@@ -258,8 +263,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
             password='test_password',
         )
         self.adapter = SnowflakeAdapter(self.config)
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
 
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
@@ -275,8 +282,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
             authenticator='test_sso_url',
         )
         self.adapter = SnowflakeAdapter(self.config)
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
 
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
@@ -292,8 +301,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
             authenticator='externalbrowser'
         )
         self.adapter = SnowflakeAdapter(self.config)
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
 
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,
@@ -311,8 +322,10 @@ class TestSnowflakeAdapter(unittest.TestCase):
         )
 
         self.adapter = SnowflakeAdapter(self.config)
-        self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
 
+        self.snowflake.assert_not_called()
+        conn.handle
         self.snowflake.assert_has_calls([
             mock.call(
                 account='test_account', autocommit=False,


### PR DESCRIPTION
Fixes #1584 

Lazily open database connections when connections are acquired. It's a little tricky as we have to defer the opening call until connection time, so we stash that in a special object, and if that's what the "handle" is, we call the stored method, which in turn sets the handle.