### PR TITLE
fix an RPC hang when enddocs tags were missing (#2066)

### DIFF
--- a/core/dbt/clients/_jinja_blocks.py
+++ b/core/dbt/clients/_jinja_blocks.py
@@ -356,10 +356,11 @@ class BlockIterator:
                 self.current = None
 
         if self.current:
+            linecount = self.data[:self.current.end].count('\n') + 1
             dbt.exceptions.raise_compiler_error((
                 'Reached EOF without finding a close tag for '
-                '{0.block_type_name} (searched from position {0.end})'
-            ).format(self.current))
+                '{} (searched from line {})'
+            ).format(self.current.block_type_name, linecount))
 
         if collect_raw_data:
             raw_data = self.data[self.last_position:]

--- a/core/dbt/clients/_jinja_blocks.py
+++ b/core/dbt/clients/_jinja_blocks.py
@@ -357,8 +357,8 @@ class BlockIterator:
 
         if self.current:
             dbt.exceptions.raise_compiler_error((
-                'Reached EOF without finding a close block for '
-                '{0.block_type_name} (from {0.end})'
+                'Reached EOF without finding a close tag for '
+                '{0.block_type_name} (searched from position {0.end})'
             ).format(self.current))
 
         if collect_raw_data:

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -66,6 +66,12 @@ class RuntimeException(RuntimeError, Exception):
                 node.resource_type,
                 node.original_file_path
             )
+
+        if hasattr(node, 'contents'):
+            # handle FileBlocks. They aren't really nodes but we want to render
+            # out the path we know at least. This indicates an error during
+            # block parsing.
+            return '{}'.format(node.path.original_file_path)
         return "{} {} ({})".format(
             node.resource_type,
             node.name,

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -116,8 +116,7 @@ class BlockSearcher(Generic[BlockSearchResult], Iterable[BlockSearchResult]):
 
         except CompilationException as exc:
             if exc.node is None:
-                # TODO(jeb): attach info about resource type/file path here
-                exc.node = NotImplemented
+                exc.node = source_file
             raise
 
     def __iter__(self) -> Iterator[BlockSearchResult]:


### PR DESCRIPTION
Fix #2066 

Fix an issue with rendering the output of a failed jinja block parsing pass where dbt would raise an exception while raising an exception, due to `str(exc)` failing by implementing a TODO I wrote a long time ago...

Added tests so we don't experience this again, hopefully.