### PR TITLE
slim the manifest

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -126,23 +126,22 @@ NativeSandboxEnvironment.template_class = NativeSandboxTemplate  # type: ignore
 
 
 class TemplateCache:
-
     def __init__(self):
-        self.file_cache = {}
+        self.file_cache: Dict[str, jinja2.Template] = {}
 
-    def get_node_template(self, node):
-        key = (node.package_name, node.original_file_path)
+    def get_node_template(self, node) -> jinja2.Template:
+        key = node.macro_sql
 
         if key in self.file_cache:
             return self.file_cache[key]
 
         template = get_template(
-            string=node.raw_sql,
+            string=node.macro_sql,
             ctx={},
             node=node,
         )
-        self.file_cache[key] = template
 
+        self.file_cache[key] = template
         return template
 
     def clear(self):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -533,7 +533,9 @@ class ProviderContext(ManifestContext):
                 'can only load_agate_table for seeds (got a {})'
                 .format(self.model.resource_type)
             )
-        path = self.model.seed_file_path
+        path = os.path.join(
+            self.model.root_path, self.model.original_file_path
+        )
         column_types = self.model.config.column_types
         try:
             table = agate_helper.from_csv(path, text_columns=column_types)

--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -16,7 +16,7 @@ from dbt.contracts.graph.parsed import (
 )
 from dbt.node_types import NodeType
 from dbt.contracts.util import Replaceable
-from dbt.exceptions import InternalException, RuntimeException
+from dbt.exceptions import RuntimeException
 
 from hologram import JsonSchemaMixin
 from dataclasses import dataclass, field
@@ -95,13 +95,6 @@ class CompiledRPCNode(CompiledNode):
 class CompiledSeedNode(CompiledNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Seed]})
     config: SeedConfig = field(default_factory=SeedConfig)
-    seed_file_path: str = ''
-
-    def __post_init__(self):
-        if self.seed_file_path == '':
-            raise InternalException(
-                'Seeds should always have a seed_file_path'
-            )
 
     @property
     def empty(self):

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -698,7 +698,6 @@ class Manifest:
             disabled=self.disabled,
             child_map=forward_edges,
             parent_map=backward_edges,
-            files=self.files,
         )
 
     @classmethod
@@ -835,5 +834,3 @@ class WritableManifest(JsonSchemaMixin, Writable):
     parent_map: Optional[NodeEdgeMap]
     child_map: Optional[NodeEdgeMap]
     metadata: ManifestMetadata
-    # map of original_file_path to all unique IDs provided by that file
-    files: Mapping[str, SourceFile]

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -20,7 +20,7 @@ from hologram.helpers import (
 from dbt.clients.system import write_file
 import dbt.flags
 from dbt.contracts.graph.unparsed import (
-    UnparsedNode, UnparsedMacro, UnparsedDocumentationFile, Quoting, Docs,
+    UnparsedNode, UnparsedDocumentation, Quoting, Docs,
     UnparsedBaseNode, FreshnessThreshold, ExternalTable,
     AdditionalPropertiesAllowed, HasYamlMetadata, MacroArgument
 )
@@ -274,13 +274,6 @@ class SeedConfig(NodeConfig):
 class ParsedSeedNode(ParsedNode):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Seed]})
     config: SeedConfig = field(default_factory=SeedConfig)
-    seed_file_path: str = ''
-
-    def __post_init__(self):
-        if self.seed_file_path == '':
-            raise dbt.exceptions.InternalException(
-                'Seeds should always have a seed_file_path'
-            )
 
     @property
     def empty(self):
@@ -496,7 +489,7 @@ class ParsedMacroPatch(ParsedPatch):
 
 
 @dataclass
-class ParsedMacro(UnparsedMacro, HasUniqueID):
+class ParsedMacro(UnparsedBaseNode, HasUniqueID):
     name: str
     macro_sql: str
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Macro]})
@@ -523,7 +516,7 @@ class ParsedMacro(UnparsedMacro, HasUniqueID):
 
 
 @dataclass
