### PR TITLE
Rework insert_overwrite incremental strategy

### DIFF
--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -15,50 +15,66 @@
 {% endmacro %}
 
 
-{% macro bq_partition_merge(strategy, tmp_relation, target_relation, sql, unique_key, partition_by, dest_columns) %}
+{% macro bq_insert_overwrite(tmp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns) %}
   {%- set partition_type =
       'date' if partition_by.data_type in ('timestamp, datetime') 
       else partition_by.data_type -%}
 
-  {% set predicate -%}
-      {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_upsert)
-  {%- endset %}
-
-  {%- set source_sql -%}
-  (
-    select * from {{ tmp_relation }}
-  )
-  {%- endset -%}
-
-  -- generated script to merge partitions into {{ target_relation }}
-  declare dbt_partitions_for_upsert array<{{ partition_type }}>;
-  declare _dbt_max_partition {{ partition_by.data_type }};
-
-  set _dbt_max_partition = (
-      select max({{ partition_by.field }}) from {{ this }}
-  );
-
-  -- 1. create a temp table
-  {{ create_table_as(True, tmp_relation, sql) }}
-
-  -- 2. define partitions to update
-  set (dbt_partitions_for_upsert) = (
-      select as struct
-          array_agg(distinct {{ partition_by.render() }})
-      from {{ tmp_relation }}
-  );
+  {% if partitions is not none and partitions != [] %} {# static #}
   
-  -- 3. run the merge statement
-  {% if strategy == 'merge' %}
-  {{ get_merge_sql(target_relation, source_sql, unique_key, dest_columns, [predicate]) }};
-  {% elif strategy == 'insert_overwrite' %}
-  {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate]) }};
-  {% else %}
-    {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
-  {% endif %}
+      {% set predicate -%}
+          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in (
+              {% for partition in partitions %}
+                '{{partition}}' {{- ',' if not loop.last -}}
+              {% endfor %}
+          )
+      {%- endset %}
 
-  -- 4. clean up the temp table
-  drop table if exists {{ tmp_relation }}
+      {%- set source_sql -%}
+        (
+          {{sql}}
+        )
+      {%- endset -%}
+      
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate]) }}
+  
+  {% else %} {# dynamic #}
+  
+      {% set predicate -%}
+          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_upsert)
+      {%- endset %}
+
+      {%- set source_sql -%}
+      (
+        select * from {{ tmp_relation }}
+      )
+      {%- endset -%}
+
+      -- generated script to merge partitions into {{ target_relation }}
+      declare dbt_partitions_for_upsert array<{{ partition_type }}>;
+      declare _dbt_max_partition {{ partition_by.data_type }};
+
+      set _dbt_max_partition = (
+          select max({{ partition_by.field }}) from {{ this }}
+      );
+
+      -- 1. create a temp table
+      {{ create_table_as(True, tmp_relation, sql) }}
+
+      -- 2. define partitions to update
+      set (dbt_partitions_for_upsert) = (
+          select as struct
+              array_agg(distinct {{ partition_by.render() }})
+          from {{ tmp_relation }}
+      );
+      
+      -- 3. run the merge statement
+      {{ get_insert_overwrite_merge_sql(target_relation, source_sql, dest_columns, [predicate]) }};
+
+      -- 4. clean up the temp table
+      drop table if exists {{ tmp_relation }}
+  
+  {% endif %}
 
 {% endmacro %}
 
