### PR TITLE
allow "dbt debug" from subdirectories (#2086)

### DIFF
--- a/core/dbt/adapters/factory.py
+++ b/core/dbt/adapters/factory.py
@@ -49,10 +49,10 @@ class AdpaterContainer:
             mod: Any = import_module('.' + name, 'dbt.adapters')
         except ModuleNotFoundError as exc:
             # if we failed to import the target module in particular, inform
-            # the user about it via a runtiem error
-            logger.info(f'Error importing adapter: {exc}')
+            # the user about it via a runtime error
             if exc.name == 'dbt.adapters.' + name:
                 raise RuntimeException(f'Could not find adapter type {name}!')
+            logger.info(f'Error importing adapter: {exc}')
             # otherwise, the error had to have come from some underlying
             # library. Log the stack trace.
             logger.debug('', exc_info=True)

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -112,6 +112,8 @@ class TestDebugInvalidProject(DBTIntegrationTest):
         for line in splitout:
             if line.strip().startswith('dbt_project.yml file'):
                 self.assertIn('ERROR not found', line)
+            elif line.strip().startswith('profiles.yml file'):
+                self.assertNotIn('ERROR invalid', line)
 
     @use_profile('postgres')
     def test_postgres_invalid_project_outside_current_dir(self):


### PR DESCRIPTION
Fixes #2086

When you run `dbt debug` from a subdirectory, it finds `dbt_project.yml` and therefore is able to find a profile name, and parse your profile.
When dbt_project.yml is missing, fail more gracefully.
When dbt_project.yml is missing and no profile is provided:
 * read everything in profiles.yml
 * validate the default target for each profile
 * print no connection info
 * mark profiles.yml as valid if all default targets were valid