### PR TITLE
Make dbt support documentation for snapshots and seeds (and analyses) (#1974)

### DIFF
--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -1,4 +1,6 @@
 from copy import deepcopy
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
 
 from .profile import Profile
 from .project import Project
@@ -12,73 +14,32 @@ from dbt.adapters.factory import get_relation_class_by_name
 from hologram import ValidationError
 
 
+@dataclass
 class RuntimeConfig(Project, Profile):
-    """The runtime configuration, as constructed from its components. There's a
-    lot because there is a lot of stuff!
-    """
-    def __init__(self, project_name, version, project_root, source_paths,
-                 macro_paths, data_paths, test_paths, analysis_paths,
-                 docs_paths, target_path, snapshot_paths, clean_targets,
-                 log_path, modules_path, quoting, models, on_run_start,
-                 on_run_end, seeds, snapshots, dbt_version, profile_name,
-                 target_name, config, threads, credentials, packages,
-                 query_comment, args):
-        # 'vars'
-        self.args = args
-        self.cli_vars = parse_cli_vars(getattr(args, 'vars', '{}'))
-        # 'project'
-        Project.__init__(
-            self,
-            project_name=project_name,
-            version=version,
-            project_root=project_root,
-            profile_name=profile_name,
-            source_paths=source_paths,
-            macro_paths=macro_paths,
-            data_paths=data_paths,
-            test_paths=test_paths,
-            analysis_paths=analysis_paths,
-            docs_paths=docs_paths,
-            target_path=target_path,
-            snapshot_paths=snapshot_paths,
-            clean_targets=clean_targets,
-            log_path=log_path,
-            modules_path=modules_path,
-            quoting=quoting,
-            models=models,
-            on_run_start=on_run_start,
-            on_run_end=on_run_end,
-            seeds=seeds,
-            snapshots=snapshots,
-            dbt_version=dbt_version,
-            packages=packages,
-            query_comment=query_comment,
-        )
-        # 'profile'
-        Profile.__init__(
-            self,
-            profile_name=profile_name,
-            target_name=target_name,
-            config=config,
-            threads=threads,
-            credentials=credentials
-        )
+    args: Any
+    cli_vars: Dict[str, Any]
+
+    def __post_init__(self):
         self.validate()
 
     @classmethod
-    def from_parts(cls, project, profile, args):
+    def from_parts(
+        cls, project: Project, profile: Profile, args: Any,
+    ) -> 'RuntimeConfig':
         """Instantiate a RuntimeConfig from its components.
 
-        :param profile Profile: A parsed dbt Profile.
-        :param project Project: A parsed dbt Project.
-        :param args argparse.Namespace: The parsed command-line arguments.
+        :param profile: A parsed dbt Profile.
+        :param project: A parsed dbt Project.
+        :param args: The parsed command-line arguments.
         :returns RuntimeConfig: The new configuration.
         """
-        quoting = (
+        quoting: Dict[str, Any] = (
             get_relation_class_by_name(profile.credentials.type)
             .get_default_quote_policy()
             .replace_dict(project.quoting)
         ).to_dict()
+
+        cli_vars: Dict[str, Any] = parse_cli_vars(getattr(args, 'vars', '{}'))
 
         return cls(
             project_name=project.project_name,
@@ -109,17 +70,18 @@ class RuntimeConfig(Project, Profile):
             config=profile.config,
             threads=profile.threads,
             credentials=profile.credentials,
-            args=args
+            args=args,
+            cli_vars=cli_vars,
         )
 
-    def new_project(self, project_root):
+    def new_project(self, project_root: str) -> 'RuntimeConfig':
         """Given a new project root, read in its project dictionary, supply the
         existing project's profile info, and create a new project file.
 
-        :param project_root str: A filepath to a dbt project.
+        :param project_root: A filepath to a dbt project.
         :raises DbtProfileError: If the profile is invalid.
         :raises DbtProjectError: If project is missing or invalid.
-        :returns RuntimeConfig: The new configuration.
+        :returns: The new configuration.
         """
         # copy profile
         profile = Profile(**self.to_profile_info())
@@ -136,7 +98,7 @@ class RuntimeConfig(Project, Profile):
         cfg.quoting = deepcopy(self.quoting)
         return cfg
 
-    def serialize(self):
+    def serialize(self) -> Dict[str, Any]:
         """Serialize the full configuration to a single dictionary. For any
         instance that has passed validate() (which happens in __init__), it
         matches the Configuration contract.
@@ -149,9 +111,6 @@ class RuntimeConfig(Project, Profile):
         result.update(self.to_profile_info(serialize_credentials=True))
         result['cli_vars'] = deepcopy(self.cli_vars)
         return result
-
-    def __str__(self):
-        return str(self.serialize())
 
     def validate(self):
         """Validate the configuration against its contract.
@@ -167,16 +126,21 @@ class RuntimeConfig(Project, Profile):
             self.validate_version()
 
     @classmethod
-    def from_args(cls, args):
+    def from_args(
+        cls, args: Any, project_profile_name: Optional[str] = None
+    ) -> 'RuntimeConfig':
         """Given arguments, read in dbt_project.yml from the current directory,
         read in packages.yml if it exists, and use them to find the profile to
         load.
 
-        :param args argparse.Namespace: The arguments as parsed from the cli.
+        :param args: The arguments as parsed from the cli.
         :raises DbtProjectError: If the project is invalid or missing.
         :raises DbtProfileError: If the profile is invalid or missing.
         :raises ValidationException: If the cli variables are invalid.
         """
+        # project_profile_name is ignored, we just need it to appease mypy
+        # (Profile.from_args uses it)
+
         # build the project and read in packages.yml
         project = Project.from_args(args)
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -78,7 +78,14 @@ class NodeDescription(NamedTested):
 
 
 @dataclass
-class UnparsedNodeUpdate(ColumnDescription, NodeDescription):
+class HasYamlMetadata(JsonSchemaMixin):
+    original_file_path: str
+    yaml_key: str
+    package_name: str
+
+
+@dataclass
+class UnparsedNodeUpdate(ColumnDescription, NodeDescription, HasYamlMetadata):
     def __post_init__(self):
         NodeDescription.__post_init__(self)
 
@@ -218,6 +225,10 @@ class UnparsedSourceDefinition(JsonSchemaMixin, Replaceable):
     )
     loaded_at_field: Optional[str] = None
     tables: List[UnparsedSourceTableDefinition] = field(default_factory=list)
+
+    @property
+    def yaml_key(self) -> 'str':
+        return 'sources'
 
 
 @dataclass

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -193,6 +193,13 @@ class UserConfig(ExtensibleJsonSchemaMixin, Replaceable):
         if self.printer_width:
             printer.printer_width(self.printer_width)
 
+    @classmethod
+    def from_maybe_dict(cls, value: Optional[Dict[str, Any]]) -> 'UserConfig':
+        if value is None:
+            return cls()
+        else:
+            return cls.from_dict(value)
+
 
 @dataclass
 class ProfileConfig(HyphenatedJsonSchemaMixin, Replaceable):

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -96,6 +96,18 @@ class ColumnQuotingDeprecation(DBTDeprecation):
     '''
 
 
+class ModelsKeyNonModelDeprecation(DBTDeprecation):
+    _name = 'models-key-mismatch'
+
+    _description = '''
+    patch instruction in {patch.original_file_path} under key
+    "models" was for node "{node.name}", but the node with the same
+    name (from {node.original_file_path}) had resource type
+    "{node.resource_type}". Nodes should be described under their resource
+    specific key. Support for this will be removed in a future release.
+    '''.strip()
+
+
 _adapter_renamed_description = """\
 The adapter function `adapter.{old_name}` is deprecated and will be removed in
  a future release of dbt. Please use `adapter.{new_name}` instead.
@@ -136,6 +148,7 @@ deprecations_list: List[DBTDeprecation] = [
     MaterializationReturnDeprecation(),
     NotADictionaryDeprecation(),
     ColumnQuotingDeprecation(),
+    ModelsKeyNonModelDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -3,6 +3,7 @@ from typing import Optional, Set, List, Dict, ClassVar
 import dbt.links
 import dbt.exceptions
 import dbt.flags
+from dbt.ui import printer
 
 
 class DBTDeprecation:
@@ -28,57 +29,47 @@ class DBTDeprecation:
     def show(self, *args, **kwargs) -> None:
         if self.name not in active_deprecations:
             desc = self.description.format(**kwargs)
-            dbt.exceptions.warn_or_error(
-                "* Deprecation Warning: {}\n".format(desc)
-            )
+            msg = printer.line_wrap_message(f"* Deprecation Warning: {desc}\n")
+            dbt.exceptions.warn_or_error(msg)
             active_deprecations.add(self.name)
-
-
-class DBTRepositoriesDeprecation(DBTDeprecation):
-    _name = "repositories"
-
-    _description = """
-    The dbt_project.yml configuration option 'repositories' is
-  deprecated. Please place dependencies in the `packages.yml` file instead.
-  The 'repositories' option will be removed in a future version of dbt.
-
-  For more information, see: https://docs.getdbt.com/docs/package-management
-
-  # Example packages.yml contents:
-
-{recommendation}
-  """.lstrip()
 
 
 class GenerateSchemaNameSingleArgDeprecated(DBTDeprecation):
     _name = 'generate-schema-name-single-arg'
 
-    _description = '''As of dbt v0.14.0, the `generate_schema_name` macro
-  accepts a second "node" argument. The one-argument form of `generate_schema_name`
-  is deprecated, and will become unsupported in a future release.
+    _description = '''\
+    As of dbt v0.14.0, the `generate_schema_name` macro accepts a second "node"
+    argument. The one-argument form of `generate_schema_name` is deprecated,
+    and will become unsupported in a future release.
 
-  For more information, see:
+
+
+    For more information, see:
+
     https://docs.getdbt.com/v0.14/docs/upgrading-to-014
-  '''  # noqa
+    '''
 
 
 class MaterializationReturnDeprecation(DBTDeprecation):
     _name = 'materialization-return'
 
-    _description = '''
+    _description = '''\
     The materialization ("{materialization}") did not explicitly return a list
     of relations to add to the cache. By default the target relation will be
     added, but this behavior will be removed in a future version of dbt.
 
-  For more information, see:
-  https://docs.getdbt.com/v0.15/docs/creating-new-materializations#section-6-returning-relations
+
+
+    For more information, see:
+
+    https://docs.getdbt.com/v0.15/docs/creating-new-materializations#section-6-returning-relations
     '''.lstrip()
 
 
 class NotADictionaryDeprecation(DBTDeprecation):
     _name = 'not-a-dictionary'
 
-    _description = '''
+    _description = '''\
     The object ("{obj}") was used as a dictionary. In a future version of dbt
     this capability will be removed from objects of this type.
     '''.lstrip()
@@ -87,11 +78,14 @@ class NotADictionaryDeprecation(DBTDeprecation):
 class ColumnQuotingDeprecation(DBTDeprecation):
     _name = 'column-quoting-unset'
 
-    _description = '''
+    _description = '''\
     The quote_columns parameter was not set for seeds, so the default value of
     False was chosen. The default will change to True in a future release.
 
+
+
     For more information, see:
+
     https://docs.getdbt.com/v0.15/docs/seeds#section-specify-column-quoting
     '''
 
@@ -99,20 +93,27 @@ class ColumnQuotingDeprecation(DBTDeprecation):
 class ModelsKeyNonModelDeprecation(DBTDeprecation):
     _name = 'models-key-mismatch'
 
-    _description = '''
-    patch instruction in {patch.original_file_path} under key
-    "models" was for node "{node.name}", but the node with the same
-    name (from {node.original_file_path}) had resource type
-    "{node.resource_type}". Nodes should be described under their resource
-    specific key. Support for this will be removed in a future release.
-    '''.strip()
+    _description = '''\
+        "{node.name}" is a {node.resource_type} node, but it is specified in
+        the {patch.yaml_key} section of {patch.original_file_path}.
+
+
+
+        To fix this warning, place the `{node.name}` specification under
+        the {expected_key} key instead.
+
+        This warning will become an error in a future release.
+        '''.strip()
 
 
 _adapter_renamed_description = """\
 The adapter function `adapter.{old_name}` is deprecated and will be removed in
- a future release of dbt. Please use `adapter.{new_name}` instead.
- Documentation for {new_name} can be found here:
- https://docs.getdbt.com/docs/adapter"""
+a future release of dbt. Please use `adapter.{new_name}` instead.
+
+Documentation for {new_name} can be found here:
+
+    https://docs.getdbt.com/docs/adapter
+"""
 
 
 def renamed_method(old_name: str, new_name: str):
@@ -143,7 +144,6 @@ def warn(name, *args, **kwargs):
 active_deprecations: Set[str] = set()
 
 deprecations_list: List[DBTDeprecation] = [
-    DBTRepositoriesDeprecation(),
     GenerateSchemaNameSingleArgDeprecated(),
     MaterializationReturnDeprecation(),
     NotADictionaryDeprecation(),

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -29,7 +29,7 @@ class DBTDeprecation:
     def show(self, *args, **kwargs) -> None:
         if self.name not in active_deprecations:
             desc = self.description.format(**kwargs)
-            msg = printer.line_wrap_message(f"* Deprecation Warning: {desc}\n")
+            msg = printer.line_wrap_message(desc, prefix='* Deprecation Warning: ')
             dbt.exceptions.warn_or_error(msg)
             active_deprecations.add(self.name)
 
@@ -63,7 +63,7 @@ class MaterializationReturnDeprecation(DBTDeprecation):
     For more information, see:
 
     https://docs.getdbt.com/v0.15/docs/creating-new-materializations#section-6-returning-relations
-    '''.lstrip()
+    '''
 
 
 class NotADictionaryDeprecation(DBTDeprecation):
@@ -72,7 +72,7 @@ class NotADictionaryDeprecation(DBTDeprecation):
     _description = '''\
     The object ("{obj}") was used as a dictionary. In a future version of dbt
     this capability will be removed from objects of this type.
-    '''.lstrip()
+    '''
 
 
 class ColumnQuotingDeprecation(DBTDeprecation):
@@ -94,16 +94,16 @@ class ModelsKeyNonModelDeprecation(DBTDeprecation):
     _name = 'models-key-mismatch'
 
     _description = '''\
-        "{node.name}" is a {node.resource_type} node, but it is specified in
-        the {patch.yaml_key} section of {patch.original_file_path}.
+    "{node.name}" is a {node.resource_type} node, but it is specified in
+    the {patch.yaml_key} section of {patch.original_file_path}.
 
 
 
-        To fix this warning, place the `{node.name}` specification under
-        the {expected_key} key instead.
+    To fix this warning, place the `{node.name}` specification under
+    the {expected_key} key instead.
 
-        This warning will become an error in a future release.
-        '''.strip()
+    This warning will become an error in a future release.
+    '''
 
 
 _adapter_renamed_description = """\

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -29,7 +29,9 @@ class DBTDeprecation:
     def show(self, *args, **kwargs) -> None:
         if self.name not in active_deprecations:
             desc = self.description.format(**kwargs)
-            msg = printer.line_wrap_message(desc, prefix='* Deprecation Warning: ')
+            msg = printer.line_wrap_message(
+                desc, prefix='* Deprecation Warning: '
+            )
             dbt.exceptions.warn_or_error(msg)
             active_deprecations.add(self.name)
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -445,13 +445,14 @@ def _get_target_failure_msg(model, target_model_name, target_model_package,
     if include_path:
         source_path_string = ' ({})'.format(model.original_file_path)
 
-    return ("{} '{}'{} depends on model '{}' {}which {}"
-            .format(model.resource_type.title(),
-                    model.unique_id,
-                    source_path_string,
-                    target_model_name,
-                    target_package_string,
-                    reason))
+    return "{} '{}'{} depends on a node named '{}' {}which {}".format(
+        model.resource_type.title(),
+        model.unique_id,
+        source_path_string,
+        target_model_name,
+        target_package_string,
+        reason
+    )
 
 
 def get_target_disabled_msg(model, target_model_name, target_model_package):

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from hologram.helpers import StrEnum
 
 
@@ -33,6 +35,22 @@ class NodeType(StrEnum):
             cls.Seed,
             cls.Snapshot,
         ]]
