### PR TITLE
Fix for non-json-serializable values in BigQuery nested columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix skipped node count in stdout at the end of a run ([#2095](https://github.com/fishtown-analytics/dbt/issues/2095), [#2310](https://github.com/fishtown-analytics/dbt/pull/2310))
 - Fix an issue where BigQuery incorrectly used a relation's quote policy as the basis for the information schema's include policy, instead of the relation's include policy. ([#2188](https://github.com/fishtown-analytics/dbt/issues/2188), [#2325](https://github.com/fishtown-analytics/dbt/pull/2325))
 - Fix "dbt deps" command so it respects the "--project-dir" arg if specified. ([#2338](https://github.com/fishtown-analytics/dbt/issues/2338), [#2339](https://github.com/fishtown-analytics/dbt/issues/2339))
-- Fix Object of type Decimal is not JSON serializable" error when BigQuery queries returned numeric types in nested data structures ([#2336](https://github.com/fishtown-analytics/dbt/issues/2336), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
+- Fix "Object of type Decimal is not JSON serializable" error when BigQuery queries returned numeric types in nested data structures ([#2336](https://github.com/fishtown-analytics/dbt/issues/2336), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
 
 ### Under the hood
 - Added more tests for source inheritance ([#2264](https://github.com/fishtown-analytics/dbt/issues/2264), [#2291](https://github.com/fishtown-analytics/dbt/pull/2291))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix skipped node count in stdout at the end of a run ([#2095](https://github.com/fishtown-analytics/dbt/issues/2095), [#2310](https://github.com/fishtown-analytics/dbt/pull/2310))
 - Fix an issue where BigQuery incorrectly used a relation's quote policy as the basis for the information schema's include policy, instead of the relation's include policy. ([#2188](https://github.com/fishtown-analytics/dbt/issues/2188), [#2325](https://github.com/fishtown-analytics/dbt/pull/2325))
 - Fix "dbt deps" command so it respects the "--project-dir" arg if specified. ([#2338](https://github.com/fishtown-analytics/dbt/issues/2338), [#2339](https://github.com/fishtown-analytics/dbt/issues/2339))
+- Fix Object of type Decimal is not JSON serializable" error when BigQuery queries returned numeric types in nested data structures ([#2336](https://github.com/fishtown-analytics/dbt/issues/2336), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
 
 ### Under the hood
 - Added more tests for source inheritance ([#2264](https://github.com/fishtown-analytics/dbt/issues/2264), [#2291](https://github.com/fishtown-analytics/dbt/pull/2291))

--- a/core/dbt/clients/agate_helper.py
+++ b/core/dbt/clients/agate_helper.py
@@ -4,6 +4,7 @@ import agate
 import datetime
 import isodate
 import json
+import dbt.utils
 from typing import Iterable, List, Dict, Union, Optional, Any
 
 from dbt.exceptions import RuntimeException
@@ -92,7 +93,7 @@ def table_from_data_flat(data, column_names: Iterable[str]) -> agate.Table:
         row = []
         for value in list(_row.values()):
             if isinstance(value, (dict, list, tuple)):
-                row.append(json.dumps(value))
+                row.append(json.dumps(value, cls=dbt.utils.JSONEncoder))
             else:
                 row.append(value)
         rows.append(row)

--- a/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
+++ b/test/integration/022_bigquery_test/test_bigquery_repeated_records.py
@@ -26,8 +26,8 @@ class TestBaseBigQueryRun(DBTIntegrationTest):
             cast('Stonebreaker' as string) as lname
           ) as user,
           [
-            struct(1 as val_1, 2 as val_2),
-            struct(3 as val_1, 4 as val_2)
+            struct(1 as val_1, cast(2.12 as numeric) as val_2),
+            struct(3 as val_1, cast(4.83 as numeric) as val_2)
           ] as val
 
         union all
@@ -38,8 +38,8 @@ class TestBaseBigQueryRun(DBTIntegrationTest):
             cast('Brickmaker' as string) as lname
           ) as user,
           [
-            struct(7 as val_1, 8 as val_2),
-            struct(9 as val_1, 0 as val_2)
+            struct(7 as val_1, cast(8 as numeric) as val_2),
+            struct(9 as val_1, cast(null as numeric) as val_2)
           ] as val
         """
 
@@ -54,8 +54,8 @@ class TestBaseBigQueryRun(DBTIntegrationTest):
                 '{"fname": "Johnny", "lname": "Brickmaker"}'
             ],
             "val": [
-                '[{"val_1": 1, "val_2": 2}, {"val_1": 3, "val_2": 4}]',
-                '[{"val_1": 7, "val_2": 8}, {"val_1": 9, "val_2": 0}]'
+                '[{"val_1": 1, "val_2": 2.12}, {"val_1": 3, "val_2": 4.83}]',
+                '[{"val_1": 7, "val_2": 8}, {"val_1": 9, "val_2": null}]'
             ]
         }
 


### PR DESCRIPTION
resolves #2336

### Description

Use the Decimal-aware json encoder when constructing an agate table from a nested BigQuery response


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.