### PR TITLE
Fix snapshot check all with an added column (#1797)

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
@@ -93,6 +93,32 @@
     ) %}
 {% endmacro %}
 
+
+{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}
+    {%- set query_columns = get_columns_in_query(node['injected_sql']) -%}
+    {%- if not target_exists -%}
+        {# no table yet -> return whatever the query does #}
+        {{ return([false, query_columns]) }}
+    {%- endif -%}
+    {# handle any schema changes #}
+    {%- set target_table = node.get('alias', node.get('name')) -%}
+    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}
+    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}
+    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
+    {%- set ns.column_added = false -%}
+
+    {%- set intersection = [] -%}
+    {%- for col in query_columns -%}
+        {%- if col in existing_cols -%}
+            {%- do intersection.append(col) -%}
+        {%- else -%}
+            {% set ns.column_added = true %}
+        {%- endif -%}
+    {%- endfor -%}
+    {{ return([ns.column_added, intersection]) }}
+{%- endmacro %}
+
+
 {% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}
     {% set check_cols_config = config['check_cols'] %}
     {% set primary_key = config['unique_key'] %}
@@ -107,24 +133,29 @@
     {%- endif %}
     {% set updated_at = snapshot_string_as_time(now) %}
 
+    {% set column_added = false %}
+
     {% if check_cols_config == 'all' %}
-        {% set check_cols = get_columns_in_query(node['injected_sql']) %}
+        {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists) %}
     {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}
         {% set check_cols = check_cols_config %}
     {% else %}
         {% do exceptions.raise_compiler_error("Invalid value for 'check_cols': " ~ check_cols_config) %}
     {% endif %}
 
