### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Contributors:
  - [@rodrigodelmonte](https://github.com/rodrigodelmonte) [#2298](https://github.com/fishtown-analytics/dbt/pull/2298)
  - [@sumanau7](https://github.com/sumanau7) ([#2279](https://github.com/fishtown-analytics/dbt/pull/2279), [#2263](https://github.com/fishtown-analytics/dbt/pull/2263), [#2297](https://github.com/fishtown-analytics/dbt/pull/2297))
  - [@nickwu241](https://github.com/nickwu241) [#2339](https://github.com/fishtown-analytics/dbt/issues/2339)
+ - [@Fokko](https://github.com/Fokko) [#2361](https://github.com/fishtown-analytics/dbt/pull/2361)
 
 ## dbt 0.16.1 (April 14, 2020)
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -87,4 +87,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -60,4 +60,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -79,4 +79,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -59,4 +59,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -61,4 +61,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    python_requires=">=3.6.2",
 )


### PR DESCRIPTION
This will let people know that they are running a too old version of Python. It requires 3.6.2+ because of the usage of the NoReturn hint: https://docs.python.org/3/library/typing.html#typing.NoReturn

resolves #2360

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->



### Description

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
