### PR TITLE
Make the contents of the raw blocks regex pattern non-greedy (#2241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.16.1 (Relase date TBD)
 
+### Fixes
+- Fix an issue with raw blocks where multiple raw blocks in the same file resulted in an error ([#2241](https://github.com/fishtown-analytics/dbt/issues/2241), [#2252](https://github.com/fishtown-analytics/dbt/pull/2252))
+
 ### Under the hood
 - Pin google libraries to higher minimum values, add more dependencies as explicit ([#2233](https://github.com/fishtown-analytics/dbt/issues/2233), [#2249](https://github.com/fishtown-analytics/dbt/pull/2249))
 

--- a/core/dbt/clients/_jinja_blocks.py
+++ b/core/dbt/clients/_jinja_blocks.py
@@ -69,7 +69,7 @@ BLOCK_START_PATTERN = regex(''.join((
 
 RAW_BLOCK_PATTERN = regex(''.join((
     r'(?:\s*\{\%\-|\{\%)\s*raw\s*(?:\-\%\}\s*|\%\})',
-    r'(?:.*)',
+    r'(?:.*?)',
     r'(?:\s*\{\%\-|\{\%)\s*endraw\s*(?:\-\%\}\s*|\%\})',
 )))
 

--- a/test/unit/test_docs_blocks.py
+++ b/test/unit/test_docs_blocks.py
@@ -64,6 +64,25 @@ TEST_DOCUMENTATION_FILE = r'''
 )
 
 
+MULTIPLE_RAW_BLOCKS = r'''
+{% docs some_doc %}
+{% raw %}
+    ```
+    {% docs %}some doc{% enddocs %}
+    ```
+{% endraw %}
+{% enddocs %}
+
+{% docs other_doc %}
+{% raw %}
+    ```
+    {% docs %}other doc{% enddocs %}
+    ```
+{% endraw %}
+{% enddocs %}
+'''
+
+
 class DocumentationParserTest(unittest.TestCase):
     def setUp(self):
         if os.name == 'nt':
@@ -164,3 +183,28 @@ class DocumentationParserTest(unittest.TestCase):
             self.assertIsInstance(result, ParsedDocumentation)
         self.assertEqual(results[0].name, 'snowplow_sessions')
         self.assertEqual(results[1].name, 'snowplow_sessions__session_id')
+
+    def test_multiple_raw_blocks(self):
+        parser = docs.DocumentationParser(
+            results=ParseResult.rpc(),
+            root_project=self.root_project_config,
+            project=self.subdir_project_config,
+            macro_manifest=Manifest.from_macros())
+
+        file_block = self._build_file(MULTIPLE_RAW_BLOCKS, 'test_file.md')
+
+        parser.parse_file(file_block)
+        results = sorted(parser.results.docs.values(), key=lambda n: n.name)
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertIsInstance(result, ParsedDocumentation)
+            self.assertEqual(result.package_name, 'some_package')
+            self.assertEqual(result.original_file_path, self.testfile_path)
+            self.assertEqual(result.root_path, self.subdir_path)
+            self.assertEqual(result.resource_type, NodeType.Documentation)
+            self.assertEqual(result.path, 'test_file.md')
+
+        self.assertEqual(results[0].name, 'other_doc')
+        self.assertEqual(results[0].block_contents, '```\n    {% docs %}other doc{% enddocs %}\n    ```')
+        self.assertEqual(results[1].name, 'some_doc')
+        self.assertEqual(results[1].block_contents, '```\n    {% docs %}some doc{% enddocs %}\n    ```', )


### PR DESCRIPTION
resolves #2241

### Description
This fixes an issue where a file with multiple raw blocks got treated as one _big_ one, from the first `{% raw %}` to the last `{% endraw %}`. The trick was to add a non-greedy qualifier to the regex pattern that matches raw block bodies. I also added a unit test.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
