### PR TITLE
Render profile_name in the base context (#2230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.16.1 (Relase date TBD)
 
+### Fixes
+- dbt now renders the project name in the "base" context, in particular giving it access to `var` and `env_var` ([#2230](https://github.com/fishtown-analytics/dbt/issues/2230), [#2251](https://github.com/fishtown-analytics/dbt/pull/2251))
+
 ### Under the hood
 - Pin google libraries to higher minimum values, add more dependencies as explicit ([#2233](https://github.com/fishtown-analytics/dbt/issues/2233), [#2249](https://github.com/fishtown-analytics/dbt/pull/2249))
 

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain
 from typing import List, Dict, Any, Optional, TypeVar, Union, Tuple, Callable
 import hashlib
@@ -204,9 +204,18 @@ def _raw_project_from(project_root: str) -> Dict[str, Any]:
 
 @dataclass
 class PartialProject:
-    profile_name: Optional[str]
-    project_name: Optional[str]
-    project_root: str
+    profile_name: Optional[str] = field(metadata=dict(
+        description='The unrendered profile name in the project, if set'
+    ))
+    project_name: Optional[str] = field(metadata=dict(
+        description=(
+            'The name of the project. This should always be set and will not '
+            'be rendered'
+        )
+    ))
+    project_root: str = field(
+        metadata=dict(description='The root directory of the project'),
+    )
     project_dict: Dict[str, Any]
 
     def render(self, renderer):
@@ -217,6 +226,11 @@ class PartialProject:
             packages_dict,
             renderer,
         )
+
+    def render_profile_name(self, renderer) -> Optional[str]:
+        if self.profile_name is None:
+            return None
+        return renderer.render_value(self.profile_name)
 
 
 @dataclass

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -47,6 +47,9 @@ class ConfigRenderer:
         :param key str: The key to convert on.
         :return Any: The rendered entry.
         """
+        # the project name is never rendered
+        if keypath == ('name',):
+            return value
         # query comments and hooks should be treated as raw sql, they'll get
         # rendered later.
         # Same goes for 'vars' declarations inside 'models'/'seeds'

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -150,8 +150,9 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         # build the profile using the base renderer and the one fact we know
         cli_vars: Dict[str, Any] = parse_cli_vars(getattr(args, 'vars', '{}'))
         renderer = ConfigRenderer(generate_base_context(cli_vars=cli_vars))
+        profile_name = partial.render_profile_name(renderer)
         profile = Profile.render_from_args(
-            args, renderer, partial.profile_name
+            args, renderer, profile_name
         )
 
         # get a new renderer using our target information and render the

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -182,9 +182,11 @@ class DebugTask(BaseTask):
         project_profile: Optional[str] = None
         if os.path.exists(self.project_path):
             try:
-                project_profile = Project.partial_load(
+                partial = Project.partial_load(
                     os.path.dirname(self.project_path)
-                ).profile_name
+                )
+                renderer = ConfigRenderer(generate_base_context(self.cli_vars))
+                project_profile = partial.render_profile_name(renderer)
             except dbt.exceptions.DbtProjectError:
                 pass
 

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -1,7 +1,6 @@
 import io
 import json
 import os
-from unittest import mock
 from pytest import mark
 
 from test.integration.base import DBTIntegrationTest, use_profile
@@ -23,7 +22,9 @@ class BaseTestSimpleCopy(DBTIntegrationTest):
 
     @property
     def project_config(self):
-        return self.seed_quote_cfg_with({})
+        return self.seed_quote_cfg_with({
+            'profile': '{{ "tes" ~ "t" }}'
+        })
 
     def seed_quote_cfg_with(self, extra):
         cfg = {

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -74,6 +74,12 @@ class TestDebug(DBTIntegrationTest):
         self.assertGotValue(re.compile(r'\s+Connection test'), 'ERROR')
 
 
+class TestDebugProfileVariable(TestDebug):
+    @property
+    def project_config(self):
+        return {'profile': '{{ "te" ~ "st" }}'}
+
+
 class TestDebugInvalidProject(DBTIntegrationTest):
     @property
     def schema(self):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -169,7 +169,7 @@ class BaseConfigTest(unittest.TestCase):
             'env_value_pass': 'env-postgres-pass',
             'env_value_dbname': 'env-postgres-dbname',
             'env_value_schema': 'env-postgres-schema',
-            'env_value_project': 'blah',
+            'env_value_profile': 'default',
         }
 
 
@@ -951,7 +951,8 @@ class TestVariableProjectFile(BaseFileTest):
     def setUp(self):
         super().setUp()
         self.default_project_data['version'] = "{{ var('cli_version') }}"
-        self.default_project_data['name'] = "{{ env_var('env_value_project') }}"
+        self.default_project_data['name'] = "blah"
+        self.default_project_data['profile'] = "{{ env_var('env_value_profile') }}"
         self.write_project(self.default_project_data)
         # and after the fact, add the project root
         self.default_project_data['project-root'] = self.project_dir
@@ -966,6 +967,7 @@ class TestVariableProjectFile(BaseFileTest):
 
         self.assertEqual(project.version, "0.1.2")
         self.assertEqual(project.project_name, 'blah')
+        self.assertEqual(project.profile_name, 'default')
 
 
 class TestRuntimeConfig(BaseConfigTest):
@@ -1126,26 +1128,27 @@ class TestVariableRuntimeConfigFiles(BaseFileTest):
         super().setUp()
         self.default_project_data.update({
             'version': "{{ var('cli_version') }}",
-            'name': "{{ env_var('env_value_project') }}",
+            'name': "blah",
+            'profile': "{{ env_var('env_value_profile') }}",
             'on-run-end': [
-                "{{ env_var('env_value_project') }}",
+                "{{ env_var('env_value_profile') }}",
             ],
             'models': {
                 'foo': {
-                    'post-hook': "{{ env_var('env_value_target') }}",
+                    'post-hook': "{{ env_var('env_value_profile') }}",
                 },
                 'bar': {
                     # just gibberish, make sure it gets interpreted
-                    'materialized': "{{ env_var('env_value_project') }}",
+                    'materialized': "{{ env_var('env_value_profile') }}",
                 }
             },
             'seeds': {
                 'foo': {
-                    'post-hook': "{{ env_var('env_value_target') }}",
+                    'post-hook': "{{ env_var('env_value_profile') }}",
                 },
                 'bar': {
                     # just gibberish, make sure it gets interpreted
-                    'materialized': "{{ env_var('env_value_project') }}",
+                    'materialized': "{{ env_var('env_value_profile') }}",
                 }
             },
         })
@@ -1162,11 +1165,12 @@ class TestVariableRuntimeConfigFiles(BaseFileTest):
 
         self.assertEqual(config.version, "0.1.2")
         self.assertEqual(config.project_name, 'blah')
+        self.assertEqual(config.profile_name, 'default')
         self.assertEqual(config.credentials.host, 'cli-postgres-host')
         self.assertEqual(config.credentials.user, 'env-postgres-user')
         # make sure hooks are not interpreted
-        self.assertEqual(config.on_run_end, ["{{ env_var('env_value_project') }}"])
-        self.assertEqual(config.models['foo']['post-hook'], "{{ env_var('env_value_target') }}")
-        self.assertEqual(config.models['bar']['materialized'], 'blah')
-        self.assertEqual(config.seeds['foo']['post-hook'], "{{ env_var('env_value_target') }}")
-        self.assertEqual(config.seeds['bar']['materialized'], 'blah')
+        self.assertEqual(config.on_run_end, ["{{ env_var('env_value_profile') }}"])
+        self.assertEqual(config.models['foo']['post-hook'], "{{ env_var('env_value_profile') }}")
+        self.assertEqual(config.models['bar']['materialized'], 'default')  # rendered!
+        self.assertEqual(config.seeds['foo']['post-hook'], "{{ env_var('env_value_profile') }}")
+        self.assertEqual(config.seeds['bar']['materialized'], 'default')  # rendered!


### PR DESCRIPTION
resolves #2230

### Description
Render the `profile` field in `dbt_project.yml` in the base context.

This does _not_ render the project name field in any context, as that makes everything extra difficult and impacts plugin loading. Previously we did allow this, but behavior was inconsistent: It would only act sensibly if the project with a variable name was the root project.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
