### PR TITLE
Add logging for a file path that can't be cleaned

### DIFF
--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -36,5 +36,6 @@ class CleanTask(ProjectOnlyTask):
                 shutil.rmtree(path, True)
                 logger.info(" Cleaned {}/*".format(path))
             else:
-                logger.info("ERROR: not cleaning {}/* because it is protected".format(path))
+                logger.info("ERROR: not cleaning {}/* because it is "
+                            "protected".format(path))
         logger.info("Finished cleaning all paths.")

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -36,5 +36,5 @@ class CleanTask(ProjectOnlyTask):
                 shutil.rmtree(path, True)
                 logger.info(" Cleaned {}/*".format(path))
             else:
-                logger.info("{}/* cannot be cleaned".format(path))
+                logger.info("ERROR: not cleaning {}/* because it is protected".format(path))
         logger.info("Finished cleaning all paths.")

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -35,4 +35,6 @@ class CleanTask(ProjectOnlyTask):
             if not self.__is_protected_path(path):
                 shutil.rmtree(path, True)
                 logger.info(" Cleaned {}/*".format(path))
+            else:
+                logger.info("{}/* cannot be cleaned".format(path))
         logger.info("Finished cleaning all paths.")

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -21,7 +21,7 @@ class CleanTask(ProjectOnlyTask):
         abs_path = os.path.abspath(path)
         protected_paths = self.config.source_paths + \
             self.config.test_paths + ['.']
-        protected_abs_paths = [os.path.abspath for p in protected_paths]
+        protected_abs_paths = [os.path.abspath(p) for p in protected_paths]
         return abs_path in set(protected_abs_paths) or \
             self.__is_project_path(abs_path)
 


### PR DESCRIPTION
Closes https://github.com/fishtown-analytics/dbt/issues/2059

In a case where your `dbt_project.yml` file has:
```
source-paths: ["models"]

clean-targets:
  - "models"
  - "dbt_modules"
```

when you run `dbt clean` you'll see a message that looks like:

```
Checking models/*
Checking dbt_modules/*
 Cleaned dbt_modules/*
```

Because it doesn't tell you you did something wrong, you may not notice that the `model/*` file wasn't cleaned (rightfully so!). This MR proposes that the messaging be:
```
Checking model/*
model/* cannot be cleaned.
Checking dbt_modules/*
 Cleaned dbt_modules/*
```

No functional differences, just more details. 