### PR TITLE
Column and table comments for postgres/redshift (#2333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Sources (and therefore freshness tests) can be enabled and disabled via dbt_project.yml ([#2283](https://github.com/fishtown-analytics/dbt/issues/2283), [#2312](https://github.com/fishtown-analytics/dbt/pull/2312), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - schema.yml files are now fully rendered in a context that is aware of vars declared in from dbt_project.yml files ([#2269](https://github.com/fishtown-analytics/dbt/issues/2269), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - Sources from dependencies can be overridden in schema.yml files ([#2287](https://github.com/fishtown-analytics/dbt/issues/2287), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
+- Implement persist_docs for both `relation` and `comments` on postgres and redshift, and extract them when getting the catalog. ([#2333](https://github.com/fishtown-analytics/dbt/issues/2333), [#2378](https://github.com/fishtown-analytics/dbt/pull/2378))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -78,6 +78,7 @@
   as (
     {{ sql }}
   );
+
 {% endmacro %}
 
 {% macro create_view_as(relation, sql) -%}
@@ -280,3 +281,41 @@
 {% macro set_sql_header(config) -%}
   {{ config.set('sql_header', caller()) }}
 {%- endmacro %}
+
+
+{%- macro set_relation_comment(relation) -%}
+  {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
+  {%- set comment = get_relation_comment(raw_persist_docs, model) -%}
+  {%- if comment is not none -%}
+    {{ alter_relation_comment(relation, comment) }}
+  {%- endif -%}
+{%- endmacro -%}
+
+
+{%- macro set_column_comments(relation) -%}
+  {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
+  {%- set column_dict = get_relation_column_comments(raw_persist_docs, model) -%}
+  {%- if column_dict is not none -%}
+    {{ alter_column_comment(relation, column_dict) }}
+  {%- endif -%}
+{%- endmacro -%}
+
+
+{# copy+pasted from the snowflake PR - delete these 4 on merge #}
+{% macro alter_column_comment(relation, column_dict) -%}
+  {{ return(adapter_macro('alter_column_comment', relation, column_dict)) }}
+{% endmacro %}
+
+{% macro default__alter_column_comment(relation, column_dict) -%}
+  {{ exceptions.raise_not_implemented(
+    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}
+{% endmacro %}
+
+{% macro alter_relation_comment(relation, relation_comment) -%}
+  {{ return(adapter_macro('alter_relation_comment', relation, relation_comment)) }}
+{% endmacro %}
+
+{% macro default__alter_relation_comment(relation, relation_comment) -%}
+  {{ exceptions.raise_not_implemented(
+    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
+++ b/core/dbt/include/global_project/macros/etc/get_relation_comment.sql
@@ -1,8 +1,3 @@
-{% macro table_options() %}
-  {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
-
-{%- endmacro -%}
-
 {% macro get_relation_comment(persist_docs, model) %}
 
   {%- if persist_docs is not mapping -%}
@@ -10,7 +5,22 @@
   {% endif %}
 
   {% if persist_docs.get('relation', false) %}
-    {{ return((model.description | tojson)[1:-1]) }}
+    {{ return(model.description) }}
+  {%- else -%}
+    {{ return(none) }}
+  {% endif %}
+
+{% endmacro %}
+
+
+{# copy+pasted from the snowflake PR - delete this on merge #}
+{% macro get_relation_column_comments(persist_docs, model) %}
+  {%- if persist_docs is not mapping -%}
+    {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ persist_docs) }}
+  {% endif %}
+
+  {% if persist_docs.get('columns', false) and model.columns|length != 0 %}
+    {{ return(model.columns) }}
   {%- else -%}
     {{ return(none) }}
   {% endif %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -4,7 +4,7 @@
   {% set unique_key = config.get('unique_key') %}
   {% set full_refresh_mode = flags.FULL_REFRESH %}
 
-  {% set target_relation = this %}
+  {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
 

--- a/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
@@ -210,9 +210,7 @@
   {% if not target_relation_exists %}
 
       {% set build_sql = build_snapshot_table(strategy, model['injected_sql']) %}
-      {% call statement('main') -%}
-          {{ create_table_as(False, target_relation, build_sql) }}
-      {% endcall %}
+      {% set final_sql = create_table_as(False, target_relation, build_sql) %}
 
   {% else %}
 
@@ -245,16 +243,18 @@
         {% do quoted_source_columns.append(adapter.quote(column.name)) %}
       {% endfor %}
 
-      {% call statement('main') %}
-          {{ snapshot_merge_sql(
-                target = target_relation,
-                source = staging_table,
-                insert_cols = quoted_source_columns
-             )
-          }}
-      {% endcall %}
+      {% set final_sql = snapshot_merge_sql(
+            target = target_relation,
+            source = staging_table,
+            insert_cols = quoted_source_columns
+         )
+      %}
 
   {% endif %}
+
+  {% call statement('main') %}
+      {{ final_sql }}
+  {% endcall %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -27,12 +27,21 @@
 
 {%- endmacro -%}
 
+
+{%- macro bigquery_escape_comment(comment) -%}
+  {%- if comment is not string -%}
+    {%- do exceptions.raise_compiler_exception('cannot escape a non-string: ' ~ comment) -%}
+  {%- endif -%}
+  {%- do return((comment | tojson)[1:-1]) -%}
+{%- endmacro -%}
+
+
 {% macro bigquery_table_options(persist_docs, temporary, kms_key_name, labels) %}
   {% set opts = {} -%}
 
   {%- set description = get_relation_comment(persist_docs, model) -%}
   {%- if description is not none -%}
-    {%- do opts.update({'description': "'" ~ description ~ "'"}) -%}
+    {%- do opts.update({'description': "'" ~ bigquery_escape_comment(description) ~ "'"}) -%}
   {%- endif -%}
   {%- if temporary -%}
     {% do opts.update({'expiration_timestamp': 'TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 12 hour)'}) %}

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -13,6 +13,7 @@
     {{ sql }}
   );
 
+  {% set relation = relation.incorporate(type='table') %}
   {{ set_relation_comment(relation) }}
   {{ set_column_comments(relation) }}
 {%- endmacro %}
@@ -20,6 +21,7 @@
 
 {% macro postgres__create_view_as(relation, sql) %}
   {{ default__create_view_as(relation, sql) }}
+  {%- set relation = relation.incorporate(type='view') -%}
   {{ set_relation_comment(relation) }}
   {{ set_column_comments(relation) }}
 {% endmacro %}

--- a/plugins/postgres/dbt/include/postgres/macros/catalog.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/catalog.sql
@@ -17,16 +17,18 @@
             when 'v' then 'VIEW'
             else 'BASE TABLE'
         end as table_type,
-        null::text as table_comment,
+        tbl_desc.description as table_comment,
         col.attname as column_name,
         col.attnum as column_index,
         pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,
-        null::text as column_comment,
+        col_desc.description as column_comment,
         pg_get_userbyid(tbl.relowner) as table_owner
 
     from pg_catalog.pg_namespace sch
     join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
     join pg_catalog.pg_attribute col on col.attrelid = tbl.oid
+    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)
+    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)
 
     where (
         {%- for schema in schemas -%}

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -50,6 +50,7 @@
     {{ sql }}
   );
 
+  {% set relation = relation.incorporate(type='table') %}
   {{ set_relation_comment(relation) }}
   {{ set_column_comments(relation) }}
 {%- endmacro %}
@@ -71,6 +72,7 @@
     For late-binding views, it's possible to set comments on the view (though they don't seem to end up anywhere).
     Unfortunately, setting comments on columns just results in an error.
   #}
+  {% set relation = relation.incorporate(type='view') %}
   {{ set_relation_comment(relation) }}
   {% if binding %}
     {{ set_column_comments(relation) }}

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -708,7 +708,7 @@ class TestDocsGenerate(DBTIntegrationTest):
     def expected_redshift_catalog(self):
         return self._expected_catalog(
             id_type='integer',
-            text_type='character varying',
+            text_type=AnyStringWith('character varying'),
             time_type='timestamp without time zone',
             view_type='VIEW',
             table_type='BASE TABLE',
@@ -787,19 +787,19 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'first_name': {
                             'name': 'first_name',
                             'index': 2,
-                            'type': 'character varying',
+                            'type': 'character varying(5)',
                             'comment': None,
                         },
                         'email': {
                             'name': 'email',
                             'index': 3,
-                            'type': 'character varying',
+                            'type': 'character varying(23)',
                             'comment': None,
                         },
                         'ip_address': {
                             'name': 'ip_address',
                             'index': 4,
-                            'type': 'character varying',
+                            'type': 'character varying(14)',
                             'comment': None,
                         },
                         'updated_at': {

--- a/test/integration/060_persist_docs_tests/models/my_fun_docs.md
+++ b/test/integration/060_persist_docs_tests/models/my_fun_docs.md
@@ -1,0 +1,10 @@
+{% docs my_fun_doc %}
+name Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+
+{% enddocs %}

--- a/test/integration/060_persist_docs_tests/models/schema.yml
+++ b/test/integration/060_persist_docs_tests/models/schema.yml
@@ -1,0 +1,45 @@
+version: 2
+
+models:
+  - name: table_model
+    description: |
+      Table model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+      - name: name
+        description: |
+          Some stuff here and then a call to
+          {{ doc('my_fun_doc')}}
+  - name: view_model
+    description: |
+      View model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting

--- a/test/integration/060_persist_docs_tests/models/table_model.sql
+++ b/test/integration/060_persist_docs_tests/models/table_model.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='table') }}
+select 1 as id, 'Joe' as name

--- a/test/integration/060_persist_docs_tests/models/view_model.sql
+++ b/test/integration/060_persist_docs_tests/models/view_model.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='view') }}
+select 2 as id, 'Bob' as name

--- a/test/integration/060_persist_docs_tests/test_persist_docs.py
+++ b/test/integration/060_persist_docs_tests/test_persist_docs.py
@@ -1,0 +1,124 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+
+import json
+
+
+class BasePersistDocsTest(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "persist_docs_060"
+
+    @property
+    def models(self):
+        return "models"
+
+    def _assert_common_comments(self, *comments):
+        for comment in comments:
+            assert '"with double quotes"' in comment
+            assert """'''abc123'''""" in comment
+            assert '\n' in comment
+            assert 'Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting' in comment
+            assert '/* comment */' in comment
+            assert '--\n' in comment
+
+    def _assert_has_table_comments(self, table_node):
+        table_comment = table_node['metadata']['comment']
+        assert table_comment.startswith('Table model description')
+
+        table_id_comment = table_node['columns']['id']['comment']
+        assert table_id_comment.startswith('id Column description')
+
+        table_name_comment = table_node['columns']['name']['comment']
+        assert table_name_comment.startswith('Some stuff here and then a call to')
+
+        self._assert_common_comments(
+            table_comment, table_id_comment, table_name_comment
+        )
+
+    def _assert_has_view_comments(self, view_node, has_node_comments=True, has_column_comments=True):
+        view_comment = view_node['metadata']['comment']
+        if has_node_comments:
+            assert view_comment.startswith('View model description')
+            self._assert_common_comments(view_comment)
+        else:
+            assert view_comment is None
+
+        view_id_comment = view_node['columns']['id']['comment']
+        if has_column_comments:
+            assert view_id_comment.startswith('id Column description')
+            self._assert_common_comments(view_id_comment)
+        else:
+            assert view_id_comment is None
+
+        view_name_comment = view_node['columns']['name']['comment']
+        assert view_name_comment is None
+
+
+class TestPersistDocs(BasePersistDocsTest):
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'models': {
+                'test': {
+                    '+persist_docs': {
+                        "relation": True,
+                        "columns": True,
+                    },
+                }
+            }
+        }
+
+    def run_has_comments_pglike(self):
+        self.run_dbt()
+        self.run_dbt(['docs', 'generate'])
+        with open('target/catalog.json') as fp:
+            catalog_data = json.load(fp)
+        assert 'nodes' in catalog_data
+        assert len(catalog_data['nodes']) == 2
+        table_node = catalog_data['nodes']['model.test.table_model']
+        view_node = self._assert_has_table_comments(table_node)
+
+        view_node = catalog_data['nodes']['model.test.view_model']
+        self._assert_has_view_comments(view_node)
+
+    @use_profile('postgres')
+    def test_postgres_comments(self):
+        self.run_has_comments_pglike()
+
+    @use_profile('redshift')
+    def test_redshift_comments(self):
+        self.run_has_comments_pglike()
+
+
+class TestPersistDocsLateBinding(BasePersistDocsTest):
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'models': {
+                'test': {
+                    '+persist_docs': {
+                        "relation": True,
+                        "columns": True,
+                    },
+                    'view_model': {
+                        'bind': False,
+                    }
+                }
+            }
+        }
+
+    @use_profile('redshift')
+    def test_redshift_late_binding_view(self):
+        self.run_dbt()
+        self.run_dbt(['docs', 'generate'])
+        with open('target/catalog.json') as fp:
+            catalog_data = json.load(fp)
+        assert 'nodes' in catalog_data
+        assert len(catalog_data['nodes']) == 2
+        table_node = catalog_data['nodes']['model.test.table_model']
+        view_node = self._assert_has_table_comments(table_node)
+
+        view_node = catalog_data['nodes']['model.test.view_model']
+        self._assert_has_view_comments(view_node, False, False)

--- a/test/unit/test_jinja.py
+++ b/test/unit/test_jinja.py
@@ -313,13 +313,19 @@ class TestBlockLexer(unittest.TestCase):
         body = '{% snapshot foo %}select * from thing{% endsnapshot%}{% endif %}'
         with self.assertRaises(CompilationException) as err:
             extract_toplevel_blocks(body)
-        self.assertIn('Got an unexpected control flow end tag, got endif but never saw a preceeding if (@ 53)', str(err.exception))
+        self.assertIn('Got an unexpected control flow end tag, got endif but never saw a preceeding if (@ 1:53)', str(err.exception))
 
     def test_if_endfor(self):
         body = '{% if x %}...{% endfor %}{% endif %}'
         with self.assertRaises(CompilationException) as err:
             extract_toplevel_blocks(body)
-        self.assertIn('Got an unexpected control flow end tag, got endfor but expected endif next (@ 13)', str(err.exception))
+        self.assertIn('Got an unexpected control flow end tag, got endfor but expected endif next (@ 1:13)', str(err.exception))
+
+    def test_if_endfor_newlines(self):
+        body = '{% if x %}\n    ...\n    {% endfor %}\n{% endif %}'
+        with self.assertRaises(CompilationException) as err:
+            extract_toplevel_blocks(body)
+        self.assertIn('Got an unexpected control flow end tag, got endfor but expected endif next (@ 3:4)', str(err.exception))
 
 
 bar_block = '''{% mytype bar %}


### PR DESCRIPTION
resolves #2333 

### Description
This is very much based off the work being done by @snowflakeseitz in #2321 
I intentionally copy+pasted the common `adapter_macro`s to make merging easier.

With this PR, redshift and postgres now generate column and table comments during view and table creation. Their get_catalog macros also now include those comments in the output (instead of null) and the end up in the catalog itself.

I added tests as well, of course!

Redshift is a little special:
 - you can comment on late-binding views, but the comment isn't available anywhere as far as I can tell. I set it up so dbt still issues these commands, because maybe I just couldn't find them
 - you can't comment at all on late-binding view columns (it's an error!)

One annoying/weird quirk we might need to think about: When you do have comments, results lines show up as `COMMENT in XXXs` instead of `CREATE TABLE in XXXs`. That's a little goofy! Maybe comments _should_ work like hooks do.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
