### PR TITLE
Preserve the case of schemas and databases when listing relations (#2403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,23 @@
 ## dbt 0.17.0 (Release TBD)
 
+### Breaking changes
+- The `list_relations_without_caching`, `drop_schema`, and `create_schema` macros and methods now accept a single argument of a Relation object with no identifier field. ([#2411](https://github.com/fishtown-analytics/dbt/pull/2411))
+
 ### Features
 - Added warning to nodes selector if nothing was matched ([#2115](https://github.com/fishtown-analytics/dbt/issues/2115), [#2343](https://github.com/fishtown-analytics/dbt/pull/2343))
 - Suport column descriptions for BigQuery models ([#2335](https://github.com/fishtown-analytics/dbt/issues/2335), [#2402](https://github.com/fishtown-analytics/dbt/pull/2402))
+
 
 ### Fixes
 - When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
 - Fix for logic error in compilation errors for duplicate data test names ([#2406](https://github.com/fishtown-analytics/dbt/issues/2406), [#2407](https://github.com/fishtown-analytics/dbt/pull/2407))
 - Fix list_schemas macro failing for BigQuery ([#2412](https://github.com/fishtown-analytics/dbt/issues/2412), [#2413](https://github.com/fishtown-analytics/dbt/issues/2413))
 - Fix for making schema tests work for community plugin [dbt-sqlserver](https://github.com/mikaelene/dbt-sqlserver) [#2414](https://github.com/fishtown-analytics/dbt/pull/2414)
+- Fix a bug where quoted uppercase schemas on snowflake were not processed properly during cache building. ([#2403](https://github.com/fishtown-analytics/dbt/issues/2403), [#2411](https://github.com/fishtown-analytics/dbt/pull/2411))
 
 Contributors:
  - [@azhard](https://github.com/azhard) [#2413](https://github.com/fishtown-analytics/dbt/pull/2413)
  - [@mikaelene](https://github.com/mikaelene) [#2414](https://github.com/fishtown-analytics/dbt/pull/2414)
-
-Contributors:
 - [@raalsky](https://github.com/Raalsky) ([#2343](https://github.com/fishtown-analytics/dbt/pull/2343))
 
 ## dbt 0.17.0b1 (May 5, 2020)

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -174,31 +174,31 @@ class SQLAdapter(BaseAdapter):
             kwargs={'relation': relation}
         )
 
-    def create_schema(self, database: str, schema: str) -> None:
-        logger.debug('Creating schema "{}"."{}".', database, schema)
+    def create_schema(self, relation: BaseRelation) -> None:
+        relation = relation.without_identifier()
+        logger.debug('Creating schema "{}"', relation)
         kwargs = {
-            'database_name': self.quote_as_configured(database, 'database'),
-            'schema_name': self.quote_as_configured(schema, 'schema'),
+            'relation': relation,
         }
         self.execute_macro(CREATE_SCHEMA_MACRO_NAME, kwargs=kwargs)
         self.commit_if_has_connection()
         # we can't update the cache here, as if the schema already existed we
         # don't want to (incorrectly) say that it's empty
 
-    def drop_schema(self, database: str, schema: str) -> None:
-        logger.debug('Dropping schema "{}"."{}".', database, schema)
+    def drop_schema(self, relation: BaseRelation) -> None:
+        relation = relation.without_identifier()
+        logger.debug('Dropping schema "{}".', relation)
         kwargs = {
-            'database_name': self.quote_as_configured(database, 'database'),
-            'schema_name': self.quote_as_configured(schema, 'schema'),
+            'relation': relation,
         }
         self.execute_macro(DROP_SCHEMA_MACRO_NAME, kwargs=kwargs)
         # we can update the cache here
-        self.cache.drop_schema(database, schema)
+        self.cache.drop_schema(relation.database, relation.schema)
 
     def list_relations_without_caching(
-            self, information_schema, schema
+        self, schema_relation: BaseRelation,
     ) -> List[BaseRelation]:
-        kwargs = {'information_schema': information_schema, 'schema': schema}
+        kwargs = {'schema_relation': schema_relation}
         results = self.execute_macro(
             LIST_RELATIONS_MACRO_NAME,
             kwargs=kwargs

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -44,23 +44,23 @@
     {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
 {% endmacro %}
 
-{% macro create_schema(database_name, schema_name) -%}
-  {{ adapter_macro('create_schema', database_name, schema_name) }}
+{% macro create_schema(relation) -%}
+  {{ adapter_macro('create_schema', relation) }}
 {% endmacro %}
 
-{% macro default__create_schema(database_name, schema_name) -%}
+{% macro default__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-    create schema if not exists {{database_name}}.{{schema_name}}
+    create schema if not exists {{ relation.without_identifier() }}
   {% endcall %}
 {% endmacro %}
 
-{% macro drop_schema(database_name, schema_name) -%}
-  {{ adapter_macro('drop_schema', database_name, schema_name) }}
+{% macro drop_schema(relation) -%}
+  {{ adapter_macro('drop_schema', relation) }}
 {% endmacro %}
 
-{% macro default__drop_schema(database_name, schema_name) -%}
+{% macro default__drop_schema(relation) -%}
   {%- call statement('drop_schema') -%}
-    drop schema if exists {{database_name}}.{{schema_name}} cascade
+    drop schema if exists {{ relation.without_identifier() }} cascade
   {% endcall %}
 {% endmacro %}
 
@@ -262,12 +262,12 @@
 {% endmacro %}
 
 
-{% macro list_relations_without_caching(information_schema, schema) %}
-  {{ return(adapter_macro('list_relations_without_caching', information_schema, schema)) }}
+{% macro list_relations_without_caching(schema_relation) %}
+  {{ return(adapter_macro('list_relations_without_caching', schema_relation)) }}
 {% endmacro %}
 
 
-{% macro default__list_relations_without_caching(information_schema, schema) %}
+{% macro default__list_relations_without_caching(schema_relation) %}
   {{ exceptions.raise_not_implemented(
     'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}
 {% endmacro %}

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -98,6 +98,7 @@ class Catalog(Dict[CatalogKey, CatalogTable]):
         sources: Dict[str, CatalogTable] = {}
 
         node_map, source_map = get_unique_id_mapping(manifest)
+        table: CatalogTable
         for table in self.values():
             key = table.key()
             if key in node_map:

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -497,7 +497,7 @@ class GraphRunnableTask(ManifestTask):
                         'Got an information schema with no database!'
                     )
                 if info.schema is None:
-                    # we are not in teh business of creating null schemas, so
+                    # we are not in the business of creating null schemas, so
                     # skip this
                     continue
                 db: str = info.database

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -6,8 +6,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 from typing import Optional, Dict, List, Set, Tuple, Iterable
 
 from dbt.task.base import ConfiguredTask
-from dbt.adapters.base import SchemaSearchMap
-from dbt.adapters.base.relation import InformationSchema
+from dbt.adapters.base import BaseRelation
 from dbt.adapters.factory import get_adapter
 from dbt.logger import (
     GLOBAL_LOGGER as logger,
@@ -431,48 +430,42 @@ class GraphRunnableTask(ManifestTask):
 
     def get_model_schemas(
         self, adapter, selected_uids: Iterable[str]
-    ) -> SchemaSearchMap:
+    ) -> Set[BaseRelation]:
         if self.manifest is None:
             raise InternalException('manifest was None in get_model_schemas')
-        search_map = SchemaSearchMap()
+        result: Set[BaseRelation] = set()
 
         for node in self.manifest.nodes.values():
             if node.unique_id not in selected_uids:
                 continue
             if node.is_refable and not node.is_ephemeral:
                 relation = adapter.Relation.create_from(self.config, node)
-                # we're going to be creating these schemas, so preserve the
-                # case.
-                search_map.add(relation, preserve_case=True)
+                result.add(relation.without_identifier())
 
-        return search_map
+        return result
 
     def create_schemas(self, adapter, selected_uids: Iterable[str]):
         required_schemas = self.get_model_schemas(adapter, selected_uids)
         # we want the string form of the information schema database
-        required_databases: List[str] = []
-        for info in required_schemas:
-            include_policy = info.include_policy.replace(
-                schema=False, identifier=False, database=True
+        required_databases: Set[BaseRelation] = set()
+        for required in required_schemas:
+            db_only = required.include(
+                database=True, schema=False, identifier=False
             )
-            db_only = info.replace(
-                include_policy=include_policy,
-                information_schema_view=None,
-            )
-            required_databases.append(db_only)
+            required_databases.add(db_only)
 
         existing_schemas_lowered: Set[Tuple[str, Optional[str]]] = set()
 
-        def list_schemas(info: InformationSchema) -> List[Tuple[str, str]]:
+        def list_schemas(db_only: BaseRelation) -> List[Tuple[str, str]]:
             # the database name should never be None here (or where are we
             # listing schemas from?)
-            if info.database is None:
+            if db_only.database is None:
                 raise InternalException(
-                    f'Got an invalid information schema of {info} (database '
-                    f'was None)'
+                    f'Got an invalid database-only portion of {db_only} '
+                    f'(database was None)'
                 )
-            database_name = info.database
-            database_quoted = str(info)
+            database_name: str = db_only.database
+            database_quoted = str(db_only)
             with adapter.connection_named(f'list_{database_name}'):
                 # we should never create a null schema, so just filter them out
                 return [
@@ -481,9 +474,11 @@ class GraphRunnableTask(ManifestTask):
                     if s is not None
                 ]
 
-        def create_schema(db: str, schema: str) -> None:
+        def create_schema(relation: BaseRelation) -> None:
+            db = relation.database
+            schema = relation.schema
             with adapter.connection_named(f'create_{db}_{schema}'):
-                adapter.create_schema(db, schema)
+                adapter.create_schema(relation)
 
         list_futures = []
         create_futures = []
@@ -496,21 +491,23 @@ class GraphRunnableTask(ManifestTask):
             for ls_future in as_completed(list_futures):
                 existing_schemas_lowered.update(ls_future.result())
 
-            for info, schema in required_schemas.search():
+            for info in required_schemas:
                 if info.database is None:
                     raise InternalException(
                         'Got an information schema with no database!'
                     )
+                if info.schema is None:
+                    # we are not in teh business of creating null schemas, so
+                    # skip this
+                    continue
                 db: str = info.database
-                lower_schema: Optional[str] = None
-                if schema is not None:
-                    lower_schema = schema.lower()
+                schema: str = info.schema
 
-                db_schema = (db.lower(), lower_schema)
+                db_schema = (db.lower(), schema.lower())
                 if db_schema not in existing_schemas_lowered:
                     existing_schemas_lowered.add(db_schema)
                     create_futures.append(
-                        tpe.submit(create_schema, db, schema)
+                        tpe.submit(create_schema, info)
                     )
 
             for create_future in as_completed(create_futures):

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -74,8 +74,8 @@
   {{ adapter.create_schema(database_name, schema_name) }}
 {% endmacro %}
 
-{% macro bigquery__drop_schema(database_name, schema_name) -%}
-  {{ adapter.drop_schema(database_name, schema_name) }}
+{% macro bigquery__drop_schema(relation) -%}
+  {{ adapter.drop_schema(relation) }}
 {% endmacro %}
 
 {% macro bigquery__drop_relation(relation) -%}
@@ -89,8 +89,8 @@
 {% endmacro %}
 
 
-{% macro bigquery__list_relations_without_caching(information_schema, schema) -%}
-  {{ return(adapter.list_relations_without_caching(information_schema, schema)) }}
+{% macro bigquery__list_relations_without_caching(schema_relation) -%}
+  {{ return(adapter.list_relations_without_caching(schema_relation)) }}
 {%- endmacro %}
 
 

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -14,21 +14,21 @@
   );
 {%- endmacro %}
 
-{% macro postgres__create_schema(database_name, schema_name) -%}
-  {% if database_name -%}
-    {{ adapter.verify_database(database_name) }}
+{% macro postgres__create_schema(relation) -%}
+  {% if relation.database -%}
+    {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
   {%- call statement('create_schema') -%}
-    create schema if not exists {{ schema_name }}
+    create schema if not exists {{ relation.without_identifier().include(database=False) }}
   {%- endcall -%}
 {% endmacro %}
 
-{% macro postgres__drop_schema(database_name, schema_name) -%}
-  {% if database_name -%}
-    {{ adapter.verify_database(database_name) }}
+{% macro postgres__drop_schema(relation) -%}
+  {% if relation.database -%}
+    {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
   {%- call statement('drop_schema') -%}
-    drop schema if exists {{ schema_name }} cascade
+    drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade
   {%- endcall -%}
 {% endmacro %}
 
@@ -54,23 +54,23 @@
 {% endmacro %}
 
 
-{% macro postgres__list_relations_without_caching(information_schema, schema) %}
+{% macro postgres__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     select
-      '{{ information_schema.database }}' as database,
+      '{{ schema_relation.database }}' as database,
       tablename as name,
       schemaname as schema,
       'table' as type
     from pg_tables
-    where schemaname ilike '{{ schema }}'
+    where schemaname ilike '{{ schema_relation.schema }}'
     union all
     select
-      '{{ information_schema.database }}' as database,
+      '{{ schema_relation.database }}' as database,
       viewname as name,
       schemaname as schema,
       'view' as type
     from pg_views
-    where schemaname ilike '{{ schema }}'
+    where schemaname ilike '{{ schema_relation.schema }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -66,13 +66,13 @@
 {% endmacro %}
 
 
-{% macro redshift__create_schema(database_name, schema_name) -%}
-  {{ postgres__create_schema(database_name, schema_name) }}
+{% macro redshift__create_schema(relation) -%}
+  {{ postgres__create_schema(relation) }}
 {% endmacro %}
 
 
-{% macro redshift__drop_schema(database_name, schema_name) -%}
-  {{ postgres__drop_schema(database_name, schema_name) }}
+{% macro redshift__drop_schema(relation) -%}
+  {{ postgres__drop_schema(relation) }}
 {% endmacro %}
 
 
@@ -153,8 +153,8 @@
 {% endmacro %}
 
 
-{% macro redshift__list_relations_without_caching(information_schema, schema) %}
-  {{ return(postgres__list_relations_without_caching(information_schema, schema)) }}
+{% macro redshift__list_relations_without_caching(schema_relation) %}
+  {{ return(postgres__list_relations_without_caching(schema_relation)) }}
 {% endmacro %}
 
 

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -113,9 +113,9 @@ class SnowflakeAdapter(SQLAdapter):
         return [row['name'] for row in results]
 
     def list_relations_without_caching(
-            self, information_schema, schema
+            self, schema_relation: SnowflakeRelation
     ) -> List[SnowflakeRelation]:
-        kwargs = {'information_schema': information_schema, 'schema': schema}
+        kwargs = {'schema_relation': schema_relation}
         try:
             results = self.execute_macro(
                 LIST_RELATIONS_MACRO_NAME,

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -92,18 +92,16 @@
 {% endmacro %}
 
 
-{% macro snowflake__list_relations_without_caching(information_schema, schema) %}
-  {%- set db_name = adapter.quote_as_configured(information_schema.database, 'database') -%}
-  {%- set schema_name = adapter.quote_as_configured(schema, 'schema') -%}
+{% macro snowflake__list_relations_without_caching(schema_relation) %}
   {%- set sql -%}
-    show terse objects in {{ db_name }}.{{ schema_name }}
+    show terse objects in {{ schema_relation }}
   {%- endset -%}
 
   {%- set result = run_query(sql) -%}
   {% set maximum = 10000 %}
   {% if (result | length) >= maximum %}
     {% set msg %}
-      Too many schemas in schema {{ database }}.{{ schema }}! dbt can only get
+      Too many schemas in schema  {{ schema_relation }}! dbt can only get
       information about schemas with fewer than {{ maximum }} objects.
     {% endset %}
     {% do exceptions.raise_compiler_error(msg) %}

--- a/test/integration/001_simple_copy_test/test_simple_copy.py
+++ b/test/integration/001_simple_copy_test/test_simple_copy.py
@@ -290,11 +290,14 @@ class TestSnowflakeSimpleLowercasedSchemaQuoted(BaseLowercasedSchemaTest):
         })
 
     @use_profile("snowflake")
-    def test__snowflake__seed__quoting_switch_schema(self):
+    def test__snowflake__seed__quoting_switch_schema_lower(self):
         self.use_default_project({
             "data-paths": [self.dir("snowflake-seed-initial")],
         })
 
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+        # this is intentional - should not error!
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)
 
@@ -303,6 +306,32 @@ class TestSnowflakeSimpleLowercasedSchemaQuoted(BaseLowercasedSchemaTest):
             "quoting": {"identifier": False, "schema": False},
         })
         results = self.run_dbt(["seed"], expect_pass=False)
+
+
+class TestSnowflakeSimpleUppercasedSchemaQuoted(BaseTestSimpleCopy):
+    @property
+    def project_config(self):
+        return self.seed_quote_cfg_with({
+            'quoting': {'identifier': False, 'schema': True}
+        })
+
+    @use_profile("snowflake")
+    def test__snowflake__seed__quoting_switch_schema_upper(self):
+        self.use_default_project({
+            "data-paths": [self.dir("snowflake-seed-initial")],
+        })
+
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+        # this is intentional - should not error!
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+
+        self.use_default_project({
+            "data-paths": [self.dir("snowflake-seed-update")],
+            "quoting": {"identifier": False, "schema": False},
+        })
+        results = self.run_dbt(["seed"])
 
 
 class TestSnowflakeIncrementalOverwrite(BaseTestSimpleCopy):

--- a/test/integration/037_external_reference_test/test_external_reference.py
+++ b/test/integration/037_external_reference_test/test_external_reference.py
@@ -30,7 +30,7 @@ class TestExternalReference(DBTIntegrationTest):
         # otherwise postgres hangs forever.
         self._drop_schemas()
         with self.get_connection():
-            self.adapter.drop_schema(self.default_database, self.external_schema)
+            self._drop_schema_named(self.default_database, self.external_schema)
         super().tearDown()
 
     @use_profile('postgres')
@@ -56,7 +56,7 @@ class TestExternalDependency(DBTIntegrationTest):
         # otherwise postgres hangs forever.
         self._drop_schemas()
         with self.get_connection():
-            self.adapter.drop_schema(self.default_database, self.external_schema)
+            self._drop_schema_named(self.default_database, self.external_schema)
         super().tearDown()
 
     @use_profile('postgres')

--- a/test/integration/054_adapter_methods_test/models/model.sql
+++ b/test/integration/054_adapter_methods_test/models/model.sql
@@ -3,13 +3,13 @@
 
 {% if execute %}
     {# don't ever do any of this #}
-    {%- do adapter.drop_schema(upstream.database, upstream.schema) -%}
+    {%- do adapter.drop_schema(upstream) -%}
     {% set existing = adapter.get_relation(upstream.database, upstream.schema, upstream.identifier) %}
     {% if existing is not none %}
         {% do exceptions.raise_compiler_error('expected ' ~ ' to not exist, but it did') %}
     {% endif %}
 
-    {%- do adapter.create_schema(upstream.database, upstream.schema) -%}
+    {%- do adapter.create_schema(upstream) -%}
 
     {% set sql = create_view_as(upstream, 'select 2 as id') %}
     {% do run_query(sql) %}

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -466,7 +466,8 @@ class DBTIntegrationTest(unittest.TestCase):
 
     def _create_schema_named(self, database, schema):
         if self.adapter_type == 'bigquery':
-            self.adapter.create_schema(database, schema)
+            relation = self.adapter.Relation.create(database=database, schema=schema)
+            self.adapter.create_schema(relation)
         else:
             schema_fqn = self._get_schema_fqn(database, schema)
             self.run_sql(self.CREATE_SCHEMA_STATEMENT.format(schema_fqn))
@@ -474,7 +475,8 @@ class DBTIntegrationTest(unittest.TestCase):
 
     def _drop_schema_named(self, database, schema):
         if self.adapter_type == 'bigquery' or self.adapter_type == 'presto':
-            self.adapter.drop_schema(database, schema)
+            relation = self.adapter.Relation.create(database=database, schema=schema)
+            self.adapter.drop_schema(relation)
         else:
             schema_fqn = self._get_schema_fqn(database, schema)
             self.run_sql(self.DROP_SCHEMA_STATEMENT.format(schema_fqn))

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -216,13 +216,15 @@ class TestConnectionNamePassthrough(BaseTestBigQueryAdapter):
         self.mock_connection_manager.get_bq_table.assert_called_once_with('db', 'schema', 'my_model')
 
     def test_create_schema(self):
-        self.adapter.create_schema('db', 'schema')
+        relation = BigQueryRelation.create(database='db', schema='schema')
+        self.adapter.create_schema(relation)
         self.mock_connection_manager.create_dataset.assert_called_once_with('db', 'schema')
 
     @patch.object(BigQueryAdapter, 'check_schema_exists')
     def test_drop_schema(self, mock_check_schema):
         mock_check_schema.return_value = True
-        self.adapter.drop_schema('db', 'schema')
+        relation = BigQueryRelation.create(database='db', schema='schema')
+        self.adapter.drop_schema(relation)
         self.mock_connection_manager.drop_dataset.assert_called_once_with('db', 'schema')
 
     def test_get_columns_in_relation(self):

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -145,11 +145,14 @@ class TestRuntimeWrapper(unittest.TestCase):
         found = self.wrapper.get_relation('database', 'schema', 'identifier')
 
         self.assertEqual(found, rel)
-        # it gets called with an information schema relation as the first arg,
-        # which is hard to mock.
-        self.responder.list_relations_without_caching.assert_called_once_with(
-            mock.ANY, 'schema'
-        )
+
+        self.responder.list_relations_without_caching.assert_called_once_with(mock.ANY)
+        # extract the argument
+        assert len(self.responder.list_relations_without_caching.mock_calls) == 1
+        assert len(self.responder.list_relations_without_caching.call_args[0]) == 1
+        arg = self.responder.list_relations_without_caching.call_args[0][0]
+        assert arg.database == 'database'
+        assert arg.schema == 'schema'
 
 
 def assert_has_keys(

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -209,7 +209,7 @@ class TestPostgresAdapter(unittest.TestCase):
             connect_timeout=10)
 
     @mock.patch.object(PostgresAdapter, 'execute_macro')
-    @mock.patch.object(PostgresAdapter, '_get_cache_schemas')
+    @mock.patch.object(PostgresAdapter, '_get_catalog_schemas')
     def test_get_catalog_various_schemas(self, mock_get_schemas, mock_execute):
         column_names = ['table_database', 'table_schema', 'table_name']
         rows = [
@@ -297,7 +297,11 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         self.load_patch.stop()
 
     def test_quoting_on_drop_schema(self):
-        self.adapter.drop_schema(database='postgres', schema='test_schema')
+        relation = self.adapter.Relation.create(
+            database='postgres', schema='test_schema',
+            quote_policy=self.adapter.config.quoting,
+        )
+        self.adapter.drop_schema(relation)
 
         self.mock_execute.assert_has_calls([
             mock.call('/* dbt */\ndrop schema if exists "test_schema" cascade', None)

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -82,10 +82,12 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.load_patch.stop()
 
     def test_quoting_on_drop_schema(self):
-        self.adapter.drop_schema(
+        relation = SnowflakeAdapter.Relation.create(
             database='test_database',
-            schema='test_schema'
+            schema='test_schema',
+            quote_policy=self.adapter.config.quoting
         )
+        self.adapter.drop_schema(relation)
 
         self.mock_execute.assert_has_calls([
             mock.call('/* dbt */\ndrop schema if exists test_database."test_schema" cascade', None)


### PR DESCRIPTION
resolves #2403 


### Description
There's hopefully nothing too wild or controversial in here - this is a substantial change, but it should fix some correctness issues in how dbt lists schemas. I think in the long run this will be more pleasant for adapter authors than having to figure out how to render the database/schema in each of those, and just defer it to the relations.

Change `list_relations_without_caching` (both the macro and the method) to take a single argument, a `Relation` with no `identifier` and `identifier` set to not include. Macros can use this to get a database-specific representation of the relation. The logic around creating missing schemas was updated similarly - dbt will faithfully issue "create schema" statements for whatever you give it, rather than coercing everything to lowercase and wrapping it in the given quoting.

In the process and for the same reasons, I updated `drop_schema` and `create_schema` to take the same kind of argument.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
