### PR TITLE
Fix for catalog generation with external tables (bigquery)

### DIFF
--- a/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/catalog.sql
@@ -154,14 +154,14 @@
 
             -- coalesce name and type for External tables - these columns are not
             -- present in the COLUMN_FIELD_PATHS resultset
-            coalesce(columns.column_name, '<null>') as column_name,
+            coalesce(columns.column_name, '<unknown>') as column_name,
             -- invent a row number to account for nested fields -- BQ does
             -- not treat these nested properties as independent fields
             row_number() over (
                 partition by relation_id
                 order by columns.column_index, columns.column_name
             ) as column_index,
-            coalesce(columns.column_type, '<null>') as column_type,
+            coalesce(columns.column_type, '<unknown>') as column_type,
             columns.column_comment,
 
             'Location' as `stats__location__label`,


### PR DESCRIPTION
Fixes #1950 by coalescing column names and types to a dummy string. This PR works by:
1. fixing the `concat` statement used in the `else` clause for the `table_type`. This was necessary because external tables have a `type` of `null`, not `3` (or similar). The existing `concat` query evaluated to `null` errantly before this change.
2. Coalesce column names and types to avoid issues with the big series of left-joins at the bottom of the query. If a relation does not contain columns (ie. an external google sheet), they should render as a stringy `<unknown>` instead of literal `null/None` values.

Note: External tables will show a single column, `<unknown>` in the documentation site. That's a suitable behavior until BQ makes it possible to fetch columns from external tables via the information schema.