### PR TITLE
Clickable doc serve URL

### DIFF
--- a/core/dbt/task/serve.py
+++ b/core/dbt/task/serve.py
@@ -20,7 +20,7 @@ class ServeTask(ProjectOnlyTask):
 
         logger.info("Serving docs at 0.0.0.0:{}".format(port))
         logger.info(
-            "To access from your browser, navigate to http://localhost:{}."
+            "To access from your browser, navigate to: http://localhost:{}"
             .format(port)
         )
         logger.info("Press Ctrl+C to exit.\n\n")

--- a/core/dbt/task/serve.py
+++ b/core/dbt/task/serve.py
@@ -20,7 +20,7 @@ class ServeTask(ProjectOnlyTask):
 
         logger.info("Serving docs at 0.0.0.0:{}".format(port))
         logger.info(
-            "To access from your browser, navigate to: http://localhost:{}"
+            "To access from your browser, navigate to:  http://localhost:{}"
             .format(port)
         )
         logger.info("Press Ctrl+C to exit.\n\n")


### PR DESCRIPTION
Fixes #2027 - this resolves an issue where the period ('.') after the URL causes hyperlink-detection to work incorrectly in tools like VS Code.

Before this fix, the link is clickable but the user does not reach the desired page due to the included '.' in the passed url.

After this fix, the link is clickable and also directs to the correct URL.