-    {% set row_changed_expr -%}
-        (
-        {% for col in check_cols %}
-            {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}
-            or
-            ({{ snapshotted_rel }}.{{ col }} is null) != ({{ current_rel }}.{{ col }} is null)
-            {%- if not loop.last %} or {% endif %}
-
-        {% endfor %}
-        )
+    {%- set row_changed_expr -%}
+    (
+    {%- if column_added -%}
+        TRUE
+    {%- else -%}
+    {%- for col in check_cols -%}
+        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}
+        or
+        ({{ snapshotted_rel }}.{{ col }} is null) != ({{ current_rel }}.{{ col }} is null)
+        {%- if not loop.last %} or {% endif -%}
+    {%- endfor -%}
+    {%- endif -%}
+    )
     {%- endset %}
 
     {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -103,6 +103,12 @@
 {%- endmacro %}
 
 
+{% macro bigquery__snapshot_string_as_time(timestamp) -%}
+    {%- set result = 'TIMESTAMP("' ~ timestamp ~ '")' -%}
+    {{ return(result) }}
+{%- endmacro %}
+
+
 {% macro bigquery__list_schemas(database) -%}
   {{ return(adapter.list_schemas()) }}
 {% endmacro %}

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -104,6 +104,12 @@
   now()
 {%- endmacro %}
 
+{% macro postgres__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "'" ~ timestamp ~ "'::timestamp without time zone" -%}
+    {{ return(result) }}
+{%- endmacro %}
+
+
 {% macro postgres__snapshot_get_time() -%}
   {{ current_timestamp() }}::timestamp without time zone
 {%- endmacro %}

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -172,6 +172,12 @@
   {{ current_timestamp() }}::timestamp
 {%- endmacro %}
 
+
+{% macro redshift__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "'" ~ timestamp ~ "'::timestamp" -%}
+    {{ return(result) }}
+{%- endmacro %}
+
 {% macro redshift__make_temp_relation(base_relation, suffix) %}
     {% do return(postgres__make_temp_relation(base_relation, suffix)) %}
 {% endmacro %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -108,6 +108,13 @@
   convert_timezone('UTC', current_timestamp())
 {%- endmacro %}
 
+
+{% macro snowflake__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "to_timestamp_ntz('" ~ timestamp ~ "')" -%}
+    {{ return(result) }}
+{%- endmacro %}
+
+
 {% macro snowflake__snapshot_get_time() -%}
   to_timestamp_ntz({{ current_timestamp() }})
 {%- endmacro %}

--- a/test/integration/004_simple_snapshot_test/data/seed.csv
+++ b/test/integration/004_simple_snapshot_test/data/seed.csv
@@ -1,0 +1,4 @@
+id,first_name
+1,Judith
+2,Arthur
+3,Rachel

--- a/test/integration/004_simple_snapshot_test/data/seed_newcol.csv
+++ b/test/integration/004_simple_snapshot_test/data/seed_newcol.csv
@@ -1,0 +1,4 @@
+id,first_name,last_name
+1,Judith,Kennedy
+2,Arthur,Kelly
+3,Rachel,Moreno

--- a/test/integration/004_simple_snapshot_test/macros/test_no_overlaps.sql
+++ b/test/integration/004_simple_snapshot_test/macros/test_no_overlaps.sql
@@ -1,0 +1,109 @@
+{% macro get_snapshot_unique_id() -%}
+    {{ return(adapter_macro('get_snapshot_unique_id', )) }}
+{%- endmacro %}
+
+{% macro default__get_snapshot_unique_id() -%}
+  {% do return("id || '-' || first_name") %}
+{%- endmacro %}
+
+
+{% macro bigquery__get_snapshot_unique_id() -%}
+    {%- do return('concat(cast(id as string), "-", first_name)') -%}
+{%- endmacro %}
+
+
+{% macro test_no_overlaps(model, keys) %}
+    with base as (
+        select
+            {{ get_snapshot_unique_id() }} as dbt_unique_id,
+            *
+        from {{ model }}
+    ),
+    matches as (
+        select rel1.* from base rel1
+        inner join base rel2
+        using (dbt_unique_id)
+        where not (
+            ((rel1.dbt_valid_from <= rel2.dbt_valid_to) or
+             (rel2.dbt_valid_to is null)
+             )
+            and
+            ((rel1.dbt_valid_to >= rel2.dbt_valid_from) or
+              (rel1.dbt_valid_to is null))
+        )
+    )
+    select count(*) from matches
+{% endmacro %}
+
+{#
+    mostly copy+pasted from dbt_utils, but I removed some parameters and added
+    a query that calls get_snapshot_unique_id
+#}
+{% macro test_mutually_exclusive_ranges(model) %}
+
+with base as (
+    select {{ get_snapshot_unique_id() }} as dbt_unique_id,
+    *
+    from {{ model }}
+),
+window_functions as (
+
+    select
+        dbt_valid_from as lower_bound,
+        coalesce(dbt_valid_to, '2099-1-1T00:00:01') as upper_bound,
+
+        lead(dbt_valid_from) over (
+            partition by dbt_unique_id
+            order by dbt_valid_from
+        ) as next_lower_bound,
+
+        row_number() over (
+            partition by dbt_unique_id
+            order by dbt_valid_from desc
+        ) = 1 as is_last_record
+
+    from base
+
+),
+
+calc as (
+    -- We want to return records where one of our assumptions fails, so we'll use
+    -- the `not` function with `and` statements so we can write our assumptions nore cleanly
+    select
+        *,
+
+        -- For each record: lower_bound should be < upper_bound.
+        -- Coalesce it to return an error on the null case (implicit assumption
+        -- these columns are not_null)
+        coalesce(
+            lower_bound < upper_bound,
+            is_last_record
+        ) as lower_bound_less_than_upper_bound,
+
+        -- For each record: upper_bound {{ allow_gaps_operator }} the next lower_bound.
+        -- Coalesce it to handle null cases for the last record.
+        coalesce(
+            upper_bound <= next_lower_bound,
+            is_last_record,
+            false
+        ) as upper_bound_less_than_or_equal_to_next_lower_bound
+
+    from window_functions
+
+),
+
+validation_errors as (
+
+    select
+        *
+    from calc
+
+    where not(
+        -- THE FOLLOWING SHOULD BE TRUE --
+        lower_bound_less_than_upper_bound
+        and upper_bound_less_than_or_equal_to_next_lower_bound
+    )
+)
+
+select count(*) from validation_errors
+{% endmacro %}

--- a/test/integration/004_simple_snapshot_test/models/schema.yml
+++ b/test/integration/004_simple_snapshot_test/models/schema.yml
@@ -1,0 +1,5 @@
+version: 2
+models:
+  - name: snapshot_actual
+    tests:
+      - mutually_exclusive_ranges

--- a/test/integration/004_simple_snapshot_test/test-snapshots-checkall/snapshot.sql
+++ b/test/integration/004_simple_snapshot_test/test-snapshots-checkall/snapshot.sql
@@ -1,0 +1,4 @@
+{% snapshot my_snapshot %}
+    {{ config(check_cols='all', unique_key='id', strategy='check', target_database=database, target_schema=schema) }}
+    select * from {{ ref(var('seed_name', 'seed')) }}
+{% endsnapshot %}

--- a/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
+++ b/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
@@ -33,6 +33,7 @@ class BaseSimpleSnapshotTest(DBTIntegrationTest):
         self.assertTablesEqual(actual, expected)
 
     def assert_expected(self):
+        self.run_dbt(['test'])
         self.assert_case_tables_equal('snapshot_actual', 'snapshot_expected')
 
 
@@ -42,6 +43,7 @@ class TestSimpleSnapshotFiles(BaseSimpleSnapshotTest):
         return {
             "data-paths": ['data'],
             "snapshot-paths": ['test-snapshots-pg'],
+            'macro-paths': ['macros'],
         }
 
     @use_profile('postgres')
@@ -98,7 +100,7 @@ class TestCustomSnapshotFiles(BaseSimpleSnapshotTest):
     def project_config(self):
         return {
             'data-paths': ['data'],
-            'macro-paths': ['custom-snapshot-macros'],
+            'macro-paths': ['custom-snapshot-macros', 'macros'],
             'snapshot-paths': ['test-snapshots-pg-custom'],
         }
 
@@ -128,7 +130,7 @@ class TestNamespacedCustomSnapshotFiles(BaseSimpleSnapshotTest):
     def project_config(self):
         return {
             'data-paths': ['data'],
-            'macro-paths': ['custom-snapshot-macros'],
+            'macro-paths': ['custom-snapshot-macros', 'macros'],
             'snapshot-paths': ['test-snapshots-pg-custom-namespaced'],
         }
 
@@ -152,7 +154,7 @@ class TestInvalidNamespacedCustomSnapshotFiles(BaseSimpleSnapshotTest):
     def project_config(self):
         return {
             'data-paths': ['data'],
-            'macro-paths': ['custom-snapshot-macros'],
+            'macro-paths': ['custom-snapshot-macros', 'macros'],
             'snapshot-paths': ['test-snapshots-pg-custom-invalid'],
         }
 
@@ -179,6 +181,7 @@ class TestSimpleSnapshotFileSelects(DBTIntegrationTest):
             "data-paths": ['data'],
             "snapshot-paths": ['test-snapshots-select',
                                'test-snapshots-pg'],
+            'macro-paths': ['macros'],
         }
 
     @use_profile('postgres')
@@ -236,7 +239,8 @@ class TestConfiguredSnapshotFileSelects(TestSimpleSnapshotFileSelects):
                     'strategy': 'timestamp',
                     'updated_at': 'updated_at',
                 }
-            }
+            },
+            'macro-paths': ['macros'],
         }
 
 
