### PR TITLE
set the circleci config version to 2.1 (#2207)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   unit:
     docker: &test_only


### PR DESCRIPTION
resolves #2207 

### Description
Since this branch passes tests, I understand that to mean that "enable pipelines" is a safe setting in circleci's repository settings page. Upon merge, I'll also set that value.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~ - N/A, CI-only change
