### PR TITLE
Add a `get-manifest` API method (#2168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt next (release TBD)
 
+### Features
+- Added a `get-manifest` API call. ([#2168](https://github.com/fishtown-analytics/dbt/issues/2168), [#2232](https://github.com/fishtown-analytics/dbt/pull/2232))
+
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
 

--- a/core/dbt/rpc/builtins.py
+++ b/core/dbt/rpc/builtins.py
@@ -10,6 +10,7 @@ from dbt.contracts.rpc import (
     LastParse,
     GCParameters,
     GCResult,
+    GetManifestResult,
     KillParameters,
     KillResult,
     KillResultStatus,
@@ -27,6 +28,7 @@ from dbt.contracts.rpc import (
     PollInProgressResult,
     PollKilledResult,
     PollExecuteCompleteResult,
+    PollGetManifestResult,
     PollRunCompleteResult,
     PollCompileCompleteResult,
     PollCatalogCompleteResult,
@@ -144,6 +146,7 @@ def poll_complete(
         PollCatalogCompleteResult,
         PollRemoteEmptyCompleteResult,
         PollRunOperationCompleteResult,
+        PollGetManifestResult
     ]]
 
     if isinstance(result, RemoteExecutionResult):
@@ -159,6 +162,8 @@ def poll_complete(
         cls = PollRemoteEmptyCompleteResult
     elif isinstance(result, RemoteRunOperationResult):
         cls = PollRunOperationCompleteResult
+    elif isinstance(result, GetManifestResult):
+        cls = PollGetManifestResult
     else:
         raise dbt.exceptions.InternalException(
             'got invalid result in poll_complete: {}'.format(result)

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -369,6 +369,11 @@ class Querier:
             method='run_sql', params=params, request_id=request_id
         )
 
+    def get_manifest(self, request_id=1):
+        return self.request(
+            method='get-manifest', params={}, request_id=request_id
+        )
+
     def is_result(self, data: Dict[str, Any], id=None) -> Dict[str, Any]:
         if id is not None:
             assert data['id'] == id


### PR DESCRIPTION
resolves #2168

### Description
When a user calls `'get-manifest'`, compile all the nodes in the project and return the compiled manifest from memory.

`get-manifest` takes no arguments.
'get-manifest' returns an async ID, just like the existing compile/run/etc. The final result will be an object with `logs` and `manifest` attributes.

See #2169 for the PR about slimming this down.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
