### PR TITLE
Do not run brew audit on the default formula, it complains

### DIFF
--- a/scripts/build-dbt.py
+++ b/scripts/build-dbt.py
@@ -583,7 +583,7 @@ class HomebrewBuilder:
         )
 
     @staticmethod
-    def run_tests(formula_path: Path):
+    def run_tests(formula_path: Path, audit: bool = True):
         path = os.path.normpath(formula_path)
         run_command(['brew', 'uninstall', '--force', path])
         versions = [
@@ -595,11 +595,12 @@ class HomebrewBuilder:
             run_command(['brew', 'unlink'] + versions)
         run_command(['brew', 'install', path])
         run_command(['brew', 'test', path])
-        run_command(['brew', 'audit', '--strict', path])
+        if audit:
+            run_command(['brew', 'audit', '--strict', path])
 
     def create_default_package(self):
         os.remove(self.default_formula_path)
-        formula_contents = self.create_formula_data(versioned=False)
+        formula_contents = self.get_formula_data(versioned=False)
         self.default_formula_path.write_text(formula_contents)
 
     def build(self):
@@ -609,7 +610,7 @@ class HomebrewBuilder:
 
         if self.set_default:
             self.create_default_package()
-            self.run_tests(formula_path=self.default_formula_path)
+            self.run_tests(formula_path=self.default_formula_path, audit=False)
             self.commit_default_formula()
 
 


### PR DESCRIPTION
No issue, sorry!

### Description

Two tiny build script fixes for homebrew from when I released 0.15.3
 - When setting the default formula, call the right method
 - when setting the default formula, don't bother running `brew audit` - it will fail

This isn't required for a 0.16.0 release since the homebrew default formula stuff is messed up anyway and requires manual intervention, but I'd like to get it in...

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue (we built 0.15.3, didn't we :))
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~ N/A, this is not really a dbt change and has no impact on the final package result
