### PR TITLE
add setuptools version check for overall setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
-from setuptools import setup
 import os
+import sys
 
+from setuptools import setup
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    # the user has a downlevel version of setuptools.
+    print('Error: dbt requires setuptools v40.1.0 or higher.')
+    print('Please upgrade setuptools with "pip install --upgrade setuptools" '
+          'and try again')
+    sys.exit(1)
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md')) as f:


### PR DESCRIPTION
Checks version of `setuptools` in the overall `setup.py` for unicode support similar to `setup.py` in `dbt-core`: https://github.com/fishtown-analytics/dbt/blob/dev/0.15.1/core/setup.py#L6

This addresses https://github.com/fishtown-analytics/dbt/issues/1771