### PR TITLE
Improve docs performance (#2480)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   unit:
     docker: &test_only
-      - image: fishtownanalytics/test-container:5
+      - image: fishtownanalytics/test-container:7
         environment:
           DBT_INVOCATION_ENV: circle
     steps:
@@ -30,7 +30,7 @@ jobs:
           destination: dist
   integration-postgres-py36:
     docker: &test_and_postgres
-      - image: fishtownanalytics/test-container:5
+      - image: fishtownanalytics/test-container:7
         environment:
           DBT_INVOCATION_ENV: circle
       - image: postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
 - Fixed a number of issues with globally-scoped vars ([#2473](https://github.com/fishtown-analytics/dbt/issues/2473), [#2472](https://github.com/fishtown-analytics/dbt/issues/2472), [#2469](https://github.com/fishtown-analytics/dbt/issues/2469), [#2477](https://github.com/fishtown-analytics/dbt/pull/2477))
 - Fixed DBT Docker entrypoint ([#2470](https://github.com/fishtown-analytics/dbt/issues/2470), [#2475](https://github.com/fishtown-analytics/dbt/pull/2475))
 - Fixed a performance regression that occurred even when a user was not using the relevant feature ([#2474](https://github.com/fishtown-analytics/dbt/issues/2474), [#2478](https://github.com/fishtown-analytics/dbt/pull/2478))
+- Substantial performance improvements for parsing on large projects, especially projects with many docs definition. ([#2480](https://github.com/fishtown-analytics/dbt/issues/2480), [#2481](https://github.com/fishtown-analytics/dbt/pull/2481))
+- Expose Snowflake query id in case of an exception raised by connector ([#2201](https://github.com/fishtown-analytics/dbt/issues/2201), [#2358](https://github.com/fishtown-analytics/dbt/pull/2358))
 
 Contributors:
 - [@dmateusp](https://github.com/dmateusp) ([#2475](https://github.com/fishtown-analytics/dbt/pull/2475))
+- [@ChristianKohlberg](https://github.com/ChristianKohlberg) (#2358](https://github.com/fishtown-analytics/dbt/pull/2358))
 
 ## dbt 0.17.0rc1 (May 12, 2020)
 
@@ -67,7 +70,6 @@ Contributors:
 - Add a 'depends_on' attribute to the log record extra field ([#2316](https://github.com/fishtown-analytics/dbt/issues/2316), [#2341](https://github.com/fishtown-analytics/dbt/pull/2341))
 - Added a '--no-browser' argument to "dbt docs serve" so you can serve docs in an environment that only has a CLI browser which would otherwise deadlock dbt ([#2004](https://github.com/fishtown-analytics/dbt/issues/2004), [#2364](https://github.com/fishtown-analytics/dbt/pull/2364))
 -  Snowflake now uses "describe table" to get the columns in a relation ([#2260](https://github.com/fishtown-analytics/dbt/issues/2260), [#2324](https://github.com/fishtown-analytics/dbt/pull/2324))
-- Expose Snowflake query id in case of an exception raised by connector ([#2201](https://github.com/fishtown-analytics/dbt/issues/2201), [#2358](https://github.com/fishtown-analytics/dbt/pull/2358))
 - Sources (and therefore freshness tests) can be enabled and disabled via dbt_project.yml ([#2283](https://github.com/fishtown-analytics/dbt/issues/2283), [#2312](https://github.com/fishtown-analytics/dbt/pull/2312), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - schema.yml files are now fully rendered in a context that is aware of vars declared in from dbt_project.yml files ([#2269](https://github.com/fishtown-analytics/dbt/issues/2269), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))
 - Sources from dependencies can be overridden in schema.yml files ([#2287](https://github.com/fishtown-analytics/dbt/issues/2287), [#2357](https://github.com/fishtown-analytics/dbt/pull/2357))

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y  --no-install-recommends \
         netcat postgresql curl git ssh  software-properties-common \
         make build-essential ca-certificates libpq-dev \
-        libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit \
+        libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit libyaml-dev \
         && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get install -y \

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -493,7 +493,12 @@ def _requote_result(raw_value: str, rendered: str) -> str:
     return f'{quote_char}{rendered}{quote_char}'
 
 
-_HAS_RENDER_CHARS_PAT = re.compile(r'{[{%]')
+# performance note: Local benmcharking (so take it with a big grain of salt!)
+# on this indicates that it is is on average slightly slower than
+# checking two separate patterns, but the standard deviation is smaller with
+# one pattern. The time difference between the two was ~2 std deviations, which
+# is small enough that I've just chosen the more readable option.
+_HAS_RENDER_CHARS_PAT = re.compile(r'({[{%]|[}%]})')
 
 
 def get_rendered(

--- a/core/dbt/clients/yaml_helper.py
+++ b/core/dbt/clients/yaml_helper.py
@@ -1,7 +1,16 @@
+from typing import Any
+
 import dbt.exceptions
 
 import yaml
 import yaml.scanner
+
+# the C version is faster, but it doesn't always exist
+YamlLoader: Any
+try:
+    from yaml import CSafeLoader as YamlLoader
+except ImportError:
+    from yaml import SafeLoader as YamlLoader
 
 
 YAML_ERROR_MESSAGE = """
@@ -44,9 +53,13 @@ def contextualized_yaml_error(raw_contents, error):
                                      raw_error=error)
 
 
+def safe_load(contents):
+    return yaml.load(contents, Loader=YamlLoader)
+
+
 def load_yaml_text(contents):
     try:
-        return yaml.safe_load(contents)
+        return safe_load(contents)
     except (yaml.scanner.ScannerError, yaml.YAMLError) as e:
         if hasattr(e, 'problem_mark'):
             error = contextualized_yaml_error(contents, e)

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -7,6 +7,7 @@ from typing import (
 from dbt import flags
 from dbt import tracking
 from dbt.clients.jinja import undefined_error, get_rendered
+from dbt.clients import yaml_helper
 from dbt.contracts.graph.compiled import CompiledResource
 from dbt.exceptions import raise_compiler_error, MacroReturn
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -383,7 +384,7 @@ class BaseContext(metaclass=ContextMeta):
             -- ["good"]
         """
         try:
-            return yaml.safe_load(value)
+            return yaml_helper.safe_load(value)
         except (AttributeError, ValueError, yaml.YAMLError):
             return default
 

--- a/core/dbt/parser/docs.py
+++ b/core/dbt/parser/docs.py
@@ -1,17 +1,17 @@
 from typing import Iterable
 
-import jinja2.runtime
+import re
 
-from dbt.clients.jinja import get_template
-from dbt.contracts.graph.unparsed import UnparsedDocumentationFile
+from dbt.clients.jinja import get_rendered
 from dbt.contracts.graph.parsed import ParsedDocumentation
-from dbt.exceptions import CompilationException, InternalException
 from dbt.node_types import NodeType
 from dbt.parser.base import Parser
 from dbt.parser.search import (
-    FullBlock, FileBlock, FilesystemSearcher, BlockSearcher
+    BlockContents, FileBlock, FilesystemSearcher, BlockSearcher
 )
-from dbt.utils import deep_merge, DOCS_PREFIX
+
+
+SHOULD_PARSE_RE = re.compile(r'{[{%]')
 
 
 class DocumentationParser(Parser[ParsedDocumentation]):
@@ -35,58 +35,28 @@ class DocumentationParser(Parser[ParsedDocumentation]):
         # need to be part of the unique ID.
         return '{}.{}'.format(self.project.project_name, resource_name)
 
-    # TODO: could this class just render() the tag.contents() and skip this
-    # whole extra module.__dict__.items() thing?
-    def _parse_template_docs(self, template, docfile):
-        for key, item in template.module.__dict__.items():
-            if type(item) != jinja2.runtime.Macro:
-                continue
+    def parse_block(
+        self, block: BlockContents
+    ) -> Iterable[ParsedDocumentation]:
+        unique_id = self.generate_unique_id(block.name)
+        contents = get_rendered(block.contents, {}).strip()
 
-            if not key.startswith(DOCS_PREFIX):
-                continue
-
-            name = key.replace(DOCS_PREFIX, '')
-
-            unique_id = self.generate_unique_id(name)
-
-            merged = deep_merge(
-                docfile.to_dict(),
-                {
-                    'name': name,
-                    'unique_id': unique_id,
-                    'block_contents': item().strip(),
-                }
-            )
-            merged.pop('file_contents', None)
-            yield ParsedDocumentation.from_dict(merged)
-
-    def parse_block(self, block: FullBlock) -> Iterable[ParsedDocumentation]:
-        base_node = UnparsedDocumentationFile(
+        doc = ParsedDocumentation(
             root_path=self.project.project_root,
             path=block.file.path.relative_path,
             original_file_path=block.path.original_file_path,
             package_name=self.project.project_name,
-            # set contents to the actual internal contents of the block
-            file_contents=block.contents,
+            unique_id=unique_id,
+            name=block.name,
+            block_contents=contents,
         )
-        try:
-            template = get_template(block.contents, {})
-        except CompilationException as e:
-            e.add_node(base_node)
-            raise
-        all_docs = list(self._parse_template_docs(template, base_node))
-        if len(all_docs) != 1:
-            raise InternalException(
-                'Got {} docs in an extracted docs block: block parser '
-                'mismatched with jinja'.format(len(all_docs))
-            )
-        return all_docs
+        return [doc]
 
     def parse_file(self, file_block: FileBlock):
-        searcher: Iterable[FullBlock] = BlockSearcher(
+        searcher: Iterable[BlockContents] = BlockSearcher(
             source=[file_block],
             allowed_blocks={'docs'},
-            source_tag_factory=FullBlock,
+            source_tag_factory=BlockContents,
         )
         for block in searcher:
             for parsed in self.parse_block(block):

--- a/core/dbt/task/run_operation.py
+++ b/core/dbt/task/run_operation.py
@@ -28,10 +28,8 @@ class RunOperationTask(ManifestTask):
         return dbt.utils.parse_cli_vars(self.args.args)
 
     def compile_manifest(self) -> None:
-        # skip building a linker, but do make sure to build the flat graph
         if self.manifest is None:
             raise InternalException('manifest was None in compile_manifest')
-        self.manifest.build_flat_graph()
 
     def _run_unsafe(self) -> agate.Table:
         adapter = get_adapter(self.config)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -72,7 +72,6 @@ class ManifestTask(ConfiguredTask):
                 'compile_manifest called before manifest was loaded'
             )
         self.linker = compile_manifest(self.config, self.manifest)
-        self.manifest.build_flat_graph()
 
     def _runtime_initialize(self):
         self.load_manifest()

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from dbt.clients import yaml_helper
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt import version as dbt_version
 from snowplow_tracker import Subject, Tracker, Emitter, logger as sp_logger
@@ -144,7 +145,7 @@ class User:
         else:
             with open(self.cookie_path, "r") as fh:
                 try:
-                    user = yaml.safe_load(fh)
+                    user = yaml_helper.safe_load(fh)
                     if user is None:
                         user = self.set_cookie()
                 except yaml.reader.ReaderError:

--- a/test/integration/060_persist_docs_tests/test_persist_docs.py
+++ b/test/integration/060_persist_docs_tests/test_persist_docs.py
@@ -1,4 +1,5 @@
 from test.integration.base import DBTIntegrationTest, use_profile
+import os
 
 import json
 
@@ -19,7 +20,10 @@ class BasePersistDocsTest(DBTIntegrationTest):
             assert '\n' in comment
             assert 'Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting' in comment
             assert '/* comment */' in comment
-            assert '--\n' in comment
+            if os.name == 'nt':
+                assert '--\r\n' in comment or '--\n' in comment
+            else:
+                assert '--\n' in comment
 
     def _assert_has_table_comments(self, table_node):
         table_comment = table_node['metadata']['comment']


### PR DESCRIPTION
resolves #2480

### Description
Improve the docs/schema.yml parsing performance pretty significantly.

On a sample project with ~1k sources and ~50k docs blocks, the result of `time dbt ls > /dev/null` improved from a bit over 15 minutes on my machine to a bit under 1.5 minutes.

There are ~4~ 5 major parts to this PR:
 - in `get_rendered`, do a quick regex check to see if there are any `{%` or `{{` in the document. If not, we just return that value.
   - except native mode, where we could also do this (we'd have to call `ast.literal_eval` like the native renderer, though!). The ROI seemed low.
 - When parsing docs, instead of building a full template and rendering that and doing a bunch of extra rendering, just examine the contents of the docs blocks. This way, docs parsing can use the `get_rendered` improvements (otherwise the `{% docs my_docs %}...` triggers the match)
 - When loading yaml, use the CSafeLoader if it's available. To get it, users will have to have cython (I'm not 100% on this) and headers for libyaml on their system at `pip install` time. We could see about adding libyaml to homebrew too I guess.
 - To resolve refs/sources/docs, dbt now builds up a cache and digs through that. Although constructing the cache takes O(n) the first time something is resolved, subsequent searches are O(1).
 - New!: We used to call build_flat_graph twice, which is unnecessary - we do it after parsing and that is sufficient, there's no reason to call it at runtime.

I had to add special validation to `ref` handling to catch non-hashable inputs earlier as an error, previously we did the search but we'd fail to find the matching ref.


This PR has some unit test changes, but the goal is to not have to change the integration tests here.

There is a bit of extra indirection on the resolve-caching level: The cache logic internally stores unique IDs and does lookups on the manifest at resolution time to pick out the actual doc/source/node. This avoids having to rebuild the cache just because a node was compiled and makes it a bit easier to handle the `run_sql` case where we insert our new node into the manifest.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
