### PR TITLE
fix a bunch of issues caused by virtualenv 20, tox 3.14, six, and ubuntu (#2128)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,14 @@ jobs:
       - run:
           name: Build wheels
           command: |
+            python3.8 -m venv "${PYTHON_ENV}"
+            export PYTHON_BIN=${PYTHON_ENV}
             $PYTHON_BIN -m pip install -U pip setuptools
             $PYTHON_BIN -m pip install -r requirements.txt
             $PYTHON_BIN -m pip install -r dev_requirements.txt
             /bin/bash ./scripts/build-wheels.sh
           environment:
-            PYTHON_BIN: /home/tox/venv3.8/bin/python
+            PYTHON_ENV: /home/tox/build_venv/
       - store_artifacts:
           path: ./dist
           destination: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit:
     docker: &test_only
-      - image: fishtownjacob/test-container:3
+      - image: fishtownjacob/test-container:4
         environment:
           DBT_INVOCATION_ENV: circle
     steps:
@@ -26,7 +26,7 @@ jobs:
           destination: dist
   integration-postgres-py36:
     docker: &test_and_postgres
-      - image: fishtownjacob/test-container:3
+      - image: fishtownjacob/test-container:4
         environment:
           DBT_INVOCATION_ENV: circle
       - image: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Build wheels
           command: |
             python3.8 -m venv "${PYTHON_ENV}"
-            export PYTHON_BIN=${PYTHON_ENV}
+            export PYTHON_BIN="${PYTHON_ENV}/bin/python"
             $PYTHON_BIN -m pip install -U pip setuptools
             $PYTHON_BIN -m pip install -r requirements.txt
             $PYTHON_BIN -m pip install -r dev_requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
         python python-dev python-pip \
         python3.6 python3.6-dev python3-pip python3.6-venv \
         python3.7 python3.7-dev python3.7-venv \
-        python3.8 python3.8-dev python3.8-venv && \
+        python3.8 python3.8-dev python3.8-venv \
+        python3.9 python3.9-dev python3.9-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -mU dbt_test_user
@@ -22,27 +23,9 @@ RUN mkdir /home/tox && chown dbt_test_user /home/tox
 WORKDIR /usr/app
 VOLUME /usr/app
 
-RUN pip3 install tox wheel
-
-RUN python2.7 -m pip install virtualenv wheel && \
-    python2.7 -m virtualenv /home/tox/venv2.7 && \
-    /home/tox/venv2.7/bin/python -m pip install -U pip tox && \
-    chown -R dbt_test_user /home/tox/venv2.7
-
-RUN python3.6 -m pip install -U pip wheel && \
-    python3.6 -m venv /home/tox/venv3.6 && \
-    /home/tox/venv3.6/bin/python -m pip install -U pip tox && \
-    chown -R dbt_test_user /home/tox/venv3.6
-
-RUN python3.7 -m pip install -U pip wheel && \
-    python3.7 -m venv /home/tox/venv3.7 && \
-    /home/tox/venv3.7/bin/python -m pip install -U pip tox && \
-    chown -R dbt_test_user /home/tox/venv3.7
-
-RUN python3.8 -m pip install -U pip wheel && \
-    python3.8 -m venv /home/tox/venv3.8 && \
-    /home/tox/venv3.8/bin/python -m pip install -U pip tox && \
-    chown -R dbt_test_user /home/tox/venv3.8
+RUN pip3 install -U "tox==3.14.4" wheel "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" "setuptools==45.2.0"
+# tox fails if the 'python' interpreter (python2) doesn't have `tox` installed
+RUN pip install -U "tox==3.14.4" "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" "setuptools==44.0.0"
 
 USER dbt_test_user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN mkdir /home/tox && chown dbt_test_user /home/tox
 WORKDIR /usr/app
 VOLUME /usr/app
 
-RUN pip3 install -U "tox==3.14.4" wheel "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" "setuptools==45.2.0"
+RUN pip3 install -U "tox==3.14.4" wheel "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" setuptools
 # tox fails if the 'python' interpreter (python2) doesn't have `tox` installed
-RUN pip install -U "tox==3.14.4" "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" "setuptools==44.0.0"
+RUN pip install -U "tox==3.14.4" "six>=1.14.0,<1.15.0" "virtualenv==20.0.3" setuptools
 
 USER dbt_test_user
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,9 @@ pytest==4.4.0
 flake8>=3.5.0
 pytz==2017.2
 bumpversion==0.5.3
-tox==2.5.0
+tox==3.14.4
+virtualenv==20.0.3
+six>=1.14.0
 ipdb
 pytest-xdist>=1.28.0,<2
 flaky>=3.5.3,<4


### PR DESCRIPTION
This seems to fix the dbt image issues described in #2128 

`virtualenv` upgraded to v20, which seems to have broken a lot of existing `tox` behavior, though it's perhaps a coincidence? I don't know, but tests work with this image now.

I locked a bunch of versions, now it works for me 🤷‍♂ 
I also pushed a new test container and pointed circle at it, everything seems ok?

While I was at it, removed a bunch of superfluous venv stuff that we never use anyway (because tox builds our virtualenvs) and added a 3.9 image.