+
+    @classmethod
+    def documentable(cls) -> List['NodeType']:
+        return [
+            cls.Model,
+            cls.Seed,
+            cls.Snapshot,
+            cls.Analysis,
+            cls.Source,
+        ]
+
+    def pluralize(self) -> str:
+        if self == 'analysis':
+            return 'analyses'
+        else:
+            return f'{self}s'
 
 
 class RunHookType(StrEnum):

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -42,7 +42,6 @@ class NodeType(StrEnum):
             cls.Model,
             cls.Seed,
             cls.Snapshot,
-            cls.Analysis,
             cls.Source,
         ]
 

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -79,10 +79,6 @@ class BaseParser(Generic[FinalValue]):
         source_file.contents = file_contents.strip()
         return source_file
 
-    def parse_file_from_path(self, path: FilePath):
-        block = FileBlock(file=self.load_file(path))
-        self.parse_file(block)
-
 
 class Parser(BaseParser[FinalValue], Generic[FinalValue]):
     def __init__(

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -2,7 +2,7 @@ import itertools
 import os
 import pickle
 from datetime import datetime
-from typing import Dict, Optional, Mapping, Callable, Any
+from typing import Dict, Optional, Mapping, Callable, Any, List, Type
 
 from dbt.include.global_project import PACKAGES
 import dbt.exceptions
@@ -15,7 +15,7 @@ from dbt.config import Project, RuntimeConfig
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest, FilePath, FileHash
 from dbt.exceptions import raise_compiler_error
-from dbt.parser.base import BaseParser
+from dbt.parser.base import BaseParser, Parser
 from dbt.parser.analysis import AnalysisParser
 from dbt.parser.data_test import DataTestParser
 from dbt.parser.docs import DocumentationParser
@@ -36,7 +36,7 @@ PARSING_STATE = DbtProcessState('parsing')
 DEFAULT_PARTIAL_PARSE = False
 
 
-_parser_types = [
+_parser_types: List[Type[Parser]] = [
     ModelParser,
     SnapshotParser,
     AnalysisParser,
@@ -161,7 +161,7 @@ class ManifestLoader:
         macro_manifest: Manifest,
         old_results: Optional[ParseResult],
     ) -> None:
-        parsers = []
+        parsers: List[Parser] = []
         for cls in _parser_types:
             parser = cls(self.results, project, self.root_project,
                          macro_manifest)

--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -94,25 +94,21 @@ class ParseResult(JsonSchemaMixin, Writable, Replaceable):
             # subtract 2 for the "Compilation Error" indent
             # note that the line wrap eats newlines, so if you want newlines,
             # this is the result :(
-            msg = '\n'.join([
-                printer.line_wrap_message(
-                    f'''\
-                    dbt found two macros named "{macro.name}" in the project
-                    "{macro.package_name}".
-                    ''',
-                    subtract=2
-                ),
-                '',
-                printer.line_wrap_message(
-                    f'''\
-                    To fix this error, rename or remove one of the following
-                    macros:
-                    ''',
-                    subtract=2
-                ),
-                f'   - {macro.original_file_path}',
-                f'   - {other_path}'
-            ])
+            msg = printer.line_wrap_message(
+                f'''\
+                dbt found two macros named "{macro.name}" in the project
+                "{macro.package_name}".
+
+
+                To fix this error, rename or remove one of the following
+                macros:
+
+                    - {macro.original_file_path}
+
+                    - {other_path}
+                ''',
+                subtract=2
+            )
             raise_compiler_error(msg)
 
         self.macros[macro.unique_id] = macro

--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -188,11 +188,16 @@ class ParseResult(JsonSchemaMixin, Writable, Replaceable):
                     .format(node_id, old_file)
                 )
 
+        patched = False
         for name in old_file.patches:
             patch = _expect_value(
                 name, old_result.patches, old_file, "patches"
             )
             self.add_patch(source_file, patch)
+            patched = True
+
+        if patched:
+            self.get_file(source_file).patches.sort()
 
         return True
 

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -93,10 +93,10 @@ class SourceTarget:
             return self.table.tests
 
 
-ModelTarget = UnparsedNodeUpdate
+NodeTarget = UnparsedNodeUpdate
 
 
-Target = TypeVar('Target', ModelTarget, SourceTarget)
+Target = TypeVar('Target', NodeTarget, SourceTarget)
 
 
 @dataclass
@@ -257,7 +257,7 @@ class TestBuilder(Generic[Target]):
         return macro_name
 
     def describe_test_target(self) -> str:
-        if isinstance(self.target, ModelTarget):
+        if isinstance(self.target, NodeTarget):
             fmt = "model('{0}')"
         elif isinstance(self.target, SourceTarget):
             fmt = "source('{0.source}', '{0.table}')"
@@ -268,7 +268,7 @@ class TestBuilder(Generic[Target]):
         raise NotImplementedError('describe_test_target not implemented!')
 
     def get_test_name(self) -> Tuple[str, str]:
-        if isinstance(self.target, ModelTarget):
+        if isinstance(self.target, NodeTarget):
             name = self.name
         elif isinstance(self.target, SourceTarget):
             name = 'source_' + self.name
@@ -290,7 +290,7 @@ class TestBuilder(Generic[Target]):
         )
 
     def build_model_str(self):
