### PR TITLE
fix commit messages by using the stack properly (#2073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
 - Added timeout to registry download call ([#2195](https://github.com/fishtown-analytics/dbt/issues/2195), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))
+- When a macro is called with invalid arguments, include the calling model in the output ([#2073](https://github.com/fishtown-analytics/dbt/issues/2073), [#2238](https://github.com/fishtown-analytics/dbt/pull/2238))
 
 Contributors:
  - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -371,6 +371,9 @@ def catch_jinja(node=None) -> Iterator[None]:
         raise CompilationException(str(e), node) from e
     except jinja2.exceptions.UndefinedError as e:
         raise CompilationException(str(e), node) from e
+    except CompilationException as exc:
+        exc.add_node(node)
+        raise
 
 
 def parse(string):

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -53,6 +53,12 @@ class RuntimeException(RuntimeError, Exception):
         self.node = node
         self.msg = msg
 
+    def add_node(self, node=None):
+        if node is not None and node is not self.node:
+            if self.node is not None:
+                self.stack.append(self.node)
+            self.node = node
+
     @property
     def type(self):
         return 'Runtime'
@@ -849,8 +855,7 @@ def wrapper(model):
             try:
                 return func(*args, **kwargs)
             except RuntimeException as exc:
-                if exc.node is None:
-                    exc.node = model
+                exc.add_node(model)
                 raise exc
         return inner
     return wrap

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -172,7 +172,7 @@ class BaseRunner(metaclass=abc.ABCMeta):
 
     def _handle_catchable_exception(self, e, ctx):
         if e.node is None:
-            e.node = ctx.node
+            e.add_node(ctx.node)
 
         logger.debug(str(e), exc_info=True)
         return str(e)

--- a/core/dbt/parser/docs.py
+++ b/core/dbt/parser/docs.py
@@ -71,7 +71,7 @@ class DocumentationParser(Parser[ParsedDocumentation]):
         try:
             template = get_template(block.contents, {})
         except CompilationException as e:
-            e.node = base_node
+            e.add_node(base_node)
             raise
         all_docs = list(self._parse_template_docs(template, base_node))
         if len(all_docs) != 1:

--- a/core/dbt/parser/macros.py
+++ b/core/dbt/parser/macros.py
@@ -63,7 +63,7 @@ class MacroParser(BaseParser[ParsedMacro]):
             try:
                 ast = jinja.parse(block.full_block)
             except CompilationException as e:
-                e.node = base_node
+                e.add_node(base_node)
                 raise e
 
             macro_nodes = list(ast.find_all(jinja2.nodes.Macro))

--- a/core/dbt/parser/search.py
+++ b/core/dbt/parser/search.py
@@ -116,7 +116,7 @@ class BlockSearcher(Generic[BlockSearchResult], Iterable[BlockSearchResult]):
 
         except CompilationException as exc:
             if exc.node is None:
-                exc.node = source_file
+                exc.add_node(source_file)
             raise
 
     def __iter__(self) -> Iterator[BlockSearchResult]:

--- a/core/dbt/rpc/node_runners.py
+++ b/core/dbt/rpc/node_runners.py
@@ -24,7 +24,7 @@ class GenericRPCRunner(CompileRunner, Generic[RPCSQLResult]):
         logger.debug('Got an exception: {}'.format(e), exc_info=True)
         if isinstance(e, dbt.exceptions.Exception):
             if isinstance(e, dbt.exceptions.RuntimeException):
-                e.node = ctx.node
+                e.add_node(ctx.node)
             return dbt_error(e)
         elif isinstance(e, RPCException):
             return e

--- a/test/integration/011_invalid_model_tests/bad-macros/macros.sql
+++ b/test/integration/011_invalid_model_tests/bad-macros/macros.sql
@@ -1,0 +1,3 @@
+{% macro some_macro(arg) %}
+	{{ arg }}
+{% endmacro %}

--- a/test/integration/011_invalid_model_tests/models-4/bad_macro.sql
+++ b/test/integration/011_invalid_model_tests/models-4/bad_macro.sql
@@ -1,0 +1,2 @@
+{{ some_macro(invalid='test') }}
+select 1 as id


### PR DESCRIPTION
resolves #2073

### Description
Actually use the `stack` attribute on caught exceptions, change some `.node` settings to use the stack.

The output of a model (`x`) that calls a macro (`hello`) with an invalid argument looks like this:

```
$ dbt compile
Running with dbt=0.17.0-a1
Encountered an error:
Compilation Error in model x (models/x.sql)
  macro 'dbt_macro__hello' takes no keyword argument 'invalid'

  > in macro hello (macros/hello.sql)
  > called by model x (models/x.sql)
```

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
