### PR TITLE
Put protobuf in version jail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## dbt 0.17.0 (Release TBD)
 
+### Under the hood
+- Lock protobufs to the last version that had fully functioning releases on all supported platforms ([#2490](https://github.com/fishtown-analytics/dbt/issues/2490), [#2491](https://github.com/fishtown-analytics/dbt/pull/2491))
+
+
+### dbt 0.17.0rc3 (May 27, 2020)
+
 
 ### Fixes
 - When no columns are documented and persist_docs.columns is True, skip creating comments instead of failing with errors ([#2439](https://github.com/fishtown-analytics/dbt/issues/2439), [#2440](https://github.com/fishtown-analytics/dbt/pull/2440))

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -40,6 +40,7 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
+        'protobuf>=3.6.0,<3.12',
         'google-cloud-core>=1.3.0,<1.4',
         'google-cloud-bigquery>=1.24.0,<1.25.0',
         'google-api-core>=1.16.0,<1.17.0',


### PR DESCRIPTION
resolves (not fully so please do not autoclose) #2490 

### Description
Pin protobuf to `>=3.6.0,<3.12`.
3.11 was the last good release, 3.6 is the minimum bound supplied by googleapis-common-protos 1.6.0 (which we have locked dbt-bigquery to for other good reasons).


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
