### PR TITLE
increase the google-cloud-bigquery lower bound to ensure we support "range_partitioning"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - When dbt encounters databases, schemas, or tables with names that look like numbers, treat them as strings ([#2206](https://github.com/fishtown-analytics/dbt/issues/2206), [#2208](https://github.com/fishtown-analytics/dbt/pull/2208))
+- Increased the lower bound for google-cloud-bigquery ([#2213](https://github.com/fishtown-analytics/dbt/issues/2213), [#2214](https://github.com/fishtown-analytics/dbt/pull/2214))
 
 ## dbt 0.16.0rc3 (March 11, 2020)
 

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'google-cloud-core>=1,<=1.3.0',
-        'google-cloud-bigquery>=1.15.0,<1.25.0',
+        'google-cloud-bigquery>=1.22.0,<1.25.0',
         # hidden secret dependency: bq 1.23.0 requires this but only documents
         # 1.10.0 through its dependency chain.
         # see https://github.com/googleapis/google-cloud-python/issues/9965


### PR DESCRIPTION
resolves #2213 

### Description
Increase the lower bound for google-cloud-bigquery to >=1.22.0

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
