### PR TITLE
Fix for error in error handler for duped data tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
+- Fix for logic error in compilation errors for duplicate data test names ([#2406](https://github.com/fishtown-analytics/dbt/issues/2406), [#2407](https://github.com/fishtown-analytics/dbt/pull/2407))
 
 ## dbt 0.17.0b1 (May 5, 2020)
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -729,6 +729,8 @@ def raise_duplicate_resource_name(node_1, node_2):
         get_func = 'doc("{}")'.format(duped_name)
     elif node_1.resource_type == NodeType.Test and 'schema' in node_1.tags:
         return
+    else:
+        get_func = '"{}"'.format(duped_name)
 
     raise_compiler_error(
         'dbt found two resources with the name "{}". Since these resources '


### PR DESCRIPTION
resolves #2406

### Description

If a resource type is duped but not ref-able, use a placeholder value in the error message. This message is probably incorrect/unnecessary for data tests today, and we should consider allowing data tests with duplicate names in the future.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
