### PR TITLE
put an upper bound on bigquery

### DIFF
--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -40,7 +40,12 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'google-cloud-bigquery>=1.15.0,<2',
+        'google-cloud-core>=1,<=1.1.0',
+        'google-cloud-bigquery>=1.15.0,<1.24.0',
+        # hidden secret dependency: bq requires this but only documents 1.10.0
+        # through its dependency chain.
+        # see https://github.com/googleapis/google-cloud-python/issues/9965
+        'six>=1.13.0',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
The `google-cloud-bigquery` package recently got upped to `1.23.0`, which has an implicit dependency on `six>=1.13.0`. Unfortunately, `google-cloud-bigquery` doesn't specify a `six` version, and its dependency `google-cloud-core` only specifies `six>=1.10`.

See the issue here: https://github.com/googleapis/google-cloud-python/issues/9965

This PR both explicitly requires `six>=1.13.0` to resolve the hidden dependency. 

This also excludes newer versions of `google-cloud-bigquery`/`google-cloud-core` than what's out there to hopefully avoid any new surprises.

Unfortunately this will only fix `0.15.1` and up, but that's really all we can do unless we want to cut a `0.14.5`.