### PR TITLE
Add documentation for macros/analyses (#1041)

### DIFF
--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -20,7 +20,8 @@ from dbt.contracts.graph.parsed import (
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.util import Writable, Replaceable
 from dbt.exceptions import (
-    raise_duplicate_resource_name, InternalException, raise_compiler_error
+    raise_duplicate_resource_name, InternalException, raise_compiler_error,
+    warn_or_error
 )
 from dbt.include.global_project import PACKAGES
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -593,14 +594,11 @@ class Manifest:
                 continue
             macro.patch(patch)
 
-        # log debug-level warning about nodes we couldn't find
         if patches:
             for patch in patches.values():
-                # since patches aren't nodes, we can't use the existing
-                # target_not_found warning
-                logger.debug((
-                    'WARNING: Found documentation for macro "{}" which was '
-                    'not found or is disabled').format(patch.name)
+                warn_or_error(
+                    f'WARNING: Found documentation for macro "{patch.name}" '
+                    f'which was not found'
                 )
 
     def patch_nodes(

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -1,6 +1,6 @@
 import builtins
 import functools
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
@@ -425,7 +425,9 @@ def doc_invalid_args(model, args):
         model)
 
 
-def doc_target_not_found(model, target_doc_name, target_doc_package):
+def doc_target_not_found(
+    model, target_doc_name: str, target_doc_package: Optional[str]
+) -> NoReturn:
     target_package_string = ''
 
     if target_doc_package is not None:
@@ -708,17 +710,26 @@ def raise_patch_targets_not_found(patches):
     )
 
 
-def raise_duplicate_patch_name(name, patch_1, patch_2):
+def raise_duplicate_patch_name(patch_1, patch_2):
+    name = patch_1.name
     raise_compiler_error(
-        'dbt found two schema.yml entries for the same model named {0}. '
-        'Models and their associated columns may only be described a single '
-        'time. To fix this, remove the model entry for for {0} in one of '
-        'these files:\n  - {1}\n  - {2}'
-        .format(
-            name,
-            patch_1.original_file_path,
-            patch_2.original_file_path,
-        )
+        f'dbt found two schema.yml entries for the same resource named '
+        f'{name}. Resources and their associated columns may only be '
+        f'described a single time. To fix this, remove the resource entry '
+        f'for {name} in one of these files:\n  - '
+        f'{patch_1.original_file_path}\n  - {patch_2.original_file_path}'
+    )
+
+
+def raise_duplicate_macro_patch_name(patch_1, patch_2):
+    package_name = patch_1.package_name
+    name = patch_1.name
+    raise_compiler_error(
+        f'dbt found two schema.yml entries for the same macro in package '
+        f'{package_name} named {name}. Macros may only be described a single '
+        f'time. To fix this, remove the macros entry for for {name} in one '
+        f'of these files:'
+        f'\n  - {patch_1.original_file_path}\n  - {patch_2.original_file_path}'
     )
 
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -727,7 +727,7 @@ def raise_duplicate_macro_patch_name(patch_1, patch_2):
     raise_compiler_error(
         f'dbt found two schema.yml entries for the same macro in package '
         f'{package_name} named {name}. Macros may only be described a single '
-        f'time. To fix this, remove the macros entry for for {name} in one '
+        f'time. To fix this, remove the macros entry for {name} in one '
         f'of these files:'
         f'\n  - {patch_1.original_file_path}\n  - {patch_2.original_file_path}'
     )

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -43,6 +43,8 @@ class NodeType(StrEnum):
             cls.Seed,
             cls.Snapshot,
             cls.Source,
+            cls.Macro,
+            cls.Analysis,
         ]
 
     def pluralize(self) -> str:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -309,6 +309,7 @@ class ManifestLoader:
             files=self.results.files,
         )
         manifest.patch_nodes(self.results.patches)
+        manifest.patch_macros(self.results.macro_patches)
         manifest = ParserUtils.process_sources(
             manifest, self.root_project.project_name
         )

--- a/core/dbt/parser/util.py
+++ b/core/dbt/parser/util.py
@@ -48,8 +48,8 @@ class ParserUtils:
 
     @classmethod
     def resolve_source(
-        cls, manifest: Manifest, target_source_name: Optional[str],
-        target_table_name: Optional[str], current_project: str,
+        cls, manifest: Manifest, target_source_name: str,
+        target_table_name: str, current_project: str,
         node_package: str
     ) -> Optional[ParsedSourceDefinition]:
         candidate_targets = [current_project, node_package, None]

--- a/test/integration/029_docs_generate_tests/ref_models/docs.md
+++ b/test/integration/029_docs_generate_tests/ref_models/docs.md
@@ -25,3 +25,7 @@ My table
 {% docs column_info %}
 An ID field
 {% enddocs %}
+
+{% docs macro_info %}
+My custom test that I wrote that does nothing
+{% enddocs %}

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -29,3 +29,9 @@ sources:
         columns:
           - name: id
             description: "{{ doc('column_info') }}"
+
+macros:
+  - name: test_nothing
+    description: "{{ doc('macro_info') }}"
+    meta:
+      some_key: 100

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -1459,7 +1459,10 @@ class TestParsedMacro(ContractTestCase):
             'resource_type': 'macro',
             'unique_id': 'macro.test.foo',
             'tags': [],
-            'depends_on': {'macros': []}
+            'depends_on': {'macros': []},
+            'meta': {},
+            'description': 'my macro description',
+            'docrefs': [],
         }
         macro = ParsedMacro(
             name='foo',
@@ -1471,7 +1474,10 @@ class TestParsedMacro(ContractTestCase):
             resource_type=NodeType.Macro,
             unique_id='macro.test.foo',
             tags=[],
-            depends_on=MacroDependsOn()
+            depends_on=MacroDependsOn(),
+            meta={},
+            description='my macro description',
+            docrefs=[],
         )
         self.assert_symmetric(macro, macro_dict)
         self.assertEqual(macro.local_vars(), {})


### PR DESCRIPTION
Fixes #1041 

Add and populate a `documentation` field to macros
Populate the `documentation` field on analyses like we do with models/seeds/snapshots
 - also support documenting columns, etc

Refactored parsing a bit to support the idea of:
 - macro patches (no columns, to tests)
 - analysis patches (no tests)