### PR TITLE
Fix: pedantic pluralization

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -36,7 +36,7 @@ def print_compile_stats(stats):
         NodeType.Model: 'model',
         NodeType.Test: 'test',
         NodeType.Snapshot: 'snapshot',
-        NodeType.Analysis: 'analyse',
+        NodeType.Analysis: 'analysis',
         NodeType.Macro: 'macro',
         NodeType.Operation: 'operation',
         NodeType.Seed: 'seed file',

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -514,8 +514,8 @@ def translate_aliases(kwargs, aliases):
 def pluralize(count, string):
     if count == 1:
         return "{} {}".format(count, string)
-    elif string[-2:] == 'is':   # Latin third declension i-stem
-        return "{} {}es".format(count, string[0:-2])
+    elif string == 'analysis':
+        return "{} {}".format(count, 'analyses')
     else:
         return "{} {}s".format(count, string)
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -514,6 +514,8 @@ def translate_aliases(kwargs, aliases):
 def pluralize(count, string):
     if count == 1:
         return "{} {}".format(count, string)
+    elif string[-2:] == 'is':   # Latin third declension i-stem
+        return "{} {}es".format(count, string[0:-2])
     else:
         return "{} {}s".format(count, string)
 


### PR DESCRIPTION
No more:
<img width="730" alt="Screen Shot 2019-12-17 at 10 00 31 PM" src="https://user-images.githubusercontent.com/13897643/71052199-acc8e480-2118-11ea-8b8d-e6ae7c2c7ae4.png">

https://en.wiktionary.org/wiki/Appendix:Latin_third_declension

There is, of course, [a package for this](https://pypi.org/project/inflect/). I think we're a ways away from needing it.