### PR TITLE
Exclude tests for disabled models in compile stats

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -54,6 +54,24 @@ def print_compile_stats(stats):
     logger.info("Found {}".format(stat_line))
 
 
+def _node_enabled(node):
+    # Disabled models are already excluded from the manifest
+    if node.resource_type == NodeType.Test and not node.config.enabled:
+        return False
+    else:
+        return True
+
+
+def _generate_stats(manifest):
+    stats = defaultdict(int)
+    for node_name, node in itertools.chain(
+            manifest.nodes.items(),
+            manifest.macros.items()):
+        if _node_enabled(node): stats[node.resource_type] += 1
+
+    return stats
+
+
 def _add_prepended_cte(prepended_ctes, new_cte):
     for cte in prepended_ctes:
         if cte.id == new_cte.id:
@@ -199,12 +217,7 @@ class Compiler:
 
         self.link_graph(linker, manifest)
 
-        stats = defaultdict(int)
-
-        for node_name, node in itertools.chain(
-                manifest.nodes.items(),
-                manifest.macros.items()):
-            stats[node.resource_type] += 1
+        stats = _generate_stats(manifest)
 
         if write:
             self.write_graph_file(linker, manifest)

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -67,7 +67,8 @@ def _generate_stats(manifest):
     for node_name, node in itertools.chain(
             manifest.nodes.items(),
             manifest.macros.items()):
-        if _node_enabled(node): stats[node.resource_type] += 1
+        if _node_enabled(node):
+            stats[node.resource_type] += 1
 
     return stats
 


### PR DESCRIPTION
Fix https://github.com/fishtown-analytics/dbt/issues/1804

Checks if the node is a test, and then if it is enabled.

All models enabled:
```
(env) [niallwoodward:~/dev/data-dbt]$ dbt compile                                      
Running with dbt=0.15.0-rc2
Found 328 models, 725 tests, 2 snapshots, 1 analyse, 378 macros, 3 operations, 5 seed files, 104 sources
```

One model disabled before fix (with two tests dependent on the disabled model):
```
(env) [niallwoodward:~/dev/data-dbt]$ dbt compile                                      
Running with dbt=0.14.1
Found 327 models, 735 tests, 2 snapshots, 1 analyse, 374 macros, 3 operations, 5 seed files, 104 sources
```

One model disabled after fix (with two tests dependent on the disabled model):
```
(env) [niallwoodward:~/dev/data-dbt]$ dbt compile                                      
Running with dbt=0.15.0-rc2
Found 327 models, 723 tests, 2 snapshots, 1 analyse, 378 macros, 3 operations, 5 seed files, 104 sources
```