### PR TITLE
Handle hard deletes in snapshots

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
@@ -110,10 +110,10 @@
         select
             'update' as dbt_change_type,
             snapshotted_data.dbt_scd_id,
-            source_data.dbt_valid_from as dbt_valid_to
+            coalesce(source_data.dbt_valid_from, {{ snapshot_get_time() }}) as dbt_valid_to
 
-        from source_data
-        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        from snapshotted_data
+        left join source_data  on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
         where snapshotted_data.dbt_valid_to is null
         and (
             {{ strategy.row_changed }}


### PR DESCRIPTION
resolves #249

[Related Discourse post](https://discourse.getdbt.com/t/handling-hard-deletes-from-source-tables-in-snapshots/1005)

### Description
When a record is deleted from a snapshot query result set, `dbt_valid_to` will be updated in the target snapshot as the current timestamp.


### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
