### PR TITLE
detect deps with the same name as the root

### DIFF
--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import dbt.utils
 import dbt.deprecations
 import dbt.exceptions
 
+from dbt.config import Project
 from dbt.deps.base import downloads_directory
 from dbt.deps.resolver import resolve_packages
 
@@ -12,7 +15,7 @@ from dbt.task.base import ProjectOnlyTask
 
 
 class DepsTask(ProjectOnlyTask):
-    def __init__(self, args, config=None):
+    def __init__(self, args, config: Optional[Project] = None):
         super().__init__(args=args, config=config)
 
     def track_package_install(self, package_name, source_type, version):

--- a/test/integration/006_simple_dependency_test/duplicate_dependency/dbt_project.yml
+++ b/test/integration/006_simple_dependency_test/duplicate_dependency/dbt_project.yml
@@ -1,0 +1,4 @@
+name: 'test'
+version: '1.0'
+
+profile: 'default'

--- a/test/unit/test_deps.py
+++ b/test/unit/test_deps.py
@@ -392,7 +392,7 @@ class TestPackageSpec(unittest.TestCase):
                 {'package': 'fishtown-analytics-test/b', 'version': '0.2.1'},
             ],
         })
-        resolved = resolve_packages(package_config.packages, None)
+        resolved = resolve_packages(package_config.packages, mock.MagicMock(project_name='test'))
         self.assertEqual(len(resolved), 2)
         self.assertEqual(resolved[0].name, 'fishtown-analytics-test/a')
         self.assertEqual(resolved[0].version, '0.1.3')


### PR DESCRIPTION
fixes #2029

dbt already detected when you ran `dbt deps` if multiple dependencies shared a name, but it did not detect if a dependency shared a name with the root project. This adds that detection, and adds a second check in case the user has already run `dbt deps`, or manually populated the `dbt_modules` path, or changes the root project name, etc. I tweaked the dependency message a bit to match the existing message when two deps have the same name - obviously fine to change it if that's what's desired!