### PR TITLE
Add a special as_text filter to the native env (#2384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - schema.yml files are now fully rendered in a context that is aware of vars declared in from dbt_project.yml files ([#2269](https://github.com/fishtown-analytics/dbt/issues/2269), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - Sources from dependencies can be overridden in schema.yml files ([#2287](https://github.com/fishtown-analytics/dbt/issues/2287), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - Implement persist_docs for both `relation` and `comments` on postgres and redshift, and extract them when getting the catalog. ([#2333](https://github.com/fishtown-analytics/dbt/issues/2333), [#2378](https://github.com/fishtown-analytics/dbt/pull/2378))
+- Added a filter named `as_text` to the native environment rendering code that allows users to mark a value as always being a string ([#2384](https://github.com/fishtown-analytics/dbt/issues/2384), [#2395](https://github.com/fishtown-analytics/dbt/pull/2395))
 
 ### Fixes
 - When a jinja value is undefined, give a helpful error instead of failing with cryptic "cannot pickle ParserMacroCapture" errors ([#2110](https://github.com/fishtown-analytics/dbt/issues/2110), [#2184](https://github.com/fishtown-analytics/dbt/pull/2184))

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -429,14 +429,16 @@ def get_environment(
     args['extensions'].append(DocumentationExtension)
 
     env_cls: Type[jinja2.Environment]
+    text_filter: Type
     if native:
         env_cls = NativeSandboxEnvironment
+        text_filter = TextMarker
     else:
         env_cls = MacroFuzzEnvironment
+        text_filter = str
 
     env = env_cls(**args)
-    if native:
-        env.filters['as_text'] = TextMarker
+    env.filters['as_text'] = text_filter
 
     return env
 

--- a/test/integration/042_sources_test/models/schema.yml
+++ b/test/integration/042_sources_test/models/schema.yml
@@ -22,7 +22,7 @@ sources:
     tables:
       - name: test_table
         identifier: source
-        loaded_at_field: "{{ var('test_loaded_at') }}"
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
         freshness:
           error_after: {count: 18, period: hour}
         tags:
@@ -63,7 +63,7 @@ sources:
               - id_column
       - name: disabled_test_table
         freshness: null
-        loaded_at_field: "{{ var('test_loaded_at') }}"
+        loaded_at_field: "{{ var('test_loaded_at') | as_text }}"
   - name: other_source
     schema: "{{ var('test_run_schema') }}"
     quoting:

--- a/test/unit/test_jinja.py
+++ b/test/unit/test_jinja.py
@@ -1,5 +1,6 @@
 import unittest
 
+from dbt.clients.jinja import get_rendered
 from dbt.clients.jinja import get_template
 from dbt.clients.jinja import extract_toplevel_blocks
 from dbt.exceptions import CompilationException
@@ -12,6 +13,29 @@ class TestJinja(unittest.TestCase):
         template = get_template(s, {})
         mod = template.make_module()
         self.assertEqual(mod.my_dict, {'a': 1})
+
+    def test_regular_render(self):
+        s = '{{ "some_value" }}'
+        value = get_rendered(s, {}, native=False)
+        assert value == 'some_value'
+        s = '{{ 1991 }}'
+        value = get_rendered(s, {}, native=False)
+        assert value == '1991'
+
+    def test_native_render(self):
+        s = '{{ "some_value" }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == 'some_value'
+        s = '{{ 1991 }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == 1991
+
+        s = '{{ "some_value" | as_text }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == 'some_value'
+        s = '{{ 1991 | as_text }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == '1991'
 
 
 class TestBlockLexer(unittest.TestCase):
@@ -380,3 +404,5 @@ if_you_do_this_you_are_awful = '''
 hi
 {% endmaterialization %}
 '''
+
+

--- a/test/unit/test_jinja.py
+++ b/test/unit/test_jinja.py
@@ -22,6 +22,13 @@ class TestJinja(unittest.TestCase):
         value = get_rendered(s, {}, native=False)
         assert value == '1991'
 
+        s = '{{ "some_value" | as_text }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == 'some_value'
+        s = '{{ 1991 | as_text }}'
+        value = get_rendered(s, {}, native=True)
+        assert value == '1991'
+
     def test_native_render(self):
         s = '{{ "some_value" }}'
         value = get_rendered(s, {}, native=True)


### PR DESCRIPTION
resolves #2384 

### Description
Add a special as_text filter to the native env that tells dbt to render the value as a string no matter what.

Use like `dataset: "{{ 1991 | as_text }}"` -> `dataset: "1991"`
Also, I moved the weird special quoting handling logic out and instead avoid calling the renderer on column_name arguments entirely. Much better than doing weird things with quotes!

I added some very basic unit tests that should exercise this behavior.

I don't _love_ this fix, but I think it's satisfactory and has the benefit of being really, really simple. There's just so little that can go horribly wrong!

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
