### PR TITLE
Fix a ValueError on redshift when an all-null column had a text type …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt 0.16.1 (Relase date TBD)
 
+
+### Fixes
+- Fix a redshift-only issue that caused an error when `dbt seed` found a seed with an entirely empty column that was set to a `varchar` data type. ([#2250](https://github.com/fishtown-analytics/dbt/issues/2250), [#2254](https://github.com/fishtown-analytics/dbt/pull/2254))
+
 ### Under the hood
 - Pin google libraries to higher minimum values, add more dependencies as explicit ([#2233](https://github.com/fishtown-analytics/dbt/issues/2233), [#2249](https://github.com/fishtown-analytics/dbt/pull/2249))
 

--- a/plugins/redshift/dbt/adapters/redshift/impl.py
+++ b/plugins/redshift/dbt/adapters/redshift/impl.py
@@ -35,7 +35,9 @@ class RedshiftAdapter(PostgresAdapter):
     @classmethod
     def convert_text_type(cls, agate_table, col_idx):
         column = agate_table.columns[col_idx]
-        lens = (len(d.encode("utf-8")) for d in column.values_without_nulls())
+        # `lens` must be a list, so this can't be a generator expression,
+        # because max() raises ane exception if its argument has no members.
+        lens = [len(d.encode("utf-8")) for d in column.values_without_nulls()]
         max_len = max(lens) if lens else 64
         return "varchar({})".format(max_len)
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -18,7 +18,7 @@ from dbt.clients import agate_helper
 import dbt.exceptions
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
-from .utils import config_from_parts_or_dicts, inject_adapter
+from .utils import config_from_parts_or_dicts, inject_adapter, TestAdapterConversions
 
 
 def _bq_conn():
@@ -473,3 +473,73 @@ class TestBigQueryFilterCatalog(unittest.TestCase):
             assert isinstance(row['table_database'], str)
             assert isinstance(row['table_name'], str)
             assert isinstance(row['something'], decimal.Decimal)
+
+
+class TestBigQueryAdapterConversions(TestAdapterConversions):
+    def test_convert_text_type(self):
+        rows = [
+            ['', 'a1', 'stringval1'],
+            ['', 'a2', 'stringvalasdfasdfasdfa'],
+            ['', 'a3', 'stringval3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Text)
+        expected = ['string', 'string', 'string']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_text_type(agate_table, col_idx) == expect
+
+    def test_convert_number_type(self):
+        rows = [
+            ['', '23.98', '-1'],
+            ['', '12.78', '-2'],
+            ['', '79.41', '-3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Number)
+        expected = ['int64', 'float64', 'int64']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_number_type(agate_table, col_idx) == expect
+
+    def test_convert_boolean_type(self):
+        rows = [
+            ['', 'false', 'true'],
+            ['', 'false', 'false'],
+            ['', 'false', 'true'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Boolean)
+        expected = ['bool', 'bool', 'bool']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_boolean_type(agate_table, col_idx) == expect
+
+    def test_convert_datetime_type(self):
+        rows = [
+            ['', '20190101T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190102T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190103T01:01:01Z', '2019-01-01 01:01:01'],
+        ]
+        agate_table = self._make_table_of(rows, [agate.DateTime, agate_helper.ISODateTime, agate.DateTime])
+        expected = ['datetime', 'datetime', 'datetime']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_datetime_type(agate_table, col_idx) == expect
+
+    def test_convert_date_type(self):
+        rows = [
+            ['', '2019-01-01', '2019-01-04'],
+            ['', '2019-01-02', '2019-01-04'],
+            ['', '2019-01-03', '2019-01-04'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Date)
+        expected = ['date', 'date', 'date']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_date_type(agate_table, col_idx) == expect
+
+    def test_convert_time_type(self):
+        # dbt's default type testers actually don't have a TimeDelta at all.
+        agate.TimeDelta
+        rows = [
+            ['', '120s', '10s'],
+            ['', '3m', '11s'],
+            ['', '1h', '12s'],
+        ]
+        agate_table = self._make_table_of(rows, agate.TimeDelta)
+        expected = ['time', 'time', 'time']
+        for col_idx, expect in enumerate(expected):
+            assert BigQueryAdapter.convert_time_type(agate_table, col_idx) == expect

--- a/test/unit/test_redshift_adapter.py
+++ b/test/unit/test_redshift_adapter.py
@@ -1,15 +1,17 @@
+import string
 import unittest
 from unittest import mock
+import agate
 
-import dbt.adapters
+import dbt.adapters  # noqa
 import dbt.flags as flags
-import dbt.utils
 
 from dbt.adapters.redshift import RedshiftAdapter
+from dbt.clients import agate_helper
 from dbt.exceptions import FailedToConnectException
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 
-from .utils import config_from_parts_or_dicts, mock_connection
+from .utils import config_from_parts_or_dicts, mock_connection, TestAdapterConversions
 
 
 @classmethod
@@ -212,7 +214,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password='password',
             port=5439,
             connect_timeout=10,
-            options="-c search_path=test\ test",
+            options=r"-c search_path=test\ test",
             keepalives_idle=240)
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
@@ -261,3 +263,79 @@ class TestRedshiftAdapter(unittest.TestCase):
         self.adapter.cleanup_connections()
         self._adapter = RedshiftAdapter(self.config)
         self.adapter.verify_database('redshift')
+
+
+class TestRedshiftAdapterConversions(TestAdapterConversions):
+    def test_convert_text_type(self):
+        rows = [
+            ['', 'a1', 'stringval1'],
+            ['', 'a2', 'stringvalasdfasdfasdfa'],
+            ['', 'a3', 'stringval3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Text)
+        expected = ['varchar(64)', 'varchar(2)', 'varchar(22)']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_text_type(agate_table, col_idx) == expect
+
+    def test_convert_number_type(self):
+        rows = [
+            ['', '23.98', '-1'],
+            ['', '12.78', '-2'],
+            ['', '79.41', '-3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Number)
+        expected = ['integer', 'float8', 'integer']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_number_type(agate_table, col_idx) == expect
+
+    def test_convert_boolean_type(self):
+        rows = [
+            ['', 'false', 'true'],
+            ['', 'false', 'false'],
+            ['', 'false', 'true'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Boolean)
+        expected = ['boolean', 'boolean', 'boolean']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_boolean_type(agate_table, col_idx) == expect
+
+    def test_convert_datetime_type(self):
+        rows = [
+            ['', '20190101T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190102T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190103T01:01:01Z', '2019-01-01 01:01:01'],
+        ]
+        agate_table = self._make_table_of(rows, [agate.DateTime, agate_helper.ISODateTime, agate.DateTime])
+        expected = ['timestamp without time zone', 'timestamp without time zone', 'timestamp without time zone']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_datetime_type(agate_table, col_idx) == expect
+
+    def test_convert_date_type(self):
+        rows = [
+            ['', '2019-01-01', '2019-01-04'],
+            ['', '2019-01-02', '2019-01-04'],
+            ['', '2019-01-03', '2019-01-04'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Date)
+        expected = ['date', 'date', 'date']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_date_type(agate_table, col_idx) == expect
+
+    def test_convert_time_type(self):
+        # dbt's default type testers actually don't have a TimeDelta at all.
+        agate.TimeDelta
+        rows = [
+            ['', '120s', '10s'],
+            ['', '3m', '11s'],
+            ['', '1h', '12s'],
+        ]
+        agate_table = self._make_table_of(rows, agate.TimeDelta)
+        expected = ['varchar(24)', 'varchar(24)', 'varchar(24)']
+        for col_idx, expect in enumerate(expected):
+            assert RedshiftAdapter.convert_time_type(agate_table, col_idx) == expect
+
+
+# convert_boolean_type
+# convert_datetime_type
+# convert_date_type
+# convert_time_type

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -1,3 +1,4 @@
+import agate
 import unittest
 from contextlib import contextmanager
 from unittest import mock
@@ -6,11 +7,12 @@ import dbt.flags as flags
 
 from dbt.adapters.snowflake import SnowflakeAdapter
 from dbt.adapters.base.query_headers import MacroQueryStringSetter
+from dbt.clients import agate_helper
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.parser.results import ParseResult
 from snowflake import connector as snowflake_connector
 
-from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection
+from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection, TestAdapterConversions
 
 
 class TestSnowflakeAdapter(unittest.TestCase):
@@ -376,3 +378,73 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 warehouse='test_warehouse', private_key='test_key',
                 application='dbt')
         ])
+
+
+class TestSnowflakeAdapterConversions(TestAdapterConversions):
+    def test_convert_text_type(self):
+        rows = [
+            ['', 'a1', 'stringval1'],
+            ['', 'a2', 'stringvalasdfasdfasdfa'],
+            ['', 'a3', 'stringval3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Text)
+        expected = ['text', 'text', 'text']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_text_type(agate_table, col_idx) == expect
+
+    def test_convert_number_type(self):
+        rows = [
+            ['', '23.98', '-1'],
+            ['', '12.78', '-2'],
+            ['', '79.41', '-3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Number)
+        expected = ['integer', 'float8', 'integer']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_number_type(agate_table, col_idx) == expect
+
+    def test_convert_boolean_type(self):
+        rows = [
+            ['', 'false', 'true'],
+            ['', 'false', 'false'],
+            ['', 'false', 'true'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Boolean)
+        expected = ['boolean', 'boolean', 'boolean']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_boolean_type(agate_table, col_idx) == expect
+
+    def test_convert_datetime_type(self):
+        rows = [
+            ['', '20190101T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190102T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190103T01:01:01Z', '2019-01-01 01:01:01'],
+        ]
+        agate_table = self._make_table_of(rows, [agate.DateTime, agate_helper.ISODateTime, agate.DateTime])
+        expected = ['timestamp without time zone', 'timestamp without time zone', 'timestamp without time zone']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_datetime_type(agate_table, col_idx) == expect
+
+    def test_convert_date_type(self):
+        rows = [
+            ['', '2019-01-01', '2019-01-04'],
+            ['', '2019-01-02', '2019-01-04'],
+            ['', '2019-01-03', '2019-01-04'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Date)
+        expected = ['date', 'date', 'date']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_date_type(agate_table, col_idx) == expect
+
+    def test_convert_time_type(self):
+        # dbt's default type testers actually don't have a TimeDelta at all.
+        agate.TimeDelta
+        rows = [
+            ['', '120s', '10s'],
+            ['', '3m', '11s'],
+            ['', '1h', '12s'],
+        ]
+        agate_table = self._make_table_of(rows, agate.TimeDelta)
+        expected = ['time', 'time', 'time']
+        for col_idx, expect in enumerate(expected):
+            assert SnowflakeAdapter.convert_time_type(agate_table, col_idx) == expect

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -3,10 +3,12 @@
 Note that all imports should be inside the functions to avoid import/mocking
 issues.
 """
+import string
 import os
 from unittest import mock
 from unittest import TestCase
 
+import agate
 from hologram import ValidationError
 
 
@@ -163,3 +165,25 @@ def generate_name_macros(package):
             macro_sql=sql,
         )
         yield pm
+
+
+class TestAdapterConversions(TestCase):
+    def _get_tester_for(self, column_type):
+        from dbt.clients import agate_helper
+        if column_type is agate.TimeDelta:  # dbt never makes this!
+            return agate.TimeDelta()
+
+        for instance in agate_helper.DEFAULT_TYPE_TESTER._possible_types:
+            if type(instance) is column_type:
+                return instance
+
+        raise ValueError(f'no tester for {column_type}')
+
+    def _make_table_of(self, rows, column_types):
+        column_names = list(string.ascii_letters[:len(rows[0])])
+        if isinstance(column_types, type):
+            column_types = [self._get_tester_for(column_types) for _ in column_names]
+        else:
+            column_types = [self._get_tester_for(typ) for typ in column_types]
+        table = agate.Table(rows, column_names=column_names, column_types=column_types)
+        return table


### PR DESCRIPTION
resolves #2250 


### Description

Fix a Redshift-only bug where an all-empty column in a seed that was set to any kind of varchar type would cause the seed to fail with an error.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
