### PR TITLE
Append query comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Features
 - Support for appending query comments to SQL queries. ([#2138](https://github.com/fishtown-analytics/dbt/issues/2138))
 
+Contributers:
+ - [@ilkinulas](https://github.com/ilkinulas) [#2199](https://github.com/fishtown-analytics/dbt/pull/2199)
+
 ## dbt 0.16.0rc2 (March 4, 2020)
 
 ### Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
 
 ### Features
-- Support for appending query comments to SQL queries. ([#2199](https://github.com/fishtown-analytics/dbt/pull/2199))
+- Support for appending query comments to SQL queries. ([#2138](https://github.com/fishtown-analytics/dbt/issues/2138))
 
 ## dbt 0.16.0rc2 (March 4, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
 
+### Features
+- Support for appending query comments to SQL queries. ([#2199](https://github.com/fishtown-analytics/dbt/pull/2199))
+
 ## dbt 0.16.0rc2 (March 4, 2020)
 
 ### Under the hood

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -78,25 +78,14 @@ class MacroQueryStringSetter:
         self.reset()
 
     def _get_comment_macro(self) -> Optional[str]:
-        default_comment = QueryComment().comment
         if not self.config.query_comment:
-            return default_comment
+            return QueryComment().comment
 
-        if isinstance(self.config.query_comment, str):
-            if self.config.query_comment in ('None', ''):
-                # query comment is disabled.
-                return None
-            return self.config.query_comment
+        query_comment = self.config.query_comment
+        if isinstance(query_comment, str):
+            return query_comment
 
-        comment = self.config.query_comment.comment
-
-        if comment in ('None', ''):
-            return None
-
-        if not comment:
-            return default_comment
-
-        return comment
+        return query_comment.comment
 
     def _get_context(self) -> Dict[str, Any]:
         return generate_query_header_context(self.config, self.manifest)

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -129,5 +129,7 @@ class MacroQueryStringSetter:
             wrapped = NodeWrapper(node)
         comment_str = self.generator(name, wrapped)
 
-        self.comment.set(
-            comment_str, self.config.query_comment.get('append', False))
+        append = False
+        if self.config.query_comment:
+            append = self.config.query_comment.get('append', False)
+        self.comment.set(comment_str, append)

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -82,12 +82,13 @@ class MacroQueryStringSetter:
         if not self.config.query_comment:
             return default_comment
 
+        if isinstance(self.config.query_comment, str):
+            if self.config.query_comment in ('None', ''):
+                # query comment is disabled.
+                return None
+            return self.config.query_comment
+
         comment = self.config.query_comment.comment
-
-        if comment in ('None', ''):
-            # query comment is disabled.
-            return None
-
         if not comment:
             # query comment is not specified, using default value
             return default_comment
@@ -111,6 +112,6 @@ class MacroQueryStringSetter:
         comment_str = self.generator(name, wrapped)
 
         append = False
-        if self.config.query_comment:
+        if isinstance(self.config.query_comment, QueryComment):
             append = self.config.query_comment.append
         self.comment.set(comment_str, append)

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -78,14 +78,7 @@ class MacroQueryStringSetter:
         self.reset()
 
     def _get_comment_macro(self) -> Optional[str]:
-        if not self.config.query_comment:
-            return QueryComment().comment
-
-        query_comment = self.config.query_comment
-        if isinstance(query_comment, str):
-            return query_comment
-
-        return query_comment.comment
+        return self.config.query_comment.comment
 
     def _get_context(self) -> Dict[str, Any]:
         return generate_query_header_context(self.config, self.manifest)

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -8,7 +8,6 @@ from dbt.contracts.connection import AdapterRequiredConfig
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
 from dbt.exceptions import RuntimeException
-from dbt.helper_types import NoValue
 
 
 DEFAULT_QUERY_COMMENT = '''
@@ -99,15 +98,14 @@ class MacroQueryStringSetter:
         self.reset()
 
     def _get_comment_macro(self) -> Optional[str]:
-        comment = self.config.query_comment.get('comment', NoValue())
+        if not self.config.query_comment.get('comment'):
+            # query comment is not specified, using default value
+            return DEFAULT_QUERY_COMMENT
 
+        comment = self.config.query_comment.get('comment')
         if comment in ('None', ''):
             # query comment is disabled.
             return None
-
-        if comment == NoValue():
-            # query comment is not specified, using default value
-            return DEFAULT_QUERY_COMMENT
 
         # using custom query comment
         return comment
@@ -126,5 +124,6 @@ class MacroQueryStringSetter:
         if node is not None:
             wrapped = NodeWrapper(node)
         comment_str = self.generator(name, wrapped)
-        # self.comment.set(comment_str, self.config.query_comment['append'])
-        self.comment.set(comment_str, True)
+
+        self.comment.set(
+            comment_str, self.config.query_comment.get('append', False))

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -98,6 +98,9 @@ class MacroQueryStringSetter:
         self.reset()
 
     def _get_comment_macro(self) -> Optional[str]:
+        if not self.config.query_comment:
+            return DEFAULT_QUERY_COMMENT
+
         comment = self.config.query_comment.get('comment')
 
         if comment in ('None', ''):

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -98,14 +98,15 @@ class MacroQueryStringSetter:
         self.reset()
 
     def _get_comment_macro(self) -> Optional[str]:
-        if not self.config.query_comment.get('comment'):
-            # query comment is not specified, using default value
-            return DEFAULT_QUERY_COMMENT
-
         comment = self.config.query_comment.get('comment')
+
         if comment in ('None', ''):
             # query comment is disabled.
             return None
+
+        if not comment:
+            # query comment is not specified, using default value
+            return DEFAULT_QUERY_COMMENT
 
         # using custom query comment
         return comment

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -89,11 +89,13 @@ class MacroQueryStringSetter:
             return self.config.query_comment
 
         comment = self.config.query_comment.comment
+
+        if comment in ('None', ''):
+            return None
+
         if not comment:
-            # query comment is not specified, using default value
             return default_comment
 
-        # using custom query comment
         return comment
 
     def _get_context(self) -> Dict[str, Any]:

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -203,17 +203,14 @@ def _raw_project_from(project_root: str) -> Dict[str, Any]:
 
 
 def _query_comment_from_cfg(
-        cfg_query_comment: Union[str, Dict[str, Any]]
+        cfg_query_comment: Union[QueryComment, str]
 ) -> QueryComment:
     if isinstance(cfg_query_comment, str):
         if cfg_query_comment in ('None', ''):
             return QueryComment(comment='')
         return QueryComment(comment=cfg_query_comment)
 
-    return QueryComment(
-        comment=cfg_query_comment.get('comment'),
-        append=cfg_query_comment.get('append', False)
-    )
+    return cfg_query_comment
 
 
 @dataclass

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -14,7 +14,6 @@ from dbt.exceptions import RecursionException
 from dbt.exceptions import SemverException
 from dbt.exceptions import validator_error_message
 from dbt.exceptions import warn_or_error
-from dbt.helper_types import NoValue
 from dbt.semver import VersionSpecifier
 from dbt.semver import versions_compatible
 from dbt.version import get_installed_version
@@ -203,16 +202,10 @@ def _raw_project_from(project_root: str) -> Dict[str, Any]:
 
 
 def _query_comment_from_cfg(cfg_query_comment) -> Dict[str, Any]:
-    if isinstance(cfg_query_comment, NoValue):
-        return {'comment': NoValue(), 'append': False}
-
     if isinstance(cfg_query_comment, str):
         return {'comment': cfg_query_comment, 'append': False}
 
-    return {
-        'comment': cfg_query_comment['comment'],
-        'append': cfg_query_comment['append']
-    }
+    return cfg_query_comment
 
 
 @dataclass
@@ -454,11 +447,10 @@ class Project:
             'require-dbt-version': [
                 v.to_version_string() for v in self.dbt_version
             ],
+            'query-comment': self.query_comment
         })
         if with_packages:
             result.update(self.packages.to_dict())
-        if self.query_comment != NoValue():
-            result['query-comment'] = self.query_comment
 
         return result
 

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -202,6 +202,19 @@ def _raw_project_from(project_root: str) -> Dict[str, Any]:
     return project_dict
 
 
+def _query_comment_from_cfg(cfg_query_comment) -> Dict[str, Any]:
+    if isinstance(cfg_query_comment, NoValue):
+        return {'comment': NoValue(), 'append': False}
+
+    if isinstance(cfg_query_comment, str):
+        return {'comment': cfg_query_comment, 'append': False}
+
+    return {
+        'comment': cfg_query_comment['comment'],
+        'append': cfg_query_comment['append']
+    }
+
+
 @dataclass
 class PartialProject:
     profile_name: Optional[str]
@@ -244,7 +257,7 @@ class Project:
     snapshots: Dict[str, Any]
     dbt_version: List[VersionSpecifier]
     packages: Dict[str, Any]
-    query_comment: Optional[Union[str, NoValue]]
+    query_comment: Dict[str, Any]
 
     @property
     def all_source_paths(self) -> List[str]:
@@ -356,7 +369,7 @@ class Project:
         dbt_raw_version: Union[List[str], str] = '>=0.0.0'
         if cfg.require_dbt_version is not None:
             dbt_raw_version = cfg.require_dbt_version
-        query_comment = cfg.query_comment
+        query_comment = _query_comment_from_cfg(cfg.query_comment)
 
         try:
             dbt_version = _parse_versions(dbt_raw_version)

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -2,8 +2,7 @@ import abc
 import itertools
 from dataclasses import dataclass, field
 from typing import (
-    Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType, List, Callable,
-    Union)
+    Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType, List, Callable)
 from typing_extensions import Protocol
 
 from hologram import JsonSchemaMixin
@@ -201,6 +200,6 @@ class QueryComment(JsonSchemaMixin):
 
 class AdapterRequiredConfig(HasCredentials, Protocol):
     project_name: str
-    query_comment: Optional[Union[QueryComment, str]]
+    query_comment: QueryComment
     cli_vars: Dict[str, Any]
     target_path: str

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -173,8 +173,34 @@ class HasCredentials(Protocol):
     threads: int
 
 
+DEFAULT_QUERY_COMMENT = '''
+{%- set comment_dict = {} -%}
+{%- do comment_dict.update(
+    app='dbt',
+    dbt_version=dbt_version,
+    profile_name=target.get('profile_name'),
+    target_name=target.get('target_name'),
+) -%}
+{%- if node is not none -%}
+  {%- do comment_dict.update(
+    node_id=node.unique_id,
+  ) -%}
+{% else %}
+  {# in the node context, the connection name is the node_id #}
+  {%- do comment_dict.update(connection_name=connection_name) -%}
+{%- endif -%}
+{{ return(tojson(comment_dict)) }}
+'''
+
+
+@dataclass
+class QueryComment(JsonSchemaMixin):
+    comment: str = DEFAULT_QUERY_COMMENT
+    append: bool = False
+
+
 class AdapterRequiredConfig(HasCredentials, Protocol):
     project_name: str
-    query_comment: Dict[str, Any]
+    query_comment: QueryComment
     cli_vars: Dict[str, Any]
     target_path: str

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -3,7 +3,6 @@ import itertools
 from dataclasses import dataclass, field
 from typing import (
     Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType, List, Callable,
-    Union
 )
 from typing_extensions import Protocol
 
@@ -14,7 +13,6 @@ from hologram.helpers import (
 
 from dbt.contracts.util import Replaceable
 from dbt.exceptions import InternalException
-from dbt.helper_types import NoValue
 from dbt.utils import translate_aliases
 
 
@@ -177,6 +175,6 @@ class HasCredentials(Protocol):
 
 class AdapterRequiredConfig(HasCredentials, Protocol):
     project_name: str
-    query_comment: Optional[Union[str, NoValue]]
+    query_comment: Dict[str, Any]
     cli_vars: Dict[str, Any]
     target_path: str

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -195,7 +195,7 @@ DEFAULT_QUERY_COMMENT = '''
 
 @dataclass
 class QueryComment(JsonSchemaMixin):
-    comment: Optional[str] = DEFAULT_QUERY_COMMENT
+    comment: str = DEFAULT_QUERY_COMMENT
     append: bool = False
 
 

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -3,7 +3,7 @@ import itertools
 from dataclasses import dataclass, field
 from typing import (
     Any, ClassVar, Dict, Tuple, Iterable, Optional, NewType, List, Callable,
-)
+    Union)
 from typing_extensions import Protocol
 
 from hologram import JsonSchemaMixin
@@ -195,12 +195,12 @@ DEFAULT_QUERY_COMMENT = '''
 
 @dataclass
 class QueryComment(JsonSchemaMixin):
-    comment: str = DEFAULT_QUERY_COMMENT
+    comment: Optional[str] = DEFAULT_QUERY_COMMENT
     append: bool = False
 
 
 class AdapterRequiredConfig(HasCredentials, Protocol):
     project_name: str
-    query_comment: QueryComment
+    query_comment: Optional[Union[QueryComment, str]]
     cli_vars: Dict[str, Any]
     target_path: str

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,5 +1,5 @@
 from dbt.contracts.util import Replaceable, Mergeable, list_str
-from dbt.contracts.connection import UserConfigContract
+from dbt.contracts.connection import UserConfigContract, QueryComment
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt import tracking
 from dbt.ui import printer
@@ -161,7 +161,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Optional[Union[Dict[str, Any], str]] = None
+    query_comment: Optional[Union[QueryComment, str]] = None
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -3,7 +3,6 @@ from dbt.contracts.connection import UserConfigContract
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt import tracking
 from dbt.ui import printer
-from dbt.helper_types import NoValue
 
 from hologram import JsonSchemaMixin, ValidationError
 from hologram.helpers import HyphenatedJsonSchemaMixin, register_pattern, \
@@ -162,7 +161,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Optional[Union[Dict[str, Any], str]] = NoValue()
+    query_comment: Union[Dict[str, Any], str] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -1,5 +1,6 @@
 from dbt.contracts.util import Replaceable, Mergeable, list_str
 from dbt.contracts.connection import UserConfigContract, QueryComment
+from dbt.helper_types import NoValue
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt import tracking
 from dbt.ui import printer
@@ -161,7 +162,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Optional[Union[QueryComment, str]] = None
+    query_comment: Optional[Union[QueryComment, NoValue, str]] = NoValue()
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -162,7 +162,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Optional[Union[str, NoValue]] = NoValue()
+    query_comment: Optional[Union[Dict[str, Any], str]] = NoValue()
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -161,7 +161,7 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     seeds: Dict[str, Any] = field(default_factory=dict)
     snapshots: Dict[str, Any] = field(default_factory=dict)
     packages: List[PackageSpec] = field(default_factory=list)
-    query_comment: Union[Dict[str, Any], str] = field(default_factory=dict)
+    query_comment: Optional[Union[Dict[str, Any], str]] = None
 
     @classmethod
     def from_dict(cls, data, validate=True):

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,7 +64,7 @@ setup(
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<0.17',
         'dataclasses==0.6;python_version<"3.7"',
-        'hologram==0.0.5',
+        'hologram==0.0.6',
         'logbook>=1.5,<1.6',
         'pytest-logbook>=1.2.0,<1.3',
         'typing-extensions>=3.7.4,<3.8',

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -167,7 +167,7 @@ class TestNullQueryComments(TestDefaultQueryComments):
     @property
     def project_config(self):
         cfg = super().project_config
-        cfg.update({'query-comment': 'None'})
+        cfg.update({'query-comment': ''})
         return cfg
 
     def matches_comment(self, msg) -> bool:

--- a/test/integration/051_query_comments_test/test_query_comments.py
+++ b/test/integration/051_query_comments_test/test_query_comments.py
@@ -167,7 +167,7 @@ class TestNullQueryComments(TestDefaultQueryComments):
     @property
     def project_config(self):
         cfg = super().project_config
-        cfg.update({'query-comment': None})
+        cfg.update({'query-comment': 'None'})
         return cfg
 
     def matches_comment(self, msg) -> bool:

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -853,7 +853,7 @@ class TestProject(BaseConfigTest):
 
     def test_default_query_comment(self):
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment, {})
+        self.assertEqual(project.query_comment, None)
 
     def test_default_query_comment_append(self):
         self.default_project_data.update({

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -848,8 +848,15 @@ class TestProject(BaseConfigTest):
             'query-comment': 'None',
         })
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment['comment'], 'None')
-        self.assertEqual(project.query_comment['append'], False)
+        self.assertEqual(project.query_comment.comment, '')
+        self.assertEqual(project.query_comment.append, False)
+
+        self.default_project_data.update({
+            'query-comment': '',
+        })
+        project = dbt.config.Project.from_project_config(self.default_project_data, None)
+        self.assertEqual(project.query_comment.comment, '')
+        self.assertEqual(project.query_comment.append, False)
 
     def test_default_query_comment(self):
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
@@ -862,8 +869,8 @@ class TestProject(BaseConfigTest):
             },
         })
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment.get('comment'), None)
-        self.assertEqual(project.query_comment['append'], True)
+        self.assertEqual(project.query_comment.comment, None)
+        self.assertEqual(project.query_comment.append, True)
 
     def test_custom_query_comment_append(self):
         self.default_project_data.update({
@@ -873,8 +880,8 @@ class TestProject(BaseConfigTest):
             },
         })
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment['comment'], 'run by user test')
-        self.assertEqual(project.query_comment['append'], True)
+        self.assertEqual(project.query_comment.comment, 'run by user test')
+        self.assertEqual(project.query_comment.append, True)
 
 class TestProjectWithConfigs(BaseConfigTest):
     def setUp(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -14,6 +14,7 @@ import dbt.exceptions
 from dbt.adapters.postgres import PostgresCredentials
 from dbt.adapters.redshift import RedshiftCredentials
 from dbt.context.base import generate_base_context
+from dbt.contracts.connection import QueryComment, DEFAULT_QUERY_COMMENT
 from dbt.contracts.project import PackageConfig, LocalPackage, GitPackage
 from dbt.semver import VersionSpecifier
 from dbt.task.run_operation import RunOperationTask
@@ -869,7 +870,7 @@ class TestProject(BaseConfigTest):
             },
         })
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment.comment, None)
+        self.assertEqual(project.query_comment.comment, DEFAULT_QUERY_COMMENT)
         self.assertEqual(project.query_comment.append, True)
 
     def test_custom_query_comment_append(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -15,6 +15,7 @@ from dbt.adapters.postgres import PostgresCredentials
 from dbt.adapters.redshift import RedshiftCredentials
 from dbt.context.base import generate_base_context
 from dbt.contracts.project import PackageConfig, LocalPackage, GitPackage
+from dbt.helper_types import NoValueEncoder
 from dbt.semver import VersionSpecifier
 from dbt.task.run_operation import RunOperationTask
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -846,7 +846,7 @@ class TestProject(BaseConfigTest):
 
     def test_query_comment_disabled(self):
         self.default_project_data.update({
-            'query-comment': 'None',
+            'query-comment': None,
         })
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
         self.assertEqual(project.query_comment.comment, '')
@@ -861,7 +861,7 @@ class TestProject(BaseConfigTest):
 
     def test_default_query_comment(self):
         project = dbt.config.Project.from_project_config(self.default_project_data, None)
-        self.assertEqual(project.query_comment, None)
+        self.assertEqual(project.query_comment, QueryComment())
 
     def test_default_query_comment_append(self):
         self.default_project_data.update({

--- a/test/unit/test_query_headers.py
+++ b/test/unit/test_query_headers.py
@@ -1,0 +1,59 @@
+import re
+from unittest import TestCase, mock
+
+from dbt.adapters.base.query_headers import MacroQueryStringSetter
+
+from test.unit.utils import config_from_parts_or_dicts
+
+
+class TestQueryHeaders(TestCase):
+
+    def setUp(self):
+        self.profile_cfg = {
+            'outputs': {
+                'test': {
+                    'type': 'postgres',
+                    'dbname': 'postgres',
+                    'user': 'test',
+                    'host': 'test',
+                    'pass': 'test',
+                    'port': 5432,
+                    'schema': 'test'
+                },
+            },
+            'target': 'test'
+        }
+        self.project_cfg = {
+            'name': 'query_headers',
+            'version': '0.1',
+            'profile': 'test',
+        }
+        self.query = "SELECT 1;"
+
+    def test_comment_should_prepend_query_by_default(self):
+        config = config_from_parts_or_dicts(self.project_cfg, self.profile_cfg)
+        query_header = MacroQueryStringSetter(config, mock.MagicMock(macros={}))
+        sql = query_header.add(self.query)
+        self.assertTrue(re.match(f'^\/\*.*\*\/\n{self.query}$', sql))
+
+
+    def test_append_comment(self):
+        self.project_cfg.update({
+            'query-comment': {
+                'comment': 'executed by dbt',
+                'append': True
+            }
+        })
+        config = config_from_parts_or_dicts(self.project_cfg, self.profile_cfg)
+        query_header = MacroQueryStringSetter(config, mock.MagicMock(macros={}))
+        sql = query_header.add(self.query)
+        self.assertEqual(sql, f'{self.query[:-1]}\n/* executed by dbt */;')
+
+    def test_disable_query_comment(self):
+        self.project_cfg.update({
+            'query-comment': ''
+        })
+        config = config_from_parts_or_dicts(self.project_cfg, self.profile_cfg)
+        query_header = MacroQueryStringSetter(config, mock.MagicMock(macros={}))
+        sql = query_header.add(self.query)
+        self.assertEqual(sql, self.query)

--- a/test/unit/test_query_headers.py
+++ b/test/unit/test_query_headers.py
@@ -55,5 +55,4 @@ class TestQueryHeaders(TestCase):
         })
         config = config_from_parts_or_dicts(self.project_cfg, self.profile_cfg)
         query_header = MacroQueryStringSetter(config, mock.MagicMock(macros={}))
-        sql = query_header.add(self.query)
-        self.assertEqual(sql, self.query)
+        self.assertEqual(query_header.add(self.query), self.query)

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -43,8 +43,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
             'query-comment': 'dbt',
         }
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
-        self.assertEqual(self.config.query_comment['comment'], 'dbt')
-        self.assertEqual(self.config.query_comment['append'], False)
+        self.assertEqual(self.config.query_comment.comment, 'dbt')
+        self.assertEqual(self.config.query_comment.append, False)
 
         self.handle = mock.MagicMock(
             spec=snowflake_connector.SnowflakeConnection)

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -43,7 +43,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
             'query-comment': 'dbt',
         }
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
-        self.assertEqual(self.config.query_comment, 'dbt')
+        self.assertEqual(self.config.query_comment['comment'], 'dbt')
+        self.assertEqual(self.config.query_comment['append'], False)
 
         self.handle = mock.MagicMock(
             spec=snowflake_connector.SnowflakeConnection)


### PR DESCRIPTION
resolves #2138

### Description
By default comment is inserted at the beginning of the query. 

Snowflake removes leading comments from the query. https://docs.snowflake.net/manuals/release-notes/2017-04.html#queries-leading-comments-removed-during-execution

With this PR, dbt users will be able to insert the comment to the end query.

Comment location can be set in the `dbt_project.yml` file.

```yaml
# comment will be appended 
query-comment:
    comment: 'executed by dbt'
    append: True
```

```yaml
# default comment will be appended 
query-comment:
    append: True
```

### Checklist
 - [x] have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
