### PR TITLE
Explicitly convert the values to string

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -84,7 +84,8 @@ def _catalog_filter_schemas(manifest: Manifest) -> Callable[[agate.Row], bool]:
             return False
         # Since we parse the data from the yaml, so we explicitly want to cast
         # it to a string
-        return (str(table_database).lower(), str(table_schema).lower()) in schemas
+        return (str(table_database).lower(),
+                str(table_schema).lower()) in schemas
     return test
 
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -82,7 +82,9 @@ def _catalog_filter_schemas(manifest: Manifest) -> Callable[[agate.Row], bool]:
         # be filtered out
         if table_schema is None:
             return False
-        return (table_database.lower(), table_schema.lower()) in schemas
+        # Since we parse the data from the yaml, so we explicitly want to cast
+        # it to a string
+        return (str(table_database).lower(), str(table_schema).lower()) in schemas
     return test
 
 

--- a/test/integration/042_sources_test/models/schema.yml
+++ b/test/integration/042_sources_test/models/schema.yml
@@ -75,3 +75,11 @@ sources:
     schema: "{{ var('test_run_alt_schema', var('test_run_schema')) }}"
     tables:
       - name: table
+    # This will translate into a decimal, because of YAML
+  - name: 19.25
+    schema: "{{ var('test_run_schema') }}"
+    quoting:
+      identifier: True
+    tables:
+      - name: test_table
+        identifier: other_source_table

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -207,7 +207,7 @@ class TestSources(SuccessfulSourcesTest):
         self.assertTableDoesNotExist('nonsource_descendant')
 
     @use_profile('postgres')
-    def test_yaml_parse_decimal(self):
+    def test_postgres_yaml_parse_decimal(self):
         results = self.run_dbt_with_vars([
             'run', '--models', 'source:19.25'
         ])

--- a/test/integration/042_sources_test/test_sources.py
+++ b/test/integration/042_sources_test/test_sources.py
@@ -207,6 +207,13 @@ class TestSources(SuccessfulSourcesTest):
         self.assertTableDoesNotExist('nonsource_descendant')
 
     @use_profile('postgres')
+    def test_yaml_parse_decimal(self):
+        results = self.run_dbt_with_vars([
+            'run', '--models', 'source:19.25'
+        ])
+        self.assertEqual(len(results), 1)
+
+    @use_profile('postgres')
     def test_postgres_source_childrens_parents(self):
         results = self.run_dbt_with_vars([
             'run', '--models', '@source:test_source'


### PR DESCRIPTION
Since we read the value from YAML, we might get some weird stuff,
if we don't quote explicitly:

![image](https://user-images.githubusercontent.com/1134248/75672927-14a3bb80-5c82-11ea-8f8d-a8958760e4df.png)

```
MacBook-Pro-van-Fokko:dbt-source fokkodriesprong$ python3
Python 3.6.6 (v3.6.6:4cf1f54eb7, Jun 26 2018, 19:50:54)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import yaml
>>>
>>> yaml.load("name: 19.25")
{'name': 19.25}
>>> data = yaml.load("name: 19.25")
>>> type(data['name'])
<class 'float'>

>>> data = yaml.load("name: 1925")
>>> type(data['name'])
<class 'int'>

>>> data = yaml.load("name: 'no'")
>>> type(data['name'])
<class 'str'>

>>> data = yaml.load("name: no")
>>> type(data['name'])
<class 'bool'>
```

This was the case when reading numerical table names:

```
2020-03-02 09:10:33,892358 (MainThread): Traceback (most recent call last):
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/main.py", line 80, in main
    results, succeeded = handle_and_check(args)
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/main.py", line 158, in handle_and_check
    task, res = run_from_args(parsed)
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/main.py", line 210, in run_from_args
    results = task.run()
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/task/generate.py", line 201, in run
    catalog_table = adapter.get_catalog(self.manifest)
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/adapters/base/impl.py", line 1016, in get_catalog
    results = self._catalog_filter_table(table, manifest)
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/adapters/bigquery/impl.py", line 493, in _catalog_filter_table
    return super()._catalog_filter_table(table, manifest)
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/adapters/base/impl.py", line 998, in _catalog_filter_table
    return table.where(_catalog_filter_schemas(manifest))
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/agate/table/where.py", line 25, in where
    if test(row):
  File "/usr/local/Cellar/dbt/0.15.2_1/libexec/lib/python3.7/site-packages/dbt/adapters/base/impl.py", line 82, in test
    return (table_database.lower(), table_schema.lower()) in schemas
AttributeError: 'decimal.Decimal' object has no attribute 'lower'
```

resolves #2175

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
