### PR TITLE
add project names/filenames/values to rendering errors (#2499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt 0.17.0 (Release TBD)
 
+### Fixes
+- Added filename, project, and the value that failed to render to the exception raised when rendering fails. ([#2499](https://github.com/fishtown-analytics/dbt/issues/2499), [#2501](https://github.com/fishtown-analytics/dbt/pull/2501))
+
+
 ### Under the hood
 - Lock protobufs to the last version that had fully functioning releases on all supported platforms ([#2490](https://github.com/fishtown-analytics/dbt/issues/2490), [#2491](https://github.com/fishtown-analytics/dbt/pull/2491))
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -507,7 +507,14 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
         # mark the file as seen, even if there are no macros in it
         self.results.get_file(block.file)
         if dct:
-            dct = self.raw_renderer.render_data(dct)
+            try:
+                dct = self.raw_renderer.render_data(dct)
+            except CompilationException as exc:
+                raise CompilationException(
+                    f'Failed to render {block.path.original_file_path} from '
+                    f'project {self.project.project_name}: {exc}'
+                ) from exc
+
             yaml_block = YamlBlock.from_file_block(block, dct)
 
             self._parse_format_version(yaml_block)


### PR DESCRIPTION
resolves #2499 


### Description
Add some nice information to the output on errors. The failure from the original project now looks like this:
```
$ dbt ls
Encountered an error:
Compilation Error
  Failed to render models/schema.yml from project minimal: Compilation Error
    Could not render {{ doc("mydoc") }}: 'doc' is undefined
```

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
