### PR TITLE
Make databases optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Substantial performance improvements for parsing on large projects, especially projects with many docs definition. ([#2480](https://github.com/fishtown-analytics/dbt/issues/2480), [#2481](https://github.com/fishtown-analytics/dbt/pull/2481))
 - Expose Snowflake query id in case of an exception raised by connector ([#2201](https://github.com/fishtown-analytics/dbt/issues/2201), [#2358](https://github.com/fishtown-analytics/dbt/pull/2358))
 
+### Under the hood
+- Better support for optional database fields in adapters ([#2487](https://github.com/fishtown-analytics/dbt/issues/2487) [#2489](https://github.com/fishtown-analytics/dbt/pull/2489))
+
 Contributors:
 - [@dmateusp](https://github.com/dmateusp) ([#2475](https://github.com/fishtown-analytics/dbt/pull/2475))
 - [@ChristianKohlberg](https://github.com/ChristianKohlberg) (#2358](https://github.com/fishtown-analytics/dbt/pull/2358))

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -264,7 +264,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     ###
     # Caching methods
     ###
-    def _schema_is_cached(self, database: str, schema: str) -> bool:
+    def _schema_is_cached(self, database: Optional[str], schema: str) -> bool:
         """Check if the schema is cached, and by default logs if it is not."""
 
         if dbt.flags.USE_CACHE is False:
@@ -341,12 +341,8 @@ class BaseAdapter(metaclass=AdapterMeta):
         # it's possible that there were no relations in some schemas. We want
         # to insert the schemas we query into the cache's `.schemas` attribute
         # so we can check it later
-        cache_update: Set[Tuple[str, Optional[str]]] = set()
+        cache_update: Set[Tuple[Optional[str], Optional[str]]] = set()
         for relation in cache_schemas:
-            if relation.database is None:
-                raise InternalException(
-                    'Got a None database in a cached schema!'
-                )
             cache_update.add((relation.database, relation.schema))
         self.cache.update_schemas(cache_update)
 
@@ -646,7 +642,9 @@ class BaseAdapter(metaclass=AdapterMeta):
 
         self.expand_column_types(from_relation, to_relation)
 
-    def list_relations(self, database: str, schema: str) -> List[BaseRelation]:
+    def list_relations(
+        self, database: Optional[str], schema: str
+    ) -> List[BaseRelation]:
         if self._schema_is_cached(database, schema):
             return self.cache.get_relations(database, schema)
 

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -6,7 +6,7 @@ import dbt.exceptions
 from collections.abc import Mapping, Hashable
 from dataclasses import dataclass, fields
 from typing import (
-    Optional, TypeVar, Generic, Any, Type, Dict, Union, List, Iterator, Tuple,
+    Optional, TypeVar, Generic, Any, Type, Dict, Union, Iterator, Tuple,
     Set
 )
 from typing_extensions import Protocol
@@ -278,16 +278,11 @@ class BaseRelation(FakeAPIObject, Hashable):
             yield key, path_part
 
     def render(self) -> str:
-        parts: List[str] = [
-            part for _, part in self._render_iterator() if part is not None
-        ]
-
-        if len(parts) == 0:
-            raise dbt.exceptions.RuntimeException(
-                "No path parts are included! Nothing to render."
-            )
-
-        return '.'.join(parts)
+        # if there is nothing set, this will return the empty string.
+        return '.'.join(
+            part for _, part in self._render_iterator()
+            if part is not None
+        )
 
     def quoted(self, identifier):
         return '{quote_char}{identifier}{quote_char}'.format(

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -83,7 +83,7 @@ class DependsOn(MacroDependsOn):
 
 @dataclass
 class HasRelationMetadata(JsonSchemaMixin, Replaceable):
-    database: str
+    database: Optional[str]
     schema: str
 
 

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -248,7 +248,7 @@ class StatsItem(JsonSchemaMixin):
     id: str
     label: str
     value: Primitive
-    description: str
+    description: Optional[str]
     include: bool
 
 

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -10,6 +10,7 @@ from dbt.logger import (
     JsonOnly,
     GLOBAL_LOGGER as logger,
 )
+from dbt.utils import lowercase
 from hologram.helpers import StrEnum
 from hologram import JsonSchemaMixin
 
@@ -238,7 +239,7 @@ Primitive = Union[bool, str, float, None]
 
 CatalogKey = NamedTuple(
     'CatalogKey',
-    [('database', str), ('schema', str), ('name', str)]
+    [('database', Optional[str]), ('schema', str), ('name', str)]
 )
 
 
@@ -268,7 +269,7 @@ ColumnMap = Dict[str, ColumnMetadata]
 @dataclass
 class TableMetadata(JsonSchemaMixin):
     type: str
-    database: str
+    database: Optional[str]
     schema: str
     name: str
     comment: Optional[str]
@@ -285,7 +286,7 @@ class CatalogTable(JsonSchemaMixin, Replaceable):
 
     def key(self) -> CatalogKey:
         return CatalogKey(
-            self.metadata.database.lower(),
+            lowercase(self.metadata.database),
             self.metadata.schema.lower(),
             self.metadata.name.lower(),
         )

--- a/core/dbt/include/global_project/macros/etc/get_custom_database.sql
+++ b/core/dbt/include/global_project/macros/etc/get_custom_database.sql
@@ -14,6 +14,10 @@
 
 #}
 {% macro generate_database_name(custom_database_name=none, node=none) -%}
+    {% do return(adapter_macro('generate_database_name', custom_database_name, node)) %}
+{%- endmacro %}
+
+{% macro default__generate_database_name(custom_database_name=none, node=none) -%}
     {%- set default_database = target.database -%}
     {%- if custom_database_name is none -%}
 

--- a/core/dbt/node_runners.py
+++ b/core/dbt/node_runners.py
@@ -27,6 +27,7 @@ from dbt.node_types import NodeType
 import dbt.tracking
 import dbt.ui.printer
 import dbt.flags
+import dbt.utils
 
 
 INTERNAL_ERROR_STRING = """This is an error in dbt. Please try again. If \
@@ -491,8 +492,7 @@ class FreshnessRunner(BaseRunner):
                           skip=False, failed=None):
         execution_time = time.time() - start_time
         thread_id = threading.current_thread().name
-        if status is not None:
-            status = status.lower()
+        status = dbt.utils.lowercase(status)
         return PartialResult(
             node=node,
             status=status,

--- a/core/dbt/parser/base.py
+++ b/core/dbt/parser/base.py
@@ -120,7 +120,9 @@ class RelationUpdate:
         self, parsed_node: Any, config_dict: Dict[str, Any]
     ) -> None:
         override = config_dict.get(self.component)
-        new_value = self.updater(override, parsed_node).strip()
+        new_value = self.updater(override, parsed_node)
+        if isinstance(new_value, str):
+            new_value = new_value.strip()
         setattr(parsed_node, self.component, new_value)
 
 

--- a/core/dbt/task/generate.py
+++ b/core/dbt/task/generate.py
@@ -62,9 +62,15 @@ class Catalog(Dict[CatalogKey, CatalogTable]):
             self.add_column(col)
 
     def get_table(self, data: PrimitiveDict) -> CatalogTable:
+        database = data.get('table_database')
+        if database is None:
+            dkey: Optional[str] = None
+        else:
+            dkey = str(database)
+
         try:
             key = CatalogKey(
-                str(data['table_database']),
+                dkey,
                 str(data['table_schema']),
                 str(data['table_name']),
             )
@@ -164,8 +170,9 @@ def format_stats(stats: PrimitiveDict) -> StatsDict:
 
 
 def mapping_key(node: CompileResultNode) -> CatalogKey:
+    dkey = dbt.utils.lowercase(node.database)
     return CatalogKey(
-        node.database.lower(), node.schema.lower(), node.identifier.lower()
+        dkey, node.schema.lower(), node.identifier.lower()
     )
 
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -490,6 +490,13 @@ def coerce_dict_str(value: Any) -> Optional[Dict[str, Any]]:
         return None
 
 
+def lowercase(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    else:
+        return value.lower()
+
+
 # some types need to make constants available to the jinja context as
 # attributes, and regular properties only work with objects. maybe this should
 # be handled by the RelationProxy?


### PR DESCRIPTION
resolves #2487


### Description
This makes spark viable with `database=None`!
 
`generate_database_name` is now an adapter macro, most things that insisted database was a `str` now accept `Optional[str]`.

Also, database-specific stats description fields can now be `None`. Otherwise due to agate behavior, even the empty string isn't allowed.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or tests are not required/relevant for this PR~ The fact that existing tests don't fail should be sufficient here!
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
