### PR TITLE
(#2195) Added timeout to registry download call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
+- Added timeout to registry download call ([#2195](https://github.com/fishtown-analytics/dbt/issues/2195), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))
+
+Contributors:
+ - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))
 
 ## dbt 0.16.0 (Release date TBD)
 

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -324,7 +324,8 @@ def run_cmd(
 
 
 def download(url: str, path: str, timeout: Union[float, tuple] = None) -> None:
-    response = requests.get(url, timeout=timeout)
+    connection_timeout = timeout or float(os.getenv('DBT_HTTP_TIMEOUT', 10))
+    response = requests.get(url, timeout=connection_timeout)
     with open(path, 'wb') as handle:
         for block in response.iter_content(1024 * 64):
             handle.write(block)

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -10,7 +10,7 @@ import tarfile
 import requests
 import stat
 from typing import (
-    Type, NoReturn, List, Optional, Dict, Any, Tuple, Callable
+    Type, NoReturn, List, Optional, Dict, Any, Tuple, Callable, Union
 )
 
 import dbt.exceptions
@@ -323,8 +323,8 @@ def run_cmd(
     return out, err
 
 
-def download(url: str, path: str) -> None:
-    response = requests.get(url)
+def download(url: str, path: str, timeout: Union[float, tuple] = None) -> None:
+    response = requests.get(url, timeout=timeout)
     with open(path, 'wb') as handle:
         for block in response.iter_content(1024 * 64):
             handle.write(block)

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -52,7 +52,6 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         return RegistryPackageMetadata.from_dict(dct)
 
     def install(self, project, renderer):
-        connection_timeout = float(os.getenv('DBT_HTTP_TIMEOUT', 10))
         metadata = self.fetch_metadata(project, renderer)
 
         tar_name = '{}.{}.tar.gz'.format(self.package, self.version)
@@ -62,7 +61,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         system.make_directory(os.path.dirname(tar_path))
 
         download_url = metadata.downloads.tarball
-        system.download(download_url, tar_path, timeout=connection_timeout)
+        system.download(download_url, tar_path)
         deps_path = project.modules_path
         package_name = self.get_project_name(project, renderer)
         system.untar_package(tar_path, deps_path, package_name)

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -52,6 +52,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         return RegistryPackageMetadata.from_dict(dct)
 
     def install(self, project, renderer):
+        connection_timeout = float(os.getenv('DBT_HTTP_TIMEOUT', 10))
         metadata = self.fetch_metadata(project, renderer)
 
         tar_name = '{}.{}.tar.gz'.format(self.package, self.version)
@@ -61,7 +62,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         system.make_directory(os.path.dirname(tar_path))
 
         download_url = metadata.downloads.tarball
-        system.download(download_url, tar_path, timeout=10)
+        system.download(download_url, tar_path, timeout=connection_timeout)
         deps_path = project.modules_path
         package_name = self.get_project_name(project, renderer)
         system.untar_package(tar_path, deps_path, package_name)

--- a/core/dbt/deps/registry.py
+++ b/core/dbt/deps/registry.py
@@ -61,7 +61,7 @@ class RegistryPinnedPackage(RegistryPackageMixin, PinnedPackage):
         system.make_directory(os.path.dirname(tar_path))
 
         download_url = metadata.downloads.tarball
-        system.download(download_url, tar_path)
+        system.download(download_url, tar_path, timeout=10)
         deps_path = project.modules_path
         package_name = self.get_project_name(project, renderer)
         system.untar_package(tar_path, deps_path, package_name)


### PR DESCRIPTION
resolves #2195 (potentially)

### Description

Added a 10 seconds timeout to every download call during `dbt deps`. I think the timeout is only for waiting until the response will be started to emmiting (the download process may be longer than timeout). See [requests - Timeouts](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts) for more info.

> You can tell Requests to stop waiting for a response after a given number of seconds with the timeout parameter. Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely:

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
