### PR TITLE
Return proper error message when empty profiles.yml is used for project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@
 - When a warn exception is not in a jinja do block, return an empty string instead of None ([#2222](https://github.com/fishtown-analytics/dbt/issues/2222), [#2259](https://github.com/fishtown-analytics/dbt/pull/2259))
 - Add dbt plugin versions to --version([#2272](https://github.com/fishtown-analytics/dbt/issues/2272), [#2279](https://github.com/fishtown-analytics/dbt/pull/2279))
 - Made file names lookups case-insensitve (.sql, .SQL, .yml, .YML) and if .yaml files are found, raise a warning indicating dbt will parse these files in future releases. ([#1681](https://github.com/fishtown-analytics/dbt/issues/1681), [#2263](https://github.com/fishtown-analytics/dbt/pull/2263))
+- Return error message when profile is empty in profiles.yml. ([#2292](https://github.com/fishtown-analytics/dbt/issues/2292), [#2297](https://github.com/fishtown-analytics/dbt/pull/2297))
 
 Contributors:
  - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))
  - [@ilkinulas](https://github.com/ilkinulas) [#2199](https://github.com/fishtown-analytics/dbt/pull/2199)
  - [@kyleabeauchamp](https://github.com/kyleabeauchamp) [#2262](https://github.com/fishtown-analytics/dbt/pull/2262)
  - [@jeremyyeo](https://github.com/jeremyyeo) [#2259](https://github.com/fishtown-analytics/dbt/pull/2259)
- - [@sumanau7](https://github.com/sumanau7) [#2279](https://github.com/fishtown-analytics/dbt/pull/2279)
- - [@sumanau7](https://github.com/sumanau7) [#2263](https://github.com/fishtown-analytics/dbt/pull/2263)
+ - [@sumanau7](https://github.com/sumanau7) ([#2279](https://github.com/fishtown-analytics/dbt/pull/2279), [#2263](https://github.com/fishtown-analytics/dbt/pull/2263), [#2297](https://github.com/fishtown-analytics/dbt/pull/2297)
 
 ## dbt 0.16.0 (March 23, 2020)
 

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -44,6 +44,10 @@ defined in your profiles.yml file. You can find profiles.yml here:
 {profiles_file}/profiles.yml
 """.format(profiles_file=PROFILES_DIR)
 
+EMPTY_PROFILE_MESSAGE = """
+dbt cannot run because profiles.yml is empty for this dbt project.
+"""
+
 
 def read_profile(profiles_dir: str) -> Dict[str, Any]:
     path = os.path.join(profiles_dir, 'profiles.yml')
@@ -52,7 +56,10 @@ def read_profile(profiles_dir: str) -> Dict[str, Any]:
     if os.path.isfile(path):
         try:
             contents = load_file_contents(path, strip=False)
-            return load_yaml_text(contents)
+            yaml_content = load_yaml_text(contents)
+            if not yaml_content:
+                raise DbtProfileError(EMPTY_PROFILE_MESSAGE)
+            return yaml_content
         except ValidationException as e:
             msg = INVALID_PROFILE_MESSAGE.format(error_string=e)
             raise ValidationException(msg) from e

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -44,10 +44,6 @@ defined in your profiles.yml file. You can find profiles.yml here:
 {profiles_file}/profiles.yml
 """.format(profiles_file=PROFILES_DIR)
 
-EMPTY_PROFILE_MESSAGE = """
-dbt cannot run because profiles.yml is empty for this dbt project.
-"""
-
 
 def read_profile(profiles_dir: str) -> Dict[str, Any]:
     path = os.path.join(profiles_dir, 'profiles.yml')
@@ -58,7 +54,12 @@ def read_profile(profiles_dir: str) -> Dict[str, Any]:
             contents = load_file_contents(path, strip=False)
             yaml_content = load_yaml_text(contents)
             if not yaml_content:
-                raise DbtProfileError(EMPTY_PROFILE_MESSAGE)
+                msg = f'The profiles.yml file at {path} is empty'
+                raise DbtProfileError(
+                    INVALID_PROFILE_MESSAGE.format(
+                        error_string=msg
+                    )
+                )
             return yaml_content
         except ValidationException as e:
             msg = INVALID_PROFILE_MESSAGE.format(error_string=e)
@@ -287,7 +288,6 @@ class Profile(HasCredentials):
         # user_cfg is not rendered.
         if user_cfg is None:
             user_cfg = raw_profile.get('config')
-
         # TODO: should it be, and the values coerced to bool?
         target_name, profile_data = cls.render_profile(
             raw_profile, profile_name, target_override, renderer
@@ -342,7 +342,15 @@ class Profile(HasCredentials):
         # First, we've already got our final decision on profile name, and we
         # don't render keys, so we can pluck that out
         raw_profile = raw_profiles[profile_name]
-
+        if not raw_profile:
+            msg = (
+                f'Profile {profile_name} in profiles.yml is empty'
+            )
+            raise DbtProfileError(
+                INVALID_PROFILE_MESSAGE.format(
+                    error_string=msg
+                )
+            )
         user_cfg = raw_profiles.get('config')
 
         return cls.from_raw_profile_info(
@@ -380,7 +388,6 @@ class Profile(HasCredentials):
         raw_profiles = read_profile(args.profiles_dir)
         profile_name = cls.pick_profile_name(getattr(args, 'profile', None),
                                              project_profile_name)
-
         return cls.from_raw_profiles(
             raw_profiles=raw_profiles,
             profile_name=profile_name,

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -211,6 +211,10 @@ class BaseFileTest(BaseConfigTest):
         with open(self.profile_path('profiles.yml'), 'w') as fp:
             yaml.dump(profile_data, fp)
 
+    def write_empty_profile(self):
+        with open(self.profile_path('profiles.yml'), 'w') as fp:
+            yaml.dump('', fp)
+
 
 class TestProfile(BaseConfigTest):
     def setUp(self):
@@ -529,6 +533,12 @@ class TestProfileFile(BaseFileTest):
         with self.assertRaises(dbt.exceptions.DbtProjectError) as exc:
             self.from_args(project_profile_name=None)
         self.assertIn('no profile was specified', str(exc.exception))
+
+    def test_empty_profile(self):
+        self.write_empty_profile()
+        with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
+            self.from_args()
+        self.assertIn('profiles.yml is empty', str(exc.exception))
 
 
 class TestProject(BaseConfigTest):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -157,7 +157,8 @@ class BaseConfigTest(unittest.TestCase):
                     }
                 },
                 'target': 'other-postgres',
-            }
+            },
+            'empty_profile_data': {}
         }
         self.args = Args(profiles_dir=self.profiles_dir, cli_vars='{}',
                          version_check=True, project_dir=self.project_dir)
@@ -539,6 +540,17 @@ class TestProfileFile(BaseFileTest):
         with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
             self.from_args()
         self.assertIn('profiles.yml is empty', str(exc.exception))
+
+    def test_profile_with_empty_profile_data(self):
+        renderer = empty_renderer()
+        with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
+            dbt.config.Profile.from_raw_profiles(
+                self.default_profile_data, 'empty_profile_data', renderer
+            )
+        self.assertIn(
+            'Profile empty_profile_data in profiles.yml is empty',
+            str(exc.exception)
+        )
 
 
 class TestProject(BaseConfigTest):


### PR DESCRIPTION
resolves #2292

### Description

Return proper error message when profiles.yaml is empty

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
