### PR TITLE
Generate the homebrew formula pypi urls in the build script (#2500)

### DIFF
--- a/scripts/build-dbt.py
+++ b/scripts/build-dbt.py
@@ -930,12 +930,5 @@ def main():
     upgrade_to(args)
 
 
-@dataclass
-class HomebrewRequirement:
-    name: str
-    url: str
-    sha256: str
-
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
resolves #2500 

### Description
Generate the homebrew formula's pypi urls in the build script, check the versions of `dbt` and `dbt-*` packages and ensure they match the expected values.

I also added the pypi package versions as comments in the formula file.

As a bonus, the script will now throw an exception if any dependencies are missing `sdist`s now.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
