### PR TITLE
Add documentation for contexts and manifests, plus extraction scripts (#2202)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
             $PYTHON_BIN -m pip install -r requirements.txt
             $PYTHON_BIN -m pip install -r dev_requirements.txt
             /bin/bash ./scripts/build-wheels.sh
+            $PYTHON_BIN ./scripts/collect-dbt-contexts.py > ./dist/context_metadata.json
+            $PYTHON_BIN ./scripts/collect-artifact-schema.py > ./dist/artifact_schemas.json
           environment:
             PYTHON_ENV: /home/tox/build_venv/
       - store_artifacts:

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -170,15 +170,101 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextproperty
     def dbt_version(self) -> str:
+        """The `dbt_version` variable returns the installed version of dbt that
+        is currently running. It can be used for debugging or auditing
+        purposes.
+
+        > macros/get_version.sql
+
+            {% macro get_version() %}
+              {% set msg = "The installed version of dbt is: " ~ dbt_version %}
+              {% do log(msg, info=true) %}
+            {% endmacro %}
+
+        Example output:
+
+            $ dbt run-operation get_version
+            The installed version of dbt is 0.16.0
+        """
         return dbt_version
 
     @contextproperty
     def var(self) -> Var:
+        """Variables can be passed from your `dbt_project.yml` file into models
+        during compilation. These variables are useful for configuring packages
+        for deployment in multiple environments, or defining values that should
+        be used across multiple models within a package.
+
+        To add a variable to a model, use the `var()` function:
+
+        > my_model.sql:
+
+            select * from events where event_type = '{{ var("event_type") }}'
+
+        If you try to run this model without supplying an `event_type`
+        variable, you'll receive a compilation error that looks like this:
+
+            Encountered an error:
+            ! Compilation error while compiling model package_name.my_model:
+            ! Required var 'event_type' not found in config:
+            Vars supplied to package_name.my_model = {
+            }
+
+        To supply a variable to a given model, add one or more `vars`
+        dictionaries to the `models` config in your `dbt_project.yml` file.
+        These `vars` are in-scope for all models at or below where they are
+        defined, so place them where they make the most sense. Below are three
+        different placements of the `vars` dict, all of which will make the
+        `my_model` model compile.
+
+        > dbt_project.yml:
+
+            # 1) scoped at the model level
+            models:
+              package_name:
+                my_model:
+                  materialized: view
+                  vars:
+                    event_type: activation
+            # 2) scoped at the package level
+            models:
+              package_name:
+                vars:
+                  event_type: activation
+                my_model:
+                  materialized: view
+            # 3) scoped globally
+            models:
+              vars:
+                event_type: activation
+              package_name:
+                my_model:
+                  materialized: view
+
+        ## Variable default values
+
+        The `var()` function takes an optional second argument, `default`. If
+        this argument is provided, then it will be the default value for the
+        variable if one is not explicitly defined.
+
+        > my_model.sql:
+
+            -- Use 'activation' as the event_type if the variable is not
+            -- defined.
+            select *
+            from events
+            where event_type = '{{ var("event_type", "activation") }}'
+        """
         return Var(None, self._ctx, self.cli_vars)
 
     @contextmember
     @staticmethod
     def env_var(var: str, default: Optional[str] = None) -> str:
+        """The env_var() function. Return the environment variable named 'var'.
+        If there is no such environment variable set, return the default.
+
+        If the default is None, raise an exception for an undefined variable.
+        """
         if var in os.environ:
             return os.environ[var]
         elif default is not None:
@@ -191,6 +277,7 @@ class BaseContext(metaclass=ContextMeta):
         @contextmember
         @staticmethod
         def debug():
+            """Enter a debugger at this line in the compiled jinja code."""
             import sys
             import ipdb  # type: ignore
             frame = sys._getframe(3)
@@ -199,12 +286,48 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextmember('return')
     @staticmethod
-    def _return(value: Any) -> NoReturn:
-        raise MacroReturn(value)
+    def _return(data: Any) -> NoReturn:
+        """The `return` function can be used in macros to return data to the
+        caller. The type of the data (`dict`, `list`, `int`, etc) will be
+        preserved through the return call.
+
+        :param data: The data to return to the caller
+
+
+        > macros/example.sql:
+
+            {% macro get_data() %}
+              {{ return([1,2,3]) }}
+            {% endmacro %}
+
+        > models/my_model.sql:
+
+            select
+              -- getdata() returns a list!
+              {% for i in getdata() %}
+                {{ i }}
+                {% if not loop.last %},{% endif %}
+              {% endfor %}
+
+        """
+        raise MacroReturn(data)
 
     @contextmember
     @staticmethod
     def fromjson(string: str, default: Any = None) -> Any:
+        """The `fromjson` context method can be used to deserialize a json
+        string into a Python object primitive, eg. a `dict` or `list`.
+
+        :param value: The json string to deserialize
+        :param default: A default value to return if the `string` argument
+            cannot be deserialized (optional)
+
+        Usage:
+
+            {% set my_json_str = '{"abc": 123}' %}
+            {% set my_dict = fromjson(my_json_str) %}
+            {% do log(my_dict['abc']) %}
+        """
         try:
             return json.loads(string)
         except ValueError:
@@ -215,6 +338,21 @@ class BaseContext(metaclass=ContextMeta):
     def tojson(
         value: Any, default: Any = None, sort_keys: bool = False
     ) -> Any:
+        """The `tojson` context method can be used to serialize a Python
+        object primitive, eg. a `dict` or `list` to a json string.
+
+        :param value: The value serialize to json
+        :param default: A default value to return if the `value` argument
+            cannot be serialized
+        :param sort_keys: If True, sort the keys.
+
+
+        Usage:
+
+            {% set my_dict = {"abc": 123} %}
+            {% set my_json_string = tojson(my_dict) %}
+            {% do log(my_json_string) %}
+        """
         try:
             return json.dumps(value, sort_keys=sort_keys)
         except ValueError:
@@ -223,6 +361,27 @@ class BaseContext(metaclass=ContextMeta):
     @contextmember
     @staticmethod
     def fromyaml(value: str, default: Any = None) -> Any:
+        """The fromyaml context method can be used to deserialize a yaml string
+        into a Python object primitive, eg. a `dict` or `list`.
+
+        :param value: The yaml string to deserialize
+        :param default: A default value to return if the `string` argument
+            cannot be deserialized (optional)
+
+        Usage:
+
+            {% set my_yml_str -%}
+            dogs:
+             - good
+             - bad
+            {%- endset %}
+            {% set my_dict = fromyaml(my_yml_str) %}
+            {% do log(my_dict['dogs'], info=true) %}
+            -- ["good", "bad"]
+            {% do my_dict['dogs'].pop() }
+            {% do log(my_dict['dogs'], info=true) %}
+            -- ["good"]
+        """
         try:
             return yaml.safe_load(value)
         except (AttributeError, ValueError, yaml.YAMLError):
@@ -235,6 +394,21 @@ class BaseContext(metaclass=ContextMeta):
     def toyaml(
         value: Any, default: Optional[str] = None, sort_keys: bool = False
     ) -> Optional[str]:
+        """The `tojson` context method can be used to serialize a Python
+        object primitive, eg. a `dict` or `list` to a yaml string.
+
+        :param value: The value serialize to yaml
+        :param default: A default value to return if the `value` argument
+            cannot be serialized
+        :param sort_keys: If True, sort the keys.
+
+
+        Usage:
+
+            {% set my_dict = {"abc": 123} %}
+            {% set my_yaml_string = toyaml(my_dict) %}
+            {% do log(my_yaml_string) %}
+        """
         try:
             return yaml.safe_dump(data=value, sort_keys=sort_keys)
         except (ValueError, yaml.YAMLError):
@@ -243,6 +417,18 @@ class BaseContext(metaclass=ContextMeta):
     @contextmember
     @staticmethod
     def log(msg: str, info: bool = False) -> str:
+        """Logs a line to either the log file or stdout.
+
+        :param msg: The message to log
+        :param info: If `False`, write to the log file. If `True`, write to
+            both the log file and stdout.
+
+        > macros/my_log_macro.sql
+
+            {% macro some_macro(arg1, arg2) %}
+              {{ log("Running some_macro: " ~ arg1 ~ ", " ~ arg2) }}
+            {% endmacro %}"
+        """
         if info:
             logger.info(msg)
         else:
@@ -251,6 +437,27 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextproperty
     def run_started_at(self) -> Optional[datetime.datetime]:
+        """`run_started_at` outputs the timestamp that this run started, e.g.
+        `2017-04-21 01:23:45.678`. The `run_started_at` variable is a Python
+        `datetime` object. As of 0.9.1, the timezone of this variable defaults
+        to UTC.
+
+        > run_started_at_example.sql
+
+            select
+                '{{ run_started_at.strftime("%Y-%m-%d") }}' as date_day
+            from ...
+
+
+        To modify the timezone of this variable, use the the `pytz` module:
+
+        > run_started_at_utc.sql
+
+            {% set est = modules.pytz.timezone("America/New_York") %}
+            select
+                '{{ run_started_at.astimezone(est) }}' as run_started_est
+            from ...
+        """
         if tracking.active_user is not None:
             return tracking.active_user.run_started_at
         else:
@@ -258,6 +465,9 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextproperty
     def invocation_id(self) -> Optional[str]:
+        """invocation_id outputs a UUID generated for this dbt run (useful for
+        auditing)
+        """
         if tracking.active_user is not None:
             return tracking.active_user.invocation_id
         else:
@@ -265,10 +475,51 @@ class BaseContext(metaclass=ContextMeta):
 
     @contextproperty
     def modules(self) -> Dict[str, Any]:
+        """The `modules` variable in the Jinja context contains useful Python
+        modules for operating on data.
+
+        # datetime
+
+        This variable is a pointer to the Python datetime module.
+
+        Usage:
+
+            {% set dt = modules.datetime.datetime.now() %}
+
+        # pytz
+
+        This variable is a pointer to the Python pytz module.
+
+        Usage:
+
+            {% set dt = modules.datetime.datetime(2002, 10, 27, 6, 0, 0) %}
+            {% set dt_local = modules.pytz.timezone('US/Eastern').localize(dt) %}
+            {{ dt_local }}
+        """  # noqa
         return get_context_modules()
 
     @contextproperty
     def flags(self) -> Any:
+        """The `flags` variable contains true/false values for flags provided
+        on the command line.
+
+        > flags.sql:
+
+            {% if flags.FULL_REFRESH %}
+            drop table ...
+            {% else %}
+            -- no-op
+            {% endif %}
+
+        The list of valid flags are:
+
+        - `flags.STRICT_MODE`: True if `--strict` (or `-S`) was provided on the
+            command line
+        - `flags.FULL_REFRESH`: True if `--full-refresh` was provided on the
+            command line
+        - `flags.NON_DESTRUCTIVE`: True if `--non-destructive` was provided on
+            the command line
+        """
         return flags
 
 

--- a/core/dbt/context/docs.py
+++ b/core/dbt/context/docs.py
@@ -48,6 +48,25 @@ class DocsRuntimeContext(ConfiguredContext):
 
     @contextmember
     def doc(self, *args: str) -> str:
+        """The `doc` function is used to reference docs blocks in schema.yml
+        files. It is analogous to the `ref` function. For more information,
+        consult the Documentation guide.
+
+        > orders.md:
+
+            {% docs orders %}
+            # docs
+            - go
+            - here
+            {% enddocs %}
+
+        > schema.yml
+
+            version: 2
+                models:
+                  - name: orders
+                    description: "{{ doc('orders') }}"
+        """
         # when you call doc(), this is what happens at runtime
         if len(args) == 1:
             doc_package_name = None

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -546,6 +546,43 @@ class ProviderContext(ManifestContext):
 
     @contextproperty
     def ref(self) -> Callable:
+        """The most important function in dbt is `ref()`; it's impossible to
+        build even moderately complex models without it. `ref()` is how you
+        reference one model within another. This is a very common behavior, as
+        typically models are built to be "stacked" on top of one another. Here
+        is how this looks in practice:
+
+        > model_a.sql:
+
+            select *
+            from public.raw_data
+
+        > model_b.sql:
+
+            select *
+            from {{ref('model_a')}}
+
+
+        `ref()` is, under the hood, actually doing two important things. First,
+        it is interpolating the schema into your model file to allow you to
+        change your deployment schema via configuration. Second, it is using
+        these references between models to automatically build the dependency
+        graph. This will enable dbt to deploy models in the correct order when
+        using dbt run.
+
+        The `ref` function returns a Relation object.
+
+        ## Advanced ref usage
+
+        There is also a two-argument variant of the `ref` function. With this
+        variant, you can pass both a package name and model name to `ref` to
+        avoid ambiguity. This functionality is not commonly required for
+        typical dbt usage.
+
+        > model.sql:
+
+            select * from {{ ref('package_name', 'model_name') }}"
+        """
         return self.provider.ref(
             self.db_wrapper, self.model, self.config, self.manifest
         )
@@ -558,14 +595,158 @@ class ProviderContext(ManifestContext):
 
     @contextproperty('config')
     def ctx_config(self) -> Config:
+        """The `config` variable exists to handle end-user configuration for
+        custom materializations. Configs like `unique_key` can be implemented
+        using the `config` variable in your own materializations.
+
+        For example, code in the `incremental` materialization like this:
+
+            {% materialization incremental, default -%}
+            {%- set unique_key = config.get('unique_key') -%}
+            ...
+
+        is responsible for handling model code that looks like this:
+
+            {{
+              config(
+                materialized='incremental',
+                unique_key='id'
+              )
+            }}
+
+
+        ## config.get
+
+        name: The name of the configuration variable (required)
+        default: The default value to use if this configuration is not provided
+            (optional)
+
+        The `config.get` function is used to get configurations for a model
+        from the end-user. Configs defined in this way are optional, and a
+        default value can be provided.
+
+        Example usage:
+
+            {% materialization incremental, default -%}
+              -- Example w/ no default. unique_key will be None if the user does not provide this configuration
+              {%- set unique_key = config.get('unique_key') -%}
+              -- Example w/ default value. Default to 'id' if 'unique_key' not provided
+              {%- set unique_key = config.get('unique_key', default='id') -%}
+              ...
+
+        ## config.require
+
+        name: The name of the configuration variable (required)
+
+        The `config.require` function is used to get configurations for a model
+        from the end-user. Configs defined using this function are required,
+        and failure to provide them will result in a compilation error.
+
+        Example usage:
+
+            {% materialization incremental, default -%}
+              {%- set unique_key = config.require('unique_key') -%}
+              ...
+        """  # noqa
         return self.provider.Config(self.model, self.source_config)
 
     @contextproperty
     def execute(self) -> bool:
+        """`execute` is a Jinja variable that returns True when dbt is in
+        "execute" mode.
+
+        When you execute a dbt compile or dbt run command, dbt:
+
+        - Reads all of the files in your project and generates a "manifest"
+            comprised of models, tests, and other graph nodes present in your
+            project. During this phase, dbt uses the `ref` statements it finds
+            to generate the DAG for your project. *No SQL is run during this
+            phase*, and `execute == False`.
+        - Compiles (and runs) each node (eg. building models, or running
+            tests). SQL is run during this phase, and `execute == True`.
+
+        Any Jinja that relies on a result being returned from the database will
+        error during the parse phase. For example, this SQL will return an
+        error:
+
+        > models/order_payment_methods.sql:
+
+            {% set payment_method_query %}
+            select distinct
+            payment_method
+            from {{ ref('raw_payments') }}
+            order by 1
+            {% endset %}
+            {% set results = run_query(relation_query) %}
+            {# Return the first column #}
+            {% set payment_methods = results.columns[0].values() %}
+
+        The error returned by dbt will look as follows:
+
+            Encountered an error:
+                Compilation Error in model order_payment_methods (models/order_payment_methods.sql)
+            'None' has no attribute 'table'
+
+        This is because Line #11 assumes that a table has been returned, when,
+        during the parse phase, this query hasn't been run.
+
+        To work around this, wrap any problematic Jinja in an
+        `{% if execute %}` statement:
+
+        > models/order_payment_methods.sql:
+
+            {% set payment_method_query %}
+            select distinct
+            payment_method
+            from {{ ref('raw_payments') }}
+            order by 1
+            {% endset %}
+            {% set results = run_query(relation_query) %}
+            {% if execute %}
+            {# Return the first column #}
+            {% set payment_methods = results.columns[0].values() %}
+            {% else %}
+            {% set payment_methods = [] %}
+            {% endif %}
+        """  # noqa
         return self.provider.execute
 
     @contextproperty
     def exceptions(self) -> Dict[str, Any]:
+        """The exceptions namespace can be used to raise warnings and errors in
+        dbt userspace.
+
+
+        ## raise_compiler_error
+
+        The `exceptions.raise_compiler_error` method will raise a compiler
+        error with the provided message. This is typically only useful in
+        macros or materializations when invalid arguments are provided by the
+        calling model. Note that throwing an exception will cause a model to
+        fail, so please use this variable with care!
+
+        Example usage:
+
+        > exceptions.sql:
+
+            {% if number < 0 or number > 100 %}
+              {{ exceptions.raise_compiler_error("Invalid `number`. Got: " ~ number) }}
+            {% endif %}
+
+        ## warn
+
+        The `exceptions.warn` method will raise a compiler warning with the
+        provided message. If the `--warn-error` flag is provided to dbt, then
+        this warning will be elevated to an exception, which is raised.
+
+        Example usage:
+
+        > warn.sql:
+
+            {% if number < 0 or number > 100 %}
+              {% do exceptions.warn("Invalid `number`. Got: " ~ number) %}
+            {% endif %}
+        """  # noqa
         return wrapped_exports(self.model)
 
     @contextproperty
@@ -584,6 +765,11 @@ class ProviderContext(ManifestContext):
 
     @contextproperty('adapter')
     def ctx_adapter(self) -> BaseDatabaseWrapper:
+        """`adapter` is a wrapper around the internal database adapter used by
+        dbt. It allows users to make calls to the database in their dbt models.
+        The adapter methods will be translated into specific SQL statements
+        depending on the type of adapter your project is using.
+        """
         return self.db_wrapper
 
     @contextproperty
@@ -603,6 +789,110 @@ class ProviderContext(ManifestContext):
 
     @contextproperty
     def graph(self) -> Dict[str, Any]:
+        """The `graph` context variable contains information about the nodes in
+        your dbt project. Models, sources, tests, and snapshots are all
+        examples of nodes in dbt projects.
+
+        ## The graph context variable
+
+        The graph context variable is a dictionary which maps node ids onto dictionary representations of those nodes. A simplified example might look like:
+
+            {
+              "model.project_name.model_name": {
+                "config": {"materialzed": "table", "sort": "id"},
+                "tags": ["abc", "123"],
+                "path": "models/path/to/model_name.sql",
+                ...
+              },
+              "source.project_name.source_name": {
+                "path": "models/path/to/schema.yml",
+                "columns": {
+                  "id": { .... },
+                  "first_name": { .... },
+                },
+                ...
+              }
+            }
+
+        The exact contract for these model and source nodes is not currently
+        documented, but that will change in the future.
+
+        ## Accessing models
+
+        The `model` entries in the `graph` dictionary will be incomplete or
+        incorrect during parsing. If accessing the models in your project via
+        the `graph` variable, be sure to use the `execute` flag to ensure that
+        this code only executes at run-time and not at parse-time. Do not use
+        the `graph` variable to build you DAG, as the resulting dbt behavior
+        will be undefined and likely incorrect.
+
+        Example usage:
+
+        > graph-usage.sql:
+
+            /*
+              Print information about all of the models in the Snowplow package
+            */
+            {% if execute %}
+              {% for node in graph.nodes.values()
+                 | selectattr("resource_type", "equalto", "model")
+                 | selectattr("package_name", "equalto", "snowplow") %}
+
+                {% do log(node.unique_id ~ ", materialized: " ~ node.config.materialized, info=true) %}
+
+              {% endfor %}
+            {% endif %}
+            /*
+              Example output
+            ---------------------------------------------------------------
+            model.snowplow.snowplow_id_map, materialized: incremental
+            model.snowplow.snowplow_page_views, materialized: incremental
+            model.snowplow.snowplow_web_events, materialized: incremental
+            model.snowplow.snowplow_web_page_context, materialized: table
+            model.snowplow.snowplow_web_events_scroll_depth, materialized: incremental
+            model.snowplow.snowplow_web_events_time, materialized: incremental
+            model.snowplow.snowplow_web_events_internal_fixed, materialized: ephemeral
+            model.snowplow.snowplow_base_web_page_context, materialized: ephemeral
+            model.snowplow.snowplow_base_events, materialized: ephemeral
+            model.snowplow.snowplow_sessions_tmp, materialized: incremental
+            model.snowplow.snowplow_sessions, materialized: table
+            */
+
+        ## Accessing sources
+
+        To access the sources in your dbt project programatically, filter for
+        nodes where the `resource_type == 'source'`.
+
+        Example usage:
+
+        > models/events_unioned.sql
+
+            /*
+              Union all of the Snowplow sources defined in the project
+              which begin with the string "event_"
+            */
+            {% set sources = [] -%}
+            {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "source") -%}
+              {%- if node.name.startswith('event_') and node.source_name == 'snowplow' -%}
+                {%- do sources.append(source(node.source_name, node.name)) -%}
+              {%- endif -%}
+            {%- endfor %}
+            select * from (
+              {%- for source in sources %}
+                {{ source }} {% if not loop.last %} union all {% endif %}
+              {% endfor %}
+            )
+            /*
+              Example compiled SQL
+            ---------------------------------------------------------------
+            select * from (
+              select * from raw.snowplow.event_add_to_cart union all
+              select * from raw.snowplow.event_remove_from_cart union all
+              select * from raw.snowplow.event_checkout
+            )
+            */
+
+        """  # noqa
         return self.manifest.flat_graph
 
     @contextproperty('model')
@@ -688,6 +978,35 @@ class ModelContext(ProviderContext):
 
     @contextproperty
     def this(self) -> Optional[RelationProxy]:
+        """`this` makes available schema information about the currently
+        executing model. It's is useful in any context in which you need to
+        write code that references the current model, for example when defining
+        a `sql_where` clause for an incremental model and for writing pre- and
+        post-model hooks that operate on the model in some way. Developers have
+        options for how to use `this`:
+
+            |------------------|------------------|
+            | dbt Model Syntax | Output           |
+            |------------------|------------------|
+            |     {{this}}     | "schema"."table" |
+            |------------------|------------------|
+            |  {{this.schema}} | schema           |
+            |------------------|------------------|
+            |  {{this.table}}  | table            |
+            |------------------|------------------|
+            |  {{this.name}}   | table            |
+            |------------------|------------------|
+
+        Here's an example of how to use `this` in `dbt_project.yml` to grant
+        select rights on a table to a different db user.
+
+        > example.yml:
+
+            models:
+              project-name:
+                post-hook:
+                  - "grant select on {{ this }} to db_reader"
+        """
         if self.model.resource_type == NodeType.Operation:
             return None
         return self.db_wrapper.Relation.create_from(self.config, self.model)

--- a/core/dbt/context/target.py
+++ b/core/dbt/context/target.py
@@ -14,6 +14,66 @@ class TargetContext(BaseContext):
 
     @contextproperty
     def target(self) -> Dict[str, Any]:
+        """`target` contains information about your connection to the warehouse
+        (specified in profiles.yml). Some configs are shared between all
+        adapters, while others are adapter-specific.
+
+        Common:
+
+            |----------|-----------|------------------------------------------|
+            | Variable |  Example  |                Description               |
+            |----------|-----------|------------------------------------------|
+            |   name   |    dev    | Name of the active target                |
+            |----------|-----------|------------------------------------------|
+            |  schema  | dbt_alice | Name of the dbt schema (or, dataset on   |
+            |          |           | BigQuery)                                |
+            |----------|-----------|------------------------------------------|
+            |   type   |  postgres | The active adapter being used.           |
+            |----------|-----------|------------------------------------------|
+            | threads  |    4      | The number of threads in use by dbt      |
+            |----------|-----------|------------------------------------------|
+
+        Snowflake:
+
+            |----------|-----------|------------------------------------------|
+            | Variable |  Example  |                Description               |
+            |----------|-----------|------------------------------------------|
+            | database |    RAW    | The active target's database.            |
+            |----------|-----------|------------------------------------------|
+            | warehouse| TRANSFORM | The active target's warehouse.           |
+            |----------|-----------|------------------------------------------|
+            |   user   |  USERNAME | The active target's user                 |
+            |----------|-----------|------------------------------------------|
+            | role     |  ROLENAME | The active target's role                 |
+            |----------|-----------|------------------------------------------|
+            | account  |  abc123   | The active target's account              |
+            |----------|-----------|------------------------------------------|
+
+        Postgres/Redshift:
+
+            |----------|-------------------|----------------------------------|
+            | Variable |  Example          |        Description               |
+            |----------|-------------------|----------------------------------|
+            |  dbname  | analytics         | The active target's database.    |
+            |----------|-------------------|----------------------------------|
+            |  host    | abc123.us-west-2. | The active target's host.        |
+            |          | redshift.amazonaws|                                  |
+            |          |  .com             |                                  |
+            |----------|-------------------|----------------------------------|
+            |   user   |  dbt_user         |  The active target's user        |
+            |----------|-------------------|----------------------------------|
+            |   port   |    5439           | The active target's port         |
+            |----------|-------------------|----------------------------------|
+
+        BigQuery:
+
+            |----------|-----------|------------------------------------------|
+            | Variable |  Example  |                Description               |
+            |----------|-----------|------------------------------------------|
+            | project  |  abc-123  | The active target's project.             |
+            |----------|-----------|------------------------------------------|
+
+        """
         target = dict(
             self.config.credentials.connection_info(with_aliases=True)
         )

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -182,10 +182,29 @@ class SourceFile(JsonSchemaMixin):
 
 @dataclass
 class ManifestMetadata(JsonSchemaMixin, Replaceable):
-    project_id: Optional[str] = None
-    user_id: Optional[UUID] = None
-    send_anonymous_usage_stats: Optional[bool] = None
-    adapter_type: Optional[str] = None
+    """Metadata for the manifest."""
+    project_id: Optional[str] = field(
+        default=None,
+        metadata={
+            'description': 'A unique identifier for the project',
+        },
+    )
+    user_id: Optional[UUID] = field(
+        default=None,
+        metadata={
+            'description': 'A unique identifier for the user',
+        },
+    )
+    send_anonymous_usage_stats: Optional[bool] = field(
+        default=None,
+        metadata=dict(description=(
+            'Whether dbt is configured to send anonymous usage statistics'
+        )),
+    )
+    adapter_type: Optional[str] = field(
+        default=None,
+        metadata=dict(description='The type name of the adapter'),
+    )
 
     def __post_init__(self):
         if tracking.active_user is None:
@@ -826,11 +845,33 @@ class Manifest:
 
 @dataclass
 class WritableManifest(JsonSchemaMixin, Writable):
-    nodes: Mapping[str, CompileResultNode]
-    macros: Mapping[str, ParsedMacro]
-    docs: Mapping[str, ParsedDocumentation]
-    disabled: Optional[List[ParsedNode]]
-    generated_at: datetime
-    parent_map: Optional[NodeEdgeMap]
-    child_map: Optional[NodeEdgeMap]
-    metadata: ManifestMetadata
+    nodes: Mapping[str, CompileResultNode] = field(
+        metadata=dict(description=(
+            'The nodes defined in the dbt project and its dependencies'
+        )),
+    )
+    macros: Mapping[str, ParsedMacro] = field(
+        metadata=dict(description=(
+            'The macros defined in the dbt project and its dependencies'
+        ))
+    )
+    docs: Mapping[str, ParsedDocumentation] = field(
+        metadata=dict(description=(
+            'The docs defined in the dbt project and its dependencies'
+        ))
+    )
+    disabled: Optional[List[ParsedNode]] = field(metadata=dict(
+        description='A list of the disabled nodes in the target'
+    ))
+    generated_at: datetime = field(metadata=dict(
+        description='The time at which the manifest was generated',
+    ))
+    parent_map: Optional[NodeEdgeMap] = field(metadata=dict(
+        description='A mapping from child nodes to their dependencies',
+    ))
+    child_map: Optional[NodeEdgeMap] = field(metadata=dict(
+        description='A mapping from parent nodes to their dependents',
+    ))
+    metadata: ManifestMetadata = field(metadata=dict(
+        description='Metadata about the manifest',
+    ))

--- a/scripts/collect-artifact-schema.py
+++ b/scripts/collect-artifact-schema.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from dataclasses import dataclass
+from typing import Dict, Any
+import json
+
+from hologram import JsonSchemaMixin
+from dbt.contracts.graph.manifest import WritableManifest
+from dbt.contracts.results import (
+    CatalogResults, ExecutionResult, FreshnessExecutionResult
+)
+
+
+@dataclass
+class Schemas(JsonSchemaMixin):
+    manifest: Dict[str, Any]
+    catalog: Dict[str, Any]
+    run_results: Dict[str, Any]
+    freshness_results: Dict[str, Any]
+
+
+def main():
+    schemas = Schemas(
+        manifest=WritableManifest.json_schema(),
+        catalog=CatalogResults.json_schema(),
+        run_results=ExecutionResult.json_schema(),
+        freshness_results=FreshnessExecutionResult.json_schema(),
+    )
+    print(json.dumps(schemas.to_dict()))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/collect-dbt-contexts.py
+++ b/scripts/collect-dbt-contexts.py
@@ -1,0 +1,120 @@
+7#!/usr/bin/env python
+
+import inspect
+import json
+from dataclasses import dataclass
+from typing import List, Optional, Iterable, Union, Dict, Any
+from hologram import JsonSchemaMixin
+
+
+from dbt.context.base import BaseContext
+from dbt.context.target import TargetContext
+from dbt.context.providers import ModelContext, MacroContext
+
+
+CONTEXTS_MAP = {
+    'base': BaseContext,
+    'target': TargetContext,
+    'model': ModelContext,
+    'macro': MacroContext,
+}
+
+
+@dataclass
+class ContextValue(JsonSchemaMixin):
+    name: str
+    value: str  # a type description
+    doc: Optional[str]
+
+
+@dataclass
+class MethodArgument(JsonSchemaMixin):
+    name: str
+    value: str  # a type description
+
+
+@dataclass
+class ContextMethod(JsonSchemaMixin):
+    name: str
+    args: List[MethodArgument]
+    result: str  # a type description
+    doc: Optional[str]
+
+
+@dataclass
+class Unknown(JsonSchemaMixin):
+    name: str
+    value: str
+    doc: Optional[str]
+
+
+ContextMember = Union[ContextValue, ContextMethod, Unknown]
+
+
+def _get_args(func: inspect.Signature) -> Iterable[MethodArgument]:
+    found_first = False
+    for argname, arg in func.parameters.items():
+        if found_first is False and argname in {'self', 'cls'}:
+            continue
+        if found_first is False:
+            found_first = True
+
+        yield MethodArgument(
+            name=argname,
+            value=inspect.formatannotation(arg.annotation),
+        )
+
+
+def collect(cls):
+    values = []
+    for name, v in cls._context_members_.items():
+        attrname = cls._context_attrs_[name]
+        attrdef = getattr(cls, attrname)
+        doc = getattr(attrdef, '__doc__')
+        if inspect.isfunction(attrdef):
+            sig = inspect.signature(attrdef)
+            result = inspect.formatannotation(sig.return_annotation)
+            sig_good_part = ContextMethod(
+                name=name,
+                args=list(_get_args(sig)),
+                result=result,
+                doc=doc,
+            )
+        elif isinstance(attrdef, property):
+            sig = inspect.signature(attrdef.fget)
+            sig_txt = inspect.formatannotation(sig.return_annotation)
+            sig_good_part = ContextValue(
+                name=name, value=sig_txt, doc=doc
+            )
+        else:
+            sig_good_part = Unknown(
+                name=name, value=repr(attrdef), doc=doc
+            )
+        values.append(sig_good_part)
+
+    return values
+
+
+@dataclass
+class ContextCatalog(JsonSchemaMixin):
+    base: List[ContextMember]
+    target: List[ContextMember]
+    model: List[ContextMember]
+    macro: List[ContextMember]
+    schema: Dict[str, Any]
+
+
+def main():
+    catalog = ContextCatalog(
+        base=collect(BaseContext),
+        target=collect(TargetContext),
+        model=collect(ModelContext),
+        macro=collect(MacroContext),
+        schema=ContextCatalog.json_schema(),
+    )
+    print(json.dumps(catalog.to_dict()))
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
resolves #2202 

### Description

Contexts are generally documented based on the dbt documentation page - a lot of copy+pasting and data reformatting (I never want to format ascii tables by hand again)
Manifest is documented using the 'description' metadata field that hologram supports
Added two scripts:
 - one to extract context metadata
 - one to extract the manifest/run result/catalog json schemas
 - both scripts run during circleCI and dump the json files to disk
   - which are then uploaded as build artifacts on circle


I left context fields that don't have documentation in the dbt docs undocumented.
The scripts are very bare-bones - they just dump some predefined json blobs out when we're building wheels in CI.
Per our conversation in sprint planning, I stopped adding description fields - we'll leave those to future PRs (and probably not from me?). It would make sense for future PRs to change the docstrings to perhaps match output we want to get into the docs? I kind of winged it!


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~ - no code/behavior changes, just build tooling!
