### PR TITLE
Fix duplicate sources crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed an argument issue with the `create_schema` macro on bigquery ([#2445](https://github.com/fishtown-analytics/dbt/issues/2445), [#2448](https://github.com/fishtown-analytics/dbt/pull/2448))
 - dbt now logs using the adapter plugin's ideas about how relations should be displayed ([dbt-spark/#74](https://github.com/fishtown-analytics/dbt-spark/issues/74), [#2450](https://github.com/fishtown-analytics/dbt/pull/2450))
 - The create_adapter_plugin.py script creates a version 2 dbt_project.yml file ([#2451](https://github.com/fishtown-analytics/dbt/issues/2451), [#2455](https://github.com/fishtown-analytics/dbt/pull/2455))
+- Fixed dbt crashing with an AttributeError on duplicate sources ([#2463](https://github.com/fishtown-analytics/dbt/issues/2463), [#2464](https://github.com/fishtown-analytics/dbt/pull/2464))
 
 
 ## dbt 0.17.0rc1 (May 12, 2020)

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -327,9 +327,15 @@ class UnpatchedSourceDefinition(UnparsedBaseNode, HasUniqueID, HasFqn):
     resource_type: NodeType = field(metadata={'restrict': [NodeType.Source]})
     patch_path: Optional[Path] = None
 
+    def get_full_source_name(self):
+        return f'{self.source.name}_{self.table.name}'
+
+    def get_source_representation(self):
+        return f'source("{self.source.name}", "{self.table.name}")'
+
     @property
     def name(self) -> str:
-        return '{0.name}_{1.name}'.format(self.source, self.table)
+        return self.get_full_source_name()
 
     @property
     def quote_columns(self) -> Optional[bool]:
@@ -390,6 +396,12 @@ class ParsedSourceDefinition(
     tags: List[str] = field(default_factory=list)
     config: SourceConfig = field(default_factory=SourceConfig)
     patch_path: Optional[Path] = None
+
+    def get_full_source_name(self):
+        return f'{self.source_name}_{self.name}'
+
+    def get_source_representation(self):
+        return f'source("{self.source.name}", "{self.table.name}")'
 
     @property
     def is_refable(self):

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -724,7 +724,8 @@ def raise_duplicate_resource_name(node_1, node_2):
     if node_1.resource_type in NodeType.refable():
         get_func = 'ref("{}")'.format(duped_name)
     elif node_1.resource_type == NodeType.Source:
-        get_func = 'source("{}", "{}")'.format(node_1.source_name, duped_name)
+        duped_name = node_1.get_full_source_name()
+        get_func = node_1.get_source_representation()
     elif node_1.resource_type == NodeType.Documentation:
         get_func = 'doc("{}")'.format(duped_name)
     elif node_1.resource_type == NodeType.Test and 'schema' in node_1.tags:

--- a/test/integration/025_duplicate_model_test/models-source-dupes/schema.yml
+++ b/test/integration/025_duplicate_model_test/models-source-dupes/schema.yml
@@ -1,0 +1,6 @@
+version: 2
+sources:
+  - name: something
+    tables:
+     - name: dupe
+     - name: dupe

--- a/test/integration/025_duplicate_model_test/test_duplicate_source.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_source.py
@@ -1,0 +1,42 @@
+from dbt.exceptions import CompilationException
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestDuplicateSourceEnabled(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_model_025"
+
+    @property
+    def models(self):
+        return "models-source-dupes"
+
+    @property
+    def profile_config(self):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "postgres",
+                        "threads": 1,
+                        "host": self.database_host,
+                        "port": 5432,
+                        "user": "root",
+                        "pass": "password",
+                        "dbname": "dbt",
+                        "schema": self.unique_schema()
+                    },
+                },
+                "target": "dev"
+            }
+        }
+
+    @use_profile("postgres")
+    def test_postgres_duplicate_model_enabled(self):
+        message = "dbt found two resources with the name"
+        try:
+            self.run_dbt(["compile"])
+            self.assertTrue(False, "dbt did not throw for duplicate sources")
+        except CompilationException as e:
+            self.assertTrue(message in str(e), "dbt did not throw the correct error message")


### PR DESCRIPTION
resolves #2463 

### Description
The only change of note here was adding a test. A more comprehensive fix would add a `typing_extensions.Protocol` that gets passed to this method and implement it for everything we pass in. That requires a lot more substantial change than I really want to make in a patch to an rc.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
