### PR TITLE
fix source patching perf with no patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The create_adapter_plugin.py script creates a version 2 dbt_project.yml file ([#2451](https://github.com/fishtown-analytics/dbt/issues/2451), [#2455](https://github.com/fishtown-analytics/dbt/pull/2455))
 - Fixed dbt crashing with an AttributeError on duplicate sources ([#2463](https://github.com/fishtown-analytics/dbt/issues/2463), [#2464](https://github.com/fishtown-analytics/dbt/pull/2464))
 - Fixed DBT Docker entrypoint ([#2470](https://github.com/fishtown-analytics/dbt/issues/2470), [#2475](https://github.com/fishtown-analytics/dbt/pull/2475))
+- Fixed a performance regression that occurred even when a user was not using the relevant feature ([#2474](https://github.com/fishtown-analytics/dbt/issues/2474), [#2478](https://github.com/fishtown-analytics/dbt/pull/2478))
 
 Contributors:
 - [@dmateusp](https://github.com/dmateusp) ([#2475](https://github.com/fishtown-analytics/dbt/pull/2475))

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -267,8 +267,9 @@ class BaseConfig(
         return self.from_dict(dct, validate=validate)
 
     def finalize_and_validate(self: T) -> T:
-        self.to_dict(validate=True)
-        return self.replace()
+        # from_dict will validate for us
+        dct = self.to_dict(omit_none=False, validate=False)
+        return self.from_dict(dct)
 
 
 @dataclass

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -46,6 +46,8 @@ class SourcePatcher:
         unpatched: UnpatchedSourceDefinition,
         patch: Optional[SourcePatch],
     ) -> UnpatchedSourceDefinition:
+        if patch is None:
+            return unpatched
 
         source_dct = unpatched.source.to_dict()
         table_dct = unpatched.table.to_dict()


### PR DESCRIPTION
resolves #2474

### Description
So, this is just about the lowest of low-hanging fruit possible, but this fix just makes dbt not bother going through the patch logic when there is no patch.

quick update: also, I fixed `finalize_and_validate` to skip a serialization/deserialization step and to avoid double-validating.

I'll keep looking at perf, but this gets us from 71.18s to ~16.11s~ 9.64s on a 676-source project.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
