### PR TITLE
In schema tests, pass rendered items (#2149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## dbt next (release TBD)
 ### Features
-- Added --fail-fast argument for dbt run and dbt test to fail on first test failure or runtime error. ([#1649](https://github.com/fishtown-analytics/dbt/issues/1649))
-- Support for appending query comments to SQL queries. ([#2138](https://github.com/fishtown-analytics/dbt/issues/2138))
+- Added --fail-fast argument for dbt run and dbt test to fail on first test failure or runtime error. ([#1649](https://github.com/fishtown-analytics/dbt/issues/1649), [#2224](https://github.com/fishtown-analytics/dbt/pull/2224))
+- Support for appending query comments to SQL queries. ([#2138](https://github.com/fishtown-analytics/dbt/issues/2138), [#2199](https://github.com/fishtown-analytics/dbt/pull/2199))
 - Added a `get-manifest` API call. ([#2168](https://github.com/fishtown-analytics/dbt/issues/2168), [#2232](https://github.com/fishtown-analytics/dbt/pull/2232))
+- Users can now use jinja as arguments to tests. Test arguments are rendered in the native context and injected into the test execution context directly. ([#2149](https://github.com/fishtown-analytics/dbt/issues/2149), [#2220](https://github.com/fishtown-analytics/dbt/pull/2220))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
@@ -10,7 +11,6 @@
 
 Contributors:
  - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))
- - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224))
  - [@ilkinulas](https://github.com/ilkinulas) [#2199](https://github.com/fishtown-analytics/dbt/pull/2199)
 
 

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -227,6 +227,12 @@ class SQLAdapter(BaseAdapter):
     def quote(self, identifier):
         return '"{}"'.format(identifier)
 
+    @classmethod
+    def unquote(cls, identifier: str) -> str:
+        if identifier.startswith('"') and identifier.endswith('"'):
+            return identifier[1:-1]
+        return identifier
+
     def list_schemas(self, database: str) -> List[str]:
         results = self.execute_macro(
             LIST_SCHEMAS_MACRO_NAME,

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -227,12 +227,6 @@ class SQLAdapter(BaseAdapter):
     def quote(self, identifier):
         return '"{}"'.format(identifier)
 
-    @classmethod
-    def unquote(cls, identifier: str) -> str:
-        if identifier.startswith('"') and identifier.endswith('"'):
-            return identifier[1:-1]
-        return identifier
-
     def list_schemas(self, database: str) -> List[str]:
         results = self.execute_macro(
             LIST_SCHEMAS_MACRO_NAME,

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -1,6 +1,7 @@
 import codecs
 import linecache
 import os
+import re
 import tempfile
 import threading
 from contextlib import contextmanager
@@ -10,15 +11,19 @@ from typing import (
 
 import jinja2
 import jinja2.ext
+import jinja2.nativetypes  # type: ignore
 import jinja2.nodes
 import jinja2.parser
 import jinja2.sandbox
 
 from dbt.utils import (
-    get_dbt_macro_name, get_docs_macro_name, get_materialization_macro_name
+    get_dbt_macro_name, get_docs_macro_name, get_materialization_macro_name,
+    deep_map
 )
 
 from dbt.clients._jinja_blocks import BlockIterator, BlockData, BlockTag
+from dbt.contracts.graph.compiled import CompiledSchemaTestNode
+from dbt.contracts.graph.parsed import ParsedSchemaTestNode
 from dbt.exceptions import (
     InternalException, raise_compiler_error, CompilationException,
     invalid_materialization_argument, MacroReturn
@@ -91,6 +96,17 @@ class MacroFuzzEnvironment(jinja2.sandbox.SandboxedEnvironment):
             filename = _linecache_inject(source, write)
 
         return super()._compile(source, filename)  # type: ignore
+
+
+class NativeSandboxEnvironment(MacroFuzzEnvironment):
+    code_generator_class = jinja2.nativetypes.NativeCodeGenerator
+
+
+class NativeSandboxTemplate(jinja2.nativetypes.NativeTemplate):  # mypy: ignore
+    environment_class = NativeSandboxEnvironment
+
+
+NativeSandboxEnvironment.template_class = NativeSandboxTemplate  # type: ignore
 
 
 class TemplateCache:
@@ -348,7 +364,11 @@ def create_undefined(node=None):
     return Undefined
 
 
-def get_environment(node=None, capture_macros=False):
+def get_environment(
+    node=None,
+    capture_macros: bool = False,
+    native: bool = False,
+) -> jinja2.Environment:
     args: Dict[str, List[Union[str, Type[jinja2.ext.Extension]]]] = {
         'extensions': ['jinja2.ext.do']
     }
@@ -359,7 +379,13 @@ def get_environment(node=None, capture_macros=False):
     args['extensions'].append(MaterializationExtension)
     args['extensions'].append(DocumentationExtension)
 
-    return MacroFuzzEnvironment(**args)
+    env_cls: Type[jinja2.Environment]
+    if native:
+        env_cls = NativeSandboxEnvironment
+    else:
+        env_cls = MacroFuzzEnvironment
+
+    return env_cls(**args)
 
 
 @contextmanager
@@ -378,21 +404,39 @@ def parse(string):
         return get_environment().parse(str(string))
 
 
-def get_template(string, ctx, node=None, capture_macros=False):
+def get_template(
+    string: str,
+    ctx: Dict[str, Any],
+    node=None,
+    capture_macros: bool = False,
+    native: bool = False,
+):
     with catch_jinja(node):
-        env = get_environment(node, capture_macros)
+        env = get_environment(node, capture_macros, native=native)
 
         template_source = str(string)
         return env.from_string(template_source, globals=ctx)
 
 
-def render_template(template, ctx, node=None):
+def render_template(template, ctx: Dict[str, Any], node=None) -> str:
     with catch_jinja(node):
         return template.render(ctx)
 
 
-def get_rendered(string, ctx, node=None, capture_macros=False):
-    template = get_template(string, ctx, node, capture_macros=capture_macros)
+def get_rendered(
+    string: str,
+    ctx: Dict[str, Any],
+    node=None,
+    capture_macros: bool = False,
+    native: bool = False,
+) -> str:
+    template = get_template(
+        string,
+        ctx,
+        node,
+        capture_macros=capture_macros,
+        native=native,
+    )
 
     return render_template(template, ctx, node)
 
@@ -424,3 +468,38 @@ def extract_toplevel_blocks(
         allowed_blocks=allowed_blocks,
         collect_raw_data=collect_raw_data
     )
+
+
+SCHEMA_TEST_KWARGS_NAME = '_dbt_schema_test_kwargs'
+
+
+def add_rendered_test_kwargs(
+    context: Dict[str, Any],
+    node: Union[ParsedSchemaTestNode, CompiledSchemaTestNode],
+    capture_macros: bool = False,
+) -> None:
+    """Render each of the test kwargs in the given context using the native
+    renderer, then insert that value into the given context as the special test
+    keyword arguments member.
+    """
+    looks_like_func = r'^\s*(env_var|ref|var|source|doc)\s*\(.+\)\s*$'
+
+    # we never care about the keypath
+    def _convert_function(value: Any, _: Any) -> Any:
+        if isinstance(value, str):
+            if re.match(looks_like_func, value) is not None:
+                # curly braces to make rendering happy
+                value = f'{{{{ {value} }}}}'
+            new_value = get_rendered(
+                value, context, node, capture_macros=capture_macros,
+                native=True
+            )
+            # this is an ugly way of checking if the value was a quoted str
+            # (we don't want to unquote column names!)
+            if not (len(value) >= 2 and new_value == value[1:-1]):
+                value = new_value
+
+        return value
+
+    kwargs = deep_map(_convert_function, node.test_metadata.kwargs)
+    context[SCHEMA_TEST_KWARGS_NAME] = kwargs

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, Any
 
 import dbt.utils
 import dbt.include
@@ -11,11 +11,17 @@ from dbt.node_types import NodeType
 from dbt.linker import Linker
 
 from dbt.context.providers import generate_runtime_model
+from dbt.contracts.graph.manifest import Manifest
 import dbt.contracts.project
 import dbt.exceptions
 import dbt.flags
 import dbt.config
-from dbt.contracts.graph.compiled import InjectedCTE, COMPILED_TYPES
+from dbt.contracts.graph.compiled import (
+    InjectedCTE,
+    COMPILED_TYPES,
+    NonSourceCompiledNode,
+    CompiledSchemaTestNode,
+)
 from dbt.contracts.graph.parsed import ParsedNode
 
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -130,6 +136,22 @@ class Compiler:
         dbt.clients.system.make_directory(self.config.target_path)
         dbt.clients.system.make_directory(self.config.modules_path)
 
+    def _create_node_context(
+        self,
+        node: NonSourceCompiledNode,
+        manifest: Manifest,
+        extra_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        context = generate_runtime_model(
+            node, self.config, manifest
+        )
+        context.update(extra_context)
+        if isinstance(node, CompiledSchemaTestNode):
+            # for test nodes, add a special keyword args value to the context
+            dbt.clients.jinja.add_rendered_test_kwargs(context, node)
+
+        return context
+
     def compile_node(self, node, manifest, extra_context=None):
         if extra_context is None:
             extra_context = {}
@@ -146,10 +168,9 @@ class Compiler:
         })
         compiled_node = _compiled_type_for(node).from_dict(data)
 
-        context = generate_runtime_model(
-            compiled_node, self.config, manifest
+        context = self._create_node_context(
+            compiled_node, manifest, extra_context
         )
-        context.update(extra_context)
 
         compiled_node.compiled_sql = dbt.clients.jinja.get_rendered(
             node.raw_sql,

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -160,33 +160,6 @@ class Compiler:
 
         injected_node, _ = prepend_ctes(compiled_node, manifest)
 
-        should_wrap = {NodeType.Test, NodeType.Operation}
-        if injected_node.resource_type in should_wrap:
-            # data tests get wrapped in count(*)
-            # TODO : move this somewhere more reasonable
-            if 'data' in injected_node.tags and \
-               injected_node.resource_type == NodeType.Test:
-                injected_node.wrapped_sql = (
-                    "select count(*) as errors "
-                    "from (\n{test_sql}\n) sbq").format(
-                        test_sql=injected_node.injected_sql)
-            else:
-                # don't wrap schema tests or analyses.
-                injected_node.wrapped_sql = injected_node.injected_sql
-
-        elif injected_node.resource_type == NodeType.Snapshot:
-            # unfortunately we do everything automagically for
-            # snapshots. in the future it'd be nice to generate
-            # the SQL at the parser level.
-            pass
-
-        elif(injected_node.resource_type == NodeType.Model and
-             injected_node.get_materialization() == 'ephemeral'):
-            pass
-
-        else:
-            injected_node.wrapped_sql = None
-
         return injected_node
 
     def write_graph_file(self, linker, manifest):

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -24,12 +24,12 @@ graph_file_name = 'graph.gpickle'
 
 
 def _compiled_type_for(model: ParsedNode):
-    if model.resource_type not in COMPILED_TYPES:
+    if type(model) not in COMPILED_TYPES:
         raise dbt.exceptions.InternalException(
             'Asked to compile {} node, but it has no compiled form'
-            .format(model.resource_type)
+            .format(type(model))
         )
-    return COMPILED_TYPES[model.resource_type]
+    return COMPILED_TYPES[type(model)]
 
 
 def print_compile_stats(stats):

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -274,7 +274,7 @@ class Project:
         """Pre-process certain special keys to convert them from None values
         into empty containers, and to turn strings into arrays of strings.
         """
-        handlers: Dict[Tuple[str, ...], Callable[[Any], Any]] = {
+        handlers: Dict[Tuple[Union[str, int], ...], Callable[[Any], Any]] = {
             ('on-run-start',): _list_if_none_or_string,
             ('on-run-end',): _list_if_none_or_string,
         }
@@ -286,7 +286,7 @@ class Project:
             handlers[(k, 'post-hook')] = _list_if_none_or_string
         handlers[('seeds', 'column_types')] = _dict_if_none
 
-        def converter(value: Any, keypath: Tuple[str, ...]) -> Any:
+        def converter(value: Any, keypath: Tuple[Union[str, int], ...]) -> Any:
             if keypath in handlers:
                 handler = handlers[keypath]
                 return handler(value)

--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -117,7 +117,6 @@ class CompiledSnapshotNode(CompiledNode):
 @dataclass
 class CompiledDataTestNode(CompiledNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
-    column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
 
 
@@ -237,8 +236,7 @@ def parsed_instance_for(compiled: CompiledNode) -> ParsedResource:
     return cls.from_dict(compiled.to_dict(), validate=False)
 
 
-# This is anything that can be in manifest.nodes and isn't a Source.
-NonSourceNode = Union[
+NonSourceCompiledNode = Union[
     CompiledAnalysisNode,
     CompiledDataTestNode,
     CompiledModelNode,
@@ -247,6 +245,9 @@ NonSourceNode = Union[
     CompiledSchemaTestNode,
     CompiledSeedNode,
     CompiledSnapshotNode,
+]
+
+NonSourceParsedNode = Union[
     ParsedAnalysisNode,
     ParsedDataTestNode,
     ParsedModelNode,
@@ -255,6 +256,13 @@ NonSourceNode = Union[
     ParsedSchemaTestNode,
     ParsedSeedNode,
     ParsedSnapshotNode,
+]
+
+
+# This is anything that can be in manifest.nodes and isn't a Source.
+NonSourceNode = Union[
+    NonSourceCompiledNode,
+    NonSourceParsedNode,
 ]
 
 # We allow either parsed or compiled nodes, or parsed sources, as some

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -301,7 +301,14 @@ class TestMetadata(JsonSchemaMixin):
 
 
 @dataclass
-class ParsedTestNode(ParsedNode):
+class ParsedDataTestNode(ParsedNode):
+    resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
+    column_name: Optional[str] = None
+    config: TestConfig = field(default_factory=TestConfig)
+
+
+@dataclass
+class ParsedSchemaTestNode(ParsedNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
@@ -580,17 +587,3 @@ class ParsedSourceDefinition(
 ParsedResource = Union[
     ParsedMacro, ParsedNode, ParsedDocumentation, ParsedSourceDefinition
 ]
-
-
-PARSED_TYPES: Dict[NodeType, Type[ParsedResource]] = {
-    NodeType.Analysis: ParsedAnalysisNode,
-    NodeType.Documentation: ParsedDocumentation,
-    NodeType.Macro: ParsedMacro,
-    NodeType.Model: ParsedModelNode,
-    NodeType.Operation: ParsedHookNode,
-    NodeType.RPCCall: ParsedRPCNode,
-    NodeType.Seed: ParsedSeedNode,
-    NodeType.Snapshot: ParsedSnapshotNode,
-    NodeType.Source: ParsedSourceDefinition,
-    NodeType.Test: ParsedTestNode,
-}

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -301,6 +301,11 @@ class TestMetadata(JsonSchemaMixin):
 
 
 @dataclass
+class HasTestMetadata(JsonSchemaMixin):
+    test_metadata: TestMetadata
+
+
+@dataclass
 class ParsedDataTestNode(ParsedNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
@@ -308,11 +313,10 @@ class ParsedDataTestNode(ParsedNode):
 
 
 @dataclass
-class ParsedSchemaTestNode(ParsedNode):
+class ParsedSchemaTestNode(ParsedNode, HasTestMetadata):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
     column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
-    test_metadata: Optional[TestMetadata] = None
 
 
 @dataclass(init=False)

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -308,7 +308,6 @@ class HasTestMetadata(JsonSchemaMixin):
 @dataclass
 class ParsedDataTestNode(ParsedNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Test]})
-    column_name: Optional[str] = None
     config: TestConfig = field(default_factory=TestConfig)
 
 

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -20,11 +20,10 @@ from dbt.contracts.results import (
 )
 from dbt.exceptions import (
     NotImplementedException, CompilationException, RuntimeException,
-    InternalException, missing_materialization
+    InternalException, missing_materialization, raise_compiler_error
 )
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
-import dbt.exceptions
 import dbt.tracking
 import dbt.ui.printer
 import dbt.flags
@@ -570,7 +569,7 @@ class TestRunner(CompileRunner):
             num_cols = len(table.columns)
             # since we just wrapped our query in `select count(*)`, we are in
             # big trouble!
-            raise dbt.exceptions.InternalException(
+            raise InternalException(
                 f"dbt itnernally failed to execute {test.unique_id}: "
                 f"Returned {num_rows} rows and {num_cols} cols, but expected "
                 f"1 row and 1 column"
@@ -587,7 +586,7 @@ class TestRunner(CompileRunner):
         num_rows = len(table.rows)
         if num_rows != 1:
             num_cols = len(table.columns)
-            dbt.exceptions.raise_compiler_error(
+            raise_compiler_error(
                 f"Bad test {test.test_metadata.name}: "
                 f"Returned {num_rows} rows and {num_cols} cols, but expected "
                 f"1 row and 1 column"

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -9,6 +9,11 @@ from dbt.adapters.base import BaseRelation
 from dbt.clients.jinja import MacroGenerator
 from dbt.compilation import compile_node
 from dbt.context.providers import generate_runtime_model
+from dbt.contracts.graph.compiled import (
+    CompiledDataTestNode,
+    CompiledSchemaTestNode,
+    CompiledTestNode,
+)
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.results import (
     RunModelResult, collect_timing_info, SourceFreshnessResult, PartialResult,
@@ -554,27 +559,55 @@ class TestRunner(CompileRunner):
         dbt.ui.printer.print_start_line(description, self.node_index,
                                         self.num_nodes)
 
-    def execute_test(self, test):
+    def execute_data_test(self, test: CompiledDataTestNode):
+        sql = (
+            f'select count(*) as errors from (\n{test.injected_sql}\n) sbq'
+        )
+        res, table = self.adapter.execute(sql, auto_begin=True, fetch=True)
+
+        num_rows = len(table.rows)
+        if num_rows != 1:
+            num_cols = len(table.columns)
+            # since we just wrapped our query in `select count(*)`, we are in
+            # big trouble!
+            raise dbt.exceptions.InternalException(
+                f"dbt itnernally failed to execute {test.unique_id}: "
+                f"Returned {num_rows} rows and {num_cols} cols, but expected "
+                f"1 row and 1 column"
+            )
+        return table[0][0]
+
+    def execute_schema_test(self, test: CompiledSchemaTestNode):
         res, table = self.adapter.execute(
-            test.wrapped_sql,
+            test.injected_sql,
             auto_begin=True,
-            fetch=True)
+            fetch=True,
+        )
 
         num_rows = len(table.rows)
         if num_rows != 1:
             num_cols = len(table.columns)
             dbt.exceptions.raise_compiler_error(
                 f"Bad test {test.test_metadata.name}: "
-                f"Returned {num_rows} rows "
-                f"and {num_cols} cols but expected 1 row and 1 column"
+                f"Returned {num_rows} rows and {num_cols} cols, but expected "
+                f"1 row and 1 column"
             )
         return table[0][0]
 
     def before_execute(self):
         self.print_start_line()
 
-    def execute(self, test, manifest):
-        failed_rows = self.execute_test(test)
+    def execute(self, test: CompiledTestNode, manifest: Manifest):
+        if isinstance(test, CompiledDataTestNode):
+            failed_rows = self.execute_data_test(test)
+        elif isinstance(test, CompiledSchemaTestNode):
+            failed_rows = self.execute_schema_test(test)
+        else:
+
+            raise InternalException(
+                f'Expected compiled schema test or compiled data test, got '
+                f'{type(test)}'
+            )
         severity = test.config.severity.upper()
 
         if failed_rows == 0:

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -570,7 +570,7 @@ class TestRunner(CompileRunner):
             # since we just wrapped our query in `select count(*)`, we are in
             # big trouble!
             raise InternalException(
-                f"dbt itnernally failed to execute {test.unique_id}: "
+                f"dbt internally failed to execute {test.unique_id}: "
                 f"Returned {num_rows} rows and {num_cols} cols, but expected "
                 f"1 row and 1 column"
             )

--- a/core/dbt/parser/data_test.py
+++ b/core/dbt/parser/data_test.py
@@ -1,18 +1,18 @@
-from dbt.contracts.graph.parsed import ParsedTestNode
+from dbt.contracts.graph.parsed import ParsedDataTestNode
 from dbt.node_types import NodeType
 from dbt.parser.base import SimpleSQLParser
 from dbt.parser.search import FilesystemSearcher, FileBlock
 from dbt.utils import get_pseudo_test_path
 
 
-class DataTestParser(SimpleSQLParser[ParsedTestNode]):
+class DataTestParser(SimpleSQLParser[ParsedDataTestNode]):
     def get_paths(self):
         return FilesystemSearcher(
             self.project, self.project.test_paths, '.sql'
         )
 
-    def parse_from_dict(self, dct, validate=True) -> ParsedTestNode:
-        return ParsedTestNode.from_dict(dct, validate=validate)
+    def parse_from_dict(self, dct, validate=True) -> ParsedDataTestNode:
+        return ParsedDataTestNode.from_dict(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -7,10 +7,21 @@ from dbt.contracts.graph.manifest import (
     SourceFile, RemoteFile, FileHash, MacroKey
 )
 from dbt.contracts.graph.parsed import (
-    ParsedNode, HasUniqueID, ParsedMacro, ParsedDocumentation, ParsedNodePatch,
-    ParsedSourceDefinition, ParsedAnalysisNode, ParsedHookNode, ParsedRPCNode,
-    ParsedModelNode, ParsedSeedNode, ParsedTestNode, ParsedSnapshotNode,
+    HasUniqueID,
+    ParsedAnalysisNode,
+    ParsedDataTestNode,
+    ParsedDocumentation,
+    ParsedHookNode,
+    ParsedMacro,
     ParsedMacroPatch,
+    ParsedModelNode,
+    ParsedNode,
+    ParsedNodePatch,
+    ParsedRPCNode,
+    ParsedSeedNode,
+    ParsedSchemaTestNode,
+    ParsedSnapshotNode,
+    ParsedSourceDefinition,
 )
 from dbt.contracts.util import Writable, Replaceable
 from dbt.exceptions import (
@@ -36,12 +47,13 @@ def _check_duplicates(
 
 ManifestNodes = Union[
     ParsedAnalysisNode,
+    ParsedDataTestNode,
     ParsedHookNode,
     ParsedModelNode,
-    ParsedSeedNode,
-    ParsedTestNode,
-    ParsedSnapshotNode,
     ParsedRPCNode,
+    ParsedSchemaTestNode,
+    ParsedSeedNode,
+    ParsedSnapshotNode,
 ]
 
 

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -5,7 +5,7 @@ from typing import (
     Generic, TypeVar, Dict, Any, Tuple, Optional, List, Sequence
 )
 
-from dbt.clients.jinja import get_rendered
+from dbt.clients.jinja import get_rendered, SCHEMA_TEST_KWARGS_NAME
 from dbt.contracts.graph.unparsed import (
     UnparsedNodeUpdate, UnparsedSourceDefinition,
     UnparsedSourceTableDefinition, UnparsedColumn, UnparsedMacroUpdate,
@@ -20,6 +20,9 @@ def get_nice_schema_test_name(
 ) -> Tuple[str, str]:
     flat_args = []
     for arg_name in sorted(args):
+        # the model is already embedded in the name, so skip it
+        if arg_name == 'model':
+            continue
         arg_val = args[arg_name]
 
         if isinstance(arg_val, dict):
@@ -233,8 +236,14 @@ class TestBuilder(Generic[Testable]):
     ) -> None:
         test_name, test_args = self.extract_test_args(test, column_name)
         self.args: Dict[str, Any] = test_args
+        if 'model' in self.args:
+            raise_compiler_error(
+                'Test arguments include "model", which is a reserved argument',
+            )
         self.package_name: str = package_name
         self.target: Testable = target
+
+        self.args['model'] = self.build_model_str()
 
         match = self.TEST_NAME_PATTERN.match(test_name)
         if match is None:
@@ -337,8 +346,6 @@ class TestBuilder(Generic[Testable]):
             raise self._bad_type()
         return fmt.format(self.target)
 
-        raise NotImplementedError('describe_test_target not implemented!')
-
     def get_test_name(self) -> Tuple[str, str]:
         if isinstance(self.target, UnparsedNodeUpdate):
             name = self.name
@@ -353,19 +360,18 @@ class TestBuilder(Generic[Testable]):
     def build_raw_sql(self) -> str:
         return (
             "{{{{ config(severity='{severity}') }}}}"
-            "{{{{ {macro}(model={model}, {kwargs}) }}}}"
+            "{{{{ {macro}(**{kwargs_name}) }}}}"
         ).format(
-            model=self.build_model_str(),
             macro=self.macro_name(),
-            kwargs=self.test_kwargs_str(),
             severity=self.severity(),
+            kwargs_name=SCHEMA_TEST_KWARGS_NAME,
         )
 
     def build_model_str(self):
         if isinstance(self.target, UnparsedNodeUpdate):
-            fmt = "ref('{0.name}')"
+            fmt = "{{{{ ref('{0.name}') }}}}"
         elif isinstance(self.target, SourceTarget):
-            fmt = "source('{0.source.name}', '{0.table.name}')"
+            fmt = "{{{{ source('{0.source.name}', '{0.table.name}') }}}}"
         else:
             raise self._bad_type()
         return fmt.format(self.target)

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -49,20 +49,6 @@ def get_nice_schema_test_name(
     return filename, name
 
 
-def as_kwarg(key: str, value: Any) -> str:
-    test_value = str(value)
-    is_function = re.match(r'^\s*(env_var|ref|var|source|doc)\s*\(.+\)\s*$',
-                           test_value)
-
-    # if the value is a function, don't wrap it in quotes!
-    if is_function:
-        formatted_value = value
-    else:
-        formatted_value = value.__repr__()
-
-    return "{key}={value}".format(key=key, value=formatted_value)
-
-
 @dataclass
 class YamlBlock(FileBlock):
     data: Dict[str, Any]
@@ -324,27 +310,11 @@ class TestBuilder(Generic[Testable]):
                 )
         return tags[:]
 
-    def test_kwargs_str(self) -> str:
-        # sort the dict so the keys are rendered deterministically (for tests)
-        return ', '.join((
-            as_kwarg(key, self.args[key])
-            for key in sorted(self.args)
-        ))
-
     def macro_name(self) -> str:
         macro_name = 'test_{}'.format(self.name)
         if self.namespace is not None:
             macro_name = "{}.{}".format(self.namespace, macro_name)
         return macro_name
-
-    def describe_test_target(self) -> str:
-        if isinstance(self.target, UnparsedNodeUpdate):
-            fmt = "model('{0}')"
-        elif isinstance(self.target, SourceTarget):
-            fmt = "source('{0.source}', '{0.table}')"
-        else:
-            raise self._bad_type()
-        return fmt.format(self.target)
 
     def get_test_name(self) -> Tuple[str, str]:
         if isinstance(self.target, UnparsedNodeUpdate):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -19,7 +19,7 @@ from dbt.contracts.graph.parsed import (
     ParsedNodePatch,
     ParsedSourceDefinition,
     ColumnInfo,
-    ParsedTestNode,
+    ParsedSchemaTestNode,
     ParsedMacroPatch,
 )
 from dbt.contracts.graph.unparsed import (
@@ -102,7 +102,7 @@ def _trimmed(inp: str) -> str:
     return inp[:44] + '...' + inp[-3:]
 
 
-class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
+class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
     """
     The schema parser is really big because schemas are really complicated!
 
@@ -131,8 +131,8 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
             self.project, self.project.all_source_paths, '.yml'
         )
 
-    def parse_from_dict(self, dct, validate=True) -> ParsedTestNode:
-        return ParsedTestNode.from_dict(dct, validate=validate)
+    def parse_from_dict(self, dct, validate=True) -> ParsedSchemaTestNode:
+        return ParsedSchemaTestNode.from_dict(dct, validate=validate)
 
     def _parse_format_version(
         self, yaml: YamlBlock
@@ -178,7 +178,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedTestNode]):
         for test in column.tests:
             self.parse_test(block, test, column)
 
-    def parse_node(self, block: SchemaTestBlock) -> ParsedTestNode:
+    def parse_node(self, block: SchemaTestBlock) -> ParsedSchemaTestNode:
         """In schema parsing, we rewrite most of the part of parse_node that
         builds the initial node to be parsed, but rendering is basically the
         same

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -94,7 +94,7 @@ class RunTask(CompileTask):
     def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context):
         compiled = compile_node(adapter, self.config, hook, self.manifest,
                                 extra_context)
-        statement = compiled.wrapped_sql
+        statement = compiled.injected_sql
         hook_index = hook.index or num_hooks
         hook_obj = get_hook(statement, index=hook_index)
         return hook_obj.sql or ''

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -212,7 +212,10 @@ def _deep_map(
     return ret
 
 
-def deep_map(func, value):
+def deep_map(
+    func: Callable[[Any, Tuple[Union[str, int], ...]], Any],
+    value: Any
+) -> Any:
     """map the function func() onto each non-container value in 'value'
     recursively, returning a new value. As long as func does not manipulate
     value, then deep_map will also not manipulate it.

--- a/core/setup.py
+++ b/core/setup.py
@@ -64,7 +64,7 @@ setup(
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<0.17',
         'dataclasses==0.6;python_version<"3.7"',
-        'hologram==0.0.6',
+        'hologram==0.0.7',
         'logbook>=1.5,<1.6',
         'pytest-logbook>=1.2.0,<1.3',
         'typing-extensions>=3.7.4,<3.8',

--- a/core/setup.py
+++ b/core/setup.py
@@ -53,7 +53,7 @@ setup(
         'scripts/dbt',
     ],
     install_requires=[
-        'Jinja2>=2.10,<3',
+        'Jinja2>=2.11,<3',
         'PyYAML>=3.11',
         'sqlparse>=0.2.3,<0.4',
         'networkx>=2.3,<3',

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -304,12 +304,6 @@ class BigQueryAdapter(BaseAdapter):
         return '`{}`'.format(identifier)
 
     @classmethod
-    def unquote(cls, identifier: str) -> str:
-        if identifier.startswith('`') and identifier.endswith('`'):
-            return identifier[1:-1]
-        return identifier
-
-    @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "string"
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -304,6 +304,12 @@ class BigQueryAdapter(BaseAdapter):
         return '`{}`'.format(identifier)
 
     @classmethod
+    def unquote(cls, identifier: str) -> str:
+        if identifier.startswith('`') and identifier.endswith('`'):
+            return identifier[1:-1]
+        return identifier
+
+    @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "string"
 

--- a/test/integration/008_schema_tests_test/macros-v2/macros/tests.sql
+++ b/test/integration/008_schema_tests_test/macros-v2/macros/tests.sql
@@ -24,3 +24,19 @@
     )
 
 {% endmacro %}
+
+
+{% macro test_equivalent(model, value) %}
+    {% set expected = 'foo-bar' %}
+    select
+    {% if value == expected %}
+        0
+    {% else %}
+        {% set msg -%}
+        got "{{ value }}", expected "{{ expected }}"
+        {%- endset %}
+        {% do log(msg, info=True) %}
+        1
+    {% endif %}
+    as id
+{% endmacro %}

--- a/test/integration/008_schema_tests_test/models-v2/render_test_arg_models/model.sql
+++ b/test/integration/008_schema_tests_test/models-v2/render_test_arg_models/model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test/integration/008_schema_tests_test/models-v2/render_test_arg_models/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/render_test_arg_models/schema.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+  - name: model
+    tests:
+      - equivalent:
+          value: "{{ var('myvar', 'baz') }}-bar"

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -337,3 +337,27 @@ class TestQuotedSchemaTestColumns(DBTIntegrationTest):
         self.assertEqual(len(results), 1)
         results = self.run_dbt(['test', '-m', 'source:my_source_2'])
         self.assertEqual(len(results), 2)
+
+
+class TestVarsSchemaTests(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "schema_tests_008"
+
+    @property
+    def models(self):
+        return "models-v2/render_test_arg_models"
+
+    @property
+    def project_config(self):
+        return {
+            "macro-paths": ["macros-v2/macros"],
+        }
+
+    @use_profile('postgres')
+    def test_postgres_argument_rendering(self):
+        results = self.run_dbt()
+        self.assertEqual(len(results), 1)
+        results = self.run_dbt(['test', '--vars', '{myvar: foo}'])
+        self.assertEqual(len(results), 1)
+        self.run_dbt(['test'], expect_pass=False)

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -110,5 +110,4 @@ class TestCLIInvocationWithProfilesDir(ModelCopyingIntegrationTest):
 
         # make sure the test runs against `custom_schema`
         for test_result in res:
-            self.assertTrue(self.custom_schema,
-                            test_result.node.wrapped_sql)
+            self.assertTrue(self.custom_schema, test_result.node.injected_sql)

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -962,7 +962,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'seed.test.seed': {
                     'build_path': None,
@@ -1044,7 +1043,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': '',
-                    'wrapped_sql': None,
                 },
                 'test.test.not_null_model_id': {
                     'alias': 'not_null_model_id',
@@ -1090,7 +1088,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('count(*)'),
-                    'wrapped_sql': AnyStringWith('count(*)'),
                     'test_metadata': {
                         'namespace': None,
                         'name': 'not_null',
@@ -1141,7 +1138,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('select 0'),
-                    'wrapped_sql': AnyStringWith('select 0'),
                     'test_metadata': {
                         'namespace': 'test',
                         'name': 'nothing',
@@ -1192,7 +1188,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': AnyStringWith('count(*)'),
-                    'wrapped_sql': AnyStringWith('count(*)'),
                     'test_metadata': {
                         'namespace': None,
                         'name': 'unique',
@@ -1398,7 +1393,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'model.test.ephemeral_summary': {
                     'alias': 'ephemeral_summary',
@@ -1462,7 +1456,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [ANY],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'model.test.view_summary': {
                     'alias': 'view_summary',
@@ -1525,7 +1518,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'seed.test.seed': {
                     'alias': 'seed',
@@ -1604,7 +1596,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': '',
-                    'wrapped_sql': None,
                 },
                 'source.test.my_source.my_table': {
                     'columns': {
@@ -1998,7 +1989,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'model.test.multi_clustered': {
                     'alias': 'multi_clustered',
@@ -2077,7 +2067,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'model.test.nested_view': {
                     'alias': 'nested_view',
@@ -2157,7 +2146,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'model.test.nested_table': {
                     'alias': 'nested_table',
@@ -2201,7 +2189,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'seed.test.seed': {
                     'build_path': None,
@@ -2283,7 +2270,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': '',
-                    'wrapped_sql': None,
                 },
             },
             'child_map': {
@@ -2533,7 +2519,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
                 'seed.test.seed': {
                     'build_path': None,
@@ -2615,7 +2600,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'extra_ctes_injected': True,
                     'extra_ctes': [],
                     'injected_sql': ANY,
-                    'wrapped_sql': None,
                 },
             },
             'parent_map': {
@@ -2880,7 +2864,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': model_database,
                     'tags': [],
                     'unique_id': 'model.test.model',
-                    'wrapped_sql': None
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -2969,7 +2952,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': [],
                     'unique_id': 'seed.test.seed',
-                    'wrapped_sql': None,
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -3025,7 +3007,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': ['schema'],
                     'unique_id': 'test.test.not_null_model_id',
-                    'wrapped_sql': AnyStringWith('id is null'),
                     'test_metadata': {
                         'namespace': None,
                         'name': 'not_null',
@@ -3086,7 +3067,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'tags': ['schema'],
                     'unique_id': 'test.test.test_nothing_model_',
-                    'wrapped_sql': AnyStringWith('select 0'),
                     'test_metadata': {
                         'namespace': 'test',
                         'name': 'nothing',
@@ -3147,7 +3127,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'tags': ['schema'],
                     'unique_id': 'test.test.unique_model_id',
-                    'wrapped_sql': AnyStringWith('count(*)'),
                     'test_metadata': {
                         'namespace': None,
                         'name': 'unique',
@@ -3259,7 +3238,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': [],
                     'unique_id': 'model.test.ephemeral_summary',
-                    'wrapped_sql': None,
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -3338,7 +3316,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': [],
                     'unique_id': 'model.test.view_summary',
-                    'wrapped_sql': None,
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],
@@ -3427,7 +3404,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'database': self.default_database,
                     'tags': [],
                     'unique_id': 'seed.test.seed',
-                    'wrapped_sql': None
                 },
                 'thread_id': ANY,
                 'timing': [ANY, ANY],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1073,7 +1073,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/not_null_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(model=ref('model'), column_name='id') }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -1091,7 +1091,10 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': None,
                         'name': 'not_null',
-                        'kwargs': {'column_name': 'id'},
+                        'kwargs': {
+                            'column_name': 'id',
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
                 'test.test.test_nothing_model_': {
@@ -1123,7 +1126,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/test_nothing_model_.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(model=ref('model'), ) }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -1141,7 +1144,9 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': 'test',
                         'name': 'nothing',
-                        'kwargs': {},
+                        'kwargs': {
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
                 'test.test.unique_model_id': {
@@ -1173,7 +1178,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/unique_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(model=ref('model'), column_name='id') }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -1191,7 +1196,10 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': None,
                         'name': 'unique',
-                        'kwargs': {'column_name': 'id'},
+                        'kwargs': {
+                            'column_name': 'id',
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
             },
@@ -2999,7 +3007,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/not_null_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(model=ref('model'), column_name='id') }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -3010,7 +3018,10 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': None,
                         'name': 'not_null',
-                        'kwargs': {'column_name': 'id'},
+                        'kwargs': {
+                            'column_name': 'id',
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
                 'thread_id': ANY,
@@ -3059,7 +3070,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/test_nothing_model_.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(model=ref('model'), ) }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -3070,7 +3081,9 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': 'test',
                         'name': 'nothing',
-                        'kwargs': {},
+                        'kwargs': {
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
                 'thread_id': ANY,
@@ -3119,7 +3132,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/unique_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(model=ref('model'), column_name='id') }}",
+                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'resource_type': 'test',
                     'root_path': self.test_root_dir,
@@ -3130,7 +3143,10 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'test_metadata': {
                         'namespace': None,
                         'name': 'unique',
-                        'kwargs': {'column_name': 'id'},
+                        'kwargs': {
+                            'column_name': 'id',
+                            'model': "{{ ref('model') }}",
+                        },
                     },
                 },
                 'thread_id': ANY,

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -1,7 +1,7 @@
 import pickle
 
 from dbt.contracts.graph.compiled import (
-    CompiledModelNode, InjectedCTE, CompiledTestNode
+    CompiledModelNode, InjectedCTE, CompiledSchemaTestNode
 )
 from dbt.contracts.graph.parsed import (
     DependsOn, NodeConfig, TestConfig
@@ -183,8 +183,8 @@ class TestCompiledModelNode(ContractTestCase):
         self.assert_fails_validation(bad_type)
 
 
-class TestCompiledTestNode(ContractTestCase):
-    ContractType = CompiledTestNode
+class TestCompiledSchemaTestNode(ContractTestCase):
+    ContractType = CompiledSchemaTestNode
 
     def _minimum(self):
         return {

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -313,7 +313,6 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             'extra_ctes': [{'id': 'whatever', 'sql': 'select * from other'}],
             'extra_ctes_injected': True,
             'injected_sql': 'with whatever as (select * from other) select * from whatever',
-            'wrapped_sql': 'select count(*) from (with whatever as (select * from other) select * from whatever) sbq',
             'column_name': 'id',
         }
         node = self.ContractType(
@@ -341,7 +340,6 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             extra_ctes=[InjectedCTE('whatever', 'select * from other')],
             extra_ctes_injected=True,
             injected_sql='with whatever as (select * from other) select * from whatever',
-            wrapped_sql='select count(*) from (with whatever as (select * from other) select * from whatever) sbq',
             column_name='id',
         )
         self.assert_symmetric(node, node_dict)

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -4,7 +4,7 @@ from dbt.contracts.graph.compiled import (
     CompiledModelNode, InjectedCTE, CompiledSchemaTestNode
 )
 from dbt.contracts.graph.parsed import (
-    DependsOn, NodeConfig, TestConfig
+    DependsOn, NodeConfig, TestConfig, TestMetadata
 )
 from dbt.node_types import NodeType
 
@@ -200,6 +200,10 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             'database': 'test_db',
             'schema': 'test_schema',
             'alias': 'bar',
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
 
     def test_basic_uncompiled(self):
@@ -239,6 +243,10 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             'compiled': False,
             'extra_ctes': [],
             'extra_ctes_injected': False,
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
         node = self.ContractType(
             package_name='test',
@@ -263,6 +271,7 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             compiled=False,
             extra_ctes=[],
             extra_ctes_injected=False,
+            test_metadata=TestMetadata(namespace=None, name='foo', kwargs={}),
         )
         self.assert_symmetric(node, node_dict)
         self.assertFalse(node.empty)
@@ -314,6 +323,10 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             'extra_ctes_injected': True,
             'injected_sql': 'with whatever as (select * from other) select * from whatever',
             'column_name': 'id',
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
         node = self.ContractType(
             package_name='test',
@@ -341,6 +354,7 @@ class TestCompiledSchemaTestNode(ContractTestCase):
             extra_ctes_injected=True,
             injected_sql='with whatever as (select * from other) select * from whatever',
             column_name='id',
+            test_metadata=TestMetadata(namespace=None, name='foo', kwargs={}),
         )
         self.assert_symmetric(node, node_dict)
         self.assertFalse(node.empty)

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -22,6 +22,7 @@ from dbt.contracts.graph.parsed import (
     ParsedSourceDefinition,
     ParsedDocumentation,
     ParsedHookNode,
+    TestMetadata,
 )
 from dbt.contracts.graph.unparsed import Quoting
 
@@ -568,6 +569,10 @@ class TestParsedSchemaTestNode(ContractTestCase):
             'schema': 'test_schema',
             'alias': 'bar',
             'meta': {},
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
 
     def _complex(self):
@@ -613,6 +618,10 @@ class TestParsedSchemaTestNode(ContractTestCase):
                 },
             },
             'column_name': 'id',
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
 
     def test_ok(self):
@@ -649,6 +658,10 @@ class TestParsedSchemaTestNode(ContractTestCase):
             },
             'docs': {'show': True},
             'columns': {},
+            'test_metadata': {
+                'name': 'foo',
+                'kwargs': {},
+            },
         }
         node = self.ContractType(
             package_name='test',
@@ -670,6 +683,7 @@ class TestParsedSchemaTestNode(ContractTestCase):
             tags=[],
             meta={},
             config=TestConfig(),
+            test_metadata=TestMetadata(namespace=None, name='foo', kwargs={}),
         )
         self.assert_symmetric(node, node_dict)
         self.assertFalse(node.empty)
@@ -714,6 +728,7 @@ class TestParsedSchemaTestNode(ContractTestCase):
             columns={'a': ColumnInfo('a', 'a text field',{})},
             column_name='id',
             docs=Docs(show=False),
+            test_metadata=TestMetadata(namespace=None, name='foo', kwargs={}),
         )
         self.assert_symmetric(node, node_dict)
         self.assertFalse(node.empty)

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -2,11 +2,26 @@ import pickle
 
 from dbt.node_types import NodeType
 from dbt.contracts.graph.parsed import (
-    ParsedModelNode, DependsOn, NodeConfig, ColumnInfo, Hook, ParsedTestNode,
-    TestConfig, ParsedSnapshotNode, TimestampSnapshotConfig, All,
-    CheckSnapshotConfig, SnapshotStrategy, IntermediateSnapshotNode,
-    ParsedNodePatch, ParsedMacro, Docs, MacroDependsOn, ParsedSourceDefinition,
-    ParsedDocumentation, ParsedHookNode
+    ParsedModelNode,
+    DependsOn,
+    NodeConfig,
+    ColumnInfo,
+    Hook,
+    ParsedSchemaTestNode,
+    TestConfig,
+    ParsedSnapshotNode,
+    TimestampSnapshotConfig,
+    All,
+    CheckSnapshotConfig,
+    SnapshotStrategy,
+    IntermediateSnapshotNode,
+    ParsedNodePatch,
+    ParsedMacro,
+    Docs,
+    MacroDependsOn,
+    ParsedSourceDefinition,
+    ParsedDocumentation,
+    ParsedHookNode,
 )
 from dbt.contracts.graph.unparsed import Quoting
 
@@ -535,8 +550,8 @@ class TestParsedHookNode(ContractTestCase):
         self.assert_fails_validation(bad_index)
 
 
-class TestParsedTestNode(ContractTestCase):
-    ContractType = ParsedTestNode
+class TestParsedSchemaTestNode(ContractTestCase):
+    ContractType = ParsedSchemaTestNode
 
     def _minimum(self):
         return {

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -34,7 +34,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset({
 
 REQUIRED_COMPILED_NODE_KEYS = frozenset(REQUIRED_PARSED_NODE_KEYS | {
     'compiled', 'extra_ctes_injected', 'extra_ctes', 'compiled_sql',
-    'injected_sql', 'wrapped_sql'
+    'injected_sql',
 })
 
 

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -364,6 +364,7 @@ class SchemaParserModelsTest(SchemaParserTest):
             tests[0].test_metadata.kwargs,
             {
                 'column_name': 'color',
+                'model': "{{ ref('my_model') }}",
                 'values': ['red', 'blue', 'green'],
             }
         )
@@ -385,6 +386,7 @@ class SchemaParserModelsTest(SchemaParserTest):
             tests[1].test_metadata.kwargs,
             {
                 'column_name': 'color',
+                'model': "{{ ref('my_model') }}",
                 'arg': 100,
             },
         )
@@ -403,6 +405,7 @@ class SchemaParserModelsTest(SchemaParserTest):
             tests[2].test_metadata.kwargs,
             {
                 'column_name': 'color',
+                'model': "{{ ref('my_model') }}",
             },
         )
 

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -24,7 +24,7 @@ from dbt.contracts.graph.manifest import (
 )
 from dbt.contracts.graph.parsed import (
     ParsedModelNode, ParsedMacro, ParsedNodePatch, ParsedSourceDefinition,
-    NodeConfig, DependsOn, ColumnInfo, ParsedTestNode, TestConfig,
+    NodeConfig, DependsOn, ColumnInfo, ParsedDataTestNode, TestConfig,
     ParsedSnapshotNode, TimestampSnapshotConfig, SnapshotStrategy,
     ParsedAnalysisNode, ParsedDocumentation
 )
@@ -687,7 +687,7 @@ class DataTestParserTest(BaseParserTest):
         self.parser.parse_file(block)
         self.assert_has_results_length(self.parser.results, nodes=1)
         node = list(self.parser.results.nodes.values())[0]
-        expected = ParsedTestNode(
+        expected = ParsedDataTestNode(
             alias='test_1',
             name='test_1',
             database='test',


### PR DESCRIPTION
resolves #2149 

### Description

In schema tests, render parameters and pass them in as rendered items.
This PR formally splits data tests and schema tests - data tests don't get a column name or test metadata since that's nonsensical for them.

This PR includes some backwards compatibility changes, so there should be no regressions. Initially I was going to have the "legacy form" arguments  (like `ref("my_model")` instead of `{{ ref("my_model") }}`) emit a deprecation warning, but it's actually really annoying and overly verbose, so I think I'd like to keep the shorthand form.

Edit: I added jinja2 2.11.x as a requirement for this PR, as it fixes some issues with quoting in the native renderer.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
