### PR TITLE
Fix include_policy vs. quote_policy bug in BigQueryRelation (#2188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Made file names lookups case-insensitve (.sql, .SQL, .yml, .YML) and if .yaml files are found, raise a warning indicating dbt will parse these files in future releases. ([#1681](https://github.com/fishtown-analytics/dbt/issues/1681), [#2263](https://github.com/fishtown-analytics/dbt/pull/2263))
 - Return error message when profile is empty in profiles.yml. ([#2292](https://github.com/fishtown-analytics/dbt/issues/2292), [#2297](https://github.com/fishtown-analytics/dbt/pull/2297))
 - Fix skipped node count in stdout at the end of a run ([#2095](https://github.com/fishtown-analytics/dbt/issues/2095), [#2310](https://github.com/fishtown-analytics/dbt/pull/2310))
+- Fix an issue where BigQuery incorrectly used a relation's quote policy as the basis for the information schema's include policy, instead of the relation's include policy. ([#2188](https://github.com/fishtown-analytics/dbt/issues/2188), [#2325](https://github.com/fishtown-analytics/dbt/pull/2325))
 
 Contributors:
  - [@raalsky](https://github.com/Raalsky) ([#2224](https://github.com/fishtown-analytics/dbt/pull/2224), [#2228](https://github.com/fishtown-analytics/dbt/pull/2228))

--- a/plugins/bigquery/dbt/adapters/bigquery/relation.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/relation.py
@@ -65,7 +65,7 @@ class BigQueryInformationSchema(InformationSchema):
         if information_schema_view == '__TABLES__':
             identifier = False
 
-        return relation.quote_policy.replace(
+        return relation.include_policy.replace(
             schema=schema,
             identifier=identifier,
         )

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -12,6 +12,7 @@ import dbt.flags as flags
 from dbt.adapters.bigquery import BigQueryCredentials
 from dbt.adapters.bigquery import BigQueryAdapter
 from dbt.adapters.bigquery import BigQueryRelation
+from dbt.adapters.bigquery.relation import BigQueryInformationSchema
 from dbt.adapters.bigquery.connections import BigQueryConnectionManager
 from dbt.adapters.base.query_headers import MacroQueryStringSetter
 from dbt.clients import agate_helper
@@ -312,6 +313,60 @@ class TestBigQueryRelation(unittest.TestCase):
         }
         with self.assertRaises(hologram.ValidationError):
             BigQueryRelation.from_dict(kwargs)
+
+
+class TestBigQueryInformationSchema(unittest.TestCase):
+    def setUp(self):
+        flags.STRICT_MODE = True
+
+    def test_replace(self):
+
+        kwargs = {
+            'type': None,
+            'path': {
+                'database': 'test-project',
+                'schema': 'test_schema',
+                'identifier': 'my_view'
+            },
+            # test for #2188
+            'quote_policy': {
+                'database': False
+            },
+            'include_policy': {
+                'database': True,
+                'schema': True,
+                'identifier': True,
+            }
+        }
+        relation = BigQueryRelation.from_dict(kwargs)
+        info_schema = relation.information_schema()
+
+        tables_schema = info_schema.replace(information_schema_view='__TABLES__')
+        assert tables_schema.information_schema_view == '__TABLES__'
+        assert tables_schema.include_policy.schema is True
+        assert tables_schema.include_policy.identifier is False
+        assert tables_schema.include_policy.database is True
+        assert tables_schema.quote_policy.schema is True
+        assert tables_schema.quote_policy.identifier is False
+        assert tables_schema.quote_policy.database is False
+
+        schemata_schema = info_schema.replace(information_schema_view='SCHEMATA')
+        assert schemata_schema.information_schema_view == 'SCHEMATA'
+        assert schemata_schema.include_policy.schema is False
+        assert schemata_schema.include_policy.identifier is True
+        assert schemata_schema.include_policy.database is True
+        assert schemata_schema.quote_policy.schema is True
+        assert schemata_schema.quote_policy.identifier is False
+        assert schemata_schema.quote_policy.database is False
+
+        other_schema = info_schema.replace(information_schema_view='SOMETHING_ELSE')
+        assert other_schema.information_schema_view == 'SOMETHING_ELSE'
+        assert other_schema.include_policy.schema is True
+        assert other_schema.include_policy.identifier is True
+        assert other_schema.include_policy.database is True
+        assert other_schema.quote_policy.schema is True
+        assert other_schema.quote_policy.identifier is False
+        assert other_schema.quote_policy.database is False
 
 
 class TestBigQueryConnectionManager(unittest.TestCase):


### PR DESCRIPTION
resolves #2188

### Description
The BigQuery information schema previously used its quote policy as the basis
for a new include policy, rather than its include policy. This PR corrects that mistake.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
