### PR TITLE
fix version-loading logic to respect multiple plugins at the same path (#2410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - When tracking is disabled due to errors, do not reset the invocation ID ([#2398](https://github.com/fishtown-analytics/dbt/issues/2398), [#2400](https://github.com/fishtown-analytics/dbt/pull/2400))
 - Fix for logic error in compilation errors for duplicate data test names ([#2406](https://github.com/fishtown-analytics/dbt/issues/2406), [#2407](https://github.com/fishtown-analytics/dbt/pull/2407))
 - Fix list_schemas macro failing for BigQuery ([#2412](https://github.com/fishtown-analytics/dbt/issues/2412), [#2413](https://github.com/fishtown-analytics/dbt/issues/2413))
+- When plugins are installed in the same folder as dbt core, report their versions. ([#2410](https://github.com/fishtown-analytics/dbt/issues/2410), [#2418](https://github.com/fishtown-analytics/dbt/pull/2418))
 - Fix for making schema tests work for community plugin [dbt-sqlserver](https://github.com/mikaelene/dbt-sqlserver) [#2414](https://github.com/fishtown-analytics/dbt/pull/2414)
 
 Contributors:

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import os
 import glob
 import json
@@ -66,8 +67,12 @@ def get_version_information():
 
 
 def _get_adapter_plugin_names() -> Iterator[str]:
-    adapters_spec = importlib.util.find_spec('dbt.adapters')
-    for adapters_path in adapters_spec.submodule_search_locations:
+    spec = importlib.util.find_spec('dbt.adapters')
+    # If None, then nothing provides an importable 'dbt.adapters', so we will
+    # not be reporting plugin versions today
+    if spec is None or spec.submodule_search_locations is None:
+        return
+    for adapters_path in spec.submodule_search_locations:
         version_glob = os.path.join(adapters_path, '*', '__version__.py')
         for version_path in glob.glob(version_glob):
             # the path is like .../dbt/adapters/{plugin_name}/__version__.py


### PR DESCRIPTION
resolves #2410 

### Description
The previous check only looked at one `__version__.py` file per dbt folder (which is the case in an "editable" install), but the normal case is actually for all plugins to be in the same folder. Handle both cases.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
