### PR TITLE
WIP: first commit - added aliasing to unique and not_null

### DIFF
--- a/core/dbt/include/global_project/macros/schema_tests/not_null.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/not_null.sql
@@ -4,8 +4,8 @@
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
 select count(*)
-from {{ model }}
-where {{ column_name }} is null
+from {{ model }} AS aliased
+where aliased.{{ column_name }} is null
 
 {% endmacro %}
 

--- a/core/dbt/include/global_project/macros/schema_tests/unique.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/unique.sql
@@ -7,11 +7,11 @@ select count(*)
 from (
 
     select
-        {{ column_name }}
+        aliased.{{ column_name }}
 
-    from {{ model }}
-    where {{ column_name }} is not null
-    group by {{ column_name }}
+    from {{ model }} AS aliased
+    where aliased.{{ column_name }} is not null
+    group by aliased.{{ column_name }}
     having count(*) > 1
 
 ) validation_errors


### PR DESCRIPTION
# Description
Small fix for the bug identified in this issue: https://github.com/fishtown-analytics/dbt/issues/2061.

Added aliasing to the unique and not_null schema tests to fix bug where they would fail if model and column had the same name.

# Changes
core/dbt/include/global_project/macros/schema_tests/not_null.sql -> added alias
core/dbt/include/global_project/macros/schema_tests/unique.sql -> added alias

# Tests
Hoping that someone from fishtown can kick of the CI tests - I did not run the make file tests locally. I think the aliasing is completely standard sql and should be db agnostic - I am slightly concerned if `aliased.{{ column_name }}` will compile with a space to `aliased. some_column`.
