### PR TITLE
Fix cancelled ephemeral models (#1993)

### DIFF
--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -242,6 +242,11 @@ class GraphRunnableTask(ManifestTask):
                 raise
 
             for conn_name in adapter.cancel_open_connections():
+                if self.manifest is not None:
+                    node = self.manifest.nodes.get(conn_name)
+                    if node is not None and node.is_ephemeral_model:
+                        continue
+                # if we don't have a manifest/don't have a node, print anyway.
                 dbt.ui.printer.print_cancel_line(conn_name)
 
             pool.join()


### PR DESCRIPTION
Fix #1993 

Suppress messages from cancelling models if the models are ephemeral. Temp connections and connections that aren't models/ephemeral models are still included in the output.