### PR TITLE
fix get_columns_in_relation on snowflake (#2504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dbt 0.17.0 (Release TBD)
 
 ### Fixes
+- On snowflake, get_columns_in_relation now returns an empty list again if the relation does not exist, instead of raising an exception. ([#2504](https://github.com/fishtown-analytics/dbt/issues/2504), [#2509](https://github.com/fishtown-analytics/dbt/pull/2509))
 - Added filename, project, and the value that failed to render to the exception raised when rendering fails. ([#2499](https://github.com/fishtown-analytics/dbt/issues/2499), [#2501](https://github.com/fishtown-analytics/dbt/pull/2501))
 
 

--- a/plugins/snowflake/dbt/adapters/snowflake/impl.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/impl.py
@@ -112,6 +112,15 @@ class SnowflakeAdapter(SQLAdapter):
 
         return [row['name'] for row in results]
 
+    def get_columns_in_relation(self, relation):
+        try:
+            return super().get_columns_in_relation(relation)
+        except DatabaseException as exc:
+            if 'does not exist or not authorized' in str(exc):
+                return []
+            else:
+                raise
+
     def list_relations_without_caching(
             self, schema_relation: SnowflakeRelation
     ) -> List[SnowflakeRelation]:

--- a/test/integration/054_adapter_methods_test/test_adapter_methods.py
+++ b/test/integration/054_adapter_methods_test/test_adapter_methods.py
@@ -10,22 +10,33 @@ class TestBaseCaching(DBTIntegrationTest):
     def models(self):
         return "models"
 
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'test-paths': ['tests']
+        }
+
     @use_profile('postgres')
     def test_postgres_adapter_methods(self):
+        self.run_dbt(['compile'])  # trigger any compile-time issues
         self.run_dbt()
         self.assertTablesEqual('model', 'expected')
 
     @use_profile('redshift')
     def test_redshift_adapter_methods(self):
+        self.run_dbt(['compile'])  # trigger any compile-time issues
         self.run_dbt()
         self.assertTablesEqual('model', 'expected')
 
     @use_profile('snowflake')
     def test_snowflake_adapter_methods(self):
+        self.run_dbt(['compile'])  # trigger any compile-time issues
         self.run_dbt()
         self.assertTablesEqual('MODEL', 'EXPECTED')
 
     @use_profile('bigquery')
     def test_bigquery_adapter_methods(self):
+        self.run_dbt(['compile'])  # trigger any compile-time issues
         self.run_dbt()
         self.assertTablesEqual('model', 'expected')

--- a/test/integration/054_adapter_methods_test/tests/get_columns_in_relation.sql
+++ b/test/integration/054_adapter_methods_test/tests/get_columns_in_relation.sql
@@ -1,0 +1,7 @@
+{% set columns = adapter.get_columns_in_relation(ref('model')) %}
+{% set limit_query = 0 %}
+{% if (columns | length) == 0 %}
+	{% set limit_query = 1 %}
+{% endif %}
+
+select 1 as id limit {{ limit_query }}


### PR DESCRIPTION
Also add a test for adapter methods to catch this if it regresses

resolves #2504 


### Description

This was a regression caused by using `describe table ...` instead of selecting from the information schema, and not catching the exception when that happened on a missing table. Previously, and on all other adapters, this results in an empty list.

This is pretty straightforward, we've done it plenty of other places.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
