### PR TITLE
Add Dockerize to test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ARG DOCKERIZE_VERSION=v0.6.1
 
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
@@ -21,6 +22,9 @@ RUN apt-get update && \
 RUN useradd -mU dbt_test_user
 RUN mkdir /usr/app && chown dbt_test_user /usr/app
 RUN mkdir /home/tox && chown dbt_test_user /home/tox
+RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /usr/app
 VOLUME /usr/app


### PR DESCRIPTION
resolves https://github.com/fishtown-analytics/dbt-spark/issues/63


### Description

Hi there, would you consider adding `dockerize` to the main test image to avoid having to download it at every integration test on `dbt-spark` ?

See Circleci in `dbt-spark`: https://github.com/fishtown-analytics/dbt-spark/blob/master/.circleci/config.yml#L40

See what the CircleCi can be changed to, if this change was implemented: https://github.com/fishtown-analytics/dbt-spark/pull/64

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] ~This PR includes tests, or tests are not required/relevant for this PR~
 - [ ] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~