@@ -77,6 +93,7 @@
 
   {%- set raw_partition_by = config.get('partition_by', none) -%}
   {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
+  {%- set partitions = config.get('partitions', none) -%}
   {%- set cluster_by = config.get('cluster_by', none) -%}
 
   {{ run_hooks(pre_hooks) }}
@@ -98,14 +115,22 @@
      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
 
      {#-- if partitioned, use BQ scripting to get the range of partition values to be updated --#}
-     {% if partition_by is not none %}
-        {% set build_sql = bq_partition_merge(
-            strategy,
+     {% if strategy == 'insert_overwrite' %}
+     
+        {% set missing_partition_msg -%}
+          The 'insert_overwrite' strategy requires the `partition_by` config.
+        {%- endset %}
+        {% if partition_by is none %}
+          {% do exceptions.raise_compiler_error(missing_partition_msg) %}
+        {% endif %}
+        
+        {% set build_sql = bq_insert_overwrite(
             tmp_relation,
             target_relation,
             sql,
             unique_key,
             partition_by,
+            partitions,
             dest_columns) %}
 
      {% else %}

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -24,9 +24,7 @@
   
       {% set predicate -%}
           {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in (
-              {% for partition in partitions %}
-                '{{partition}}' {{- ',' if not loop.last -}}
-              {% endfor %}
+              {{ partitions | join (', ') }}
           )
       {%- endset %}
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -41,7 +41,7 @@
   {% else %} {# dynamic #}
   
       {% set predicate -%}
-          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_upsert)
+          {{ partition_by.render(alias='DBT_INTERNAL_DEST') }} in unnest(dbt_partitions_for_replacement)
       {%- endset %}
 
       {%- set source_sql -%}
@@ -51,7 +51,7 @@
       {%- endset -%}
 
       -- generated script to merge partitions into {{ target_relation }}
-      declare dbt_partitions_for_upsert array<{{ partition_type }}>;
+      declare dbt_partitions_for_replacement array<{{ partition_type }}>;
       declare _dbt_max_partition {{ partition_by.data_type }};
 
       set _dbt_max_partition = (
@@ -62,7 +62,7 @@
       {{ create_table_as(True, tmp_relation, sql) }}
 
       -- 2. define partitions to update
-      set (dbt_partitions_for_upsert) = (
+      set (dbt_partitions_for_replacement) = (
           select as struct
               array_agg(distinct {{ partition_by.render() }})
           from {{ tmp_relation }}

--- a/test/integration/052_column_quoting/test_column_quotes.py
+++ b/test/integration/052_column_quoting/test_column_quotes.py
@@ -47,7 +47,7 @@ class TestColumnQuotingDefault(BaseColumnQuotingTest):
 
     @use_profile('bigquery')
     def test_bigquery_column_quotes(self):
-        self._run_columnn_quotes(strategy='insert_overwrite')
+        self._run_columnn_quotes(strategy='merge')
 
 
 class TestColumnQuotingDisabled(BaseColumnQuotingTest):
@@ -74,10 +74,6 @@ class TestColumnQuotingDisabled(BaseColumnQuotingTest):
     @use_profile('snowflake')
     def test_snowflake_column_quotes(self):
         self._run_columnn_quotes()
-
-    @use_profile('bigquery')
-    def test_bigquery_column_quotes(self):
-        self._run_columnn_quotes(strategy='insert_overwrite')
 
     @use_profile('snowflake')
     def test_snowflake_column_quotes_merged(self):
@@ -112,10 +108,6 @@ class TestColumnQuotingEnabled(BaseColumnQuotingTest):
     @use_profile('snowflake')
     def test_snowflake_column_quotes(self):
         self._run_columnn_quotes()
-
-    @use_profile('bigquery')
-    def test_bigquery_column_quotes(self):
-        self._run_columnn_quotes(strategy='insert_overwrite')
 
     @use_profile('snowflake')
     def test_snowflake_column_quotes_merged(self):


### PR DESCRIPTION
resolves #2196

### Description

Reimplement `insert_overwrite` incremental strategy on BigQuery, with two options:
* Static partitions for replacement, if supplied by the user to the `partitions` model config
* Dynamic partitions, determined by dbt via the multi-query script developed in #2140 + #2153

Benchmarks calculated in [this sheet]( https://docs.google.com/spreadsheets/d/1mR2EAvwgTikjZVtPpBGgToPC8H59YbVfckG4OzVsVFE/). **TL;DR:**
* `incremental_overwrite` with static (user-supplied) partitions is always cheapest and usually fastest
* among other approaches:
    * `merge` (default) with a cluster key is faster and cheaper at small data volumes
    * `insert_overwrite` dynamic is always slowest, but its cost scales better than either `merge` at larger data volumes (> 50 GB)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
