### PR TITLE
Fix issue with table databases/schemas/names becoming numbers (#2206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt 0.16.0 (Release date TBD)
+
+### Fixes
+- When dbt encounters databases, schemas, or tables with names that look like numbers, treat them as strings ([#2206](https://github.com/fishtown-analytics/dbt/issues/2206), [#2208](https://github.com/fishtown-analytics/dbt/pull/2208))
+
 ## dbt 0.16.0rc3 (March 11, 2020)
 
 ### Fixes


### PR DESCRIPTION
resolves #2206 
resolves #2175

### Description
Forcibly convert all table databases, table schemas, and table names to strings.

An alternative I considered is changing how we execute macros (and subsequently turn a database cursor into an agate table) in order to avoid going database -> interpreted type -> text. That required some seriously invasive changes to how we execute macros, but is probably more correct.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
