### PR TITLE
Detect duplicate macros (#1891)

### DIFF
--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -92,15 +92,27 @@ class ParseResult(JsonSchemaMixin, Writable, Replaceable):
             # detect that the macro exists and emit an error
             other_path = self.macros[macro.unique_id].original_file_path
             # subtract 2 for the "Compilation Error" indent
-            msg = printer.line_wrap_message(
-                f'''\
-                dbt found two macros in the project "{macro.package_name}" with
-                the name "{macro.name}" (defined in
-                "{macro.original_file_path}" and "{other_path}"). Since these
-                resources have the same name, dbt will choose one to be called
-                when {macro.name} is used. To fix this, remove or change the
-                name of one of these macros.''',
-                subtract=2)
+            # note that the line wrap eats newlines, so if you want newlines,
+            # this is the result :(
+            msg = '\n'.join([
+                printer.line_wrap_message(
+                    f'''\
+                    dbt found two macros named "{macro.name}" in the project
+                    "{macro.package_name}".
+                    ''',
+                    subtract=2
+                ),
+                '',
+                printer.line_wrap_message(
+                    f'''\
+                    To fix this error, rename or remove one of the following
+                    macros:
+                    ''',
+                    subtract=2
+                ),
+                f'   - {macro.original_file_path}',
+                f'   - {other_path}'
+            ])
             raise_compiler_error(msg)
 
         self.macros[macro.unique_id] = macro

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -1,3 +1,5 @@
+import textwrap
+import time
 from typing import Dict, Optional, Tuple
 
 from dbt.logger import GLOBAL_LOGGER as logger, DbtStatusMessage, TextOnly
@@ -6,7 +8,6 @@ from dbt.tracking import InvocationProcessor
 from dbt.utils import get_materialization
 import dbt.ui.colors
 
-import time
 
 USE_COLORS = False
 
@@ -380,3 +381,10 @@ def print_run_end_messages(results, early_exit: bool = False) -> None:
             print_run_result_error(warning, is_warning=True)
 
         print_run_status_line(results)
+
+
+def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True) -> str:
+    width = PRINTER_WIDTH - subtract
+    if dedent:
+        msg = textwrap.dedent(msg)
+    return textwrap.fill(msg, width=width)

--- a/test/integration/006_simple_dependency_test/local_dependency/macros/dep_macro.sql
+++ b/test/integration/006_simple_dependency_test/local_dependency/macros/dep_macro.sql
@@ -1,0 +1,3 @@
+{% macro some_overridden_macro() -%}
+100
+{%- endmacro %}

--- a/test/integration/006_simple_dependency_test/macros/main_macro.sql
+++ b/test/integration/006_simple_dependency_test/macros/main_macro.sql
@@ -1,0 +1,4 @@
+{# This macro also exists in the dependency -dbt should be fine with that #}
+{% macro some_overridden_macro() -%}
+999
+{%- endmacro %}

--- a/test/integration/025_duplicate_model_test/macros-bad-same/macros.sql
+++ b/test/integration/025_duplicate_model_test/macros-bad-same/macros.sql
@@ -1,0 +1,5 @@
+{% macro some_macro() %}
+{% endmacro %}
+
+{% macro some_macro() %}
+{% endmacro %}

--- a/test/integration/025_duplicate_model_test/macros-bad-separate/one.sql
+++ b/test/integration/025_duplicate_model_test/macros-bad-separate/one.sql
@@ -1,0 +1,2 @@
+{% macro some_macro() %}
+{% endmacro %}

--- a/test/integration/025_duplicate_model_test/macros-bad-separate/two.sql
+++ b/test/integration/025_duplicate_model_test/macros-bad-separate/two.sql
@@ -1,0 +1,2 @@
+{% macro some_macro() %}
+{% endmacro %}

--- a/test/integration/025_duplicate_model_test/test_duplicate_macro.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_macro.py
@@ -1,0 +1,52 @@
+import os
+from dbt.exceptions import CompilationException
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestDuplicateMacroEnabledSameFile(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_macro_025"
+
+    @property
+    def models(self):
+        return "models-3"
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['macros-bad-same']
+        }
+
+    @use_profile('postgres')
+    def test_postgres_duplicate_macros(self):
+        with self.assertRaises(CompilationException) as exc:
+            self.run_dbt(['compile'])
+        self.assertIn('some_macro', str(exc.exception))
+        self.assertIn(os.path.join('macros-bad-same', 'macros.sql'), str(exc.exception))
+
+
+class TestDuplicateMacroEnabledDifferentFiles(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_macro_025"
+
+    @property
+    def models(self):
+        return "models-3"
+
+    @property
+    def project_config(self):
+        return {
+            'macro-paths': ['macros-bad-separate']
+        }
+
+    @use_profile('postgres')
+    def test_postgres_duplicate_macros(self):
+        with self.assertRaises(CompilationException) as exc:
+            self.run_dbt(['compile'])
+        self.assertIn('some_macro', str(exc.exception))
+        self.assertIn(os.path.join('macros-bad-separate', 'one.sql'), str(exc.exception))
+        self.assertIn(os.path.join('macros-bad-separate', 'two.sql'), str(exc.exception))


### PR DESCRIPTION
Fixes #1891 

Originally I wrote this as a `warn_or_error`, but upon reflection that made no sense, as your code will almost certainly end up doing things you don't want it to do.

I added a little helper in `dbt.ui.printer` that uses the stdlib `textwrap` and dbt's `PRINTER_WIDTH` to generate reasonable-seeming output.