@@ -253,16 +257,15 @@ class TestSimpleSnapshotFilesBigquery(DBTIntegrationTest):
     def project_config(self):
         return {
             "snapshot-paths": ['test-snapshots-bq'],
+            'macro-paths': ['macros'],
         }
 
     def assert_expected(self):
+        self.run_dbt(['test'])
         self.assertTablesEqual('snapshot_actual', 'snapshot_expected')
 
     @use_profile('bigquery')
     def test__bigquery__simple_snapshot(self):
-        self.use_default_project()
-        self.use_profile('bigquery')
-
         self.run_sql_file("seed_bq.sql")
 
         self.run_dbt(["snapshot"])
@@ -276,11 +279,8 @@ class TestSimpleSnapshotFilesBigquery(DBTIntegrationTest):
 
         self.assert_expected()
 
-
     @use_profile('bigquery')
     def test__bigquery__snapshot_with_new_field(self):
-        self.use_default_project()
-        self.use_profile('bigquery')
 
         self.run_sql_file("seed_bq.sql")
 
@@ -341,6 +341,7 @@ class TestCrossDBSnapshotFiles(DBTIntegrationTest):
             paths = ['test-snapshots-bq']
         return {
             'snapshot-paths': paths,
+            'macro-paths': ['macros'],
         }
 
     def run_snapshot(self):
@@ -395,6 +396,7 @@ class TestCrossSchemaSnapshotFiles(DBTIntegrationTest):
         paths = ['test-snapshots-pg']
         return {
             'snapshot-paths': paths,
+            'macro-paths': ['macros'],
         }
 
     def target_schema(self):
@@ -427,6 +429,7 @@ class TestBadSnapshot(DBTIntegrationTest):
     def project_config(self):
         return {
             "snapshot-paths": ['test-snapshots-invalid'],
+            'macro-paths': ['macros'],
         }
 
     @use_profile('postgres')
@@ -456,6 +459,7 @@ class TestCheckCols(TestSimpleSnapshotFiles):
         return {
             "data-paths": ['data'],
             "snapshot-paths": ['test-check-col-snapshots'],
+            'macro-paths': ['macros'],
         }
 
 
@@ -472,7 +476,8 @@ class TestConfiguredCheckCols(TestCheckCols):
                     "strategy": "check",
                     "check_cols": ["email"],
                 }
-            }
+            },
+            'macro-paths': ['macros'],
         }
 
 
@@ -493,6 +498,7 @@ class TestCheckColsBigquery(TestSimpleSnapshotFilesBigquery):
         return {
             "data-paths": ['data'],
             "snapshot-paths": ['test-check-col-snapshots-bq'],
+            'macro-paths': ['macros'],
         }
 
     @use_profile('bigquery')
@@ -562,6 +568,7 @@ class TestLongText(DBTIntegrationTest):
     def project_config(self):
         return {
             "snapshot-paths": ['test-snapshots-longtext'],
+            'macro-paths': ['macros'],
         }
 
     @use_profile('postgres')

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -619,7 +619,7 @@ class DBTIntegrationTest(unittest.TestCase):
                 else:
                     return
             except BaseException as e:
-                if conn.handle and not conn.handle.is_closed():
+                if conn.handle and not conn.handle.closed:
                     conn.handle.rollback()
                 print(sql)
                 print(e)

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -545,10 +545,6 @@ class DBTIntegrationTest(unittest.TestCase):
         final_args.append('--log-cache-events')
 
         logger.info("Invoking dbt with {}".format(final_args))
-        if args is None:
-            args = ["run"]
-
-        logger.info("Invoking dbt with {}".format(args))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):


### PR DESCRIPTION
Fixes #1797

This PR is based on #1994, in the interest of avoiding the merge conflict.

If rows were added to a snapshot, dbt now expands the snapshot table, sets the new column value to `null` for all the old records, and treats every new row as an updated row.

Added tests.