### PR TITLE
Fix an error in exception handling for duplicate macros (#2288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix a bug where third party plugins that used the default `list_schemas` and `information_schema_name` macros with database quoting enabled double-quoted the database name in their queries ([#2267](https://github.com/fishtown-analytics/dbt/issues/2267), [#2281](https://github.com/fishtown-analytics/dbt/pull/2281))
 - The BigQuery "partitions" config value can now be used in `dbt_project.yml` ([#2256](https://github.com/fishtown-analytics/dbt/issues/2256), [#2280](https://github.com/fishtown-analytics/dbt/pull/2280))
 - dbt deps once again does not require a profile, but if profile-specific fields are accessed users will get an error ([#2231](https://github.com/fishtown-analytics/dbt/issues/2231), [#2290](https://github.com/fishtown-analytics/dbt/pull/2290))
+- Macro name collisions between dbt and plugins now raise an appropriate exception, instead of an AttributeError ([#2288](https://github.com/fishtown-analytics/dbt/issues/2288), [#2293](https://github.com/fishtown-analytics/dbt/pull/2293))
 
 ### Under the hood
 - Pin google libraries to higher minimum values, add more dependencies as explicit ([#2233](https://github.com/fishtown-analytics/dbt/issues/2233), [#2249](https://github.com/fishtown-analytics/dbt/pull/2249))

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -644,10 +644,10 @@ def approximate_relation_match(target, relation):
 
 
 def raise_duplicate_macro_name(node_1, node_2, namespace) -> NoReturn:
-    duped_name = node_1.namespace
+    duped_name = node_1.name
     if node_1.package_name != node_2.package_name:
         extra = (
-            ' ({} and {} are both in the {} namespace)'
+            ' ("{}" and "{}" are both in the "{}" namespace)'
             .format(node_1.package_name, node_2.package_name, namespace)
         )
     else:

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dbt.exceptions import raise_duplicate_macro_name, CompilationException
+from .utils import MockMacro
+
+
+def test_raise_duplicate_macros_different_package():
+    macro_1 = MockMacro(package='dbt', name='some_macro')
+    macro_2 = MockMacro(package='dbt-myadapter', name='some_macro')
+
+    with pytest.raises(CompilationException) as exc:
+        raise_duplicate_macro_name(
+            node_1=macro_1,
+            node_2=macro_2,
+            namespace='dbt',
+        )
+    assert 'dbt-myadapter' in str(exc.value)
+    assert 'some_macro' in str(exc.value)
+    assert 'namespace "dbt"' in str(exc.value)
+    assert '("dbt" and "dbt-myadapter" are both in the "dbt" namespace)' in str(exc.value)
+
+
+def test_raise_duplicate_macros_same_package():
+    macro_1 = MockMacro(package='dbt', name='some_macro')
+    macro_2 = MockMacro(package='dbt', name='some_macro')
+
+    with pytest.raises(CompilationException) as exc:
+        raise_duplicate_macro_name(
+            node_1=macro_1,
+            node_2=macro_2,
+            namespace='dbt',
+        )
+    assert 'some_macro' in str(exc.value)
+    assert 'namespace "dbt"' in str(exc.value)
+    assert "are both in" not in str(exc.value)

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -24,19 +24,7 @@ except ImportError:
 
 from dbt.logger import GLOBAL_LOGGER as logger # noqa
 
-from .utils import config_from_parts_or_dicts, generate_name_macros
-
-
-def MockMacro(package, name='my_macro', kwargs={}):
-    macro = MagicMock(
-        __class__=ParsedMacro,
-        resource_type=NodeType.Macro,
-        package_name=package,
-        unique_id=f'macro.{package}.{name}',
-        **kwargs
-    )
-    macro.name = name
-    return macro
+from .utils import config_from_parts_or_dicts, generate_name_macros, MockMacro
 
 
 class GraphTest(unittest.TestCase):

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -16,13 +16,14 @@ from dbt.contracts.graph.parsed import (
     DependsOn,
     NodeConfig,
     ParsedSeedNode,
-    ParsedMacro,
     ParsedSourceDefinition,
     ParsedDocumentation,
 )
 from dbt.contracts.graph.compiled import CompiledModelNode
 from dbt.node_types import NodeType
 import freezegun
+
+from .utils import MockMacro
 
 
 REQUIRED_PARSED_NODE_KEYS = frozenset({
@@ -634,19 +635,6 @@ class MixedManifestTest(unittest.TestCase):
 
 
 # Tests of the manifest search code (find_X_by_Y)
-
-def MockMacro(package, name='my_macro', kwargs={}):
-    macro = mock.MagicMock(
-        __class__=ParsedMacro,
-        resource_type=NodeType.Macro,
-        package_name=package,
-        unique_id=f'macro.{package}.{name}',
-        **kwargs
-    )
-    macro.name = name
-    return macro
-
-
 def MockMaterialization(package, name='my_materialization', adapter_type=None, kwargs={}):
     if adapter_type is None:
         adapter_type = 'default'

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -187,3 +187,24 @@ class TestAdapterConversions(TestCase):
             column_types = [self._get_tester_for(typ) for typ in column_types]
         table = agate.Table(rows, column_names=column_names, column_types=column_types)
         return table
+
+
+def MockMacro(package, name='my_macro', kwargs={}):
+    from dbt.contracts.graph.parsed import ParsedMacro
+    from dbt.node_types import NodeType
+
+    mock_kwargs = dict(
+        resource_type=NodeType.Macro,
+        package_name=package,
+        unique_id=f'macro.{package}.{name}',
+        original_file_path='/dev/null',
+    )
+
+    mock_kwargs.update(kwargs)
+
+    macro = mock.MagicMock(
+        spec=ParsedMacro,
+        **mock_kwargs
+    )
+    macro.name = name
+    return macro


### PR DESCRIPTION
resolves #2288


### Description
Use `name`, not `namespace` (which does not exist), for the macro name. Added a test.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
