### PR TITLE
add --no-browser argument to docs serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Users can supply paths as arguments to `--models` and `--select`, either explicitily by prefixing with `path:` or implicitly with no prefix. ([#454](https://github.com/fishtown-analytics/dbt/issues/454), [#2258](https://github.com/fishtown-analytics/dbt/pull/2258))
 - dbt now builds the relation cache for "dbt compile" and "dbt ls" as well as "dbt run" ([#1705](https://github.com/fishtown-analytics/dbt/issues/1705), [#2319](https://github.com/fishtown-analytics/dbt/pull/2319))
 - Snowflake now uses "show terse objects" to build the relations cache instead of selecting from the information schema ([#2174](https://github.com/fishtown-analytics/dbt/issues/2174), [#2322](https://github.com/fishtown-analytics/dbt/pull/2322))
--  Snowflake now uses "describe table" to get the columns in a relation ([#2260](https://github.com/fishtown-analytics/dbt/issues/2260), [#2324](https://github.com/fishtown-analytics/dbt/pull/2324))
+- Snowflake now uses "describe table" to get the columns in a relation ([#2260](https://github.com/fishtown-analytics/dbt/issues/2260), [#2324](https://github.com/fishtown-analytics/dbt/pull/2324))
+- Added a '--no-browser' argument to "dbt docs serve" so you can serve docs in an environment that only has a CLI browser which would otherwise deadlock dbt ([#2004](https://github.com/fishtown-analytics/dbt/issues/2004), [#2364](https://github.com/fishtown-analytics/dbt/pull/2364))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -536,6 +536,11 @@ def _build_docs_serve_subparser(subparsers, base_subparser):
         Specify the port number for the docs server.
         '''
     )
+    serve_sub.add_argument(
+        '--no-browser',
+        dest='open_browser',
+        action='store_false',
+    )
     serve_sub.set_defaults(cls=serve_task.ServeTask, which='serve',
                            rpc_method=None)
     return serve_sub

--- a/core/dbt/task/serve.py
+++ b/core/dbt/task/serve.py
@@ -31,10 +31,11 @@ class ServeTask(ConfiguredTask):
             SimpleHTTPRequestHandler  # type: ignore
         )  # type: ignore
 
-        try:
-            webbrowser.open_new_tab('http://127.0.0.1:{}'.format(port))
-        except webbrowser.Error:
-            pass
+        if self.args.open_browser:
+            try:
+                webbrowser.open_new_tab(f'http://127.0.0.1:{port}')
+            except webbrowser.Error:
+                pass
 
         try:
             httpd.serve_forever()  # blocks


### PR DESCRIPTION
resolves #2004 


### Description
This was hard to fix in any normal way, because python's `webbrowser` module doesn't provide any way to skip certain browsers or say "only use gui browsers". I just added a CLI flag that lets users disable attempting to open a tab at all.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
