### PR TITLE
Do not create already-existing schemas (#2186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt next (release TBD)
+
+### Fixes
+- If database quoting is enabled, do not attempt to create schemas that already exist ([#2186](https://github.com/fishtown-analytics/dbt/issues/2186), [#2187](https://github.com/fishtown-analytics/dbt/pull/2187))
+
 ## dbt 0.16.0rc2 (March 4, 2020)
 
 ### Under the hood

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, List, Set, Tuple, Iterable
 
 from dbt.task.base import ConfiguredTask
 from dbt.adapters.base import SchemaSearchMap
+from dbt.adapters.base.relation import InformationSchema
 from dbt.adapters.factory import get_adapter
 from dbt.logger import (
     GLOBAL_LOGGER as logger,
@@ -406,15 +407,17 @@ class GraphRunnableTask(ManifestTask):
                 include_policy=include_policy,
                 information_schema_view=None,
             )
-            required_databases.append(str(db_only))
+            required_databases.append(db_only)
 
         existing_schemas_lowered: Set[Tuple[str, Optional[str]]] = set()
 
-        def list_schemas(db: str) -> List[Tuple[str, str]]:
-            with adapter.connection_named(f'list_{db}'):
+        def list_schemas(info: InformationSchema) -> List[Tuple[str, str]]:
+            database_name = info.database
+            database_quoted = str(info)
+            with adapter.connection_named(f'list_{database_name}'):
                 return [
-                    (db.lower(), s.lower())
-                    for s in adapter.list_schemas(db)
+                    (database_name.lower(), s.lower())
+                    for s in adapter.list_schemas(database_quoted)
                 ]
 
         def create_schema(db: str, schema: str) -> None:


### PR DESCRIPTION
resolves #2186 

### Description

If a schema already exists and database quoting is enabled, actually skip creating that schema.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests~, or tests are not required/relevant for this PR~
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
