### PR TITLE
Attach cli vars to configs when they come in via the RPC server (#2092)

### DIFF
--- a/core/dbt/task/rpc/cli.py
+++ b/core/dbt/task/rpc/cli.py
@@ -12,6 +12,7 @@ from dbt.rpc.method import (
     Result,
 )
 from dbt.exceptions import InternalException
+from dbt.utils import parse_cli_vars
 
 from .base import RPCTask
 
@@ -36,6 +37,11 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
 
     def set_config(self, config):
         super().set_config(config)
+
+        # patch up config with args/cli_vars
+        self.config.args = self.args
+        self.config.cli_vars = parse_cli_vars(getattr(self.args, 'vars', '{}'))
+
         if self.task_type is None:
             raise InternalException('task type not set for set_config')
         if issubclass(self.task_type, RemoteManifestMethod):

--- a/core/dbt/task/rpc/cli.py
+++ b/core/dbt/task/rpc/cli.py
@@ -1,5 +1,6 @@
 import abc
 import shlex
+import yaml
 from typing import Type, Optional
 
 
@@ -38,9 +39,13 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
     def set_config(self, config):
         super().set_config(config)
 
-        # patch up config with args/cli_vars
+        # read any cli vars we got and use it to update cli_vars
+        self.config.cli_vars.update(
+            parse_cli_vars(getattr(self.args, 'vars', '{}'))
+        )
+        # rewrite args.vars to reflect our merged vars
+        self.args.vars = yaml.safe_dump(self.config.cli_vars)
         self.config.args = self.args
-        self.config.cli_vars = parse_cli_vars(getattr(self.args, 'vars', '{}'))
 
         if self.task_type is None:
             raise InternalException('task type not set for set_config')


### PR DESCRIPTION
Fixes #2092 

This fixes #2092 by attaching the parsed CLI `vars` to the config when running the "cli_args" RPC command. This has the downside of clobbering any arguments provided via `dbt rpc --vars "{...}"`. Hopefully that's a sacrifice we're willing to make!