### PR TITLE
Update DEBUG_LOG_FORMAT to correctly zero-pad the microsecond portion

### DIFF
--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -36,9 +36,8 @@ colorama.init(wrap=colorama_wrap)
 
 
 STDOUT_LOG_FORMAT = '{record.message}'
-# TODO: can we change the time to just "{record.time:%Y-%m-%d %H:%M:%S.%f%z}"?
 DEBUG_LOG_FORMAT = (
-    '{record.time:%Y-%m-%d %H:%M:%S%z},{record.time.microsecond:03} '
+    '{record.time:%Y-%m-%d %H:%M:%S.%f%z} '
     '({record.thread_name}): '
     '{record.message}'
 )


### PR DESCRIPTION
Currently, when running dbt with the --debug flag, the microsecond portion of the timestamp does not have leading zeros, which causes jagged formatting.  Example:

```
2020-02-05 22:56:50,953988 (MainThread): Parsing macros/materializations/...
2020-02-05 22:56:50,989795 (MainThread): Parsing macros/materializations/...
2020-02-05 22:56:51,48211 (MainThread): Partial parsing not enabled
2020-02-05 22:56:51,80875 (MainThread): Acquiring new bigquery connection "model.mytable".
2020-02-05 22:56:51,81005 (MainThread): Opening a new connection, currently in state init
2020-02-05 22:56:51,883792 (MainThread): Acquiring new bigquery connection "model.bar".
```

The fix was to just paste in the text of the TODO immediately above DEBUG_LOG_FORMAT in logger.py.

However, if that wasn't working for some other reason, another fix would be to modify DEBUG_LOG_FORMAT like this:

```
logger.py:
  DEBUG_LOG_FORMAT = (
    #'{record.time:%Y-%m-%d %H:%M:%S%z}.{record.time.microsecond:06} '
```

(i.e., change the '03' to a '06' so that 6 digits are zero-padded instead of just 3).

(I also took the liberty to change the European ',' decimal point to an American '.' decimal point.)