### PR TITLE
Make import_module available in Jinja

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -11,6 +11,7 @@ from dbt.include.global_project import PACKAGES
 from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.version import __version__ as dbt_version
+import importlib
 
 from dbt.node_types import NodeType
 
@@ -118,6 +119,7 @@ def get_context_modules() -> Dict[str, Dict[str, Any]]:
     return {
         'pytz': get_pytz_module_context(),
         'datetime': get_datetime_module_context(),
+        'import_module': importlib.import_module,
     }
 
 


### PR DESCRIPTION
While initially looking for a way to use regexes in my Jinja script and reading the conversation on https://github.com/fishtown-analytics/dbt/issues/1755, I initially had a PR to add `re` in the module context, but then I thought we could also use `importlib` to make importing any built-in module possible. Since https://github.com/fishtown-analytics/dbt/pull/1996 cleaned up the code a bit, I based my PR off of it.

I've tested this PR with a simple model like this, it will use `re` to convert a list of columns names to snake_case:

```sql
select
{% set re = modules.import_module('re') %}
{%- set cols = ['CustomerId', 'CreatedAt'] %}
{%- for c in cols %}
    {{ re.sub('(.)([A-Z][a-z]+)', '\\1_\\2', c).lower() }} {%- if not loop.last %},{% endif -%}
{% endfor %}
from my_table
```

