### PR TITLE
fix --no-compile flag for docs generate

### DIFF
--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -14,7 +14,11 @@ from dbt.contracts.results import (
 )
 from dbt.exceptions import InternalException
 from dbt.include.global_project import DOCS_INDEX_FILE_PATH
+<<<<<<< HEAD
 from dbt.logger import GLOBAL_LOGGER as logger
+=======
+from dbt.perf_utils import get_full_manifest
+>>>>>>> 483b8745... fix --no-compile flag for docs generate
 import dbt.ui.printer
 import dbt.utils
 import dbt.compilation
@@ -196,8 +200,13 @@ class GenerateTask(CompileTask):
                     'compile failed, cannot generate docs'
                 )
                 return CatalogResults(
-                    {}, datetime.utcnow(), compile_results, None
+                    nodes={},
+                    generated_at=datetime.utcnow(),
+                    errors=None,
+                    _compile_results=compile_results
                 )
+        else:
+            self.manifest = get_full_manifest(self.config)
 
         shutil.copyfile(
             DOCS_INDEX_FILE_PATH,
@@ -233,7 +242,8 @@ class GenerateTask(CompileTask):
 
         path = os.path.join(self.config.target_path, CATALOG_FILENAME)
         results.write(path)
-        write_manifest(self.config, self.manifest)
+        if self.args.compile:
+            write_manifest(self.config, self.manifest)
 
         if exceptions:
             logger.error(
@@ -262,6 +272,8 @@ class GenerateTask(CompileTask):
         )
 
     def interpret_results(self, results):
+        if results is None:
+            return False
         if results.errors:
             return False
         compile_results = results._compile_results

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -14,11 +14,8 @@ from dbt.contracts.results import (
 )
 from dbt.exceptions import InternalException
 from dbt.include.global_project import DOCS_INDEX_FILE_PATH
-<<<<<<< HEAD
 from dbt.logger import GLOBAL_LOGGER as logger
-=======
 from dbt.perf_utils import get_full_manifest
->>>>>>> 483b8745... fix --no-compile flag for docs generate
 import dbt.ui.printer
 import dbt.utils
 import dbt.compilation
@@ -191,7 +188,7 @@ class GenerateTask(CompileTask):
             )
         return self.manifest
 
-    def run(self):
+    def run(self) -> CatalogResults:
         compile_results = None
         if self.args.compile:
             compile_results = CompileTask.run(self)
@@ -271,7 +268,7 @@ class GenerateTask(CompileTask):
             errors=errors,
         )
 
-    def interpret_results(self, results):
+    def interpret_results(self, results: Optional[CatalogResults]) -> bool:
         if results is None:
             return False
         if results.errors:


### PR DESCRIPTION
Fixes #2090 

I also added a test that `--no-compile` runs successfully and generates a catalog, to avoid regressing on this again.