### PR TITLE
Use "describe table" to get the columns in a relation on snowflake (#2260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added support for `db_groups` and `autocreate` flags in Redshift configurations.  ([#1995](https://github.com/fishtown-analytics/dbt/issues/1995), [#2262](https://github.com/fishtown-analytics/dbt/pull/2262))
 - Users can supply paths as arguments to `--models` and `--select`, either explicitily by prefixing with `path:` or implicitly with no prefix. ([#454](https://github.com/fishtown-analytics/dbt/issues/454), [#2258](https://github.com/fishtown-analytics/dbt/pull/2258))
 - dbt now builds the relation cache for "dbt compile" and "dbt ls" as well as "dbt run" ([#1705](https://github.com/fishtown-analytics/dbt/issues/1705), [#2319](https://github.com/fishtown-analytics/dbt/pull/2319))
+-  Snowflake now uses "describe table" to get the columns in a relation ([#2260](https://github.com/fishtown-analytics/dbt/issues/2260), [#2324](https://github.com/fishtown-analytics/dbt/pull/2324))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/plugins/snowflake/dbt/adapters/snowflake/column.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/column.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from dbt.adapters.base.column import Column
+from dbt.exceptions import RuntimeException
 
 
 @dataclass
@@ -19,3 +20,12 @@ class SnowflakeColumn(Column):
         return self.dtype.lower() in [
             'float', 'float4', 'float8', 'double', 'double precision', 'real',
         ]
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise RuntimeException("Called string_size() on non-string field!")
+
+        if self.dtype == 'text' or self.char_size is None:
+            return 16777216
+        else:
+            return int(self.char_size)


### PR DESCRIPTION
resolves #2260

### Description
Use `describe table` to get the columns in a relation on snowflake. This requires doing some extra parsing to interpret varchars and numerics (with a regex...), but that's really all we get with `describe table`.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR - existing tests all pass!
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
