### PR TITLE
call pull_information() before we enqueue the log record (#1905)

### DIFF
--- a/core/dbt/rpc/logger.py
+++ b/core/dbt/rpc/logger.py
@@ -89,6 +89,8 @@ class QueueTimeoutMessage(QueueMessage):
 
 class QueueLogHandler(logbook.queues.MultiProcessingHandler):
     def emit(self, record: logbook.LogRecord):
+        # trigger the cached proeprties here
+        record.pull_information()
         self.queue.put_nowait(QueueLogMessage.from_record(record))
 
     def emit_error(self, error: JSONRPCError):


### PR DESCRIPTION
Fixes #1905 by populating the metadata before we enqueue the logrecord (and it leaves the thread).