### PR TITLE
Column comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ Contributors:
 
 ### Features
 - Add column-level quoting control for tests ([#2106](https://github.com/fishtown-analytics/dbt/issues/2106), [#2047](https://github.com/fishtown-analytics/dbt/pull/2047))
-- Add the macros every node uses to its `depends_on.macros` list ([#2082](https://github.com/fishtown-analytics/dbt/issues/2082), [#2103](https://github.com/fishtown-analytics/dbt/pull/2103))
+- Add the macros every node uses to its `depends_on.macros` list ([#2082](https://github.com/fishtown-analytics/dbt/issues/2082), [#2103](https://github.com/fishtown-analytics/dbt/pull/2103))
 - Add `arguments` field to macros ([#2081](https://github.com/fishtown-analytics/dbt/issues/2081), [#2083](https://github.com/fishtown-analytics/dbt/issues/2083), [#2096](https://github.com/fishtown-analytics/dbt/pull/2096))
 - Batch the anonymous usage statistics requests to improve performance ([#2008](https://github.com/fishtown-analytics/dbt/issues/2008), [#2089](https://github.com/fishtown-analytics/dbt/pull/2089))
 - Add documentation for macros/analyses ([#1041](https://github.com/fishtown-analytics/dbt/issues/1041), [#2068](https://github.com/fishtown-analytics/dbt/pull/2068))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Sources from dependencies can be overridden in schema.yml files ([#2287](https://github.com/fishtown-analytics/dbt/issues/2287), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - Implement persist_docs for both `relation` and `comments` on postgres and redshift, and extract them when getting the catalog. ([#2333](https://github.com/fishtown-analytics/dbt/issues/2333), [#2378](https://github.com/fishtown-analytics/dbt/pull/2378))
 - Added a filter named `as_text` to the native environment rendering code that allows users to mark a value as always being a string ([#2384](https://github.com/fishtown-analytics/dbt/issues/2384), [#2395](https://github.com/fishtown-analytics/dbt/pull/2395))
+- Relation comments supported for Snowflake tables and views. Column comments supported for tables. ([#1722](https://github.com/fishtown-analytics/dbt/issues/1722), [#2321](https://github.com/fishtown-analytics/dbt/pull/2321))
+
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))
@@ -63,6 +65,7 @@ Contributors:
  - [@Fokko](https://github.com/Fokko) [#2361](https://github.com/fishtown-analytics/dbt/pull/2361)
  - [@franloza](https://github.com/franloza) [#2349](https://github.com/fishtown-analytics/dbt/pull/2349)
  - [@sethwoodworth](https://github.com/sethwoodworth) [#2389](https://github.com/fishtown-analytics/dbt/pull/2389)
+ - [@snowflakeseitz](https://github.com/snowflakeseitz) [#2321](https://github.com/fishtown-analytics/dbt/pull/2321)
 
 ## dbt 0.16.1 (April 14, 2020)
 

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -138,7 +138,8 @@
 {% endmacro %}
 
 {% macro default__alter_column_comment(relation, column_name, new_column_type) -%}
-  {{ log("This is not consistently implemented yet") }}
+  {{ exceptions.raise_not_implemented(
+    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}
 {% endmacro %}
 
 {% macro alter_relation_comment(relation, relation_comment) -%}
@@ -146,7 +147,8 @@
 {% endmacro %}
 
 {% macro default__alter_relation_comment(relation, relation_comment) -%}
-  {{ log("This is not consistently implemented yet") }}
+  {{ exceptions.raise_not_implemented(
+    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}
 {% endmacro %}
 
 

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -137,7 +137,7 @@
   {{ return(adapter_macro('alter_column_comment', relation, column_dict)) }}
 {% endmacro %}
 
-{% macro default__alter_column_comment(relation, column_name, new_column_type) -%}
+{% macro default__alter_column_comment(relation, column_dict) -%}
   {{ exceptions.raise_not_implemented(
     'alter_column_comment macro not implemented for adapter '+adapter.type()) }}
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -131,6 +131,27 @@
   {{ return(adapter_macro('alter_column_type', relation, column_name, new_column_type)) }}
 {% endmacro %}
 
+
+
+{% macro alter_column_comment(relation, column_dict) -%}
+  {{ return(adapter_macro('alter_column_comment', relation, column_dict)) }}
+{% endmacro %}
+
+{% macro default__alter_column_comment(relation, column_name, new_column_type) -%}
+  {{ log("This is not consistently implemented yet") }}
+{% endmacro %}
+
+{% macro alter_relation_comment(relation, relation_comment) -%}
+  {{ return(adapter_macro('alter_relation_comment', relation, relation_comment)) }}
+{% endmacro %}
+
+{% macro default__alter_relation_comment(relation, relation_comment) -%}
+  {{ log("This is not consistently implemented yet") }}
+{% endmacro %}
+
+
+
+
 {% macro default__alter_column_type(relation, column_name, new_column_type) -%}
   {#
     1. Create a new column (w/ temp name and correct type)

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -323,22 +323,3 @@
   {%- endif -%}
 {%- endmacro -%}
 
-
-{# copy+pasted from the snowflake PR - delete these 4 on merge #}
-{% macro alter_column_comment(relation, column_dict) -%}
-  {{ return(adapter_macro('alter_column_comment', relation, column_dict)) }}
-{% endmacro %}
-
-{% macro default__alter_column_comment(relation, column_dict) -%}
-  {{ exceptions.raise_not_implemented(
-    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}
-{% endmacro %}
-
-{% macro alter_relation_comment(relation, relation_comment) -%}
-  {{ return(adapter_macro('alter_relation_comment', relation, relation_comment)) }}
-{% endmacro %}
-
-{% macro default__alter_relation_comment(relation, relation_comment) -%}
-  {{ exceptions.raise_not_implemented(
-    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}
-{% endmacro %}

--- a/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
+++ b/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
@@ -26,3 +26,19 @@
   {% endif %}
 
 {% endmacro %}
+
+
+{% macro get_relation_column_comments(persist_docs, model) %}
+
+  {%- if persist_docs is not mapping -%}
+    {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
+  {% endif %}
+
+  {% if persist_docs.get('columns', false) %}
+    {{ return(model.columns) }}
+  {%- else -%}
+    {{ return(none) }}
+  {% endif %}
+
+{% endmacro %}
+

--- a/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
+++ b/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
@@ -1,7 +1,7 @@
 {% macro get_relation_comment(persist_docs, model) %}
 
   {%- if persist_docs is not mapping -%}
-    {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
+    {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ persist_docs) }}
   {% endif %}
 
   {% if persist_docs.get('relation', false) %}
@@ -13,25 +13,10 @@
 {% endmacro %}
 
 
-{# copy+pasted from the snowflake PR - delete this on merge #}
 {% macro get_relation_column_comments(persist_docs, model) %}
+
   {%- if persist_docs is not mapping -%}
     {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ persist_docs) }}
-  {% endif %}
-
-  {% if persist_docs.get('columns', false) and model.columns|length != 0 %}
-    {{ return(model.columns) }}
-  {%- else -%}
-    {{ return(none) }}
-  {% endif %}
-
-{% endmacro %}
-
-
-{% macro get_relation_column_comments(persist_docs, model) %}
-
-  {%- if persist_docs is not mapping -%}
-    {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
   {% endif %}
 
   {% if persist_docs.get('columns', false) and model.columns|length != 0 %}

--- a/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
+++ b/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
@@ -34,7 +34,7 @@
     {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
   {% endif %}
 
-  {% if persist_docs.get('columns', false) %}
+  {% if persist_docs.get('columns', false) and model.columns|length != 0 %}
     {{ return(model.columns) }}
   {%- else -%}
     {{ return(none) }}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -41,6 +41,7 @@
     {%- endif -%}
     -- add in comments
 
+    {% set relation = relation.incorporate(type='table') %}
     {% if relation_comment is not none -%}
       {{ alter_relation_comment(relation, relation_comment) }}
     {%- endif -%}
@@ -65,6 +66,7 @@
     {{ sql }}
   );
 
+  {%- set relation = relation.incorporate(type='view') -%}
   {% if relation_comment is not none -%}
     {{ alter_relation_comment(relation, relation_comment) }}
   {%- endif -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -150,3 +150,38 @@
     alter table {{ relation }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};
   {% endcall %}
 {% endmacro %}
+
+{% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
+  
+  {% call statement('alter_relation_comment') %}
+
+    alter table {{ relation }} alter COMMENT '{{ relation_comment }}'
+
+  {% endcall %}
+{% endmacro %}
+
+
+{% macro snowflake__alter_column_comment(relation, column_dict) -%}
+
+  {% call statement('alter_column_comment') %}
+
+      alter table {{ relation }} alter 
+
+      {% for column_name in column_dict %}
+        
+        {{ log("Andrew Inner Loop: "  ~adapter.quote(column_name)) }}
+
+        {% if loop.index == 1 %}
+          {{ column_name }} COMMENT '{{ column_dict[column_name]['description'] }}'
+        {% else %}
+           , {{ column_name }} COMMENT '{{ column_dict[column_name]['description'] }}'
+        {% endif %}
+
+      {% endfor %}
+
+  {% endcall %}
+{% endmacro %}
+
+
+
+

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -57,13 +57,6 @@
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
   {%- set relation_comment = get_relation_comment(raw_persist_docs, model) -%}
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-  {%- set column_comment = get_relation_column_comments(raw_persist_docs, model) -%}
->>>>>>> ff65dbdd... adding in Drews feedback
-=======
->>>>>>> 7964d517... adding in support for views
 
   {{ sql_header if sql_header is not none }}
   create or replace {% if secure -%}
@@ -71,24 +64,11 @@
   {%- endif %} view {{ relation }} {% if copy_grants -%} copy grants {%- endif %} as (
     {{ sql }}
   );
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 7964d517... adding in support for views
   {% if relation_comment is not none -%}
     {{ alter_relation_comment(relation, relation_comment) }}
   {%- endif -%}
 
-<<<<<<< HEAD
-=======
->>>>>>> ff65dbdd... adding in Drews feedback
-=======
->>>>>>> 4a84a256... fixing spacing
-=======
->>>>>>> 7964d517... adding in support for views
 {% endmacro %}
 
 {% macro snowflake__get_columns_in_relation(relation) -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -68,6 +68,7 @@
   {%- endif %} view {{ relation }} {% if copy_grants -%} copy grants {%- endif %} as (
     {{ sql }}
   );
+<<<<<<< HEAD
 
 <<<<<<< HEAD
   {% if relation_comment is not none -%}
@@ -76,6 +77,8 @@
 
 =======
 >>>>>>> ff65dbdd... adding in Drews feedback
+=======
+>>>>>>> 4a84a256... fixing spacing
 {% endmacro %}
 
 {% macro snowflake__get_columns_in_relation(relation) -%}
@@ -184,9 +187,9 @@
 
 
 {% macro snowflake__alter_column_comment(relation, column_dict) -%}
-    alter {{ relation.type }} {{ relation }} alter 
+    alter {{ relation.type }} {{ relation }} alter
     {% for column_name in column_dict %}
-        {{ column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$ {{ ',' if not loop.last else ';' }} 
+        {{ column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$ {{ ',' if not loop.last else ';' }}
     {% endfor %}
 {% endmacro %}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -65,7 +65,6 @@
   {%- endif %} view {{ relation }} {% if copy_grants -%} copy grants {%- endif %} as (
     {{ sql }}
   );
-
 {% endmacro %}
 
 {% macro snowflake__get_columns_in_relation(relation) -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -58,9 +58,12 @@
   {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
   {%- set relation_comment = get_relation_comment(raw_persist_docs, model) -%}
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
   {%- set column_comment = get_relation_column_comments(raw_persist_docs, model) -%}
 >>>>>>> ff65dbdd... adding in Drews feedback
+=======
+>>>>>>> 7964d517... adding in support for views
 
   {{ sql_header if sql_header is not none }}
   create or replace {% if secure -%}
@@ -69,16 +72,23 @@
     {{ sql }}
   );
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 <<<<<<< HEAD
+=======
+
+>>>>>>> 7964d517... adding in support for views
   {% if relation_comment is not none -%}
     {{ alter_relation_comment(relation, relation_comment) }}
   {%- endif -%}
 
+<<<<<<< HEAD
 =======
 >>>>>>> ff65dbdd... adding in Drews feedback
 =======
 >>>>>>> 4a84a256... fixing spacing
+=======
+>>>>>>> 7964d517... adding in support for views
 {% endmacro %}
 
 {% macro snowflake__get_columns_in_relation(relation) -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -57,6 +57,10 @@
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
   {%- set relation_comment = get_relation_comment(raw_persist_docs, model) -%}
+<<<<<<< HEAD
+=======
+  {%- set column_comment = get_relation_column_comments(raw_persist_docs, model) -%}
+>>>>>>> ff65dbdd... adding in Drews feedback
 
   {{ sql_header if sql_header is not none }}
   create or replace {% if secure -%}
@@ -65,10 +69,13 @@
     {{ sql }}
   );
 
+<<<<<<< HEAD
   {% if relation_comment is not none -%}
     {{ alter_relation_comment(relation, relation_comment) }}
   {%- endif -%}
 
+=======
+>>>>>>> ff65dbdd... adding in Drews feedback
 {% endmacro %}
 
 {% macro snowflake__get_columns_in_relation(relation) -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
@@ -25,15 +25,6 @@
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  -- add in table comments
-  {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
-
-  {%- set table_comment = get_relation_comment(raw_persist_docs, model) -%}
-  {%- set column_comment = get_relation_column_comments(raw_persist_docs, model) -%}
-
-  {{ alter_relation_comment(target_relation, table_comment) }}
-  {{ alter_column_comment(target_relation, column_comment) }}
-
   -- `COMMIT` happens here
   {{ adapter.commit() }}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/table.sql
@@ -25,6 +25,15 @@
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
+  -- add in table comments
+  {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
+
+  {%- set table_comment = get_relation_comment(raw_persist_docs, model) -%}
+  {%- set column_comment = get_relation_column_comments(raw_persist_docs, model) -%}
+
+  {{ alter_relation_comment(target_relation, table_comment) }}
+  {{ alter_column_comment(target_relation, column_comment) }}
+
   -- `COMMIT` happens here
   {{ adapter.commit() }}
 

--- a/test/integration/059_persist_docs_test/sf_models/incremental_test.sql
+++ b/test/integration/059_persist_docs_test/sf_models/incremental_test.sql
@@ -1,0 +1,8 @@
+{{
+  config ({
+  	"materialized" : 'incremental',
+    "persist_docs" : { "relation": true, "columns": true, "schema": true }
+  })
+}}
+
+select 1 as column1

--- a/test/integration/059_persist_docs_test/sf_models/schema.yml
+++ b/test/integration/059_persist_docs_test/sf_models/schema.yml
@@ -1,0 +1,21 @@
+models:
+  - name: view_test
+    description: >
+      View - "money" aka $$$$$
+    columns:
+      - name: column1
+        description: test 1 - abcd "" $$$ '' 
+
+  - name: incremental_test
+    description: >
+      Incremental - "money" aka $$$$$
+    columns:
+      - name: column1
+        description: test 1 - abcd "" $$$ '' 
+
+  - name: table_test
+    description: >
+      Table - "money" aka $$$$$
+    columns:
+      - name: column1
+        description: test 1 - abcd "" $$$ '' 

--- a/test/integration/059_persist_docs_test/sf_models/table_test.sql
+++ b/test/integration/059_persist_docs_test/sf_models/table_test.sql
@@ -1,0 +1,8 @@
+{{
+  config ({
+  	"materialized" : 'table',
+    "persist_docs" : { "relation": true, "columns": true, "schema": true }
+  })
+}}
+
+select 1 as column1

--- a/test/integration/059_persist_docs_test/sf_models/view_test.sql
+++ b/test/integration/059_persist_docs_test/sf_models/view_test.sql
@@ -1,0 +1,7 @@
+{{
+  config ({
+    "persist_docs" : { "relation": true, "columns": true, "schema": true }
+  })
+}}
+
+select 1 as column1


### PR DESCRIPTION
resolves:
- https://github.com/fishtown-analytics/dbt/issues/1722
- https://github.com/fishtown-analytics/dbt/issues/1573


### Description

Adding in support for Persist Docs into the Snowflake adapter and laying out a general framework for other adapters to support this feature.

Some caveats:

1) It only supports table materialization currently. Incremental materializations will not be refreshed with new docs until further logic is added to them. Additionally, views in Snowflake do not support altering column comments and must be created when the view is created.
2) Snowflake uses $$ string literal $$ to make ingesting strings with quotes easy. Therefore in your docs, if you have a $ we will replace it with [$] such that you never have two $$ next to each other.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
