### PR TITLE
alias for schema tests macros

### DIFF
--- a/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
@@ -31,7 +31,7 @@ validation_errors as (
     )
 )
 
-select count(*)
+select count(*) as validation_errors
 from validation_errors
 
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/schema_tests/not_null.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/not_null.sql
@@ -3,7 +3,7 @@
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
-select count(*)
+select count(*) as validation_errors
 from {{ model }}
 where {{ column_name }} is null
 

--- a/core/dbt/include/global_project/macros/schema_tests/relationships.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/relationships.sql
@@ -4,7 +4,7 @@
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
 
 
-select count(*)
+select count(*) as validation_errors
 from (
     select {{ column_name }} as id from {{ model }}
 ) as child

--- a/core/dbt/include/global_project/macros/schema_tests/unique.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/unique.sql
@@ -3,7 +3,7 @@
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
-select count(*)
+select count(*) as validation_errors
 from (
 
     select


### PR DESCRIPTION
resolves #2397 
### Description

Added aliases to columns returned from schema_tests macros. This will make the macros work on adapters required columnnames in their driver such as dbt-sqlserver with it's pyodbc driver


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
