### PR TITLE
rev boto3/botocore/snowflake-connector-python/google libraries (#2102)

### DIFF
--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -40,10 +40,10 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'google-cloud-core>=1,<=1.1.0',
-        'google-cloud-bigquery>=1.15.0,<1.24.0',
-        # hidden secret dependency: bq requires this but only documents 1.10.0
-        # through its dependency chain.
+        'google-cloud-core>=1,<=1.3.0',
+        'google-cloud-bigquery>=1.15.0,<1.25.0',
+        # hidden secret dependency: bq 1.23.0 requires this but only documents
+        # 1.10.0 through its dependency chain.
         # see https://github.com/googleapis/google-cloud-python/issues/9965
         'six>=1.13.0',
     ],

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -41,8 +41,9 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'dbt-postgres=={}'.format(package_version),
-        'boto3>=1.6.23,<1.10.0',
-        'botocore>=1.9.23,<1.13.0',
+        # match snowflake-connector-python supported ranges
+        'boto3>=1.4.4,<1.12',
+        'botocore>=1.5.0,<1.15',
     ],
     zip_safe=False,
     classifiers=[

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -40,10 +40,10 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'snowflake-connector-python>=1.6.12,<2.1',
-        'azure-storage-blob~=2.1',
-        'azure-storage-common~=2.1',
-        'urllib3<1.25.0',
+        'snowflake-connector-python==2.2.0',
+        'azure-common<2.0.0',
+        'azure-storage-blob<12.0.0',
+        'urllib3>=1.20,<1.26.0',
         # this seems sufficiently broad
         'cryptography>=2,<3',
     ],


### PR DESCRIPTION
Fixes #2102 

I had to update the snowflake-connector-python (and fix it at `2.2.0`) in order to expand the version range. While I was at it, I updated bigquery's range to include the newest release.
