### PR TITLE
rev the bigquery minimum versions to a big number (#2233)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.0
+current_version = 0.16.1a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## dbt 0.16.1 (Relase date TBD)
+
+### Under the hood
+- Pin google libraries to higher minimum values, add more dependencies as explicit ([#2233](https://github.com/fishtown-analytics/dbt/issues/2233), [#2249](https://github.com/fishtown-analytics/dbt/pull/2249))
+
+
+## dbt 0.16.0 (March 23, 2020)
+
 ## dbt 0.16.0rc4 (March 20, 2020)
 
 ### Fixes

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -56,5 +56,5 @@ def get_version_information():
                 .format(version_msg))
 
 
-__version__ = '0.16.0'
+__version__ = '0.16.1a1'
 installed = get_installed_version()

--- a/core/setup.py
+++ b/core/setup.py
@@ -18,7 +18,7 @@ def read(fname):
 
 
 package_name = "dbt-core"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """dbt (data build tool) is a command line tool that helps \
 analysts and engineers transform data in their warehouse more effectively"""
 

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -40,12 +40,11 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'google-cloud-core>=1,<=1.3.0',
-        'google-cloud-bigquery>=1.22.0,<1.25.0',
-        # hidden secret dependency: bq 1.23.0 requires this but only documents
-        # 1.10.0 through its dependency chain.
-        # see https://github.com/googleapis/google-cloud-python/issues/9965
-        'six>=1.13.0',
+        'google-cloud-core>=1.3.0,<1.4',
+        'google-cloud-bigquery>=1.24.0,<1.25.0',
+        'google-api-core>=1.16.0,<1.17.0',
+        'googleapis-common-protos>=1.6.0,<1.7.0',
+        'six>=1.14.0',
     ],
     zip_safe=False,
     classifiers=[

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 package_name = "dbt-bigquery"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """The bigquery adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -35,7 +35,7 @@ def _dbt_psycopg2_name():
 
 
 package_name = "dbt-postgres"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """The postgres adpter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 package_name = "dbt-redshift"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """The redshift adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 package_name = "dbt-snowflake"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """The snowflake adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt"
-package_version = "0.16.0"
+package_version = "0.16.1a1"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -182,7 +182,7 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
 
 
 class HasUserAgent:
-    PAT = re.compile(r'dbt-\d+\.\d+\.\d+[a-zA-Z]+\d+')
+    PAT = re.compile(r'dbt-\d+\.\d+\.\d+((a|b|rc)\d+)?')
 
     def __eq__(self, other):
         compare = getattr(other, 'user_agent', '')


### PR DESCRIPTION
resolves #2233 

### Description

I raised the lower bound on most of the bigquery dependencies to whatever the current version I have installed is - I'm sure this will break someone's workflow, but hopefully this will avoid us having to deal with it too often, and hopefully prevent us from getting surprised by requirements updates that add a feature we were inadvertently relying on.


While I was in here I also bumped the version and fixed a bug in the unit tests where they would fail if the version number was a final release version (but not if they were an alpha/beta/rc)

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
