### PR TITLE
Overwrite clobber config fields

### DIFF
--- a/core/dbt/source_config.py
+++ b/core/dbt/source_config.py
@@ -50,9 +50,16 @@ class SourceConfig:
     def _merge(self, *configs):
         merged_config = {}
         for config in configs:
+            # Do not attempt to deep merge clobber fields
+            config = config.copy()
+            clobber = {
+                key: config.pop(key) for key in list(config.keys())
+                if key in (self.ClobberFields | self.AdapterSpecificConfigs)
+            }
             intermediary_merged = deep_merge(
-                merged_config.copy(), config.copy()
+                merged_config, config
             )
+            intermediary_merged.update(clobber)
 
             merged_config.update(intermediary_merged)
         return merged_config

--- a/test/unit/test_source_config.py
+++ b/test/unit/test_source_config.py
@@ -120,6 +120,28 @@ class SourceConfigTest(TestCase):
         }
         self.assertEqual(cfg.config, expect)
 
+    def test__source_config_merge(self):
+        self.root_project_config.models = {'sort': ['a', 'b']}
+        cfg = SourceConfig(self.root_project_config, self.root_project_config,
+                           ['root', 'x'], NodeType.Model)
+        cfg.update_in_model_config({
+            'materialized': 'something',
+            'sort': ['d', 'e']
+        })
+        expect = {
+            'column_types': {},
+            'enabled': True,
+            'materialized': 'something',
+            'post-hook': [],
+            'pre-hook': [],
+            'persist_docs': {},
+            'quoting': {},
+            'sort': ['d', 'e'],
+            'tags': [],
+            'vars': {},
+        }
+        self.assertEqual(cfg.config, expect)
+
     def test_source_config_all_keys_accounted_for(self):
         used_keys = frozenset(SourceConfig.AppendListFields) | \
                     frozenset(SourceConfig.ExtendDictFields) | \


### PR DESCRIPTION
Fixes #2049 by updating the Source Config class to overwrite, instead of deep merge, keys marked as "clobberable".