### PR TITLE
add exceptions.warn to the dbt context (#1970)

### DIFF
--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -756,12 +756,19 @@ def warn_or_raise(exc, log_fmt=None):
         logger.warning(msg)
 
 
+def emit_warning(msg, node=None):
+    # there's no reason to expose log_fmt to macros - it's only useful for
+    # handling colors
+    return warn_or_error(msg, node=node)
+
+
 # Update this when a new function should be added to the
 # dbt context's `exceptions` key!
 CONTEXT_EXPORTS = {
     fn.__name__: fn
     for fn in
     [
+        emit_warning,
         missing_config,
         missing_materialization,
         missing_relation,

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -756,7 +756,7 @@ def warn_or_raise(exc, log_fmt=None):
         logger.warning(msg)
 
 
-def emit_warning(msg, node=None):
+def warn(msg, node=None):
     # there's no reason to expose log_fmt to macros - it's only useful for
     # handling colors
     return warn_or_error(msg, node=node)
@@ -768,7 +768,7 @@ CONTEXT_EXPORTS = {
     fn.__name__: fn
     for fn in
     [
-        emit_warning,
+        warn,
         missing_config,
         missing_materialization,
         missing_relation,

--- a/test/integration/013_context_var_tests/emit-warning-models/warnings.sql
+++ b/test/integration/013_context_var_tests/emit-warning-models/warnings.sql
@@ -1,2 +1,2 @@
-{% do exceptions.emit_warning('warning: everything is terrible but not that terrible') %}
+{% do exceptions.warn('warning: everything is terrible but not that terrible') %}
 select 1 as id

--- a/test/integration/013_context_var_tests/emit-warning-models/warnings.sql
+++ b/test/integration/013_context_var_tests/emit-warning-models/warnings.sql
@@ -1,0 +1,2 @@
+{% do exceptions.emit_warning('warning: everything is terrible but not that terrible') %}
+select 1 as id

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -149,7 +149,7 @@ class TestEmitWarning(DBTIntegrationTest):
         return "emit-warning-models"
 
     @use_profile('postgres')
-    def test_postgres_emit_warning(self):
+    def test_postgres_warn(self):
         with pytest.raises(dbt.exceptions.CompilationException):
             self.run_dbt(['run'], strict=True)
         self.run_dbt(['run'], strict=False, expect_pass=True)

--- a/test/integration/013_context_var_tests/test_context_vars.py
+++ b/test/integration/013_context_var_tests/test_context_vars.py
@@ -2,6 +2,10 @@ from test.integration.base import DBTIntegrationTest, use_profile
 
 import os
 
+import pytest
+
+import dbt.exceptions
+
 
 class TestContextVars(DBTIntegrationTest):
 
@@ -133,3 +137,19 @@ class TestContextVars(DBTIntegrationTest):
         self.assertEqual(ctx['target.user'], 'root')
         self.assertEqual(ctx['target.pass'], '')
         self.assertEqual(ctx['env_var'], '1')
+
+
+class TestEmitWarning(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "context_vars_013"
+
+    @property
+    def models(self):
+        return "emit-warning-models"
+
+    @use_profile('postgres')
+    def test_postgres_emit_warning(self):
+        with pytest.raises(dbt.exceptions.CompilationException):
+            self.run_dbt(['run'], strict=True)
+        self.run_dbt(['run'], strict=False, expect_pass=True)


### PR DESCRIPTION
Fixes #1970

Add a `warn` function to exceptions.py and export it. It is basically `warn_or_error`, but without the `log_fmt` parameter. That parameter is only used internally, and jinja can already do text formatting pretty well so it doesn't serve much purpose.

I'm not attached to the name in any way.