### PR TITLE
In dbt run, log relations for the status line instead of explicit node info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixes
 - When no columns are documented and persist_docs.columns is True, skip creating comments instead of failing with errors ([#2439](https://github.com/fishtown-analytics/dbt/issues/2439), [#2440](https://github.com/fishtown-analytics/dbt/pull/2440))
 - Fixed an argument issue with the `create_schema` macro on bigquery ([#2445](https://github.com/fishtown-analytics/dbt/issues/2445), [#2448](https://github.com/fishtown-analytics/dbt/pull/2448))
+- dbt now logs using the adapter plugin's ideas about how relations should be displayed ([dbt-spark/#74](https://github.com/fishtown-analytics/dbt-spark/issues/74), [#2450](https://github.com/fishtown-analytics/dbt/pull/2450))
 
 
 ## dbt 0.17.0rc1 (May 12, 2020)

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -376,12 +376,16 @@ def _validate_materialization_relations_dict(
 
 class ModelRunner(CompileRunner):
     def get_node_representation(self):
-        if self.config.credentials.database == self.node.database:
-            template = "{0.schema}.{0.alias}"
-        else:
-            template = "{0.database}.{0.schema}.{0.alias}"
-
-        return template.format(self.node)
+        display_quote_policy = {
+            'database': False, 'schema': False, 'identifier': False
+        }
+        relation = self.adapter.Relation.create_from(
+            self.config, self.node, quote_policy=display_quote_policy
+        )
+        # exclude the database from output if it's the default
+        if self.node.database == self.config.credentials.database:
+            relation = relation.include(database=False)
+        return str(relation)
 
     def describe_node(self):
         return "{} model {}".format(self.node.get_materialization(),


### PR DESCRIPTION
resolves https://github.com/fishtown-analytics/dbt-spark/issues/74

### Description
Instead of looking at nodes, defer to the adapter plugin's ideas about them by creating a relation from the node. I preserved the "don't show databases if it matches the default credentials" behavior, because I know people care about that!

The benefit here is that on spark, no more preceding `.`s in dbt's description of what it's building.

I would love to get this in for 0.17.0 if we can justify it to ourselves.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
