### PR TITLE
For undefined variables, explicitly raise a useful error on pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt next (release TBD)
 
+### Fixes
+- When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
+
 ## dbt 0.16.0rc2 (March 4, 2020)
 
 ### Under the hood

--- a/test/integration/003_simple_reference_test/invalid-models/descendant.sql
+++ b/test/integration/003_simple_reference_test/invalid-models/descendant.sql
@@ -1,0 +1,2 @@
+-- should be ref('model')
+select * from {{ ref(model) }}

--- a/test/integration/003_simple_reference_test/invalid-models/model.sql
+++ b/test/integration/003_simple_reference_test/invalid-models/model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/003_simple_reference_test/test_simple_reference.py
+++ b/test/integration/003_simple_reference_test/test_simple_reference.py
@@ -1,4 +1,9 @@
+import os
+
+from dbt.exceptions import CompilationException
+
 from test.integration.base import DBTIntegrationTest, use_profile
+
 
 class TestSimpleReference(DBTIntegrationTest):
     @property
@@ -184,3 +189,20 @@ class TestSimpleReference(DBTIntegrationTest):
 
         self.assertTrue('EPHEMERAL_SUMMARY' in created_models)
         self.assertEqual(created_models['EPHEMERAL_SUMMARY'], 'table')
+
+
+class TestErrorReference(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "simple_reference_003"
+
+    @property
+    def models(self):
+        return "invalid-models"
+
+    @use_profile('postgres')
+    def test_postgres_undefined_value(self):
+        with self.assertRaises(CompilationException) as exc:
+            self.run_dbt(['compile'])
+        path = os.path.join('invalid-models', 'descendant.sql')
+        self.assertIn(path, str(exc.exception))


### PR DESCRIPTION
resolves #2110 

### Description

Add a more coherent warning on pickling that indicates what the undefined value's name is and (importantly) what file it's in.

I wasn't able to fully remove the defining-Undefined-in-a-closure stuff because without it, we can't give a message indicating _where_ we found the Undefined.

This is the new behavior:
```
$ cat models/y.sql
select * from {{ ref(x) }}
$ dbt compile
Running with dbt=0.17.0-a1
Encountered an error:
Compilation Error in model y (models/y.sql)
  x is undefined
```

I would have very much liked to remove the special undefined override, but because of how jinja handles undefined values, it's actually very difficult! You can't make it just raise on undefined, because constants like `1` show up as undefined (I don't understand why or how, but I didn't spend a lot of time on that because what are you going to do, change jinja?). Jinja really only has the capability of erroring out on explicit uses of undefined:
 - `missing.x` -> can be an error (`__getattr__(self)` -> error)
 - `missing['x']` -> can be an error (`__getitem__(self)` -> error)
 - `missing` * x -> can be an error (`__mul__(self)` -> error)

Cases like `foo(missing)`where `foo` doesn't call any of the forbidden magic methods apparently can't be an error without also breaking the use of bare integers.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
