### PR TITLE
Bug: fixup bq _partitions_match for range partitions

### DIFF
--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -519,13 +519,13 @@ class BigQueryAdapter(BaseAdapter):
             table_field = table.time_partitioning.field
             return table_field == conf_partition.field
         elif conf_partition and table.range_partitioning is not None:
-            dest_part = table.range_partition.range_
+            dest_part = table.range_partitioning
             conf_part = conf_partition.range or {}
 
             return dest_part.field == conf_partition.field \
-                and dest_part.start == conf_part.get('start') \
-                and dest_part.end == conf_part.get('end') \
-                and dest_part.interval == conf_part.get('interval')
+                and dest_part.range_.start == conf_part.get('start') \
+                and dest_part.range_.end == conf_part.get('end') \
+                and dest_part.range_.interval == conf_part.get('interval')
         else:
             return False
 

--- a/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
+++ b/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
@@ -38,6 +38,13 @@ class TestChangingPartitions(DBTIntegrationTest):
         after = {"partition_by": "cur_date", "cluster_by": None}
         self.run_changes(before, after)
         self.run_changes(after, before)
+    
+    @use_profile('bigquery')
+    def test_bigquery_change_partitions_from_int(self):
+        before = {"partition_by": {"field": "id", "data_type": "int64", "range": {"start": 0, "end": 10, "interval": 1}}, "cluster_by": None}
+        after = {"partition_by": {"field": "cur_date", "data_type": "date"}, "cluster_by": None}
+        self.run_changes(before, after)
+        self.run_changes(after, before)
 
     @use_profile('bigquery')
     def test_bigquery_add_clustering(self):


### PR DESCRIPTION
Fixup to #2140 

The issue is just a matter of matching the structure of the object in the [BQ API](https://cloud.google.com/bigquery/docs/creating-integer-range-partitions).

### Steps to replicate

Running with dbt 0.16.0, create a model that is partitioned by an integer range. Change the partitioning spec and run `--full-refresh`.

First error:
``` 
AttributeError: 'Table' object has no attribute 'range_partition' 
```
It's called `range_partitioning`

Second error:
```
AttributeError: 'PartitionRange' object has no attribute 'field'
```
The `field` key is nested under `range_partitioning`, rather than under `range_partitioning.range_`