### PR TITLE
Support Postgres role scope

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -16,6 +16,7 @@ from typing import Optional
 class PostgresCredentials(Credentials):
     host: str
     user: str
+    role: Optional[str]
     port: Port
     password: str  # on postgres the password is mandatory
     search_path: Optional[str] = None
@@ -97,6 +98,9 @@ class PostgresConnectionManager(SQLConnectionManager):
                 port=credentials.port,
                 connect_timeout=10,
                 **kwargs)
+
+            if credentials.role:
+                handle.cursor().execute('set role {}'.format(credentials.role))
 
             connection.handle = handle
             connection.state = 'open'

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -135,6 +135,15 @@ class TestPostgresAdapter(unittest.TestCase):
             keepalives_idle=256)
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
+    def test_role(self, psycopg2):
+        self.config.credentials = self.config.credentials.replace(role='somerole')
+        connection = self.adapter.acquire_connection('dummy')
+
+        cursor = connection.handle.cursor()
+
+        cursor.execute.assert_called_once_with('set role somerole')
+
+    @mock.patch('dbt.adapters.postgres.connections.psycopg2')
     def test_search_path(self, psycopg2):
         self.config.credentials = self.config.credentials.replace(search_path="test")
         connection = self.adapter.acquire_connection('dummy')


### PR DESCRIPTION
First of all, I'm super happy with DBT.

It's a great tool and it rids my team and I from the tedious and error-prone flow that we used to have before switching.

Since we're multiple people working on the same project, we need to align the access rights before creating new objects in our Postgres schemas.

Our current solution is to set two pre-hooks (one for models and one for seeds) that look like this:
```
set role data_engineer
```

This works ok, but your documentation states that it's possible to set a role in the dbt profile for Snowflake connections. I would like to be able to do that in Postgres as well.

This PR partially fixes #1955 as I haven't implemented the Redshift part of the issue. I'll do that when I get more familiar with Redshift if no one beats me to it.