### PR TITLE
Fix: disabling tracking resets invocation ID (#2398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## dbt next (release TBD)
+## dbt 0.17.0 (Release TBD)
+
+### Fixes
+- When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
+
+## dbt 0.17.0b1 (May 5, 2020)
 
 ### Breaking changes
 - Added a new dbt_project.yml version format. This emits a deprecation warning currently, but support for the existing version will be removed in a future dbt version ([#2300](https://github.com/fishtown-analytics/dbt/issues/2300), [#2312](https://github.com/fishtown-analytics/dbt/pull/2312))

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -522,7 +522,7 @@ class UnsetProfileConfig(RuntimeConfig):
             # return the poisoned form
             profile = UnsetProfile()
             # disable anonymous usage statistics
-            tracking.do_not_track()
+            tracking.disable_tracking()
         return profile
 
     @classmethod

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -44,7 +44,7 @@ class TimeoutEmitter(Emitter):
         # num_ok will always be 0, unsent will always be 1 entry long, because
         # the buffer is length 1, so not much to talk about
         logger.warning('Error sending message, disabling tracking')
-        do_not_track()
+        disable_tracking()
 
     def _log_request(self, request, payload):
         sp_logger.info(f"Sending {request} request to {self.endpoint}...")
@@ -111,6 +111,12 @@ class User:
         subject = Subject()
         subject.set_user_id(self.id)
         tracker.set_subject(subject)
+
+    def disable_tracking(self):
+        self.do_not_track = True
+        self.id = None
+        self.cookie_dir = None
+        tracker.set_subject(None)
 
     def set_cookie(self):
         # If the user points dbt to a profile directory which exists AND
@@ -362,6 +368,14 @@ def track_invalid_invocation(
 def flush():
     logger.debug("Flushing usage events")
     tracker.flush()
+
+
+def disable_tracking():
+    global active_user
+    if active_user is not None:
+        active_user.disable_tracking()
+    else:
+        active_user = User(None)
 
 
 def do_not_track():

--- a/test/unit/test_tracking.py
+++ b/test/unit/test_tracking.py
@@ -1,0 +1,71 @@
+import dbt.tracking
+import datetime
+import shutil
+import tempfile
+import unittest
+
+
+class TestTracking(unittest.TestCase):
+    def setUp(self):
+        dbt.tracking.active_user = None
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        dbt.tracking.active_user = None
+        shutil.rmtree(self.tempdir)
+
+    def test_tracking_initial(self):
+        assert dbt.tracking.active_user is None
+        dbt.tracking.initialize_tracking(self.tempdir)
+        assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
+
+        invocation_id = dbt.tracking.active_user.invocation_id
+        run_started_at = dbt.tracking.active_user.run_started_at
+
+        assert dbt.tracking.active_user.do_not_track is False
+        assert isinstance(dbt.tracking.active_user.id, str)
+        assert isinstance(invocation_id, str)
+        assert isinstance(run_started_at, datetime.datetime)
+
+        dbt.tracking.disable_tracking()
+        assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
+
+        assert dbt.tracking.active_user.do_not_track is True
+        assert dbt.tracking.active_user.id is None
+        assert dbt.tracking.active_user.invocation_id == invocation_id
+        assert dbt.tracking.active_user.run_started_at == run_started_at
+
+        # this should generate a whole new user object -> new invocation_id/run_started_at
+        dbt.tracking.do_not_track()
+        assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
+
+        assert dbt.tracking.active_user.do_not_track is True
+        assert dbt.tracking.active_user.id is None
+        assert isinstance(dbt.tracking.active_user.invocation_id, str)
+        assert isinstance(dbt.tracking.active_user.run_started_at, datetime.datetime)
+        assert dbt.tracking.active_user.invocation_id != invocation_id
+        assert dbt.tracking.active_user.run_started_at != run_started_at
+
+    def test_tracking_never_ok(self):
+        assert dbt.tracking.active_user is None
+
+        # this should generate a whole new user object -> new invocation_id/run_started_at
+        dbt.tracking.do_not_track()
+        assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
+
+        assert dbt.tracking.active_user.do_not_track is True
+        assert dbt.tracking.active_user.id is None
+        assert isinstance(dbt.tracking.active_user.invocation_id, str)
+        assert isinstance(dbt.tracking.active_user.run_started_at, datetime.datetime)
+
+    def test_disable_never_enabled(self):
+        assert dbt.tracking.active_user is None
+
+        # this should generate a whole new user object -> new invocation_id/run_started_at
+        dbt.tracking.disable_tracking()
+        assert isinstance(dbt.tracking.active_user, dbt.tracking.User)
+
+        assert dbt.tracking.active_user.do_not_track is True
+        assert dbt.tracking.active_user.id is None
+        assert isinstance(dbt.tracking.active_user.invocation_id, str)
+        assert isinstance(dbt.tracking.active_user.run_started_at, datetime.datetime)

--- a/test/unit/test_tracking.py
+++ b/test/unit/test_tracking.py
@@ -44,7 +44,8 @@ class TestTracking(unittest.TestCase):
         assert isinstance(dbt.tracking.active_user.invocation_id, str)
         assert isinstance(dbt.tracking.active_user.run_started_at, datetime.datetime)
         assert dbt.tracking.active_user.invocation_id != invocation_id
-        assert dbt.tracking.active_user.run_started_at != run_started_at
+        # if you use `!=`, you might hit a race condition (especially on windows)
+        assert dbt.tracking.active_user.run_started_at is not run_started_at
 
     def test_tracking_never_ok(self):
         assert dbt.tracking.active_user is None


### PR DESCRIPTION
resolves #2398 

### Description
When dbt disabled tracking, it was creating a whole new User object, which in turn reset the invocation_id and the run_started_at. Instead, if there is an existing user object disable that one "live".

To do so, I added a new entry point, `disable_tracking()` - this way existing code in `dbt.main` will still reset the invocation ID as it already did.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
