### PR TITLE
Fix some issues around global-scoped vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - dbt now logs using the adapter plugin's ideas about how relations should be displayed ([dbt-spark/#74](https://github.com/fishtown-analytics/dbt-spark/issues/74), [#2450](https://github.com/fishtown-analytics/dbt/pull/2450))
 - The create_adapter_plugin.py script creates a version 2 dbt_project.yml file ([#2451](https://github.com/fishtown-analytics/dbt/issues/2451), [#2455](https://github.com/fishtown-analytics/dbt/pull/2455))
 - Fixed dbt crashing with an AttributeError on duplicate sources ([#2463](https://github.com/fishtown-analytics/dbt/issues/2463), [#2464](https://github.com/fishtown-analytics/dbt/pull/2464))
+- Fixed a number of issues with globally-scoped vars ([#2473](https://github.com/fishtown-analytics/dbt/issues/2473), [#2472](https://github.com/fishtown-analytics/dbt/issues/2472), [#2469](https://github.com/fishtown-analytics/dbt/issues/2469), [#2477](https://github.com/fishtown-analytics/dbt/pull/2477))
 - Fixed DBT Docker entrypoint ([#2470](https://github.com/fishtown-analytics/dbt/issues/2470), [#2475](https://github.com/fishtown-analytics/dbt/pull/2475))
 
 Contributors:

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -360,12 +360,12 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
                 if path.is_dir() and not path.name.startswith('__'):
                     yield path
 
-    def as_v1(self):
+    def as_v1(self, all_projects: Iterable[str]):
         if self.config_version == 1:
             return self
 
         return self.from_parts(
-            project=Project.as_v1(self),
+            project=Project.as_v1(self, all_projects),
             profile=self,
             args=self.args,
             dependencies=self.dependencies,

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -452,7 +452,7 @@ class ModelConfiguredVar(Var):
 
     def _generate_merged(self) -> Mapping[str, Any]:
         search_node: IsFQNResource
-        if hasattr(self.node, 'fqn'):
+        if isinstance(self.node, IsFQNResource):
             search_node = self.node
         else:
             search_node = FQNLookup(self.node.package_name)
@@ -495,8 +495,13 @@ class ParseProvider(Provider):
     source = ParseSourceResolver
 
 
-class GenerateNameProvider(ParseProvider):
+class GenerateNameProvider(Provider):
+    execute = False
+    Config = RuntimeConfigObject
+    DatabaseWrapper = ParseDatabaseWrapper
     Var = RuntimeVar
+    ref = ParseRefResolver
+    source = ParseSourceResolver
 
 
 class RuntimeProvider(Provider):

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -15,14 +15,14 @@ from dbt.config import RuntimeConfig, Project
 from dbt.context.base import (
     contextmember, contextproperty, Var
 )
-from dbt.context.configured import ManifestContext, MacroNamespace
+from dbt.context.configured import ManifestContext, MacroNamespace, FQNLookup
 from dbt.context.context_config import ContextConfigType
 from dbt.contracts.graph.manifest import Manifest, Disabled
 from dbt.contracts.graph.compiled import (
-    NonSourceNode, CompiledSeedNode, CompiledResource, CompiledNode
+    NonSourceNode, CompiledSeedNode, CompiledResource
 )
 from dbt.contracts.graph.parsed import (
-    ParsedMacro, ParsedSourceDefinition, ParsedSeedNode, ParsedNode
+    ParsedMacro, ParsedSourceDefinition, ParsedSeedNode
 )
 from dbt.exceptions import (
     InternalException,
@@ -36,6 +36,7 @@ from dbt.exceptions import (
     source_target_not_found,
     wrapped_exports,
 )
+from dbt.legacy_config_updater import IsFQNResource
 from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.node_types import NodeType
 
@@ -450,17 +451,17 @@ class ModelConfiguredVar(Var):
         yield self.config
 
     def _generate_merged(self) -> Mapping[str, Any]:
-        cli_vars = self.config.cli_vars
-
-        # once sources have FQNs, add ParsedSourceDefinition
-        if not isinstance(self.node, (CompiledNode, ParsedNode)):
-            return cli_vars
+        search_node: IsFQNResource
+        if hasattr(self.node, 'fqn'):
+            search_node = self.node
+        else:
+            search_node = FQNLookup(self.node.package_name)
 
         adapter_type = self.config.credentials.type
 
         merged = MultiDict()
         for project in self.packages_for_node():
-            merged.add(project.vars.vars_for(self.node, adapter_type))
+            merged.add(project.vars.vars_for(search_node, adapter_type))
         merged.add(self.cli_vars)
         return merged
 
@@ -492,6 +493,10 @@ class ParseProvider(Provider):
     Var = ParseVar
     ref = ParseRefResolver
     source = ParseSourceResolver
+
+
+class GenerateNameProvider(ParseProvider):
+    Var = RuntimeVar
 
 
 class RuntimeProvider(Provider):
@@ -1116,6 +1121,17 @@ def generate_parser_macro(
 ) -> Dict[str, Any]:
     ctx = MacroContext(
         macro, config, manifest, ParseProvider(), package_name
+    )
+    return ctx.to_dict()
+
+
+def generate_generate_component_name_macro(
+    macro: ParsedMacro,
+    config: RuntimeConfig,
+    manifest: Manifest,
+) -> Dict[str, Any]:
+    ctx = MacroContext(
+        macro, config, manifest, GenerateNameProvider(), None
     )
     return ctx.to_dict()
 

--- a/core/dbt/legacy_config_updater.py
+++ b/core/dbt/legacy_config_updater.py
@@ -1,6 +1,6 @@
 # TODO: rename this module.
 from typing import Dict, Any, Mapping, List
-from typing_extensions import Protocol
+from typing_extensions import Protocol, runtime_checkable
 
 import dbt.exceptions
 
@@ -16,6 +16,7 @@ class HasConfigFields(Protocol):
     sources: Dict[str, Any]
 
 
+@runtime_checkable
 class IsFQNResource(Protocol):
     fqn: List[str]
     resource_type: NodeType

--- a/core/dbt/rpc/builtins.py
+++ b/core/dbt/rpc/builtins.py
@@ -1,7 +1,7 @@
 import os
 import signal
 from datetime import datetime
-from typing import Type, Union, Any, List
+from typing import Type, Union, Any, List, Dict
 
 import dbt.exceptions
 from dbt.contracts.rpc import (
@@ -171,6 +171,10 @@ def poll_complete(
     return cls.from_result(result, tags, timing, logs)
 
 
+def _dict_logs(logs: List[LogMessage]) -> List[Dict[str, Any]]:
+    return [log.to_dict() for log in logs]
+
+
 class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
     METHOD_NAME = 'poll'
 
@@ -210,7 +214,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
                     f'At end of task {task_id}, error state but error is None'
                 )
                 raise RPCException.from_error(
-                    dbt_error(exc, logs=[l.to_dict() for l in task_logs])
+                    dbt_error(exc, logs=_dict_logs(task_logs))
                 )
             # the exception has logs already attached from the child, don't
             # overwrite those
@@ -223,7 +227,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
                     'None'
                 )
                 raise RPCException.from_error(
-                    dbt_error(exc, logs=[l.to_dict() for l in task_logs])
+                    dbt_error(exc, logs=_dict_logs(task_logs))
                 )
             return poll_complete(
                 timing=timing,
@@ -245,5 +249,5 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
                 f'Got unknown value state={state} for task {task_id}'
             )
             raise RPCException.from_error(
-                dbt_error(exc, logs=[l.to_dict() for l in task_logs])
+                dbt_error(exc, logs=_dict_logs(task_logs))
             )

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -386,7 +386,7 @@ class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
             except RPCException as exc:
                 # RPC Exceptions come already preserialized for the jsonrpc
                 # framework
-                exc.logs = [l.to_dict() for l in self.logs]
+                exc.logs = [log.to_dict() for log in self.logs]
                 exc.tags = self.tags
                 raise
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -36,21 +36,11 @@ class ExitCodes(int, Enum):
     UnhandledError = 2
 
 
-def to_bytes(s):
-    return s.encode('latin-1')
-
-
 def coalesce(*args):
     for arg in args:
         if arg is not None:
             return arg
     return None
-
-
-def chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
 
 
 def get_profile_from_project(project):

--- a/test/integration/013_context_var_tests/bad-generate-macros/generate_names.sql
+++ b/test/integration/013_context_var_tests/bad-generate-macros/generate_names.sql
@@ -1,0 +1,4 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {% do var('somevar') %}
+    {% do return(dbt.generate_schema_name(custom_schema_name, node)) %}
+{%- endmacro %}

--- a/test/integration/013_context_var_tests/dependency-data/root_model_expected.csv
+++ b/test/integration/013_context_var_tests/dependency-data/root_model_expected.csv
@@ -1,0 +1,2 @@
+first_dep_global,from_root
+dep_never_overridden,root_root_value

--- a/test/integration/013_context_var_tests/dependency-models/inside/model.sql
+++ b/test/integration/013_context_var_tests/dependency-models/inside/model.sql
@@ -1,0 +1,3 @@
+select
+	'{{ var("first_dep_override") }}' as first_dep_global,
+	'{{ var("from_root_to_root") }}' as from_root

--- a/test/integration/013_context_var_tests/first_dependency/data/first_dep_expected.csv
+++ b/test/integration/013_context_var_tests/first_dependency/data/first_dep_expected.csv
@@ -1,0 +1,2 @@
+first_dep_global,from_root
+first_dep_global_value_overridden,root_first_value

--- a/test/integration/013_context_var_tests/first_dependency/dbt_project.yml
+++ b/test/integration/013_context_var_tests/first_dependency/dbt_project.yml
@@ -1,0 +1,27 @@
+
+name: 'first_dep'
+version: '1.0'
+config-version: 2
+
+profile: 'default'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+require-dbt-version: '>=0.1.0'
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+vars:
+  first_dep:
+    first_dep_global: 'first_dep_global_value_overridden'
+
+
+seeds:
+  quote_columns: False

--- a/test/integration/013_context_var_tests/first_dependency/models/nested/first_dep_model.sql
+++ b/test/integration/013_context_var_tests/first_dependency/models/nested/first_dep_model.sql
@@ -1,0 +1,3 @@
+select
+    '{{ var("first_dep_global") }}' as first_dep_global,
+    '{{ var("from_root_to_first") }}' as from_root

--- a/test/integration/013_context_var_tests/second_dependency_v1/data/second_dep_expected.csv
+++ b/test/integration/013_context_var_tests/second_dependency_v1/data/second_dep_expected.csv
@@ -1,0 +1,2 @@
+from_root,from_second
+root_second_value,second_to_second_override_value

--- a/test/integration/013_context_var_tests/second_dependency_v1/dbt_project.yml
+++ b/test/integration/013_context_var_tests/second_dependency_v1/dbt_project.yml
@@ -1,0 +1,43 @@
+
+name: 'second_dep'
+version: '1.0'
+
+profile: 'default'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+require-dbt-version: '>=0.1.0'
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+seeds:
+  quote_columns: False
+
+
+models:
+  second_dep:
+    vars:
+      from_second_to_second: 'never_see_me'
+    inner:
+      vars:
+        from_second_to_second: 'second_to_second_override_value'
+  first_dep:
+    vars:
+      from_second_to_first: 'never_see_me_either'
+    nested:
+      vars:
+        from_second_to_first: 'second_to_first_override_value'
+  test:
+    vars:
+      from_second_to_root: 'also_never_see_me'
+    inside:
+      vars:
+        from_second_to_root: 'second_to_root_override_value'

--- a/test/integration/013_context_var_tests/second_dependency_v1/models/inner/second_dep_model.sql
+++ b/test/integration/013_context_var_tests/second_dependency_v1/models/inner/second_dep_model.sql
@@ -1,0 +1,3 @@
+select
+    '{{ var("from_root_to_second") }}' as from_root,
+    '{{ var("from_second_to_second") }}' as from_second

--- a/test/integration/013_context_var_tests/trivial-models/model.sql
+++ b/test/integration/013_context_var_tests/trivial-models/model.sql
@@ -1,0 +1,1 @@
+select 1 as id


### PR DESCRIPTION
resolves #2469
resolves #2473
resolves #2472 

### Description
- Fix global-level var rewriting from v2 -> v1
  - to do this, I inverted how var rewriting works: This skips including vars for packages that aren't actually used in the project, which I am not sorry about. It does mean that top-level vars can't be dicts, which we should absolutely document, but I also feel pretty good about. I think could add them in with the `+` syntax in the future.
- Add top-level vars to more lookup fields
  - A few places handle `vars`, and a couple only handled the package-scoped ones. I believe I've resolved all of them.
- When a user calls var() in a `generate_*_name` macro, on failure it now raises (like at runtime)
  - to do that, I added a new special provider that those macros use that mostly acts like the parse-time context (because it is), except `var` and `config` act as if it were runtime. Maybe `config.get` just should not work at all?
 
- When a node has no FQN, pretend the FQN is just the package name when returning vars
  - This makes most things behave reasonably. I think in an ideal world the `generate_*_name` macros would somehow resolve vars against the `node` they're passed instead of the context's node. That's a much more complicated problem that probably deserves its own issue/PR process!

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
