### PR TITLE
fail more gracefully when setuptools is downlevel (#1975)

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import find_namespace_packages
 except ImportError:
     # the user has a downlevel version of setuptools.
-    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
     print('Please upgrade setuptools with "pip install --upgrade setuptools" '
           'and try again')
     sys.exit(1)

--- a/core/setup.py
+++ b/core/setup.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
-from setuptools import setup
 import os
+import sys
+
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
 
 
 def read(fname):

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
-from setuptools import setup
 import os
+import sys
+
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
+
 
 package_name = "dbt-bigquery"
 package_version = "0.15.0"

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import find_namespace_packages
 except ImportError:
     # the user has a downlevel version of setuptools.
-    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
     print('Please upgrade setuptools with "pip install --upgrade setuptools" '
           'and try again')
     sys.exit(1)

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import find_namespace_packages
 except ImportError:
     # the user has a downlevel version of setuptools.
-    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
     print('Please upgrade setuptools with "pip install --upgrade setuptools" '
           'and try again')
     sys.exit(1)

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
-from setuptools import setup
 import os
+import sys
+
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
+
 
 PSYCOPG2_MESSAGE = '''
 No package name override was set.

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import find_namespace_packages
 except ImportError:
     # the user has a downlevel version of setuptools.
-    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
     print('Please upgrade setuptools with "pip install --upgrade setuptools" '
           'and try again')
     sys.exit(1)

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
-from setuptools import setup
 import os
+import sys
+
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
 
 
 package_name = "dbt-redshift"

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import find_namespace_packages
 except ImportError:
     # the user has a downlevel version of setuptools.
-    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
     print('Please upgrade setuptools with "pip install --upgrade setuptools" '
           'and try again')
     sys.exit(1)

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
-from setuptools import setup
 import os
+import sys
+
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires v40.1.0 or higher of setuptools.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
+
 
 package_name = "dbt-snowflake"
 package_version = "0.15.0"


### PR DESCRIPTION
Fixes #1975 

When we can't import `find_namespace_packages`, print a message and exit with a non-zero code.

Before:
```
$ pip install -r requirements.txt
Processing ./core
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/31/mrzqbbtd3rn4hmgbhrtkfyxm0000gn/T/pip-wc7b1oy9-build/setup.py", line 2, in <module>
        from setuptools import find_namespace_packages
    ImportError: cannot import name 'find_namespace_packages'
```

Now:
```
$ pip install -r requirements.txt
Processing ./core
    Complete output from command python setup.py egg_info:
    Error: dbt requires setuptools v40.1.0 or higher.
    Please upgrade setuptools with "pip install --upgrade setuptools" and try again
```