### PR TITLE
Use threadpools for filling the cache and listing schemas (#2127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Fix an issue where dbt rendered source test args, fix issue where dbt ran an extra compile pass over the wrapped SQL. ([#2114](https://github.com/fishtown-analytics/dbt/issues/2114), [#2150](https://github.com/fishtown-analytics/dbt/pull/2150))
 - Set more upper bounds for jinja2,requests, and idna dependencies, upgrade snowflake-connector-python ([#2147](https://github.com/fishtown-analytics/dbt/issues/2147), [#2151](https://github.com/fishtown-analytics/dbt/pull/2151))
 
+### Under the hood
+- Parallelize filling the cache and listing schemas in each database during startup ([#2127](https://github.com/fishtown-analytics/dbt/issues/2127), [#2157](https://github.com/fishtown-analytics/dbt/pull/2157))
+
 Contributors:
  - [@bubbomb](https://github.com/bubbomb) ([#2080](https://github.com/fishtown-analytics/dbt/pull/2080))
  - [@sonac](https://github.com/sonac) ([#2078](https://github.com/fishtown-analytics/dbt/pull/2078))

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -1,6 +1,6 @@
 import os
 import time
-from concurrent.futures import as_completed, wait
+from concurrent.futures import as_completed
 from datetime import datetime
 from multiprocessing.dummy import Pool as ThreadPool
 from typing import Optional, Dict, List, Set, Tuple, Iterable

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -1,8 +1,9 @@
 import os
 import time
+from concurrent.futures import as_completed, wait
 from datetime import datetime
 from multiprocessing.dummy import Pool as ThreadPool
-from typing import Optional, Dict, List, Set, Tuple
+from typing import Optional, Dict, List, Set, Tuple, Iterable
 
 from dbt.task.base import ConfiguredTask
 from dbt.adapters.factory import get_adapter
@@ -374,7 +375,9 @@ class GraphRunnableTask(ManifestTask):
         failures = [r for r in results if r.error or r.fail]
         return len(failures) == 0
 
-    def get_model_schemas(self, selected_uids):
+    def get_model_schemas(
+        self, selected_uids: Iterable[str]
+    ) -> Set[Tuple[str, str]]:
         if self.manifest is None:
             raise InternalException('manifest was None in get_model_schemas')
 
@@ -387,18 +390,45 @@ class GraphRunnableTask(ManifestTask):
 
         return schemas
 
-    def create_schemas(self, adapter, selected_uids):
+    def create_schemas(self, adapter, selected_uids: Iterable[str]):
         required_schemas = self.get_model_schemas(selected_uids)
         required_databases = set(db for db, _ in required_schemas)
 
         existing_schemas_lowered: Set[Tuple[str, str]] = set()
-        for db in required_databases:
-            existing_schemas_lowered.update(
-                (db.lower(), s.lower()) for s in adapter.list_schemas(db))
 
-        for db, schema in required_schemas:
-            if (db.lower(), schema.lower()) not in existing_schemas_lowered:
+        def list_schemas(db: str) -> List[Tuple[str, str]]:
+            with adapter.connection_named(f'list_{db}'):
+                return [
+                    (db.lower(), s.lower())
+                    for s in adapter.list_schemas(db)
+                ]
+
+        def create_schema(db: str, schema: str) -> None:
+            with adapter.connection_named(f'create_{db}_{schema}'):
                 adapter.create_schema(db, schema)
+
+        list_futures = []
+        create_futures = []
+
+        with dbt.utils.executor(self.config) as tpe:
+            list_futures = [
+                tpe.submit(list_schemas, db) for db in required_databases
+            ]
+
+            for ls_future in as_completed(list_futures):
+                existing_schemas_lowered.update(ls_future.result())
+
+            for db, schema in required_schemas:
+                db_schema = (db.lower(), schema.lower())
+                if db_schema not in existing_schemas_lowered:
+                    existing_schemas_lowered.add(db_schema)
+                    create_futures.append(
+                        tpe.submit(create_schema, db, schema)
+                    )
+
+            for create_future in as_completed(create_futures):
+                # trigger/re-raise any excceptions while creating schemas
+                create_future.result()
 
     def get_result(self, results, elapsed_time, generated_at):
         return ExecutionResult(

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -71,7 +71,6 @@ class TestSimpleCopy(BaseTestSimpleCopy):
                 select * from {schema}.unrelated_materialized_view
             )
         '''.format(schema=self.unique_schema()))
-
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
         results = self.run_dbt()

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -25,6 +25,7 @@ def normalize(path):
 
 class Obj:
     which = 'blah'
+    single_threaded = False
 
 
 def mock_connection(name):


### PR DESCRIPTION
(maybe) resolves #2127 

### Description

Parallelize the parts of dbt that fill the cache and list schemas (by database), using `concurrent.futures.ThreadPoolExecutor`.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
