### PR TITLE
Parse model hooks for refs (#1957)

### DIFF
--- a/test/integration/014_hook_tests/ref-hook-models/hooked.sql
+++ b/test/integration/014_hook_tests/ref-hook-models/hooked.sql
@@ -1,0 +1,21 @@
+{{
+    config({
+        "pre_hook": "\
+            insert into {{this.schema}}.on_model_hook select
+                state,
+                '{{ target.dbname }}' as \"target.dbname\",\
+                '{{ target.host }}' as \"target.host\",\
+                '{{ target.name }}' as \"target.name\",\
+                '{{ target.schema }}' as \"target.schema\",\
+                '{{ target.type }}' as \"target.type\",\
+                '{{ target.user }}' as \"target.user\",\
+                '{{ target.get(\"pass\", \"\") }}' as \"target.pass\",\
+                {{ target.port }} as \"target.port\",\
+                {{ target.threads }} as \"target.threads\",\
+                '{{ run_started_at }}' as \"run_started_at\",\
+                '{{ invocation_id }}' as \"invocation_id\"\
+                from {{ ref('pre') }}\
+        "
+    })
+}}
+select 1 as id

--- a/test/integration/014_hook_tests/ref-hook-models/post.sql
+++ b/test/integration/014_hook_tests/ref-hook-models/post.sql
@@ -1,0 +1,1 @@
+select 'end' as state

--- a/test/integration/014_hook_tests/ref-hook-models/pre.sql
+++ b/test/integration/014_hook_tests/ref-hook-models/pre.sql
@@ -1,0 +1,1 @@
+select 'start' as state

--- a/test/integration/014_hook_tests/test_model_hooks.py
+++ b/test/integration/014_hook_tests/test_model_hooks.py
@@ -62,6 +62,7 @@ MODEL_POST_HOOK = """
    )
 """
 
+
 class BaseTestPrePost(DBTIntegrationTest):
     def setUp(self):
         DBTIntegrationTest.setUp(self)
@@ -151,6 +152,45 @@ class TestPrePostModelHooks(BaseTestPrePost):
 
         self.check_hooks('start')
         self.check_hooks('end')
+
+
+class TestHookRefs(BaseTestPrePost):
+    @property
+    def project_config(self):
+        return {
+            'models': {
+                'test': {
+                    'hooked': {
+                        'post-hook': ['''
+                        insert into {{this.schema}}.on_model_hook select
+                        state,
+                        '{{ target.dbname }}' as "target.dbname",
+                        '{{ target.host }}' as "target.host",
+                        '{{ target.name }}' as "target.name",
+                        '{{ target.schema }}' as "target.schema",
+                        '{{ target.type }}' as "target.type",
+                        '{{ target.user }}' as "target.user",
+                        '{{ target.get("pass", "") }}' as "target.pass",
+                        {{ target.port }} as "target.port",
+                        {{ target.threads }} as "target.threads",
+                        '{{ run_started_at }}' as "run_started_at",
+                        '{{ invocation_id }}' as "invocation_id"
+                    from {{ ref('post') }}'''.strip()],
+                    }
+                },
+            }
+        }
+
+    @property
+    def models(self):
+        return 'ref-hook-models'
+
+    @use_profile('postgres')
+    def test_postgres_pre_post_model_hooks_refed(self):
+        self.run_dbt(['run'])
+
+        self.check_hooks('start', count=1)
+        self.check_hooks('end', count=1)
 
 
 class TestPrePostModelHooksOnSeeds(DBTIntegrationTest):


### PR DESCRIPTION
Fixes #1957

Add a parse pass for model hooks, parse them like models, attach the hook refs as if they were on the model.
Add a test exercising refs in model hooks.