### PR TITLE
Fix incorrect SKIP count in stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - When a Redshift table is defined as "auto", don't provide diststyle ([#2246](https://github.com/fishtown-analytics/dbt/issues/2246), [#2298](https://github.com/fishtown-analytics/dbt/pull/2298))
 - Made file names lookups case-insensitve (.sql, .SQL, .yml, .YML) and if .yaml files are found, raise a warning indicating dbt will parse these files in future releases. ([#1681](https://github.com/fishtown-analytics/dbt/issues/1681), [#2263](https://github.com/fishtown-analytics/dbt/pull/2263))
 - Return error message when profile is empty in profiles.yml. ([#2292](https://github.com/fishtown-analytics/dbt/issues/2292), [#2297](https://github.com/fishtown-analytics/dbt/pull/2297))
+- Fix skipped node count in stdout at the end of a run ([#2095](https://github.com/fishtown-analytics/dbt/issues/2095), [#2310](https://github.com/fishtown-analytics/dbt/pull/2310))
 
 Contributors:
  - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -69,6 +69,10 @@ class PartialResult(JsonSchemaMixin, Writable):
 class WritableRunModelResult(PartialResult):
     skip: bool = False
 
+    @property
+    def skipped(self):
+        return self.skip
+
 
 @dataclass
 class RunModelResult(WritableRunModelResult):

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -1,10 +1,8 @@
-import io
 import json
 import os
 from pytest import mark
 
 from test.integration.base import DBTIntegrationTest, use_profile
-from dbt.logger import log_manager
 
 
 class BaseTestSimpleCopy(DBTIntegrationTest):
@@ -409,24 +407,14 @@ class TestQuotedDatabase(BaseTestSimpleCopy):
             "data-paths": [self.dir("seed-initial")],
         })
 
-    def setUp(self):
-        super().setUp()
-        self.initial_stdout = log_manager.stdout
-        self.initial_stderr = log_manager.stderr
-        self.stringbuf = io.StringIO()
-        log_manager.set_output_stream(self.stringbuf)
-
-    def tearDown(self):
-        log_manager.set_output_stream(self.initial_stdout, self.initial_stderr)
-        super().tearDown()
-
     def seed_get_json(self, expect_pass=True):
-        self.run_dbt(
+        results, output = self.run_dbt_and_capture(
             ['--debug', '--log-format=json', '--single-threaded', 'seed'],
             expect_pass=expect_pass
         )
+
         logs = []
-        for line in self.stringbuf.getvalue().split('\n'):
+        for line in output.split('\n'):
             try:
                 log = json.loads(line)
             except ValueError:
@@ -435,6 +423,7 @@ class TestQuotedDatabase(BaseTestSimpleCopy):
             if log['extra'].get('run_state') != 'internal':
                 continue
             logs.append(log)
+
         self.assertGreater(len(logs), 0)
         return logs
 

--- a/test/integration/021_concurrency_test/test_concurrency.py
+++ b/test/integration/021_concurrency_test/test_concurrency.py
@@ -26,7 +26,7 @@ class TestConcurrency(DBTIntegrationTest):
 
         self.run_sql_file("update.sql")
 
-        results = self.run_dbt(expect_pass=False)
+        results, output = self.run_dbt_and_capture(expect_pass=False)
         self.assertEqual(len(results), 7)
 
         self.assertTablesEqual("seed", "view_model")
@@ -35,6 +35,8 @@ class TestConcurrency(DBTIntegrationTest):
         self.assertTablesEqual("seed", "table_b")
         self.assertTableDoesNotExist("invalid")
         self.assertTableDoesNotExist("skip")
+
+        self.assertIn('PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7', output)
 
     @use_profile('snowflake')
     def test__snowflake__concurrency(self):

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1,5 +1,6 @@
 import json
 import os
+import io
 import random
 import shutil
 import tempfile
@@ -536,6 +537,22 @@ class DBTIntegrationTest(unittest.TestCase):
             "dbt exit state did not match expected")
 
         return res
+
+
+    def run_dbt_and_capture(self, *args, **kwargs):
+        try:
+            initial_stdout = log_manager.stdout
+            initial_stderr = log_manager.stderr
+            stringbuf = io.StringIO()
+            log_manager.set_output_stream(stringbuf)
+
+            res = self.run_dbt(*args, **kwargs)
+            stdout = stringbuf.getvalue()
+
+        finally:
+            log_manager.set_output_stream(initial_stdout, initial_stderr)
+
+        return res, stdout
 
     def run_dbt_and_check(self, args=None, strict=True, parser=False, profiles_dir=True):
         log_manager.reset_handlers()


### PR DESCRIPTION
resolves #2095

### Description

Fixes the logic around determining the number of skipped nodes in a run.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
