### PR TITLE
Fix manifest search (#2032)

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -265,12 +265,12 @@ class HasCredentialsContext(ConfigRenderContext):
             # adapter packages are part of the global project space
             _add_macro_map(context, package_name, macro_map)
 
-            if package_name == self.config.project_name:
-                # If we're in the root project, allow global override
-                global_macros.append(macro_map)
-            elif package_name == self.search_package_name:
+            if package_name == self.search_package_name:
                 # If we're in the current project, allow local override
                 local_macros.append(macro_map)
+            elif package_name == self.config.project_name:
+                # If we're in the root project, allow global override
+                global_macros.append(macro_map)
             elif package_name in PACKAGES:
                 # If it comes from a dbt package, allow global override
                 global_macros.append(macro_map)

--- a/core/dbt/context/operation.py
+++ b/core/dbt/context/operation.py
@@ -1,6 +1,11 @@
-import dbt.context.common
+from typing import Optional, Dict, Any
+
 from dbt.context import runtime
+from dbt.context.common import generate_execute_macro
 from dbt.exceptions import raise_compiler_error
+from dbt.config import RuntimeConfig
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.parsed import ParsedMacro
 
 
 class RefResolver(runtime.RefResolver):
@@ -23,7 +28,12 @@ class Provider(runtime.Provider):
     ref = RefResolver
 
 
-def generate(model, runtime_config, manifest):
-    return dbt.context.common.generate_execute_macro(
-        model, runtime_config, manifest, Provider()
+def generate(
+    model: ParsedMacro,
+    runtime_config: RuntimeConfig,
+    manifest: Manifest,
+    package_name: Optional[str]
+) -> Dict[str, Any]:
+    return generate_execute_macro(
+        model, runtime_config, manifest, Provider(), package_name
     )

--- a/core/dbt/context/parser.py
+++ b/core/dbt/context/parser.py
@@ -141,10 +141,10 @@ def generate(model, runtime_config, manifest, source_config):
         )
 
 
-def generate_macro(model, runtime_config, manifest):
+def generate_macro(model, runtime_config, manifest, package_name):
     # parser.generate_macro is called by the get_${attr}_func family of Parser
     # methods, which preparse and cache the generate_${attr}_name family of
     # macros for use during parsing
     return dbt.context.common.generate_execute_macro(
-        model, runtime_config, manifest, Provider()
+        model, runtime_config, manifest, Provider(), package_name
     )

--- a/core/dbt/context/runtime.py
+++ b/core/dbt/context/runtime.py
@@ -1,12 +1,17 @@
-from dbt.utils import get_materialization, add_ephemeral_model_prefix
+from typing import Dict, Any
+
 
 import dbt.clients.jinja
 import dbt.context.base
 import dbt.context.common
 import dbt.flags
-from dbt.parser.util import ParserUtils
 
+from dbt.config import RuntimeConfig
+from dbt.contracts.graph.compiled import CompileResultNode
+from dbt.contracts.graph.manifest import Manifest
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
+from dbt.parser.util import ParserUtils
+from dbt.utils import get_materialization, add_ephemeral_model_prefix
 
 
 class RefResolver(dbt.context.common.BaseResolver):
@@ -156,7 +161,9 @@ class Provider(dbt.context.common.Provider):
     source = SourceResolver
 
 
-def generate(model, runtime_config, manifest):
+def generate(
+    model: CompileResultNode, runtime_config: RuntimeConfig, manifest: Manifest
+) -> Dict[str, Any]:
     return dbt.context.common.generate(
         model, runtime_config, manifest, Provider(), None
     )

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -496,6 +496,10 @@ class ParsedDocumentation(UnparsedDocumentationFile, HasUniqueID):
     name: str
     block_contents: str
 
+    @property
+    def search_name(self):
+        return self.name
+
 
 @dataclass
 class ParsedSourceDefinition(
@@ -547,6 +551,10 @@ class ParsedSourceDefinition(
     @property
     def has_freshness(self):
         return bool(self.freshness) and self.loaded_at_field is not None
+
+    @property
+    def search_name(self):
+        return f'{self.source_name}.{self.name}'
 
 
 ParsedResource = Union[

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -45,6 +45,10 @@ class UnparsedNode(UnparsedBaseNode, HasSQL):
         NodeType.RPCCall,
     ]})
 
+    @property
+    def search_name(self):
+        return self.name
+
 
 @dataclass
 class UnparsedRunHook(UnparsedNode):

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -88,7 +88,6 @@
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  
   create view {{ relation }} as (
     {{ sql }}
   );

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -432,7 +432,7 @@ class ModelRunner(CompileRunner):
         context = dbt.context.runtime.generate(
             model, self.config, manifest)
 
-        materialization_macro = manifest.get_materialization_macro(
+        materialization_macro = manifest.find_materialization_macro_by_name(
             self.config.project_name,
             model.get_materialization(),
             self.adapter.type())

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -16,8 +16,8 @@ class NodeType(StrEnum):
     Macro = 'macro'
 
     @classmethod
-    def executable(cls):
-        return [v.value for v in [
+    def executable(cls) -> List['NodeType']:
+        return [
             cls.Model,
             cls.Test,
             cls.Snapshot,
@@ -26,15 +26,15 @@ class NodeType(StrEnum):
             cls.Seed,
             cls.Documentation,
             cls.RPCCall,
-        ]]
+        ]
 
     @classmethod
-    def refable(cls):
-        return [v.value for v in [
+    def refable(cls) -> List['NodeType']:
+        return [
             cls.Model,
             cls.Seed,
             cls.Snapshot,
-        ]]
+        ]
 
     @classmethod
     def documentable(cls) -> List['NodeType']:

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -81,65 +81,6 @@ def compiler_warning(model, msg, resource_type='model'):
     )
 
 
-def id_matches(unique_id, target_name, target_package, nodetypes, model):
-    """Return True if the unique ID matches the given name, package, and type.
-
-    If package is None, any package is allowed.
-    nodetypes should be a container of NodeTypes that implements the 'in'
-    operator.
-    """
-    node_type = model.resource_type
-    node_parts = unique_id.split('.', 2)
-    if len(node_parts) != 3:
-        msg = "unique_id {} is malformed".format(unique_id)
-        dbt.exceptions.raise_compiler_error(msg, model)
-
-    resource_type, package_name, node_name = node_parts
-    if resource_type not in nodetypes:
-        return False
-
-    if node_type == NodeType.Source.value:
-        if node_name.count('.') != 1:
-            msg = "{} names must contain exactly 1 '.' character"\
-                .format(node_type)
-            dbt.exceptions.raise_compiler_error(msg, model)
-    else:
-        if '.' in node_name:
-            msg = "{} names cannot contain '.' characters".format(node_type)
-            dbt.exceptions.raise_compiler_error(msg, model)
-
-    if target_name != node_name:
-        return False
-
-    return target_package is None or target_package == package_name
-
-
-def find_in_subgraph_by_name(subgraph, target_name, target_package, nodetype):
-    """Find an entry in a subgraph by name. Any mapping that implements
-    .items() and maps unique id -> something can be used as the subgraph.
-
-    Names are like:
-        '{nodetype}.{target_package}.{target_name}'
-
-    You can use `None` for the package name as a wildcard.
-    """
-    for name, model in subgraph.items():
-        if id_matches(name, target_name, target_package, nodetype, model):
-            return model
-
-    return None
-
-
-def find_in_list_by_name(haystack, target_name, target_package, nodetype):
-    """Find an entry in the given list by name."""
-    for model in haystack:
-        name = model.unique_id
-        if id_matches(name, target_name, target_package, nodetype, model):
-            return model
-
-    return None
-
-
 MACRO_PREFIX = 'dbt_macro__'
 DOCS_PREFIX = 'dbt_docs__'
 

--- a/test/integration/029_docs_generate_tests/fail_macros/failure.sql
+++ b/test/integration/029_docs_generate_tests/fail_macros/failure.sql
@@ -1,0 +1,3 @@
+{% macro get_catalog(information_schemas) %}
+	{% do exceptions.raise_compiler_error('rejected: no catalogs for you') %}
+{% endmacro %}


### PR DESCRIPTION
Fixes #2032 

I went a bit further and also included the node search since it was very easy and I had a nice test suite for it...

Unify the lookup for the various macros, all of them are done in the manifest now:
 - dbt's built-in package + all plugins are part of 'core'
 - finding macros has the concept of an optional package name
 - materializations are a special case of finding macros
 - the `generate_*_name` macros are another special case (non-core dependency packages are ignored)
 - generating the macro execution context now uses the concept of an optional search_package_name
 - macro execution now binds these two together

Unify the lookup for models/docs/sources:
 - added a search_name property to those three types
 - create a 'Searchable' protocol, have the node search code accept that
 - simplify matching logic/push it into the correct types accordingly

Renamed `get_materialization_macro` to `find_materialization_macro_by_name` (consistency)

context namespacing behavior:
 - dbt run-operation now passes the named package along to macro execution if a package name is specified
 - so `dbt run-operation dependency.ad` runs with the dependency namespace as local, overriding globals
 - but `dbt run-operation my_macro` runs in the current package namespace as local, even if it ultimately runs the dependency's my_macro()
 - the current package namespace is always treated as "global", overriding core macros

Added type annotations for all the manifest stuff

Tons of tests