### PR TITLE
Fix error when trying to call list_schemas macro for BigQuery adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 - When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
 - Fix for logic error in compilation errors for duplicate data test names ([#2406](https://github.com/fishtown-analytics/dbt/issues/2406), [#2407](https://github.com/fishtown-analytics/dbt/pull/2407))
+- Fix list_schemas macro failing for BigQuery ([#2406](https://github.com/fishtown-analytics/dbt/issues/2398), [#2413](https://github.com/fishtown-analytics/dbt/issues/2413))
 
 ## dbt 0.17.0b1 (May 5, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ### Fixes
 - When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
 - Fix for logic error in compilation errors for duplicate data test names ([#2406](https://github.com/fishtown-analytics/dbt/issues/2406), [#2407](https://github.com/fishtown-analytics/dbt/pull/2407))
-- Fix list_schemas macro failing for BigQuery ([#2406](https://github.com/fishtown-analytics/dbt/issues/2398), [#2413](https://github.com/fishtown-analytics/dbt/issues/2413))
+- Fix list_schemas macro failing for BigQuery ([#2412](https://github.com/fishtown-analytics/dbt/issues/2412), [#2413](https://github.com/fishtown-analytics/dbt/issues/2413))
+
+Contributors:
+ - [@azhard](https://github.com/azhard) [#2413](https://github.com/fishtown-analytics/dbt/pull/2413)
 
 ## dbt 0.17.0b1 (May 5, 2020)
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -142,7 +142,7 @@
 
 
 {% macro bigquery__list_schemas(database) -%}
-  {{ return(adapter.list_schemas()) }}
+  {{ return(adapter.list_schemas(database)) }}
 {% endmacro %}
 
 


### PR DESCRIPTION
resolves #2412 

### Description
Adds missing `database` parameter to `adapter.list_schemas` macro that is called by `bigquery__list_schemas`


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
