### PR TITLE
fix the ambiguous alias exception to respect databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fix "Object of type Decimal is not JSON serializable" error when BigQuery queries returned numeric types in nested data structures ([#2336](https://github.com/fishtown-analytics/dbt/issues/2336), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
 - No longer query the information_schema.schemata view on bigquery ([#2320](https://github.com/fishtown-analytics/dbt/issues/2320), [#2382](https://github.com/fishtown-analytics/dbt/pull/2382))
 - Add support for `sql_header` config in incremental models ([#2136](https://github.com/fishtown-analytics/dbt/issues/2136), [#2200](https://github.com/fishtown-analytics/dbt/pull/2200))
+- The ambiguous alias check now examines the node's database value as well as the schema/identifier ([#2326](https://github.com/fishtown-analytics/dbt/issues/2326), [#2387](https://github.com/fishtown-analytics/dbt/pull/2387))
 
 ### Under the hood
 - Added more tests for source inheritance ([#2264](https://github.com/fishtown-analytics/dbt/issues/2264), [#2291](https://github.com/fishtown-analytics/dbt/pull/2291))

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -741,14 +741,15 @@ def raise_duplicate_resource_name(node_1, node_2):
             node_2.unique_id, node_2.original_file_path))
 
 
-def raise_ambiguous_alias(node_1, node_2):
-    duped_name = "{}.{}".format(node_1.schema, node_1.alias)
+def raise_ambiguous_alias(node_1, node_2, duped_name=None):
+    if duped_name is None:
+        duped_name = f"{node_1.database}.{node_1.schema}.{node_1.alias}"
 
     raise_compiler_error(
         'dbt found two resources with the database representation "{}".\ndbt '
         'cannot create two resources with identical database representations. '
-        'To fix this,\nchange the "schema" or "alias" configuration of one of '
-        'these resources:\n- {} ({})\n- {} ({})'.format(
+        'To fix this,\nchange the configuration of one of these resources:'
+        '\n- {} ({})\n- {} ({})'.format(
             duped_name,
             node_1.unique_id, node_1.original_file_path,
             node_2.unique_id, node_2.original_file_path))

--- a/test/integration/026_aliases_test/models-dupe-custom-database/README.md
+++ b/test/integration/026_aliases_test/models-dupe-custom-database/README.md
@@ -1,0 +1,2 @@
+these should succeed, as both models have the same alias,
+but they are configured to be built in _different_ schemas

--- a/test/integration/026_aliases_test/models-dupe-custom-database/model_a.sql
+++ b/test/integration/026_aliases_test/models-dupe-custom-database/model_a.sql
@@ -1,0 +1,1 @@
+select {{ string_literal(this.name) }} as tablename

--- a/test/integration/026_aliases_test/models-dupe-custom-database/model_b.sql
+++ b/test/integration/026_aliases_test/models-dupe-custom-database/model_b.sql
@@ -1,0 +1,1 @@
+select {{ string_literal(this.name) }} as tablename

--- a/test/integration/026_aliases_test/models-dupe-custom-database/schema.yml
+++ b/test/integration/026_aliases_test/models-dupe-custom-database/schema.yml
@@ -1,0 +1,12 @@
+version: 2
+models:
+- name: model_a
+  tests:
+  - expect_value:
+      field: tablename
+      value: duped_alias
+- name: model_b
+  tests:
+  - expect_value:
+      field: tablename
+      value: duped_alias

--- a/test/integration/026_aliases_test/test_aliases.py
+++ b/test/integration/026_aliases_test/test_aliases.py
@@ -93,3 +93,39 @@ class TestSameAliasDifferentSchemas(DBTIntegrationTest):
 
         # Make extra sure the tests ran
         self.assertTrue(len(res) > 0)
+
+
+class TestSameAliasDifferentDatabases(DBTIntegrationTest):
+    setup_alternate_db = True
+
+    @property
+    def schema(self):
+        return "aliases_026"
+
+    @property
+    def models(self):
+        return "models-dupe-custom-database"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            "macro-paths": ['macros'],
+            'models': {
+                'test': {
+                    'alias': 'duped_alias',
+                    'model_b': {
+                        'database': self.alternative_database,
+                    },
+                },
+            }
+        }
+
+    @use_profile('bigquery')
+    def test__bigquery_same_alias_succeeds_in_different_schemas(self):
+        results = self.run_dbt(['run'])
+        self.assertEqual(len(results), 2)
+        res = self.run_dbt(['test'])
+
+        # Make extra sure the tests ran
+        self.assertTrue(len(res) > 0)


### PR DESCRIPTION
resolves #2326 

### Description
Fixes the ambiguous alias exception so now it respects databases

- The alias name check is now tied to the behavior of adapter.Relation.create_from(...)
- Plugins that override the `include` of their relations will use whatever they render to for the check the actual exception-raising code gets the name that was compared instead of generating its own
- Finally, I added a reasonable fallback behavior since this method _was_ exposed to the context


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
