### PR TITLE
Add a `path:` selector to the node selector (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a `get-manifest` API call. ([#2168](https://github.com/fishtown-analytics/dbt/issues/2168), [#2232](https://github.com/fishtown-analytics/dbt/pull/2232))
 - Support adapter-specific aliases (like `project` and `dataset` on BigQuery) in source definitions. ([#2133](https://github.com/fishtown-analytics/dbt/issues/2133), [#2244](https://github.com/fishtown-analytics/dbt/pull/2244))
 - Users can now use jinja as arguments to tests. Test arguments are rendered in the native context and injected into the test execution context directly. ([#2149](https://github.com/fishtown-analytics/dbt/issues/2149), [#2220](https://github.com/fishtown-analytics/dbt/pull/2220))
+- Users can supply paths as arguments to `--models` and `--select`, either explicitily by prefixing with `path:` or implicitly with no prefix. ([#454](https://github.com/fishtown-analytics/dbt/issues/454), [#2258](https://github.com/fishtown-analytics/dbt/pull/2258))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -1,5 +1,7 @@
+import os
 from enum import Enum
 from itertools import chain
+from pathlib import Path
 from typing import Set, Iterable, Union, List, Container, Tuple, Optional
 
 import networkx as nx  # type: ignore
@@ -16,13 +18,24 @@ SELECTOR_CHILDREN_AND_ANCESTORS = '@'
 SELECTOR_DELIMITER = ':'
 
 
+def _probably_path(value: str):
+    """Decide if value is probably a path. Windows has two path separators, so
+    we should check both sep ('\\') and altsep ('/') there.
+    """
+    if os.path.sep in value:
+        return True
+    elif os.path.altsep is not None and os.path.altsep in value:
+        return True
+    else:
+        return False
+
+
 class SelectionCriteria:
     def __init__(self, node_spec: str):
         self.raw = node_spec
         self.select_children = False
         self.select_parents = False
         self.select_childrens_parents = False
-        self.selector_type = SELECTOR_FILTERS.FQN
 
         if node_spec.startswith(SELECTOR_CHILDREN_AND_ANCESTORS):
             self.select_childrens_parents = True
@@ -48,12 +61,19 @@ class SelectionCriteria:
             self.selector_type = SELECTOR_FILTERS(selector_type)
         else:
             self.selector_value = node_spec
+            # if the selector type has an OS path separator in it, it can't
+            # really be a valid file name, so assume it's a path.
+            if _probably_path(node_spec):
+                self.selector_type = SELECTOR_FILTERS.PATH
+            else:
+                self.selector_type = SELECTOR_FILTERS.FQN
 
 
 class SELECTOR_FILTERS(str, Enum):
     FQN = 'fqn'
     TAG = 'tag'
     SOURCE = 'source'
+    PATH = 'path'
 
     def __str__(self):
         return self._value_
@@ -219,6 +239,27 @@ class SourceSelector(ManifestSelector):
                 yield node
 
 
+class PathSelector(ManifestSelector):
+    FILTER = SELECTOR_FILTERS.PATH
+
+    def search(self, included_nodes, selector):
+        """Yield all nodes in the graph that match the given path.
+
+        :param str selector: The path selector
+        """
+        # use '.' and not 'root' for easy comparison
+        root = Path.cwd()
+        paths = set(p.relative_to(root) for p in root.glob(selector))
+        search = chain(self.parsed_nodes(included_nodes),
+                       self.source_nodes(included_nodes))
+        for node, real_node in search:
+            if (
+                Path(real_node.root_path) == root and
+                Path(real_node.original_file_path) in paths
+            ):
+                yield node
+
+
 class InvalidSelectorError(Exception):
     pass
 
@@ -231,7 +272,12 @@ class MultiSelector:
     selector types, including the glob operator, but does not handle any graph
     related behavior.
     """
-    SELECTORS = [QualifiedNameSelector, TagSelector, SourceSelector]
+    SELECTORS = [
+        QualifiedNameSelector,
+        TagSelector,
+        SourceSelector,
+        PathSelector,
+    ]
 
     def __init__(self, manifest):
         self.manifest = manifest

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -65,6 +65,26 @@ class TestSimpleDependency(BaseDependencyTest):
             2
         )
 
+    @use_profile('postgres')
+    def test_postgres_no_dependency_paths(self):
+        self.run_dbt(['deps'])
+        self.run_dbt(['seed'])
+        # this should work
+        local_path = os.path.join('local_models', 'my_model.sql')
+        results = self.run_dbt(
+            ['run', '--models',  f'+{local_path}']
+        )
+        # should run the dependency and my_model
+        self.assertEqual(len(results), 2)
+
+        # this should not work
+        dep_path = os.path.join('models', 'model_to_import.sql')
+        results = self.run_dbt(
+            ['run', '--models', f'+{dep_path}'],
+        )
+        # should not run the dependency, because it "doesn't exist".
+        self.assertEqual(len(results), 0)
+
 
 class TestMissingDependency(DBTIntegrationTest):
     @property


### PR DESCRIPTION
resolves #454 
### Description

Instead of always being FQN by default, path-like selectors default to PATH
Paths referring to non-root packages are ignored
Added a test to the dependency tests that checks both of these


```
$ dbt run --models models/x.sql
Running with dbt=0.17.0-a1
Found 3 models, 7 tests, 1 snapshot, 0 analyses, 134 macros, 0 operations, 4 seed files, 1 source

12:52:51 | Concurrency: 4 threads (target='postgres')
12:52:51 |
12:52:51 | 1 of 1 START table model dbt_postgres.x........................................ [RUN]
12:52:51 | 1 of 1 OK created table model dbt_postgres.x................................... [SELECT 1 in 0.09s]
12:52:51 |
12:52:51 | Finished running 1 table model in 0.36s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
