### PR TITLE
Direct child model selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### Features
 - Added a `full_refresh` config item that overrides the behavior of the `--full-refresh` flag ([#1009](https://github.com/fishtown-analytics/dbt/issues/1009), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
 - Added a "docs" field to macros, with a "show" subfield to allow for hiding macros from the documentation site ([#2430](https://github.com/fishtown-analytics/dbt/issues/2430))
-- Added intersection syntax for model selector ([#2167](https://github.com/fishtown-analytics/dbt/issues/2167), [#2417](https://github.com/fishtown-analytics/dbt/pull/2417)) 
+- Added intersection syntax for model selector ([#2167](https://github.com/fishtown-analytics/dbt/issues/2167), [#2417](https://github.com/fishtown-analytics/dbt/pull/2417))
+- Extends model selection syntax with at most n-th parent/children `dbt run --models 3+m1+2` ([#2052](https://github.com/fishtown-analytics/dbt/issues/2052), [#2485](https://github.com/fishtown-analytics/dbt/pull/2485)) 
 
 Contributors:
- - [@raalsky](https://github.com/Raalsky) ([#2417](https://github.com/fishtown-analytics/dbt/pull/2417))
+ - [@raalsky](https://github.com/Raalsky) ([#2417](https://github.com/fishtown-analytics/dbt/pull/2417), [#2485](https://github.com/fishtown-analytics/dbt/pull/2485))
  - [@alf-mindshift](https://github.com/alf-mindshift) ([#2431](https://github.com/fishtown-analytics/dbt/pull/2431)
 
 ## dbt 0.17.0 (Release TBD)

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -330,12 +330,29 @@ class Graph:
         return self.select_parents(ancestors_for) | ancestors_for
 
     @classmethod
-    def descendants(cls, graph, node, max_depth: int = -1):
-        return nx.descendants(graph, node)
+    def descendants(cls, graph, node, max_depth: int = None):
+        """Returns all nodes reachable from `node` in `graph`.
+
+            Parameters
+            ----------
+            G : NetworkX DiGraph
+                A directed acyclic graph (DAG)
+            source : node in `G`
+
+            Returns
+            -------
+            set()
+                The descendants of `node` in `graph`
+            """
+        if not graph.has_node(node):
+            raise nx.NetworkXError("The node %s is not in the graph." % node)
+        des = set(
+            n for n, d in nx.single_source_shortest_path_length(graph, source=node, cutoff=max_depth).items())
+        return des - {node}
 
     def select_children(self,
                         selected: Set[str],
-                        max_depth: int = -1) -> Set[str]:
+                        max_depth: int = None) -> Set[str]:
         descendants: Set[str] = set()
         for node in selected:
             descendants.update(
@@ -344,12 +361,29 @@ class Graph:
         return descendants
 
     @classmethod
-    def ancestors(cls, graph, node, max_depth: int = -1):
-        return nx.ancestors(graph, node)
+    def ancestors(cls, graph, node, max_depth: int = None):
+        """Returns all nodes having a path to `node` in `graph`.
+
+            Parameters
+            ----------
+            graph : NetworkX DiGraph
+                A directed acyclic graph (DAG)
+            node : node in `graph`
+
+            Returns
+            -------
+            set()
+                The ancestors of `node` in `graph`
+            """
+        if not graph.has_node(node):
+            raise nx.NetworkXError("The node %s is not in the graph." % node)
+        anc = set(
+            n for n, d in nx.single_source_shortest_path_length(graph, target=node, cutoff=max_depth).items())
+        return anc - {node}
 
     def select_parents(self,
                        selected: Set[str],
-                       max_depth: int = -1) -> Set[str]:
+                       max_depth: int = None) -> Set[str]:
         ancestors: Set[str] = set()
         for node in selected:
             ancestors.update(

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -338,31 +338,25 @@ class Graph:
         ancestors_for = self.select_children(selected) | selected
         return self.select_parents(ancestors_for) | ancestors_for
 
-    @classmethod
-    def descendants(cls, graph, node, max_depth: int = None):
+    def descendants(self, node, max_depth: int = None):
         """Returns all nodes reachable from `node` in `graph`"""
-        if not graph.has_node(node):
-            raise nx.NetworkXError("The node %s is not in the graph." % node)
-        des = set(
-            n for n, d in
-            nx.single_source_shortest_path_length(G=graph,
-                                                  source=node,
-                                                  cutoff=max_depth).items()
-        )
+        if not self.graph.has_node(node):
+            raise nx.NetworkXError(f"The node {node} is not in the graph.")
+        des = nx.single_source_shortest_path_length(G=self.graph,
+                                                    source=node,
+                                                    cutoff=max_depth)\
+            .keys()
         return des - {node}
 
-    @classmethod
-    def ancestors(cls, graph, node, max_depth: int = None):
+    def ancestors(self, node, max_depth: int = None):
         """Returns all nodes having a path to `node` in `graph`"""
-        if not graph.has_node(node):
-            raise nx.NetworkXError("The node %s is not in the graph." % node)
-        with nx.utils.reversed(graph):
-            anc = set(
-                n for n, d in
-                nx.single_source_shortest_path_length(G=graph,
-                                                      source=node,
-                                                      cutoff=max_depth).items()
-            )
+        if not self.graph.has_node(node):
+            raise nx.NetworkXError(f"The node {node} is not in the graph.")
+        with nx.utils.reversed(self.graph):
+            anc = nx.single_source_shortest_path_length(G=self.graph,
+                                                        source=node,
+                                                        cutoff=max_depth)\
+                .keys()
         return anc - {node}
 
     def select_children(self,
@@ -370,9 +364,7 @@ class Graph:
                         max_depth: int = None) -> Set[str]:
         descendants: Set[str] = set()
         for node in selected:
-            descendants.update(
-                Graph.descendants(self.graph, node, max_depth=max_depth)
-            )
+            descendants.update(self.descendants(node, max_depth=max_depth))
         return descendants
 
     def select_parents(self,
@@ -380,9 +372,7 @@ class Graph:
                        max_depth: int = None) -> Set[str]:
         ancestors: Set[str] = set()
         for node in selected:
-            ancestors.update(
-                Graph.ancestors(self.graph, node, max_depth=max_depth)
-            )
+            ancestors.update(self.ancestors(node, max_depth=max_depth))
         return ancestors
 
     def select_successors(self, selected: Set[str]) -> Set[str]:

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -329,16 +329,32 @@ class Graph:
         ancestors_for = self.select_children(selected) | selected
         return self.select_parents(ancestors_for) | ancestors_for
 
-    def select_children(self, selected: Set[str]) -> Set[str]:
+    @classmethod
+    def descendants(cls, graph, node, max_depth: int = -1):
+        return nx.descendants(graph, node)
+
+    def select_children(self,
+                        selected: Set[str],
+                        max_depth: int = -1) -> Set[str]:
         descendants: Set[str] = set()
         for node in selected:
-            descendants.update(nx.descendants(self.graph, node))
+            descendants.update(
+                Graph.descendants(self.graph, node, max_depth=max_depth)
+            )
         return descendants
 
-    def select_parents(self, selected: Set[str]) -> Set[str]:
+    @classmethod
+    def ancestors(cls, graph, node, max_depth: int = -1):
+        return nx.ancestors(graph, node)
+
+    def select_parents(self,
+                       selected: Set[str],
+                       max_depth: int = -1) -> Set[str]:
         ancestors: Set[str] = set()
         for node in selected:
-            ancestors.update(nx.ancestors(self.graph, node))
+            ancestors.update(
+                Graph.ancestors(self.graph, node, max_depth=max_depth)
+            )
         return ancestors
 
     def select_successors(self, selected: Set[str]) -> Set[str]:

--- a/core/dbt/graph/selector.py
+++ b/core/dbt/graph/selector.py
@@ -338,20 +338,20 @@ class Graph:
         ancestors_for = self.select_children(selected) | selected
         return self.select_parents(ancestors_for) | ancestors_for
 
-    def descendants(self, node, max_depth: int = None):
+    def descendants(self, node, max_depth: Optional[int] = None) -> Set[str]:
         """Returns all nodes reachable from `node` in `graph`"""
         if not self.graph.has_node(node):
-            raise nx.NetworkXError(f"The node {node} is not in the graph.")
+            raise InternalException(f'Node {node} not found in the graph!')
         des = nx.single_source_shortest_path_length(G=self.graph,
                                                     source=node,
                                                     cutoff=max_depth)\
             .keys()
         return des - {node}
 
-    def ancestors(self, node, max_depth: int = None):
+    def ancestors(self, node, max_depth: Optional[int] = None) -> Set[str]:
         """Returns all nodes having a path to `node` in `graph`"""
         if not self.graph.has_node(node):
-            raise nx.NetworkXError(f"The node {node} is not in the graph.")
+            raise InternalException(f'Node {node} not found in the graph!')
         with nx.utils.reversed(self.graph):
             anc = nx.single_source_shortest_path_length(G=self.graph,
                                                         source=node,
@@ -361,7 +361,7 @@ class Graph:
 
     def select_children(self,
                         selected: Set[str],
-                        max_depth: int = None) -> Set[str]:
+                        max_depth: Optional[int] = None) -> Set[str]:
         descendants: Set[str] = set()
         for node in selected:
             descendants.update(self.descendants(node, max_depth=max_depth))
@@ -369,7 +369,7 @@ class Graph:
 
     def select_parents(self,
                        selected: Set[str],
-                       max_depth: int = None) -> Set[str]:
+                       max_depth: Optional[int] = None) -> Set[str]:
         ancestors: Set[str] = set()
         for node in selected:
             ancestors.update(self.ancestors(node, max_depth=max_depth))


### PR DESCRIPTION
resolves #2052

### Description

Extends model selection syntax with at most n-th parent/children `dbt run --models 3+m1+2`

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
