### PR TITLE
Feature/compile ls relation caches (#1705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Users can now use jinja as arguments to tests. Test arguments are rendered in the native context and injected into the test execution context directly. ([#2149](https://github.com/fishtown-analytics/dbt/issues/2149), [#2220](https://github.com/fishtown-analytics/dbt/pull/2220))
 - Added support for `db_groups` and `autocreate` flags in Redshift configurations.  ([#1995](https://github.com/fishtown-analytics/dbt/issues/1995), [#2262](https://github.com/fishtown-analytics/dbt/pull/2262))
 - Users can supply paths as arguments to `--models` and `--select`, either explicitily by prefixing with `path:` or implicitly with no prefix. ([#454](https://github.com/fishtown-analytics/dbt/issues/454), [#2258](https://github.com/fishtown-analytics/dbt/pull/2258))
+- dbt now builds the relation cache for "dbt compile" and "dbt ls" as well as "dbt run" ([#1705](https://github.com/fishtown-analytics/dbt/issues/1705), [#2319](https://github.com/fishtown-analytics/dbt/pull/2319))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -88,9 +88,6 @@ class RunTask(CompileTask):
     def raise_on_first_error(self):
         return False
 
-    def populate_adapter_cache(self, adapter):
-        adapter.set_relations_cache(self.manifest)
-
     def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context):
         compiled = compile_node(adapter, self.config, hook, self.manifest,
                                 extra_context)
@@ -195,9 +192,8 @@ class RunTask(CompileTask):
             .format(stat_line=stat_line, execution=execution))
 
     def before_run(self, adapter, selected_uids):
+        super().before_run(adapter, selected_uids)
         with adapter.connection_named('master'):
-            self.create_schemas(adapter, selected_uids)
-            self.populate_adapter_cache(adapter)
             self.safe_run_hooks(adapter, RunHookType.Start, {})
 
     def after_run(self, adapter, results):

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -340,11 +340,16 @@ class GraphRunnableTask(ManifestTask):
         for dep_node_id in self.linker.get_dependent_nodes(node_id):
             self._skipped_children[dep_node_id] = cause
 
+    def populate_adapter_cache(self, adapter):
+        adapter.set_relations_cache(self.manifest)
+
     def before_hooks(self, adapter):
         pass
 
     def before_run(self, adapter, selected_uids):
-        pass
+        with adapter.connection_named('master'):
+            self.create_schemas(adapter, selected_uids)
+            self.populate_adapter_cache(adapter)
 
     def after_run(self, adapter, results):
         pass


### PR DESCRIPTION
resolves #1705

### Description
Added the populate_adapter_cache to the GraphRunnableTask before_run method
 - previously, only Run used it


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
