### PR TITLE
Correctly handle an empty dbt_project.yml in `dbt debug`

### DIFF
--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -188,6 +188,12 @@ def _raw_project_from(project_root: str) -> Dict[str, Any]:
         )
 
     project_dict = _load_yaml(project_yaml_filepath)
+
+    if not isinstance(project_dict, dict):
+        raise DbtProjectError(
+            'dbt_project.yml does not parse to a dictionary'
+        )
+
     return project_dict
 
 

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -92,6 +92,18 @@ class TestDebugInvalidProject(DBTIntegrationTest):
         self.capsys = capsys
 
     @use_profile('postgres')
+    def test_postgres_empty_project(self):
+        with open('dbt_project.yml', 'w') as f:
+            pass
+        self.run_dbt(['debug', '--profile', 'test'])
+        splitout = self.capsys.readouterr().out.split('\n')
+        for line in splitout:
+            if line.strip().startswith('dbt_project.yml file'):
+                self.assertIn('ERROR invalid', line)
+            elif line.strip().startswith('profiles.yml file'):
+                self.assertNotIn('ERROR invalid', line)
+
+    @use_profile('postgres')
     def test_postgres_badproject(self):
         # load a special project that is an error
         self.use_default_project(overrides={


### PR DESCRIPTION
It's confusing to access the dbt project from within `_load_profile()` since the project has not been validated yet. If the _project_ is invalid, the code validating the _profile_ fails.

I've tried to handle this case gracefully using the existing patterns.

Old behavior:

```
$ dbt debug
Running with dbt=0.15.2
dbt version: 0.15.2
python version: 3.7.6
python path: .../venv/bin/python
os info: Darwin-18.7.0-x86_64-i386-64bit
Using profiles.yml file at .../.dbt/profiles.yml

Encountered an error:
'NoneType' object does not support item assignment
```

New behavior:

```
$ dbt debug
Running with dbt=0.16.0-b1
dbt version: 0.16.0-b1
python version: 3.7.6
python path: .../dbt/env/bin/python
os info: Darwin-18.7.0-x86_64-i386-64bit
Using profiles.yml file at .../.dbt/profiles.yml
Using dbt_project.yml file at .../dbt/dbt_project.yml

Configuration:
  profiles.yml file [OK found and valid]
  dbt_project.yml file [ERROR invalid]

Project loading failed for the following reason:
Runtime Error
  dbt_project.yml does not parse to a dictionary

Required dependencies:
 - git [OK found]

Could not load dbt_project.yml
```

Fixes #2116.