-class ParsedDocumentation(UnparsedDocumentationFile, HasUniqueID):
+class ParsedDocumentation(UnparsedDocumentation, HasUniqueID):
     name: str
     block_contents: str
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -271,13 +271,17 @@ class UnparsedSourceDefinition(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class UnparsedDocumentationFile(JsonSchemaMixin, Replaceable):
+class UnparsedDocumentation(JsonSchemaMixin, Replaceable):
     package_name: str
     root_path: str
     path: str
     original_file_path: str
-    file_contents: str
 
     @property
     def resource_type(self):
         return NodeType.Documentation
+
+
+@dataclass
+class UnparsedDocumentationFile(UnparsedDocumentation):
+    file_contents: str

--- a/core/dbt/parser/docs.py
+++ b/core/dbt/parser/docs.py
@@ -57,6 +57,7 @@ class DocumentationParser(Parser[ParsedDocumentation]):
                     'block_contents': item().strip(),
                 }
             )
+            merged.pop('file_contents', None)
             yield ParsedDocumentation.from_dict(merged)
 
     def parse_block(self, block: FullBlock) -> Iterable[ParsedDocumentation]:

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -39,7 +39,6 @@ class MacroParser(BaseParser[ParsedMacro]):
             macro_sql=block.full_block,
             original_file_path=base_node.original_file_path,
             package_name=base_node.package_name,
-            raw_sql=base_node.raw_sql,
             root_path=base_node.root_path,
             resource_type=base_node.resource_type,
             name=name,

--- a/core/dbt/parser/seeds.py
+++ b/core/dbt/parser/seeds.py
@@ -30,19 +30,3 @@ class SeedParser(SimpleSQLParser[ParsedSeedNode]):
 
     def load_file(self, match: FilePath) -> SourceFile:
         return SourceFile.seed(match)
-
-    def _create_parsetime_node(
-        self,
-        block: FileBlock,
-        path: str,
-        config: SourceConfig,
-        name=None,
-        **kwargs,
-    ) -> ParsedSeedNode:
-        return super()._create_parsetime_node(
-            block=block,
-            path=path,
-            config=config,
-            name=name,
-            seed_file_path=block.path.full_path,
-        )

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -831,19 +831,17 @@ class TestDocsGenerate(DBTIntegrationTest):
         self.assertEqual(
             set(macro),
             {
-                'path', 'original_file_path', 'package_name', 'raw_sql',
+                'path', 'original_file_path', 'package_name',
                 'root_path', 'name', 'unique_id', 'tags', 'resource_type',
                 'depends_on', 'meta', 'description', 'patch_path', 'arguments',
                 'macro_sql',
             }
         )
         # Don't compare the sql, just make sure it exists
-        self.assertTrue(len(macro['raw_sql']) > 10)
         self.assertTrue(len(macro['macro_sql']) > 10)
-        self.assertIn(macro['macro_sql'], macro['raw_sql'])
         without_sql = {
             k: v for k, v in macro.items()
-            if k not in {'macro_sql', 'raw_sql'}
+            if k not in {'macro_sql'}
         }
         # Windows means we can't hard-code these.
         helpers_path = Normalized('macros/materializations/helpers.sql')
@@ -983,7 +981,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'resource_type': 'seed',
                     'raw_sql': '',
                     'package_name': 'test',
@@ -1233,94 +1230,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'adapter_type': self.adapter_type,
             },
             'disabled': [],
