### PR TITLE
Model intersection syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Features
 - Added a `full_refresh` config item that overrides the behavior of the `--full-refresh` flag ([#1009](https://github.com/fishtown-analytics/dbt/issues/1009), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
+- Added intersection syntax for model selector ([#2167](https://github.com/fishtown-analytics/dbt/issues/2167), [#2417](https://github.com/fishtown-analytics/dbt/pull/2417)) 
+
+Contributors:
+ - [@raalsky](https://github.com/Raalsky) ([#2417](https://github.com/fishtown-analytics/dbt/pull/2417))
 
 ## dbt 0.17.0 (Release TBD)
 

--- a/test/integration/007_graph_selection_tests/test_intersection_syntax.py
+++ b/test/integration/007_graph_selection_tests/test_intersection_syntax.py
@@ -1,0 +1,25 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestGraphSelection(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "graph_selection_tests_007"
+
+    @property
+    def models(self):
+        return "models"
+
+    @use_profile('postgres')
+    def test__postgres__specific_model(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(['run', '--models', 'users'])
+        self.assertEqual(len(results), 1)
+
+        self.assertTablesEqual("seed", "users")
+        created_models = self.get_models_in_schema()
+        self.assertFalse('users_rollup' in created_models)
+        self.assertFalse('base_users' in created_models)
+        self.assertFalse('emails' in created_models)

--- a/test/integration/007_graph_selection_tests/test_intersection_syntax.py
+++ b/test/integration/007_graph_selection_tests/test_intersection_syntax.py
@@ -12,14 +12,212 @@ class TestGraphSelection(DBTIntegrationTest):
         return "models"
 
     @use_profile('postgres')
-    def test__postgres__specific_model(self):
+    def test__postgres__same_model_intersection(self):
         self.run_sql_file("seed.sql")
 
-        results = self.run_dbt(['run', '--models', 'users'])
+        results = self.run_dbt(['run', '--models', 'users,users'])
+        # users
         self.assertEqual(len(results), 1)
 
-        self.assertTablesEqual("seed", "users")
         created_models = self.get_models_in_schema()
-        self.assertFalse('users_rollup' in created_models)
-        self.assertFalse('base_users' in created_models)
-        self.assertFalse('emails' in created_models)
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__tags_intersection(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(['run', '--models', 'tag:bi,tag:users'])
+        # users
+        self.assertEqual(len(results), 1)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_triple_descending(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(['run', '--models', '*,tag:bi,tag:users'])
+        # users
+        self.assertEqual(len(results), 1)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_triple_ascending(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(['run', '--models', 'tag:users,tag:bi,*'])
+        # users
+        self.assertEqual(len(results), 1)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_with_exclusion(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(['run', '--models', '+users_rollup_dependency,users+', '--exclude', 'users_rollup_dependency'])
+        # users, users_rollup
+        self.assertEqual(len(results), 2)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_exclude_intersection(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', '--exclude',
+             'tag:bi,users_rollup+'])
+        # users
+        self.assertEqual(len(results), 1)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_exclude_intersection_lack(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', '--exclude',
+             '@emails,@emails_alt'])
+        # users, users_rollup
+        self.assertEqual(len(results), 2)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+
+    @use_profile('postgres')
+    def test__postgres__intersection_exclude_triple_intersection(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', '--exclude',
+             '*,tag:bi,users_rollup'])
+        # users
+        self.assertEqual(len(results), 1)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_concat(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', 'emails_alt'])
+        # users, users_rollup, emails_alt
+        self.assertEqual(len(results), 3)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('users_rollup', created_models)
+        self.assertIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_concat_intersection(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', '@emails_alt,emails_alt'])
+        # users, users_rollup, emails_alt
+        self.assertEqual(len(results), 3)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('users_rollup', created_models)
+        self.assertIn('emails_alt', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_concat_exclude(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', 'emails_alt', '--exclude', 'users_rollup']
+        )
+        # users, emails_alt
+        self.assertEqual(len(results), 2)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('emails_alt', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+    @use_profile('postgres')
+    def test__postgres__intersection_concat_exclude_concat(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', 'emails_alt,@users',
+             '--exclude', 'users_rollup_dependency', 'users_rollup'])
+        # users, emails_alt
+        self.assertEqual(len(results), 2)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('emails_alt', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)
+
+
+    @use_profile('postgres')
+    def test__postgres__intersection_concat_exclude_intersection_concat(self):
+        self.run_sql_file("seed.sql")
+
+        results = self.run_dbt(
+            ['run', '--models', 'tag:bi,@users', 'emails_alt,@users',
+             '--exclude', '@users,users_rollup_dependency', '@users,users_rollup'])
+        # users, emails_alt
+        self.assertEqual(len(results), 2)
+
+        created_models = self.get_models_in_schema()
+        self.assertIn('users', created_models)
+        self.assertIn('emails_alt', created_models)
+        self.assertNotIn('users_rollup', created_models)
+        self.assertNotIn('subdir', created_models)
+        self.assertNotIn('nested_users', created_models)

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -125,7 +125,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             set(['m.X.a', 'm.X.c', 'm.Y.f', 'm.X.g'])
         )
 
-    def test__select_intersection_same_model(self):
+    def test__select_same_model_intersection(self):
         self.run_specs_and_assert(
             self.package_graph,
             ['a,a'],
@@ -133,7 +133,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             set(['m.X.a'])
         )
 
-    def test__select_intersection_layer(self):
+    def test__select_layer_intersection(self):
         self.run_specs_and_assert(
             self.package_graph,
             ['+c,c+'],
@@ -149,7 +149,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             set()
         )
 
-    def test__select_intersection_tags(self):
+    def test__select_tags_intersection(self):
         self.run_specs_and_assert(
             self.package_graph,
             ['tag:abc,tag:bcef'],
@@ -173,7 +173,7 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             set(['m.X.a'])
         )
 
-    def test__select_intersection_with_exclude(self):
+    def test__select_intersection_with_exclusion(self):
         self.run_specs_and_assert(
             self.package_graph,
             ['tag:abc,tag:bcef'],

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -125,6 +125,30 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             set(['m.X.a', 'm.X.c', 'm.Y.f', 'm.X.g'])
         )
 
+    def test__select_concat(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:abc', 'tag:bcef'],
+            [],
+            set(['m.X.a', 'm.Y.b', 'm.X.c', 'm.X.e', 'm.Y.f'])
+        )
+
+    def test__select_concat_exclude(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:abc', 'tag:bcef'],
+            ['tag:efg'],
+            set(['m.X.a', 'm.Y.b', 'm.X.c'])
+        )
+
+    def test__select_concat_exclude_concat(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:abc', 'tag:bcef'],
+            ['tag:efg', 'a'],
+            set(['m.Y.b', 'm.X.c'])
+        )
+
     def test__select_same_model_intersection(self):
         self.run_specs_and_assert(
             self.package_graph,
@@ -203,6 +227,46 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             ['*,@a,+b'],
             ['*,tag:abc,tag:bcef'],
             set(['m.X.a'])
+        )
+
+    def test__select_concat_intersection(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg', '*,tag:abc'],
+            [],
+            set(['m.X.a', 'm.Y.b', 'm.X.c', 'm.X.e', 'm.Y.f'])
+        )
+
+    def test__select_concat_intersection_exclude(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg', '*,tag:abc'],
+            ['e'],
+            set(['m.X.a', 'm.Y.b', 'm.X.c', 'm.Y.f'])
+        )
+
+    def test__select_concat_intersection_exclude_concat(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg', '*,tag:abc'],
+            ['e', 'f'],
+            set(['m.X.a', 'm.Y.b', 'm.X.c'])
+        )
+
+    def test__select_concat_intersection_exclude_intersection(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg', '*,tag:abc'],
+            ['tag:abc,tag:bcef'],
+            set(['m.X.a', 'm.X.e', 'm.Y.f'])
+        )
+
+    def test__select_concat_intersection_exclude_intersection_concat(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg', '*,tag:abc'],
+            ['tag:abc,tag:bcef', 'tag:abc,a'],
+            set(['m.X.e', 'm.Y.f'])
         )
 
     def parse_spec_and_assert(self, spec, parents, children, filter_type, filter_value, childrens_parents):

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -40,11 +40,11 @@ class GraphSelectionTest(BaseGraphSelectionTest):
 
     def add_tags(self, nodes):
         nodes['m.X.a'].tags = ['abc']
-        nodes['m.Y.b'].tags = ['abc']
-        nodes['m.X.c'].tags = ['abc']
+        nodes['m.Y.b'].tags = ['abc', 'bcef']
+        nodes['m.X.c'].tags = ['abc', 'bcef']
         nodes['m.Y.d'].tags = []
-        nodes['m.X.e'].tags = ['efg']
-        nodes['m.Y.f'].tags = ['efg']
+        nodes['m.X.e'].tags = ['efg', 'bcef']
+        nodes['m.Y.f'].tags = ['efg', 'bcef']
         nodes['m.X.g'].tags = ['efg']
 
     def run_specs_and_assert(self, graph, include, exclude, expected):
@@ -55,7 +55,6 @@ class GraphSelectionTest(BaseGraphSelectionTest):
         )
 
         self.assertEqual(selected, expected)
-
 
     def test__single_node_selection_in_package(self):
         self.run_specs_and_assert(
@@ -124,6 +123,86 @@ class GraphSelectionTest(BaseGraphSelectionTest):
             ['@X.c'],
             [],
             set(['m.X.a', 'm.X.c', 'm.Y.f', 'm.X.g'])
+        )
+
+    def test__select_intersection_same_model(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['a,a'],
+            [],
+            set(['m.X.a'])
+        )
+
+    def test__select_intersection_layer(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['+c,c+'],
+            [],
+            set(['m.X.c'])
+        )
+
+    def test__select_intersection_lack(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['a,b'],
+            [],
+            set()
+        )
+
+    def test__select_intersection_tags(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:abc,tag:bcef'],
+            [],
+            set(['m.Y.b', 'm.X.c'])
+        )
+
+    def test__select_intersection_triple_descending(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['*,tag:abc,a'],
+            [],
+            set(['m.X.a'])
+        )
+
+    def test__select_intersection_triple_ascending(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['a,tag:abc,*'],
+            [],
+            set(['m.X.a'])
+        )
+
+    def test__select_intersection_with_exclude(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:abc,tag:bcef'],
+            ['c'],
+            set(['m.Y.b'])
+        )
+
+    def test__select_intersection_exclude_intersection(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg'],
+            ['tag:bcef,@b'],
+            set(['m.Y.f'])
+        )
+
+    def test__select_intersection_exclude_intersection_lack(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['tag:bcef,tag:efg'],
+            ['tag:bcef,@a'],
+            set()
+        )
+
+    def test__select_intersection_exclude_triple_intersection(self):
+        self.run_specs_and_assert(
+            self.package_graph,
+            ['*,@a,+b'],
+            ['*,tag:abc,tag:bcef'],
+            set(['m.X.a'])
         )
 
     def parse_spec_and_assert(self, spec, parents, children, filter_type, filter_value, childrens_parents):


### PR DESCRIPTION
resolves #2167

### Description

Extends nodes selection syntax with the intersection operator (`,`). In ex. the intersection of multiple tags:  `--models tag:abc,tag:def,tag:ghi` which stands for every model which has tags `abc` **and** `def` **and** `ghi`.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