-        if isinstance(self.target, ModelTarget):
+        if isinstance(self.target, NodeTarget):
             fmt = "ref('{0.name}')"
         elif isinstance(self.target, SourceTarget):
             fmt = "source('{0.source.name}', '{0.table.name}')"

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -34,7 +34,7 @@ from dbt.parser.schema_test_builders import (
     TestBuilder, SourceTarget, NodeTarget, Target,
     SchemaTestBlock, TargetBlock, YamlBlock,
 )
-from dbt.utils import get_pseudo_test_path
+from dbt.utils import get_pseudo_test_path, coerce_dict_str
 
 
 UnparsedSchemaYaml = Union[UnparsedSourceDefinition, UnparsedNodeUpdate]
@@ -118,7 +118,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
 
     def get_paths(self):
         return FilesystemSearcher(
-            self.project, self.project.source_paths, '.yml'
+            self.project, self.project.all_source_paths, '.yml'
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedTestNode:
@@ -314,11 +314,7 @@ class YamlParser(Generic[Target, Parsed]):
         path = self.yaml.path.original_file_path
 
         for entry in data:
-            str_keys = (
-                isinstance(entry, dict) and
-                all(isinstance(k, str) for k in entry)
-            )
-            if str_keys:
+            if coerce_dict_str(entry) is not None:
                 yield entry
             else:
                 msg = error_context(

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -384,7 +384,17 @@ def print_run_end_messages(results, early_exit: bool = False) -> None:
 
 
 def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True) -> str:
+    '''
+    Line wrap the given message to PRINTER_WIDTH - {subtract}. Convert double
+    newlines to newlines and avoid calling textwrap.fill() on them (like
+    markdown)
+    '''
     width = PRINTER_WIDTH - subtract
     if dedent:
         msg = textwrap.dedent(msg)
-    return textwrap.fill(msg, width=width)
+
+    # If the input had an explicit double newline, we want to preserve that
+    # (we'll turn it into a single line soon). Support windows, too.
+    splitter = '\r\n\r\n' if '\r\n\r\n' in msg else '\n\n'
+    chunks = msg.split(splitter)
+    return '\n'.join(textwrap.fill(chunk, width=width) for chunk in chunks)

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -383,7 +383,9 @@ def print_run_end_messages(results, early_exit: bool = False) -> None:
         print_run_status_line(results)
 
 
-def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True) -> str:
+def line_wrap_message(
+    msg: str, subtract: int = 0, dedent: bool = True, prefix: str = ''
+) -> str:
     '''
     Line wrap the given message to PRINTER_WIDTH - {subtract}. Convert double
     newlines to newlines and avoid calling textwrap.fill() on them (like
@@ -392,6 +394,9 @@ def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True) -> str:
     width = PRINTER_WIDTH - subtract
     if dedent:
         msg = textwrap.dedent(msg)
+
+    if prefix:
+        msg = f'{prefix}{msg}'
 
     # If the input had an explicit double newline, we want to preserve that
     # (we'll turn it into a single line soon). Support windows, too.

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -532,6 +532,17 @@ def restrict_to(*restrictions):
     return {'restrict': list(restrictions)}
 
 
+def coerce_dict_str(value: Any) -> Optional[Dict[str, Any]]:
+    """For annoying mypy reasons, this helper makes dealing with nested dicts
+    easier. You get either `None` if it's not a Dict[str, Any], or the
+    Dict[str, Any] you expected (to pass it to JsonSchemaMixin.from_dict(...)).
+    """
+    if (isinstance(value, dict) and all(isinstance(k, str) for k in value)):
+        return value
+    else:
+        return None
+
+
 # some types need to make constants available to the jinja context as
 # attributes, and regular properties only work with objects. maybe this should
 # be handled by the RelationProxy?

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -9,7 +9,7 @@ import json
 import os
 from enum import Enum
 from typing import (
-    Tuple, Type, Any, Optional, TypeVar, Dict, Iterable, Set, List
+    Tuple, Type, Any, Optional, TypeVar, Dict, Iterable, Set, List, Union
 )
 from typing_extensions import Protocol
 
@@ -511,13 +511,20 @@ def translate_aliases(kwargs, aliases):
     return result
 
 
-def pluralize(count, string):
-    if count == 1:
-        return "{} {}".format(count, string)
-    elif string == 'analysis':
-        return "{} {}".format(count, 'analyses')
+def _pluralize(string: Union[str, NodeType]) -> str:
+    try:
+        convert = NodeType(string)
+    except ValueError:
+        return f'{string}s'
     else:
-        return "{} {}s".format(count, string)
+        return convert.pluralize()
+
+
+def pluralize(count, string: Union[str, NodeType]):
+    pluralized: str = str(string)
+    if count != 1:
+        pluralized = _pluralize(string)
+    return f'{count} {pluralized}'
 
 
 def restrict_to(*restrictions):

--- a/test/integration/004_simple_snapshot_test/models/schema.yml
+++ b/test/integration/004_simple_snapshot_test/models/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+snapshots:
   - name: snapshot_actual
     tests:
       - mutually_exclusive_ranges

--- a/test/integration/005_simple_seed_test/models-bq/schema.yml
+++ b/test/integration/005_simple_seed_test/models-bq/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: seed_enabled
   columns:
   - name: birthday

--- a/test/integration/005_simple_seed_test/models-pg/schema.yml
+++ b/test/integration/005_simple_seed_test/models-pg/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: seed_enabled
   columns:
   - name: birthday

--- a/test/integration/005_simple_seed_test/models-rs/schema.yml
+++ b/test/integration/005_simple_seed_test/models-rs/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: seed_enabled
   columns:
   - name: birthday

--- a/test/integration/005_simple_seed_test/models-snowflake/schema.yml
+++ b/test/integration/005_simple_seed_test/models-snowflake/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: seed_enabled
   columns:
   - name: birthday

--- a/test/integration/012_deprecation_tests/data/seed.csv
+++ b/test/integration/012_deprecation_tests/data/seed.csv
@@ -1,0 +1,3 @@
+a,b
+1,hello
+2,goodbye

--- a/test/integration/012_deprecation_tests/models-key-mismatch/schema.yml
+++ b/test/integration/012_deprecation_tests/models-key-mismatch/schema.yml
@@ -1,0 +1,4 @@
+version: 2
+models:
+  - name: seed
+    description: my cool seed

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -93,7 +93,8 @@ class TestModelsKeyMismatchDeprecation(BaseTestDeprecations):
         # this should fail at compile_time
         with self.assertRaises(dbt.exceptions.CompilationException) as exc:
             self.run_dbt(strict=True)
-        self.assertIn('had resource type', str(exc.exception))
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        self.assertIn('"seed" is a seed node, but it is specified in the models section', exc_str)
 
     @use_profile('postgres')
     def test_postgres_deprecations(self):

--- a/test/integration/014_hook_tests/seed-models-bq/schema.yml
+++ b/test/integration/014_hook_tests/seed-models-bq/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: example_seed
   columns:
   - name: a

--- a/test/integration/014_hook_tests/seed-models/schema.yml
+++ b/test/integration/014_hook_tests/seed-models/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+seeds:
 - name: example_seed
   columns:
   - name: new_col

--- a/test/integration/014_hook_tests/test-snapshot-models/schema.yml
+++ b/test/integration/014_hook_tests/test-snapshot-models/schema.yml
@@ -1,5 +1,5 @@
 version: 2
-models:
+snapshots:
 - name: example_snapshot
   columns:
   - name: new_col

--- a/test/integration/029_docs_generate_tests/models/schema.yml
+++ b/test/integration/029_docs_generate_tests/models/schema.yml
@@ -19,3 +19,17 @@ models:
         description: The last time this user's email was updated
     tests:
       - test.nothing
+seeds:
+  - name: seed
+    description: "The test seed"
+    columns:
+      - name: id
+        description: The user ID number
+      - name: first_name
+        description: The user's first name
+      - name: email
+        description: The user's email
+      - name: ip_address
+        description: The user's IP address
+      - name: updated_at
+        description: The last time this user's email was updated

--- a/test/integration/029_docs_generate_tests/seed/schema.yml
+++ b/test/integration/029_docs_generate_tests/seed/schema.yml
@@ -1,14 +1,10 @@
 version: 2
-
-models:
-  - name: model
-    description: "The test model"
+seeds:
+  - name: seed
+    description: "The test seed"
     columns:
       - name: id
         description: The user ID number
-        tests:
-          - unique
-          - not_null
       - name: first_name
         description: The user's first name
       - name: email
@@ -17,5 +13,3 @@ models:
         description: The user's IP address
       - name: updated_at
         description: The last time this user's email was updated
-    tests:
-      - test.nothing

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -949,7 +949,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'tags': [],
                         'quote_columns': True,
                     },
-                    'patch_path': None,
+                    'patch_path': schema_yml_path,
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
@@ -969,8 +969,39 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'alias': 'seed',
-                    'description': '',
-                    'columns': {},
+                    'description': 'The test seed',
+                    'columns': {
+                        'id': {
+                            'name': 'id',
+                            'description': 'The user ID number',
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'first_name': {
+                            'name': 'first_name',
+                            'description': "The user's first name",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'email': {
+                            'name': 'email',
+                            'description': "The user's email",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'ip_address': {
+                            'name': 'ip_address',
+                            'description': "The user's IP address",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'updated_at': {
+                            'name': 'updated_at',
+                            'description': "The last time this user's email was updated",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                    },
                     'docrefs': [],
                     'compiled': True,
                     'compiled_sql': '',
@@ -1197,7 +1228,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'docs': [],
                     'macros': [],
                     'nodes': ['test.test.unique_model_id', 'test.test.not_null_model_id', 'test.test.test_nothing_model_'],
-                    'patches': ['model'],
+                    'patches': ['model', 'seed'],
                     'sources': [],
                 },
             },
@@ -2510,7 +2541,38 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'node': {
                     'alias': 'seed',
                     'build_path': None,
-                    'columns': {},
+                    'columns': {
+                        'id': {
+                            'description': 'The user ID number',
+                            'name': 'id',
+                            'data_type': None,
+                            'meta': {}
+                        },
+                        'first_name': {
+                            'description': "The user's first name",
+                            'name': 'first_name',
+                            'data_type': None,
+                            'meta': {}
+                        },
+                        'email': {
+                            'description': "The user's email",
+                            'name': 'email',
+                            'data_type': None,
+                            'meta': {}
+                        },
+                        'ip_address': {
+                            'description': "The user's IP address",
+                            'name': 'ip_address',
+                            'data_type': None,
+                            'meta': {}
+                        },
+                        'updated_at': {
+                            'description': "The last time this user's email was updated",
+                            'name': 'updated_at',
+                            'data_type': None,
+                            'meta': {}
+                        }
+                    },
                     'compiled': True,
                     'compiled_sql': '',
                     'config': {
@@ -2527,7 +2589,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     },
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': []},
-                    'description': '',
+                    'description': 'The test seed',
                     'docrefs': [],
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
@@ -2537,7 +2599,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
                     'package_name': 'test',
-                    'patch_path': None,
+                    'patch_path': schema_yml_path,
                     'path': 'seed.csv',
                     'raw_sql': '',
                     'refs': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -848,7 +848,9 @@ class TestDocsGenerate(DBTIntegrationTest):
     def expected_seeded_manifest(self, model_database=None):
         models_path = self.dir('models')
         model_sql_path = os.path.join(models_path, 'model.sql')
-        schema_yml_path = os.path.join(models_path, 'schema.yml')
+        model_schema_yml_path = os.path.join(models_path, 'schema.yml')
+        seed_schema_yml_path = os.path.join(self.dir('seed'), 'schema.yml')
+
         my_schema_name = self.unique_schema()
 
         if model_database is None:
@@ -924,7 +926,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'meta': {},
                         },
                     },
-                    'patch_path': schema_yml_path,
+                    'patch_path': model_schema_yml_path,
                     'docrefs': [],
                     'compiled': True,
                     'compiled_sql': ANY,
@@ -949,7 +951,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'tags': [],
                         'quote_columns': True,
                     },
-                    'patch_path': schema_yml_path,
+                    'patch_path': seed_schema_yml_path,
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
@@ -1032,7 +1034,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'fqn': ['test', 'schema_test', 'not_null_model_id'],
                     'name': 'not_null_model_id',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/not_null_model_id.sql'),
@@ -1080,7 +1082,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'fqn': ['test', 'schema_test', 'test_nothing_model_'],
                     'name': 'test_nothing_model_',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/test_nothing_model_.sql'),
@@ -1128,7 +1130,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': '',
                     'fqn': ['test', 'schema_test', 'unique_model_id'],
                     'name': 'unique_model_id',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/unique_model_id.sql'),
@@ -1228,7 +1230,16 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'docs': [],
                     'macros': [],
                     'nodes': ['test.test.unique_model_id', 'test.test.not_null_model_id', 'test.test.test_nothing_model_'],
-                    'patches': ['model', 'seed'],
+                    'patches': ['model'],
+                    'sources': [],
+                },
+                normalize('seed/schema.yml'): {
+                    'path': self._path_to('seed', 'schema.yml'),
+                    'checksum': self._checksum_file('seed/schema.yml'),
+                    'docs': [],
+                    'macros': [],
+                    'nodes': [],
+                    'patches': ['seed'],
                     'sources': [],
                 },
             },
@@ -1466,7 +1477,38 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'seed.test.seed': {
                     'alias': 'seed',
                     'build_path': None,
-                    'columns': {},
+                    'columns': {
+                        'id': {
+                            'name': 'id',
+                            'description': 'The user ID number',
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'first_name': {
+                            'name': 'first_name',
+                            'description': "The user's first name",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'email': {
+                            'name': 'email',
+                            'description': "The user's email",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'ip_address': {
+                            'name': 'ip_address',
+                            'description': "The user's IP address",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'updated_at': {
+                            'name': 'updated_at',
+                            'description': "The last time this user's email was updated",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                    },
                     'config': {
                         'column_types': {},
                         'enabled': True,
@@ -1481,13 +1523,13 @@ class TestDocsGenerate(DBTIntegrationTest):
                     },
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': []},
-                    'description': '',
+                    'description': 'The test seed',
                     'docrefs': [],
                     'fqn': ['test', 'seed'],
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
                     'package_name': 'test',
-                    'patch_path': None,
+                    'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
                     'raw_sql': '',
                     'refs': [],
@@ -1735,7 +1777,15 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': self._path_to('ref_models', 'schema.yml'),
                     'sources': ['source.test.my_source.my_table'],
                 },
-
+                normalize('seed/schema.yml'): {
+                    'path': self._path_to('seed', 'schema.yml'),
+                    'checksum': self._checksum_file('seed/schema.yml'),
+                    'docs': [],
+                    'macros': [],
+                    'nodes': [],
+                    'patches': ['seed'],
+                    'sources': [],
+                },
             },
         }
 
@@ -2017,7 +2067,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'seed.test.seed': {
                     'build_path': None,
-                    'patch_path': None,
+                    'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
@@ -2051,8 +2101,39 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'alias': 'seed',
-                    'columns': {},
-                    'description': '',
+                    'columns': {
+                        'id': {
+                            'name': 'id',
+                            'description': 'The user ID number',
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'first_name': {
+                            'name': 'first_name',
+                            'description': "The user's first name",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'email': {
+                            'name': 'email',
+                            'description': "The user's email",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'ip_address': {
+                            'name': 'ip_address',
+                            'description': "The user's IP address",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'updated_at': {
+                            'name': 'updated_at',
+                            'description': "The last time this user's email was updated",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                    },
+                    'description': 'The test seed',
                     'docrefs': [],
                     'compiled': True,
                     'compiled_sql': '',
@@ -2150,6 +2231,15 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'patches': ['nested_view', 'clustered', 'multi_clustered'],
                     'docs': [],
                     'macros': [],
+                    'sources': [],
+                },
+                normalize('seed/schema.yml'): {
+                    'path': self._path_to('seed', 'schema.yml'),
+                    'checksum': self._checksum_file('seed/schema.yml'),
+                    'docs': [],
+                    'macros': [],
+                    'nodes': [],
+                    'patches': ['seed'],
                     'sources': [],
                 },
             },
@@ -2265,7 +2355,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'seed.test.seed': {
                     'build_path': None,
-                    'patch_path': None,
+                    'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
@@ -2299,8 +2389,39 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'alias': 'seed',
-                    'columns': {},
-                    'description': '',
+                    'columns': {
+                        'id': {
+                            'name': 'id',
+                            'description': 'The user ID number',
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'first_name': {
+                            'name': 'first_name',
+                            'description': "The user's first name",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'email': {
+                            'name': 'email',
+                            'description': "The user's email",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'ip_address': {
+                            'name': 'ip_address',
+                            'description': "The user's IP address",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'updated_at': {
+                            'name': 'updated_at',
+                            'description': "The last time this user's email was updated",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                    },
+                    'description': 'The test seed',
                     'docrefs': [],
                     'compiled': True,
                     'compiled_sql': ANY,
@@ -2367,6 +2488,15 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'patches': ['model'],
                     'sources': []
                 },
+                normalize('seed/schema.yml'): {
+                    'path': self._path_to('seed', 'schema.yml'),
+                    'checksum': self._checksum_file('seed/schema.yml'),
+                    'docs': [],
+                    'macros': [],
+                    'nodes': [],
+                    'patches': ['seed'],
+                    'sources': [],
+                },
             },
         }
 
@@ -2418,7 +2548,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         """
         models_path = self.dir('models')
         model_sql_path = os.path.join(models_path, 'model.sql')
-        schema_yml_path = os.path.join(models_path, 'schema.yml')
+        model_schema_yml_path = os.path.join(models_path, 'schema.yml')
+        seed_schema_yml_path = os.path.join(self.dir('seed'), 'schema.yml')
 
         if model_database is None:
             model_database = self.alternative_database
@@ -2516,7 +2647,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'name': 'model',
                     'original_file_path': model_sql_path,
                     'package_name': 'test',
-                    'patch_path': schema_yml_path,
+                    'patch_path': model_schema_yml_path,
                     'path': 'model.sql',
                     'raw_sql': LineIndifferent(_read_file(model_sql_path).rstrip('\r\n')),
                     'refs': [['seed']],
@@ -2599,7 +2730,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
                     'package_name': 'test',
-                    'patch_path': schema_yml_path,
+                    'patch_path': seed_schema_yml_path,
                     'path': 'seed.csv',
                     'raw_sql': '',
                     'refs': [],
@@ -2651,7 +2782,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'injected_sql': AnyStringWith('id is null'),
                     'meta': {},
                     'name': 'not_null_model_id',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/not_null_model_id.sql'),
@@ -2709,7 +2840,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'injected_sql': AnyStringWith('select 0'),
                     'meta': {},
                     'name': 'test_nothing_model_',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/test_nothing_model_.sql'),
@@ -2767,7 +2898,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'injected_sql': AnyStringWith('count(*)'),
                     'meta': {},
                     'name': 'unique_model_id',
-                    'original_file_path': schema_yml_path,
+                    'original_file_path': model_schema_yml_path,
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/unique_model_id.sql'),
@@ -3013,7 +3144,38 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'node': {
                     'alias': 'seed',
                     'build_path': None,
-                    'columns': {},
+                    'columns': {
+                        'id': {
+                            'name': 'id',
+                            'description': 'The user ID number',
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'first_name': {
+                            'name': 'first_name',
+                            'description': "The user's first name",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'email': {
+                            'name': 'email',
+                            'description': "The user's email",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'ip_address': {
+                            'name': 'ip_address',
+                            'description': "The user's IP address",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                        'updated_at': {
+                            'name': 'updated_at',
+                            'description': "The last time this user's email was updated",
+                            'data_type': None,
+                            'meta': {},
+                        },
+                    },
                     'compiled': True,
                     'compiled_sql': '',
                     'config': {
@@ -3030,7 +3192,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     },
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': []},
-                    'description': '',
+                    'description': 'The test seed',
                     'docrefs': [],
                     'extra_ctes': [],
                     'extra_ctes_injected': True,
@@ -3040,7 +3202,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'name': 'seed',
                     'original_file_path': self.dir('seed/seed.csv'),
                     'package_name': 'test',
-                    'patch_path': None,
+                    'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
                     'raw_sql': '',
                     'refs': [],

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -537,7 +537,7 @@ class TestProject(BaseConfigTest):
         self.assertEqual(project.data_paths, ['data'])
         self.assertEqual(project.test_paths, ['test'])
         self.assertEqual(project.analysis_paths, [])
-        self.assertEqual(project.docs_paths, ['models'])
+        self.assertEqual(project.docs_paths, ['models', 'data', 'snapshots'])
         self.assertEqual(project.target_path, 'target')
         self.assertEqual(project.clean_targets, ['target'])
         self.assertEqual(project.log_path, 'logs')
@@ -577,7 +577,7 @@ class TestProject(BaseConfigTest):
         project = dbt.config.Project.from_project_config(
             self.default_project_data
         )
-        self.assertEqual(project.docs_paths, ['other-models'])
+        self.assertEqual(project.docs_paths, ['other-models', 'data', 'snapshots'])
         self.assertEqual(project.clean_targets, ['other-target'])
 
     def test_hashed_name(self):
@@ -1089,7 +1089,7 @@ class TestRuntimeConfigFiles(BaseFileTest):
         self.assertEqual(config.data_paths, ['data'])
         self.assertEqual(config.test_paths, ['test'])
         self.assertEqual(config.analysis_paths, [])
-        self.assertEqual(config.docs_paths, ['models'])
+        self.assertEqual(config.docs_paths, ['models', 'data', 'snapshots'])
         self.assertEqual(config.target_path, 'target')
         self.assertEqual(config.clean_targets, ['target'])
         self.assertEqual(config.log_path, 'logs')

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -303,6 +303,8 @@ class TestParsedModelNode(ContractTestCase):
         )
         patch = ParsedNodePatch(
             name='foo',
+            yaml_key='models',
+            package_name='test',
             description='The foo model',
             original_file_path='/path/to/schema.yml',
             columns={'a': ColumnInfo(name='a', description='a text field', meta={})},
@@ -408,6 +410,8 @@ class TestParsedModelNode(ContractTestCase):
         # invalid patch: description can't be None
         patch = ParsedNodePatch(
             name='foo',
+            yaml_key='models',
+            package_name='test',
             description=None,
             original_file_path='/path/to/schema.yml',
             columns={},
@@ -1360,10 +1364,14 @@ class TestParsedNodePatch(ContractTestCase):
             'columns': {},
             'docrefs': [],
             'meta': {},
+            'yaml_key': 'models',
+            'package_name': 'test',
         }
-        patch = ParsedNodePatch(
+        patch = self.ContractType(
             name='foo',
             description='The foo model',
+            yaml_key='models',
+            package_name='test',
             original_file_path='/path/to/schema.yml',
             columns={},
             docrefs=[],
@@ -1383,9 +1391,11 @@ class TestParsedNodePatch(ContractTestCase):
                     'documentation_package': 'test',
                 }
             ],
-            'meta': {'key': ['value']}
+            'meta': {'key': ['value']},
+            'yaml_key': 'models',
+            'package_name': 'test',
         }
-        patch = ParsedNodePatch(
+        patch = self.ContractType(
             name='foo',
             description='The foo model',
             original_file_path='/path/to/schema.yml',
@@ -1394,6 +1404,8 @@ class TestParsedNodePatch(ContractTestCase):
                 Docref(documentation_name='foo', documentation_package='test'),
             ],
             meta={'key': ['value']},
+            yaml_key='models',
+            package_name='test',
         )
         self.assert_symmetric(patch, dct)
         pickle.loads(pickle.dumps(patch))

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -374,10 +374,23 @@ class TestUnparsedNodeUpdate(ContractTestCase):
     ContractType = UnparsedNodeUpdate
 
     def test_defaults(self):
-        minimum = self.ContractType(name='foo')
-        from_dict = {'name': 'foo'}
+        minimum = self.ContractType(
+            name='foo',
+            yaml_key='models',
+            original_file_path='/some/fake/path',
+            package_name='test',
+        )
+        from_dict = {
+            'name': 'foo',
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
+        }
         to_dict = {
             'name': 'foo',
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
             'columns': [],
             'description': '',
             'tests': [],
@@ -389,6 +402,9 @@ class TestUnparsedNodeUpdate(ContractTestCase):
     def test_contents(self):
         update = self.ContractType(
             name='foo',
+            yaml_key='models',
+            original_file_path='/some/fake/path',
+            package_name='test',
             description='a description',
             tests=['table_test'],
             meta={'key': ['value1', 'value2']},
@@ -411,6 +427,9 @@ class TestUnparsedNodeUpdate(ContractTestCase):
         )
         dct = {
             'name': 'foo',
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
             'description': 'a description',
             'tests': ['table_test'],
             'meta': {'key': ['value1', 'value2']},
@@ -438,6 +457,9 @@ class TestUnparsedNodeUpdate(ContractTestCase):
     def test_bad_test_type(self):
         dct = {
             'name': 'foo',
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
             'description': 'a description',
             'tests': ['table_test'],
             'meta': {'key': ['value1', 'value2']},
@@ -456,6 +478,8 @@ class TestUnparsedNodeUpdate(ContractTestCase):
                         {'accepted_values': {'values': ['blue', 'green']}}
                     ],
                     'meta': {},
+                    'yaml_key': 'models',
+                    'original_file_path': '/some/fake/path',
                 },
             ],
         }
@@ -463,6 +487,9 @@ class TestUnparsedNodeUpdate(ContractTestCase):
 
         dct = {
             'name': 'foo',
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
             'description': 'a description',
             'tests': ['table_test'],
             'meta': {'key': ['value1', 'value2']},
@@ -481,6 +508,8 @@ class TestUnparsedNodeUpdate(ContractTestCase):
                         {'accepted_values': {'values': ['blue', 'green']}}
                     ],
                     'meta': {},
+                    'yaml_key': 'models',
+                    'original_file_path': '/some/fake/path',
                 },
             ],
         }
@@ -488,6 +517,9 @@ class TestUnparsedNodeUpdate(ContractTestCase):
 
         # missing a name
         dct = {
+            'yaml_key': 'models',
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test',
             'description': 'a description',
             'tests': ['table_test'],
             'meta': {'key': ['value1', 'value2']},
@@ -506,6 +538,8 @@ class TestUnparsedNodeUpdate(ContractTestCase):
                         {'accepted_values': {'values': ['blue', 'green']}}
                     ],
                     'meta': {},
+                    'yaml_key': 'models',
+                    'original_file_path': '/some/fake/path',
                 },
             ],
         }


### PR DESCRIPTION
Fixes #1974 

Adds ~three~two new sections to schema.yml: `snapshots`, and `seeds`~, and `analyses`~. They act just like "models", except they must refer to resources of the appropriate type. dbt checks correctness at patch-time.

For backwards compatibility, this PR allows snapshots/seeds ~/analyses~ tests+docs to be defined under 'models', but with a deprecation warning. There's no warning for models described by "models", of course!

I did some minor internal refactoring of the schema.yml parser, by creating two custom parser classes to handle sources vs ... "refables" I guess you could call them? I imagine creating a third for macros in the future, with similar behavior but no support for "column tests", etc.