-            'files': {
-                normalize('macros/dummy_test.sql'): {
-                    'path': self._path_to('macros', 'dummy_test.sql'),
-                    'checksum': self._checksum_file('macros/dummy_test.sql'),
-                    'docs': [],
-                    'macros': ['macro.test.test_nothing'],
-                    'nodes': [],
-                    'sources': [],
-                    'patches': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/macro.md'): {
-                    'checksum': self._checksum_file('macros/macro.md'),
-                    'docs': [
-                        'test.macro_info',
-                        'test.macro_arg_info',
-                    ],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'path': self._path_to('macros', 'macro.md'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/schema.yml'): {
-                    'path': self._path_to('macros', 'schema.yml'),
-                    'checksum': self._checksum_file('macros/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [['test', 'test_nothing']],
-                },
-                normalize('models/model.sql'): {
-                    'path': self._path_to('models', 'model.sql'),
-                    'checksum': self._checksum_file('models/model.sql'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['model.test.model'],
-                    'sources': [],
-                    'patches': [],
-                    'macro_patches': [],
-                },
-                normalize('seed/seed.csv'): {
-                    'path': self._path_to('seed', 'seed.csv'),
-                    'checksum': {
-                        'name': 'path',
-                        'checksum': self._absolute_path_to('seed', 'seed.csv'),
-                    },
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['seed.test.seed'],
-                    'sources': [],
-                    'patches': [],
-                    'macro_patches': [],
-                },
-                normalize('models/readme.md'): {
-                    'path': self._path_to('models', 'readme.md'),
-                    'checksum': self._checksum_file('models/readme.md'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'sources': [],
-                    'patches': [],
-                    'macro_patches': [],
-                },
-                normalize('models/schema.yml'): {
-                    'path': self._path_to('models', 'schema.yml'),
-                    'checksum': self._checksum_file('models/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['test.test.unique_model_id', 'test.test.not_null_model_id', 'test.test.test_nothing_model_'],
-                    'sources': [],
-                    'patches': ['model'],
-                    'macro_patches': [],
-                },
-                normalize('seed/schema.yml'): {
-                    'path': self._path_to('seed', 'schema.yml'),
-                    'checksum': self._checksum_file('seed/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'sources': [],
-                    'patches': ['seed'],
-                    'macro_patches': [],
-                },
-            },
         }
 
     def expected_postgres_references_manifest(self, model_database=None):
@@ -1593,7 +1502,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'refs': [],
                     'resource_type': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'tags': [],
@@ -1651,7 +1559,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'dbt.__overview__': ANY,
                 'test.column_info': {
                     'block_contents': 'An ID field',
-                    'file_contents': column_info,
                     'name': 'column_info',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1663,7 +1570,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'block_contents': (
                         'A summmary table of the ephemeral copy of the seed data'
                     ),
-                    'file_contents': ephemeral_summary,
                     'name': 'ephemeral_summary',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1673,7 +1579,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.source_info': {
                     'block_contents': 'My source',
-                    'file_contents': source_info,
                     'name': 'source_info',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1683,7 +1588,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.summary_count': {
                     'block_contents': 'The number of instances of the first name',
-                    'file_contents': summary_count,
                     'name': 'summary_count',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1693,7 +1597,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.summary_first_name': {
                     'block_contents': 'The first name being summarized',
-                    'file_contents': summary_first_name,
                     'name': 'summary_first_name',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1703,7 +1606,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.table_info': {
                     'block_contents': 'My table',
-                    'file_contents': table_info,
                     'name': 'table_info',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1716,7 +1618,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'A view of the summary of the ephemeral copy of the '
                         'seed data'
                     ),
-                    'file_contents': view_summary,
                     'name': 'view_summary',
                     'original_file_path': docs_path,
                     'package_name': 'test',
@@ -1726,7 +1627,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.macro_info': {
                     'block_contents': 'My custom test that I wrote that does nothing',
-                    'file_contents': macro_info,
                     'name': 'macro_info',
                     'original_file_path': self.dir('macros/macro.md'),
                     'package_name': 'test',
@@ -1736,7 +1636,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.macro_arg_info': {
                     'block_contents': 'The model for my custom test',
-                    'file_contents': macro_arg_info,
                     'name': 'macro_arg_info',
                     'original_file_path': self.dir('macros/macro.md'),
                     'package_name': 'test',
@@ -1766,129 +1665,12 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'adapter_type': self.adapter_type,
             },
             'disabled': [],
-            'files': {
-                normalize('macros/dummy_test.sql'): {
-                    'checksum': self._checksum_file('macros/dummy_test.sql'),
-                    'docs': [],
-                    'nodes': [],
-                    'macros': ['macro.test.test_nothing'],
-                    'patches': [],
-                    'path': self._path_to('macros', 'dummy_test.sql'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('ref_models/view_summary.sql'): {
-                    'checksum': self._checksum_file('ref_models/view_summary.sql'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['model.test.view_summary'],
-                    'patches': [],
-                    'path': self._path_to('ref_models', 'view_summary.sql'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('ref_models/ephemeral_summary.sql'): {
-                    'checksum': self._checksum_file('ref_models/ephemeral_summary.sql'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['model.test.ephemeral_summary'],
-                    'patches': [],
-                    'path': self._path_to('ref_models', 'ephemeral_summary.sql'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('ref_models/ephemeral_copy.sql'): {
-                    'checksum': self._checksum_file('ref_models/ephemeral_copy.sql'),
-                    'nodes': ['model.test.ephemeral_copy'],
-                    'docs': [],
-                    'macros': [],
-                    'patches': [],
-                    'path': self._path_to('ref_models', 'ephemeral_copy.sql'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('seed/seed.csv'): {
-                    'checksum': {
-                        'name': 'path',
-                        'checksum': self._absolute_path_to('seed', 'seed.csv'),
-                    },
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['seed.test.seed'],
-                    'patches': [],
-                    'path': self._path_to('seed', 'seed.csv'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('ref_models/docs.md'): {
-                    'checksum': self._checksum_file('ref_models/docs.md'),
-                    'docs': [
-                        'test.ephemeral_summary',
-                        'test.summary_first_name',
-                        'test.summary_count',
-                        'test.view_summary',
-                        'test.source_info',
-                        'test.table_info',
-                        'test.column_info',
-                    ],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'path': self._path_to('ref_models', 'docs.md'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/macro.md'): {
-                    'checksum': self._checksum_file('macros/macro.md'),
-                    'docs': [
-                        'test.macro_info',
-                        'test.macro_arg_info',
-                    ],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'path': self._path_to('macros', 'macro.md'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('ref_models/schema.yml'): {
-                    'checksum': self._checksum_file('ref_models/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': ['ephemeral_summary', 'view_summary'],
-                    'path': self._path_to('ref_models', 'schema.yml'),
-                    'sources': ['source.test.my_source.my_table'],
-                    'macro_patches': [],
-                },
-                normalize('macros/schema.yml'): {
-                    'path': self._path_to('macros', 'schema.yml'),
-                    'checksum': self._checksum_file('macros/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [['test', 'test_nothing']],
-                },
-                normalize('seed/schema.yml'): {
-                    'path': self._path_to('seed', 'schema.yml'),
-                    'checksum': self._checksum_file('seed/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': ['seed'],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-            },
             'macros': {
                 'macro.test.test_nothing': {
                     'name': 'test_nothing',
                     'depends_on': {'macros': []},
                     'description': 'My custom test that I wrote that does nothing',
                     'macro_sql': AnyStringWith('macro test_nothing'),
-                    'raw_sql': AnyStringWith('macro test_nothing'),
                     'original_file_path': self.dir('macros/dummy_test.sql'),
                     'path': self.dir('macros/dummy_test.sql'),
                     'package_name': 'test',
@@ -2204,7 +1986,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': normalize(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'resource_type': 'seed',
                     'raw_sql': '',
                     'package_name': 'test',
@@ -2306,114 +2087,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'adapter_type': self.adapter_type,
             },
             'disabled': [],
-            'files': {
-                normalize('macros/dummy_test.sql'): {
-                    'checksum': self._checksum_file('macros/dummy_test.sql'),
-                    'path': self._path_to('macros', 'dummy_test.sql'),
-                    'macros': ['macro.test.test_nothing'],
-                    'patches': [],
-                    'docs': [],
-                    'nodes': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('bq_models/clustered.sql'): {
-                    'checksum': self._checksum_file('bq_models/clustered.sql'),
-                    'path': self._path_to('bq_models', 'clustered.sql'),
-                    'nodes': ['model.test.clustered'],
-                    'patches': [],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('bq_models/multi_clustered.sql'): {
-                    'checksum': self._checksum_file('bq_models/multi_clustered.sql'),
-                    'path': self._path_to('bq_models', 'multi_clustered.sql'),
-                    'nodes': ['model.test.multi_clustered'],
-                    'patches': [],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('bq_models/nested_table.sql'): {
-                    'checksum': self._checksum_file('bq_models/nested_table.sql'),
-                    'path': self._path_to('bq_models', 'nested_table.sql'),
-                    'nodes': ['model.test.nested_table'],
-                    'patches': [],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('bq_models/nested_view.sql'): {
-                    'checksum': self._checksum_file('bq_models/nested_view.sql'),
-                    'path': self._path_to('bq_models', 'nested_view.sql'),
-                    'nodes': ['model.test.nested_view'],
-                    'patches': [],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('seed/seed.csv'): {
-                    'checksum': {
-                        'name': 'path',
-                        'checksum': self._absolute_path_to('seed', 'seed.csv'),
-                    },
-                    'path': self._path_to('seed', 'seed.csv'),
-                    'nodes': ['seed.test.seed'],
-                    'patches': [],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('bq_models/schema.yml'): {
-                    'checksum': self._checksum_file('bq_models/schema.yml'),
-                    'path': self._path_to('bq_models', 'schema.yml'),
-                    'nodes': [],
-                    'patches': ['nested_view', 'clustered', 'multi_clustered'],
-                    'docs': [],
-                    'macros': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/macro.md'): {
-                    'checksum': self._checksum_file('macros/macro.md'),
-                    'docs': [
-                        'test.macro_info',
-                        'test.macro_arg_info',
-                    ],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'path': self._path_to('macros', 'macro.md'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/schema.yml'): {
-                    'path': self._path_to('macros', 'schema.yml'),
-                    'checksum': self._checksum_file('macros/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [['test', 'test_nothing']],
-                },
-                normalize('seed/schema.yml'): {
-                    'path': self._path_to('seed', 'schema.yml'),
-                    'checksum': self._checksum_file('seed/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': ['seed'],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-            },
         }
 
     def _checksum_file(self, path):
@@ -2534,7 +2207,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'path': 'seed.csv',
                     'name': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'resource_type': 'seed',
                     'raw_sql': '',
                     'package_name': 'test',
@@ -2630,98 +2302,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'adapter_type': self.adapter_type,
             },
             'disabled': [],
-            'files': {
-                normalize('macros/dummy_test.sql'): {
-                    'checksum': self._checksum_file('macros/dummy_test.sql'),
-                    'path': self._path_to('macros', 'dummy_test.sql'),
-                    'docs': [],
-                    'macros': ['macro.test.test_nothing'],
-                    'nodes': [],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/macro.md'): {
-                    'checksum': self._checksum_file('macros/macro.md'),
-                    'docs': [
-                        'test.macro_info',
-                        'test.macro_arg_info',
-                    ],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'path': self._path_to('macros', 'macro.md'),
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('macros/schema.yml'): {
-                    'path': self._path_to('macros', 'schema.yml'),
-                    'checksum': self._checksum_file('macros/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [['test', 'test_nothing']],
-                },
-                normalize('rs_models/model.sql'): {
-                    'checksum': self._checksum_file('rs_models/model.sql'),
-                    'path': self._path_to('rs_models', 'model.sql'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['model.test.model'],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('seed/seed.csv'): {
-                    'checksum': {
-                        'name': 'path',
-                        'checksum': self._absolute_path_to('seed', 'seed.csv'),
-                    },
-                    'path': self._path_to('seed', 'seed.csv'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': ['seed.test.seed'],
-                    'patches': [],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('rs_models/schema.yml'): {
-                    'checksum': self._checksum_file('rs_models/schema.yml'),
-                    'path': self._path_to('rs_models', 'schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': ['model'],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-                normalize('seed/schema.yml'): {
-                    'path': self._path_to('seed', 'schema.yml'),
-                    'checksum': self._checksum_file('seed/schema.yml'),
-                    'docs': [],
-                    'macros': [],
-                    'nodes': [],
-                    'patches': ['seed'],
-                    'sources': [],
-                    'macro_patches': [],
-                },
-            },
         }
-
-    def verify_files(self, got_files, expected_files):
-        # I'm sure this will be fun on windows. We just want to look at this
-        # project's files.
-        my_files = {
-            os.path.relpath(k, self.test_root_dir): v
-            for k, v in got_files.items()
-            if k.startswith(self.test_root_dir)
-        }
-
-        self.assertEqual(set(my_files), set(expected_files))
-        for k in my_files:
-            self.assertEqual(my_files[k], expected_files[k])
 
     def verify_manifest(self, expected_manifest):
         self.assertTrue(os.path.exists('./target/manifest.json'))
@@ -2730,7 +2311,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         manifest_keys = frozenset({
             'nodes', 'macros', 'parent_map', 'child_map', 'generated_at',
-            'docs', 'metadata', 'docs', 'disabled', 'files'
+            'docs', 'metadata', 'docs', 'disabled'
         })
 
         self.assertEqual(frozenset(manifest), manifest_keys)
@@ -2741,8 +2322,6 @@ class TestDocsGenerate(DBTIntegrationTest):
             elif key == 'generated_at':
                 self.assertBetween(manifest['generated_at'],
                                    start=self.generate_start_time)
-            elif key == 'files':
-                self.verify_files(manifest[key], expected_manifest[key])
             else:
                 self.assertIn(key, expected_manifest)  # sanity check
                 self.assertEqual(manifest[key], expected_manifest[key])
@@ -2955,7 +2534,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'refs': [],
                     'resource_type': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'schema': schema,
                     'database': self.default_database,
                     'tags': [],
@@ -3415,7 +2993,6 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'refs': [],
                     'resource_type': 'seed',
                     'root_path': self.test_root_dir,
-                    'seed_file_path': Normalized(os.path.join(self.test_root_dir, 'seed', 'seed.csv')),
                     'schema': my_schema_name,
                     'database': self.default_database,
                     'tags': [],

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -1192,7 +1192,6 @@ class TestParsedMacro(ContractTestCase):
             'path': '/root/path.sql',
             'original_file_path': '/root/path.sql',
             'package_name': 'test',
-            'raw_sql': '{% macro foo() %}select 1 as id{% endmacro %}',
             'macro_sql': '{% macro foo() %}select 1 as id{% endmacro %}',
             'root_path': '/root/',
             'resource_type': 'macro',
@@ -1212,7 +1211,6 @@ class TestParsedMacro(ContractTestCase):
             original_file_path='/root/path.sql',
             package_name='test',
             macro_sql='{% macro foo() %}select 1 as id{% endmacro %}',
-            raw_sql='{% macro foo() %}select 1 as id{% endmacro %}',
             root_path='/root/',
             resource_type=NodeType.Macro,
             unique_id='macro.test.foo',
@@ -1243,7 +1241,6 @@ class TestParsedDocumentation(ContractTestCase):
     def _ok_dict(self):
         return {
             'block_contents': 'some doc contents',
-            'file_contents': '{% doc foo %}some doc contents{% enddoc %}',
             'name': 'foo',
             'original_file_path': '/root/docs/doc.md',
             'package_name': 'test',
@@ -1259,7 +1256,6 @@ class TestParsedDocumentation(ContractTestCase):
             root_path='/root',
             path='/root/docs',
             original_file_path='/root/docs/doc.md',
-            file_contents='{% doc foo %}some doc contents{% enddoc %}',
             name='foo',
             unique_id='test.foo',
             block_contents='some doc contents'

--- a/test/unit/test_docs_blocks.py
+++ b/test/unit/test_docs_blocks.py
@@ -135,16 +135,13 @@ class DocumentationParserTest(unittest.TestCase):
         for result in results:
             self.assertIsInstance(result, ParsedDocumentation)
             self.assertEqual(result.package_name, 'some_package')
-            self.assertNotEqual(result.file_contents, TEST_DOCUMENTATION_FILE)
             self.assertEqual(result.original_file_path, self.testfile_path)
             self.assertEqual(result.root_path, self.subdir_path)
             self.assertEqual(result.resource_type, NodeType.Documentation)
             self.assertEqual(result.path, 'test_file.md')
 
         self.assertEqual(results[0].name, 'snowplow_sessions')
-        self.assertEqual(results[0].file_contents, SNOWPLOW_SESSIONS_BLOCK)
         self.assertEqual(results[1].name, 'snowplow_sessions__session_id')
-        self.assertEqual(results[1].file_contents, SNOWPLOW_SESSIONS_SESSION_ID_BLOCK)
 
     def test_load_file_extras(self):
         TEST_DOCUMENTATION_FILE + '{% model foo %}select 1 as id{% endmodel %}'

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -197,7 +197,6 @@ class ManifestTest(unittest.TestCase):
                 'docs': {},
                 'metadata': {},
                 'disabled': [],
-                'files': {},
             }
         )
 
@@ -211,7 +210,6 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(serialized['generated_at'], '2018-02-14T09:15:13Z')
         self.assertEqual(serialized['docs'], {})
         self.assertEqual(serialized['disabled'], [])
-        self.assertEqual(serialized['files'], {})
         parent_map = serialized['parent_map']
         child_map = serialized['child_map']
         # make sure there aren't any extra/missing keys.
@@ -327,7 +325,6 @@ class ManifestTest(unittest.TestCase):
                     'adapter_type': 'postgres',
                 },
                 'disabled': [],
-                'files': {},
             }
         )
 
@@ -357,7 +354,6 @@ class ManifestTest(unittest.TestCase):
             original_file_path='seed.csv',
             root_path='',
             raw_sql='-- csv --',
-            seed_file_path='data/seed.csv'
         )
         manifest = Manifest(nodes=nodes, macros={}, docs={},
                             generated_at=datetime.utcnow(), disabled=[],
@@ -544,7 +540,6 @@ class MixedManifestTest(unittest.TestCase):
                 'docs': {},
                 'metadata': {},
                 'disabled': [],
-                'files': {},
             }
         )
 

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -53,7 +53,6 @@ class BaseParserTest(unittest.TestCase):
             sql = f'{{% macro {name}(value, node) %}} {{% if value %}} {{{{ value }}}} {{% else %}} {{{{ {source} }}}} {{% endif %}} {{% endmacro %}}'
             name_sql[name] = sql
 
-        all_sql = '\n'.join(name_sql.values())
         for name, sql in name_sql.items():
             pm = ParsedMacro(
                 name=name,
@@ -63,7 +62,6 @@ class BaseParserTest(unittest.TestCase):
                 original_file_path=normalize('macros/macro.sql'),
                 root_path=get_abs_os_path('./dbt_modules/root'),
                 path=normalize('macros/macro.sql'),
-                raw_sql=all_sql,
                 macro_sql=sql,
             )
             yield pm
@@ -626,7 +624,6 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize('macros/macro.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             path=normalize('macros/macro.sql'),
-            raw_sql=raw_sql,
             macro_sql=raw_sql,
         )
         self.assertEqual(macro, expected)
@@ -648,7 +645,6 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize('macros/macro.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             path=normalize('macros/macro.sql'),
-            raw_sql=raw_sql,
             macro_sql='{% macro bar(c, d) %}c + d{% endmacro %}',
         )
         expected_foo = ParsedMacro(
@@ -659,7 +655,6 @@ class MacroParserTest(BaseParserTest):
             original_file_path=normalize('macros/macro.sql'),
             root_path=get_abs_os_path('./dbt_modules/snowplow'),
             path=normalize('macros/macro.sql'),
-            raw_sql=raw_sql,
             macro_sql='{% macro foo(a, b) %}a ~ b{% endmacro %}',
         )
         self.assertEqual(macros, [expected_bar, expected_foo])

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -149,7 +149,6 @@ def generate_name_macros(package):
         sql = f'{{% macro {name}(value, node) %}} {{% if value %}} {{{{ value }}}} {{% else %}} {{{{ {source} }}}} {{% endif %}} {{% endmacro %}}'
         name_sql[name] = sql
 
-    all_sql = '\n'.join(name_sql.values())
     for name, sql in name_sql.items():
         pm = ParsedMacro(
             name=name,
@@ -159,7 +158,6 @@ def generate_name_macros(package):
             original_file_path=normalize('macros/macro.sql'),
             root_path='./dbt_modules/root',
             path=normalize('macros/macro.sql'),
-            raw_sql=all_sql,
             macro_sql=sql,
         )
         yield pm


### PR DESCRIPTION
resolves #2169 

### Description
Reduce the size of the manifest by removing `file_contents` from documentation and `raw_sql` from macros. I also removed `seed_file_path` from seeds.

Finally, I removed `files` from the written file. I don't think anything uses it.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
