### PR TITLE
Fix the tests (#2317)

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -425,6 +425,18 @@ def render_template(template, ctx: Dict[str, Any], node=None) -> str:
         return template.render(ctx)
 
 
+def _requote_result(raw_value, rendered):
+    double_quoted = raw_value.startswith('"') and raw_value.endswith('"')
+    single_quoted = raw_value.startswith("'") and raw_value.endswith("'")
+    if double_quoted:
+        quote_char = '"'
+    elif single_quoted:
+        quote_char = "'"
+    else:
+        quote_char = ''
+    return f'{quote_char}{rendered}{quote_char}'
+
+
 def get_rendered(
     string: str,
     ctx: Dict[str, Any],
@@ -440,7 +452,11 @@ def get_rendered(
         native=native,
     )
 
-    return render_template(template, ctx, node)
+    result = render_template(template, ctx, node)
+
+    if native and isinstance(result, str):
+        result = _requote_result(string, result)
+    return result
 
 
 def undefined_error(msg) -> NoReturn:

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -105,22 +105,6 @@ class NativeSandboxEnvironment(MacroFuzzEnvironment):
 class NativeSandboxTemplate(jinja2.nativetypes.NativeTemplate):  # mypy: ignore
     environment_class = NativeSandboxEnvironment
 
-    def render(self, *args, **kwargs):
-        """Render the template to produce a native Python type. If the
-        result is a single node, its value is returned. Otherwise, the
-        nodes are concatenated as strings. If the result can be parsed
-        with :func:`ast.literal_eval`, the parsed value is returned.
-        Otherwise, the string is returned.
-        """
-        vars = dict(*args, **kwargs)
-        try:
-            return jinja2.nativetypes.native_concat(
-                self.root_render_func(self.new_context(vars)),
-                preserve_quotes=True
-            )
-        except Exception:
-            return self.environment.handle_exception()
-
 
 NativeSandboxEnvironment.template_class = NativeSandboxTemplate  # type: ignore
 

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -1,5 +1,6 @@
 import hashlib
 import re
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import (
     Generic, TypeVar, Dict, Any, Tuple, Optional, List, Sequence
@@ -287,6 +288,7 @@ class TestBuilder(Generic[Testable]):
                     type(test_name), test_name
                 )
             )
+        test_args = deepcopy(test_args)
         if name is not None:
             test_args['column_name'] = name
         return test_name, test_args

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -196,21 +196,6 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
         for test in column.tests:
             self.parse_test(block, test, column)
 
-    def _build_raw_test_keyword_args(
-        self, parsed_node: ParsedSchemaTestNode, builder: TestBuilder
-    ) -> Dict[str, Any]:
-        """Build up the test keyword arguments."""
-        kwargs = parsed_node.test_metadata.kwargs.copy()
-        if isinstance(builder.target, UnparsedNodeUpdate):
-            fmt = "{{{{ ref('{0.name}') }}}}"
-        elif isinstance(builder.target, SourceTarget):
-            fmt = "{{{{ source('{0.source.name}', '{0.table.name}') }}}}"
-        else:
-            raise TypeError(f'invalid target type "{type(builder.target)}"')
-
-        kwargs['model'] = fmt.format(builder.target)
-        return kwargs
-
     def parse_node(self, block: SchemaTestBlock) -> ParsedSchemaTestNode:
         """In schema parsing, we rewrite most of the part of parse_node that
         builds the initial node to be parsed, but rendering is basically the

--- a/core/setup.py
+++ b/core/setup.py
@@ -53,7 +53,7 @@ setup(
         'scripts/dbt',
     ],
     install_requires=[
-        'Jinja2>=2.11,<3',
+        'Jinja2==2.11.2',
         'PyYAML>=3.11',
         'sqlparse>=0.2.3,<0.4',
         'networkx>=2.3,<3',


### PR DESCRIPTION
resolves #2317

### Description

This looks like a neat interplay between yaml's anchor/pointer notation (it's
a reference, not a copy!), and dbt inserting 'model' into the keyword args for
tests.

I've added a `copy.deepcopy` call to where dbt collects test arguments from the
underlying file, so the 'model' is inserted into a fresh keyword arguments
dictionary.

While I was in there, I also removed a method that's not called anymore.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or tests are not required/relevant for this PR~ The tests were already there!
 - [ ] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~ - I don't think this merits a CHANGELOG update?
