### PR TITLE
Fix catalog generation with unquoted resources on postgres/redshift (#1943)

### DIFF
--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -2,9 +2,10 @@
 {% macro postgres__get_catalog(information_schemas) -%}
 
   {%- call statement('catalog', fetch_result=True) -%}
-    {% if (information_schemas | length) != 1 %}
-        {{ exceptions.raise_compiler_error('postgres get_catalog requires exactly one database') }}
-    {% endif %}
+    {#
+      If the user has multiple databases set and the first one is wrong, this will fail.
+      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
+    #}
     {% set database = information_schemas[0].database %}
     {{ adapter.verify_database(database) }}
 

--- a/plugins/redshift/dbt/include/redshift/macros/catalog.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/catalog.sql
@@ -1,9 +1,6 @@
 
 {% macro redshift__get_base_catalog(information_schemas) -%}
   {%- call statement('base_catalog', fetch_result=True) -%}
-    {% if (information_schemas | length) != 1 %}
-        {{ exceptions.raise_compiler_error('redshift get_catalog requires exactly one database') }}
-    {% endif %}
     {% set database = information_schemas[0].database %}
     {{ adapter.verify_database(database) }}
 

--- a/test/integration/042_sources_test/models/view_model.sql
+++ b/test/integration/042_sources_test/models/view_model.sql
@@ -1,4 +1,3 @@
-
--- See here: https://github.com/fishtown-analytics/dbt/pull/1729
+{# See here: https://github.com/fishtown-analytics/dbt/pull/1729 #}
 
 select * from {{ ref('ephemeral_model') }}

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -349,3 +349,25 @@ class TestMalformedSources(BaseSourcesTest):
     def test_postgres_malformed_schema_strict_will_break_run(self):
         with self.assertRaises(CompilationException):
             self.run_dbt_with_vars(['seed'], strict=True)
+
+
+class TestUnquotedSources(SuccessfulSourcesTest):
+    @property
+    def project_config(self):
+        cfg = super().project_config
+        cfg['quoting'] = {
+            'identifier': False,
+            'schema': False,
+            'database': False,
+        }
+        return cfg
+
+    @use_profile('postgres')
+    def test_postgres_catalog(self):
+        self.run_dbt_with_vars(['run'])
+        self.run_dbt_with_vars(['docs', 'generate'])
+
+    @use_profile('redshift')
+    def test_redshift_catalog(self):
+        self.run_dbt_with_vars(['run'])
+        self.run_dbt_with_vars(['docs', 'generate'])


### PR DESCRIPTION
Fixes #1943 

Instead of erroring out when we get multiple distinct-looking databases in the catalog or trying to deduce the "true value" of quoted/unquoted databases, pick the first one. If the user happened to choose two actually different databases, this will either error (correctly) or give incomplete data. But at least it won't be an error when things are actually ok.