### PR TITLE
Fix project dir argument when running debug (#1733)

### DIFF
--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -69,7 +69,7 @@ class DebugTask(BaseTask):
         self.profiles_dir = getattr(self.args, 'profiles_dir',
                                     dbt.config.PROFILES_DIR)
         self.profile_path = os.path.join(self.profiles_dir, 'profiles.yml')
-        self.project_path = os.path.join(os.getcwd(), 'dbt_project.yml')
+        self.project_path = os.path.join(args.project_dir or os.getcwd(), 'dbt_project.yml')
         self.cli_vars = dbt.utils.parse_cli_vars(
             getattr(self.args, 'vars', '{}')
         )

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -69,7 +69,8 @@ class DebugTask(BaseTask):
         self.profiles_dir = getattr(self.args, 'profiles_dir',
                                     dbt.config.PROFILES_DIR)
         self.profile_path = os.path.join(self.profiles_dir, 'profiles.yml')
-        self.project_path = os.path.join(args.project_dir or os.getcwd(), 'dbt_project.yml')
+        self.project_dir = args.project_dir or os.getcwd()
+        self.project_path = os.path.join(self.project_dir, 'dbt_project.yml')
         self.cli_vars = dbt.utils.parse_cli_vars(
             getattr(self.args, 'vars', '{}')
         )
@@ -125,7 +126,7 @@ class DebugTask(BaseTask):
             return red('ERROR not found')
 
         try:
-            self.project = Project.from_current_directory(self.cli_vars)
+            self.project = Project.from_project_root(self.project_dir, self.cli_vars)
         except dbt.exceptions.DbtConfigError as exc:
             self.project_fail_details = str(exc)
             return red('ERROR invalid')

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -126,7 +126,8 @@ class DebugTask(BaseTask):
             return red('ERROR not found')
 
         try:
-            self.project = Project.from_project_root(self.project_dir, self.cli_vars)
+            self.project = Project.from_project_root(self.project_dir,
+                                                     self.cli_vars)
         except dbt.exceptions.DbtConfigError as exc:
             self.project_fail_details = str(exc)
             return red('ERROR invalid')

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -1,3 +1,5 @@
+import yaml
+
 from test.integration.base import DBTIntegrationTest,  use_profile
 import os
 import re
@@ -105,10 +107,25 @@ class TestDebugInvalidProject(DBTIntegrationTest):
                 self.assertNotIn('ERROR invalid', line)
 
     @use_profile('postgres')
-    def test_postgres_invalid_project_dir(self):
+    def test_postgres_not_found_project_dir(self):
         self.use_default_project()
         self.run_dbt(['debug', '--project-dir', 'nopass'])
         splitout = self.capsys.readouterr().out.split('\n')
         for line in splitout:
             if line.strip().startswith('dbt_project.yml file'):
                 self.assertIn('ERROR not found', line)
+
+    @use_profile('postgres')
+    def test_postgres_invalid_project_outside_current_dir(self):
+        # create a dbt_project.yml
+        project_config = {
+            'invalid-key': 'not a valid key in this project'
+        }
+        os.makedirs('custom', exist_ok=True)
+        with open("custom/dbt_project.yml", 'w') as f:
+            yaml.safe_dump(project_config, f, default_flow_style=True)
+        self.run_dbt(['debug', '--project-dir', 'custom'])
+        splitout = self.capsys.readouterr().out.split('\n')
+        for line in splitout:
+            if line.strip().startswith('dbt_project.yml file'):
+                self.assertIn('ERROR invalid', line)

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -1,8 +1,7 @@
-import yaml
-
 from test.integration.base import DBTIntegrationTest,  use_profile
 import os
 import re
+import yaml
 
 import pytest
 

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -103,3 +103,12 @@ class TestDebugInvalidProject(DBTIntegrationTest):
                 self.assertIn('ERROR invalid', line)
             elif line.strip().startswith('profiles.yml file'):
                 self.assertNotIn('ERROR invalid', line)
+
+    @use_profile('postgres')
+    def test_postgres_invalid_project_dir(self):
+        self.use_default_project()
+        self.run_dbt(['debug', '--project-dir', 'nopass'])
+        splitout = self.capsys.readouterr().out.split('\n')
+        for line in splitout:
+            if line.strip().startswith('dbt_project.yml file'):
+                self.assertIn('ERROR not found', line)

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -107,7 +107,6 @@ class TestDebugInvalidProject(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test_postgres_not_found_project_dir(self):
-        self.use_default_project()
         self.run_dbt(['debug', '--project-dir', 'nopass'])
         splitout = self.capsys.readouterr().out.split('\n')
         for line in splitout:


### PR DESCRIPTION
Fixes #1733

I did not make the class `DebugTask` inherited from `RequiresProjectTask` because it raised a `dbt.exceptions.RuntimeException` in `get_nearest_project_dir()` function if `dbt_project.yml` was not found. Instead, I just used the argument `project_dir` from arguments as first choice and set current directory as fall-back value.

The included test checks that, even if a `dbt_project.yml` is in the current directory, the `--project-dir` argument is used, leading to a "not found" error.