### PR TITLE
Track project id for deps events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Fix for making schema tests work for community plugin [dbt-sqlserver](https://github.com/mikaelene/dbt-sqlserver) [#2414](https://github.com/fishtown-analytics/dbt/pull/2414)
 - Fix a bug where quoted uppercase schemas on snowflake were not processed properly during cache building. ([#2403](https://github.com/fishtown-analytics/dbt/issues/2403), [#2411](https://github.com/fishtown-analytics/dbt/pull/2411))
 
+### Under the hood
+- Track distinct project hashes in anonymous usage metrics for package downloads ([#2351](https://github.com/fishtown-analytics/dbt/issues/2351), [#2429](https://github.com/fishtown-analytics/dbt/pull/2429))
+
 Contributors:
  - [@azhard](https://github.com/azhard) [#2413](https://github.com/fishtown-analytics/dbt/pull/2413)
  - [@mikaelene](https://github.com/mikaelene) [#2414](https://github.com/fishtown-analytics/dbt/pull/2414)

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -299,10 +299,16 @@ def track_rpc_request(options):
     )
 
 
-def track_package_install(options):
-    context = [SelfDescribingJson(PACKAGE_INSTALL_SPEC, options)]
+def track_package_install(config, args, options):
     assert active_user is not None, \
         'Cannot track package installs when active user is None'
+
+    invocation_data = get_invocation_context(active_user, config, args)
+
+    context = [
+        SelfDescribingJson(INVOCATION_SPEC, invocation_data),
+        SelfDescribingJson(PACKAGE_INSTALL_SPEC, options)
+    ]
 
     track(
         active_user,

--- a/test/integration/033_event_tracking_test/test_events.py
+++ b/test/integration/033_event_tracking_test/test_events.py
@@ -225,6 +225,19 @@ class TestEventTrackingSuccess(TestEventTracking):
     def test__postgres_event_tracking_deps(self):
         package_context = [
             {
+                'schema': 'iglu:com.dbt/invocation/jsonschema/1-0-1',
+                'data': {
+                    'project_id': '098f6bcd4621d373cade4e832627b4f6',
+                    'user_id': ANY,
+                    'invocation_id': ANY,
+                    'version': ANY,
+                    'command': 'deps',
+                    'run_type': 'regular',
+                    'options': None,
+                    'adapter_type': 'postgres'
+                }
+            },
+            {
                 'schema': 'iglu:com.dbt/package_install/jsonschema/1-0-0',
                 'data': {
                     'name': 'c5552991412d1cd86e5c20a87f3518d5',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ requires = tox-pip-version
 
 [testenv:flake8]
 basepython = python3.6
-commands = /bin/bash -c '$(which flake8) --select=E,W,F --ignore=W504 core/dbt plugins/*/dbt'
+commands = /bin/bash -c '$(which flake8) --select=E,W,F --ignore=W504,E741 core/dbt plugins/*/dbt'
 deps =
      -r ./dev_requirements.txt
 


### PR DESCRIPTION
resolves #2351

### Description
This PR de-anonymizes packages installed from the hubsite with `dbt deps`. Further, it includes a project id, adapter name, and dbt version in the information tracked for the `dbt deps` event. This information:
 - Will help us understand how packages are being used
 - Can be used to paint "live" statistics on hub.getdbt.com (eg. weekly installations)
 - Can be used by package maintainers to assess the impact of breaking changes (eg. by database, or by dbt version)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
