### PR TITLE
Move pytest-logbook dependency to dev_requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 ## dbt 0.17.0 (Release TBD)
 
+### Fixes
+- Removed `pytest-logbook` dependency from `dbt-core` ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
+
+Contributors:
+ - [@aburgel](https://github.com/aburgel) ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
+
 ## dbt 0.17.0rc4 (June 2, 2020)
 
 ### Fixes
 - On snowflake, get_columns_in_relation now returns an empty list again if the relation does not exist, instead of raising an exception. ([#2504](https://github.com/fishtown-analytics/dbt/issues/2504), [#2509](https://github.com/fishtown-analytics/dbt/pull/2509))
 - Added filename, project, and the value that failed to render to the exception raised when rendering fails. ([#2499](https://github.com/fishtown-analytics/dbt/issues/2499), [#2501](https://github.com/fishtown-analytics/dbt/pull/2501))
-- Removed `pytest-logbook` dependency from `dbt-core` ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
 
 
 ### Under the hood
 - Lock protobufs to the last version that had fully functioning releases on all supported platforms ([#2490](https://github.com/fishtown-analytics/dbt/issues/2490), [#2491](https://github.com/fishtown-analytics/dbt/pull/2491))
-
-Contributors:
- - [@aburgel](https://github.com/aburgel) ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
 
 
 ### dbt 0.17.0rc3 (May 27, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### Fixes
 - On snowflake, get_columns_in_relation now returns an empty list again if the relation does not exist, instead of raising an exception. ([#2504](https://github.com/fishtown-analytics/dbt/issues/2504), [#2509](https://github.com/fishtown-analytics/dbt/pull/2509))
 - Added filename, project, and the value that failed to render to the exception raised when rendering fails. ([#2499](https://github.com/fishtown-analytics/dbt/issues/2499), [#2501](https://github.com/fishtown-analytics/dbt/pull/2501))
+- Removed `pytest-logbook` dependency from `dbt-core` ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
 
 
 ### Under the hood
 - Lock protobufs to the last version that had fully functioning releases on all supported platforms ([#2490](https://github.com/fishtown-analytics/dbt/issues/2490), [#2491](https://github.com/fishtown-analytics/dbt/pull/2491))
+
+Contributors:
+ - [@aburgel](https://github.com/aburgel) ([#2505](https://github.com/fishtown-analytics/dbt/pull/2505))
 
 
 ### dbt 0.17.0rc3 (May 27, 2020)

--- a/core/setup.py
+++ b/core/setup.py
@@ -66,7 +66,6 @@ setup(
         'dataclasses==0.6;python_version<"3.7"',
         'hologram==0.0.7',
         'logbook>=1.5,<1.6',
-        'pytest-logbook>=1.2.0,<1.3',
         'typing-extensions>=3.7.4,<3.8',
         # the following are all to match snowflake-connector-python
         'requests>=2.18.0,<2.23.0',

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,3 +12,4 @@ flaky>=3.5.3,<4
 mypy==0.761
 wheel
 twine
+pytest-logbook>=1.2.0,<1.3


### PR DESCRIPTION
## Description

[`pytest-logbook`](https://pypi.org/project/pytest-logbook/) is only used for testing dbt, so I don't think it should be a dependency of dbt-core. I've moved it to `dev_requirements.txt` so it should still be available for tests.

I came across this because my project has a dependency on dbt-core and also uses pytest. [pytest's caplog fixture](https://docs.pytest.org/en/latest/logging.html#caplog-fixture) stopped working when we upgraded dbt to 0.15.3. I was able to trace this back to `pytest-logbook` which installs its own log capture fixture and disables (breaks?) the builtin one.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
