### PR TITLE
Make deps respect --project-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 - dbt compile and ls no longer create schemas if they don't already exist ([#2525](https://github.com/fishtown-analytics/dbt/issues/2525), [#2528](https://github.com/fishtown-analytics/dbt/pull/2528))
-
+- `dbt deps` now respects the `--project-dir` flag, so using `dbt deps --project-dir=/some/path` and then `dbt run --project-dir=/some/path` will properly find dependencies ([#2519](https://github.com/fishtown-analytics/dbt/issues/2519), [#2534](https://github.com/fishtown-analytics/dbt/pull/2534))
 
 ## dbt 0.17.0 (June 08, 2020)
 

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -353,7 +353,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
                 yield project.project_name, project
 
     def _get_project_directories(self) -> Iterator[Path]:
-        root = Path(self.project_root) / self.modules_path
+        root = Path.cwd() / self.modules_path
 
         if root.exists():
             for path in root.iterdir():

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -353,7 +353,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
                 yield project.project_name, project
 
     def _get_project_directories(self) -> Iterator[Path]:
-        root = Path.cwd() / self.modules_path
+        root = Path(self.project_root) / self.modules_path
 
         if root.exists():
             for path in root.iterdir():

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -907,6 +907,10 @@ def parse_args(args, cls=DBTArgumentParser):
     if hasattr(parsed, 'profiles_dir'):
         parsed.profiles_dir = os.path.expanduser(parsed.profiles_dir)
 
+    if getattr(parsed, 'project_dir', None) is not None:
+        expanded_user = os.path.expanduser(parsed.project_dir)
+        parsed.project_dir = os.path.abspath(expanded_user)
+
     if not hasattr(parsed, 'which'):
         # the user did not provide a valid subcommand. trigger the help message
         # and exit with a error

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -11,7 +11,7 @@ from dbt.deps.resolver import resolve_packages
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.clients import system
 
-from dbt.task.base import BaseTask
+from dbt.task.base import BaseTask, move_to_nearest_project_dir
 
 
 class DepsTask(BaseTask):
@@ -65,3 +65,10 @@ class DepsTask(BaseTask):
                     package_name=package.name,
                     source_type=package.source_type(),
                     version=package.get_version())
+
+    @classmethod
+    def from_args(cls, args):
+        # deps needs to move to the project directory, as it does put files
+        # into the modules directory
+        move_to_nearest_project_dir(args)
+        return super().from_args(args)

--- a/core/dbt/task/rpc/deps.py
+++ b/core/dbt/task/rpc/deps.py
@@ -9,10 +9,9 @@ from dbt.task.deps import DepsTask
 
 
 def _clean_deps(config):
-    modules_dir = os.path.join(config.project_root, config.modules_path)
-    if os.path.exists(modules_dir):
-        shutil.rmtree(modules_dir)
-    os.makedirs(modules_dir)
+    if os.path.exists(config.modules_path):
+        shutil.rmtree(config.modules_path)
+    os.makedirs(config.modules_path)
 
 
 class RemoteDepsTask(

--- a/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
+++ b/test/integration/004_simple_snapshot_test/test_simple_snapshot.py
@@ -406,6 +406,7 @@ class TestSimpleSnapshotFilesBigquery(DBTIntegrationTest):
 
 class TestCrossDBSnapshotFiles(DBTIntegrationTest):
     setup_alternate_db = True
+
     @property
     def schema(self):
         return "simple_snapshot_004"
@@ -464,6 +465,13 @@ class TestCrossDBSnapshotFiles(DBTIntegrationTest):
 
 class TestCrossSchemaSnapshotFiles(DBTIntegrationTest):
     NUM_SNAPSHOT_MODELS = 1
+
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.target_schema()),
+        )
+
 
     @property
     def schema(self):

--- a/test/integration/005_simple_seed_test/test_simple_seed.py
+++ b/test/integration/005_simple_seed_test/test_simple_seed.py
@@ -54,8 +54,11 @@ class TestSimpleSeed(DBTIntegrationTest):
 class TestSimpleSeedCustomSchema(DBTIntegrationTest):
 
     def setUp(self):
-        DBTIntegrationTest.setUp(self)
+        super().setUp()
         self.run_sql_file("seed.sql")
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.custom_schema_name())
+        )
 
     @property
     def schema(self):
@@ -76,9 +79,12 @@ class TestSimpleSeedCustomSchema(DBTIntegrationTest):
             },
         }
 
+    def custom_schema_name(self):
+        return "{}_{}".format(self.unique_schema(), 'custom_schema')
+
     @use_profile('postgres')
     def test_postgres_simple_seed_with_schema(self):
-        schema_name = "{}_{}".format(self.unique_schema(), 'custom_schema')
+        schema_name = self.custom_schema_name()
 
         results = self.run_dbt(["seed"])
         self.assertEqual(len(results),  1)

--- a/test/integration/006_simple_dependency_test/test_local_dependency.py
+++ b/test/integration/006_simple_dependency_test/test_local_dependency.py
@@ -25,6 +25,15 @@ class BaseDependencyTest(DBTIntegrationTest):
     def configured_schema(self):
         return self.unique_schema() + '_configured'
 
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.base_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.configured_schema())
+        )
+
     @property
     def packages_config(self):
         return {

--- a/test/integration/015_cli_invocation_tests/local_dependency/dbt_project.yml
+++ b/test/integration/015_cli_invocation_tests/local_dependency/dbt_project.yml
@@ -1,0 +1,3 @@
+name: dependency
+version: '1.0.0'
+config-version: 2

--- a/test/integration/015_cli_invocation_tests/local_dependency/macros/my_test_macro.sql
+++ b/test/integration/015_cli_invocation_tests/local_dependency/macros/my_test_macro.sql
@@ -1,0 +1,2 @@
+{% macro some_macro() %}
+{% endmacro %}

--- a/test/integration/015_cli_invocation_tests/models/subdir1/subdir2/model.sql
+++ b/test/integration/015_cli_invocation_tests/models/subdir1/subdir2/model.sql
@@ -4,4 +4,7 @@
     )
 }}
 
+{# we don't care what, just do anything that will fail without "dbt deps" #}
+{% do dependency.some_macro() %}
+
 select 1 as id

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -65,8 +65,8 @@ class TestCLIInvocationWithProfilesDir(ModelCopyingIntegrationTest):
     def setUp(self):
         super().setUp()
 
-        self.run_sql("DROP SCHEMA IF EXISTS {} CASCADE;".format(self.custom_schema))
-        self.run_sql("CREATE SCHEMA {};".format(self.custom_schema))
+        self.run_sql(f"DROP SCHEMA IF EXISTS {self.custom_schema} CASCADE;")
+        self.run_sql(f"CREATE SCHEMA {self.custom_schema};")
 
         # the test framework will remove this in teardown for us.
         if not os.path.exists('./dbt-profile'):
@@ -76,6 +76,10 @@ class TestCLIInvocationWithProfilesDir(ModelCopyingIntegrationTest):
             yaml.safe_dump(self.custom_profile_config(), f, default_flow_style=True)
 
         self.run_sql_file("seed_custom.sql")
+
+    def tearDown(self):
+        self.run_sql(f"DROP SCHEMA IF EXISTS {self.custom_schema} CASCADE;")
+        super().tearDown()
 
     def custom_profile_config(self):
         return {

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -155,6 +155,14 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
             self._run_simple_dbt_commands(workdir)
             os.chdir(workdir)
 
+    @use_profile('postgres')
+    def test_postgres_dbt_commands_with_relative_dir_as_project_dir(self):
+        workdir = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            self._run_simple_dbt_commands(os.path.relpath(workdir, tmpdir))
+            os.chdir(workdir)
+
     def _run_simple_dbt_commands(self, project_dir):
         self.run_dbt(['deps', '--project-dir', project_dir])
         self.run_dbt(['seed', '--project-dir', project_dir])

--- a/test/integration/024_custom_schema_test/test_custom_schema.py
+++ b/test/integration/024_custom_schema_test/test_custom_schema.py
@@ -2,6 +2,14 @@ from test.integration.base import DBTIntegrationTest, use_profile
 
 
 class TestCustomSchema(DBTIntegrationTest):
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v2_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.xf_schema())
+        )
 
     @property
     def schema(self):
@@ -11,6 +19,12 @@ class TestCustomSchema(DBTIntegrationTest):
     def models(self):
         return "models"
 
+    def v2_schema(self):
+        return f"{self.unique_schema()}_custom"
+
+    def xf_schema(self):
+        return f"{self.unique_schema()}_test"
+
     @use_profile('postgres')
     def test__postgres__custom_schema_no_prefix(self):
         self.run_sql_file("seed.sql")
@@ -19,19 +33,28 @@ class TestCustomSchema(DBTIntegrationTest):
         self.assertEqual(len(results), 3)
 
         schema = self.unique_schema()
-        v2_schema = "{}_custom".format(schema)
-        xf_schema = "{}_test".format(schema)
 
         self.assertTablesEqual("seed", "view_1")
-        self.assertTablesEqual("seed", "view_2", schema, v2_schema)
-        self.assertTablesEqual("agg", "view_3", schema, xf_schema)
+        self.assertTablesEqual("seed", "view_2", schema, self.v2_schema())
+        self.assertTablesEqual("agg", "view_3", schema, self.xf_schema())
 
 
 class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v1_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v2_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.xf_schema())
+        )
 
     @property
     def schema(self):
-        return "custom_schema_024"
+        return "custom_prefix_024"
 
     @property
     def models(self):
@@ -66,6 +89,15 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
             },
         }
 
+    def v1_schema(self):
+        return f"{self.unique_schema()}_dbt_test"
+
+    def v2_schema(self):
+        return f"{self.unique_schema()}_custom"
+
+    def xf_schema(self):
+        return f"{self.unique_schema()}_test"
+
     def _list_schemas(self):
         with self.get_connection():
             return set(self.adapter.list_schemas(self.default_database))
@@ -79,10 +111,7 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
     @use_profile('postgres')
     def test__postgres__custom_schema_with_prefix(self):
         schema = self.unique_schema()
-        v1_schema = f"{schema}_dbt_test"
-        v2_schema = f"{schema}_custom"
-        xf_schema = f"{schema}_test"
-        new_schemas = {v1_schema, v2_schema, xf_schema}
+        new_schemas = {self.v1_schema(), self.v2_schema(), self.xf_schema()}
 
         self.assert_schemas_not_created(new_schemas)
 
@@ -97,16 +126,27 @@ class TestCustomProjectSchemaWithPrefix(DBTIntegrationTest):
         self.assertEqual(len(results), 3)
         self.assert_schemas_created(new_schemas)
 
-        self.assertTablesEqual("seed", "view_1", schema, v1_schema)
-        self.assertTablesEqual("seed", "view_2", schema, v2_schema)
-        self.assertTablesEqual("agg", "view_3", schema, xf_schema)
+        self.assertTablesEqual("seed", "view_1", schema, self.v1_schema())
+        self.assertTablesEqual("seed", "view_2", schema, self.v2_schema())
+        self.assertTablesEqual("agg", "view_3", schema, self.xf_schema())
 
 
 class TestCustomProjectSchemaWithPrefixSnowflake(DBTIntegrationTest):
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v1_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v2_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.xf_schema())
+        )
 
     @property
     def schema(self):
-        return "custom_schema_024"
+        return "sf_custom_prefix_024"
 
     @property
     def models(self):
@@ -121,6 +161,15 @@ class TestCustomProjectSchemaWithPrefixSnowflake(DBTIntegrationTest):
             }
         }
 
+    def v1_schema(self):
+        return f"{self.unique_schema()}_DBT_TEST"
+
+    def v2_schema(self):
+        return f"{self.unique_schema()}_CUSTOM"
+
+    def xf_schema(self):
+        return f"{self.unique_schema()}_TEST"
+
     @use_profile('snowflake')
     def test__snowflake__custom_schema_with_prefix(self):
         self.run_sql_file("seed.sql")
@@ -129,20 +178,29 @@ class TestCustomProjectSchemaWithPrefixSnowflake(DBTIntegrationTest):
         self.assertEqual(len(results), 3)
 
         schema = self.unique_schema().upper()
-        v1_schema = "{}_DBT_TEST".format(schema)
-        v2_schema = "{}_CUSTOM".format(schema)
-        xf_schema = "{}_TEST".format(schema)
 
-        self.assertTablesEqual("SEED", "VIEW_1", schema, v1_schema)
-        self.assertTablesEqual("SEED", "VIEW_2", schema, v2_schema)
-        self.assertTablesEqual("AGG", "VIEW_3", schema, xf_schema)
+        self.assertTablesEqual("SEED", "VIEW_1", schema, self.v1_schema())
+        self.assertTablesEqual("SEED", "VIEW_2", schema, self.v2_schema())
+        self.assertTablesEqual("AGG", "VIEW_3", schema, self.xf_schema())
 
 
 class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
+    def setUp(self):
+        super().setUp()
+
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v1_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.v2_schema())
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.xf_schema())
+        )
 
     @property
     def schema(self):
-        return "custom_schema_024"
+        return "custom_macro_024"
 
     @property
     def models(self):
@@ -178,6 +236,15 @@ class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
             }
         }
 
+    def v1_schema(self):
+        return f"dbt_test_{self.unique_schema()}_macro"
+
+    def v2_schema(self):
+        return f"custom_{self.unique_schema()}_macro"
+
+    def xf_schema(self):
+        return f"test_{self.unique_schema()}_macro"
+
     @use_profile('postgres')
     def test__postgres__custom_schema_from_macro(self):
         self.run_sql_file("seed.sql")
@@ -186,16 +253,17 @@ class TestCustomSchemaWithCustomMacro(DBTIntegrationTest):
         self.assertEqual(len(results), 3)
 
         schema = self.unique_schema()
-        v1_schema = "dbt_test_{}_macro".format(schema)
-        v2_schema = "custom_{}_macro".format(schema)
-        xf_schema = "test_{}_macro".format(schema)
 
-        self.assertTablesEqual("seed", "view_1", schema, v1_schema)
-        self.assertTablesEqual("seed", "view_2", schema, v2_schema)
-        self.assertTablesEqual("agg", "view_3", schema, xf_schema)
+        self.assertTablesEqual("seed", "view_1", schema, self.v1_schema())
+        self.assertTablesEqual("seed", "view_2", schema, self.v2_schema())
+        self.assertTablesEqual("agg", "view_3", schema, self.xf_schema())
 
 
 class TestCustomSchemaWithCustomMacroConfigs(TestCustomSchemaWithCustomMacro):
+
+    @property
+    def schema(self):
+        return "custom_macro_cfg_024"
 
     @property
     def project_config(self):

--- a/test/integration/026_aliases_test/test_aliases.py
+++ b/test/integration/026_aliases_test/test_aliases.py
@@ -85,6 +85,15 @@ class TestSameAliasDifferentSchemas(DBTIntegrationTest):
             "macro-paths": ['macros'],
         }
 
+    def setUp(self):
+        super().setUp()
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.unique_schema() + '_schema_a')
+        )
+        self._created_schemas.add(
+            self._get_schema_fqn(self.default_database, self.unique_schema() + '_schema_b')
+        )
+
     @use_profile('postgres')
     def test__postgres_same_alias_succeeds_in_different_schemas(self):
         results = self.run_dbt(['run'])

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -125,7 +125,14 @@ class DBTIntegrationTest(unittest.TestCase):
     CREATE_SCHEMA_STATEMENT = 'CREATE SCHEMA {}'
     DROP_SCHEMA_STATEMENT = 'DROP SCHEMA IF EXISTS {} CASCADE'
 
-    prefix = "test{}{:04}".format(int(time.time()), random.randint(0, 9999))
+    _randint = random.randint(0, 9999)
+    _runtime_timedelta = (datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0))
+    _runtime = (
+        (int(_runtime_timedelta.total_seconds() * 1e6)) +
+        _runtime_timedelta.microseconds
+    )
+
+    prefix = f'test{_runtime}{_randint:04}'
     setup_alternate_db = False
 
     @property


### PR DESCRIPTION
resolves #2519 
resolves #2541 


### Description
The problem was actually the opposite of what I thought: `dbt deps` does the wrong thing if you give it `--project-dir`, and puts files relative to the current directory. But it does look in the `--project-dir` to find packages.yml, so it just downloads them to the wrong directory.
 Subsequent `dbt` commands that do respect `--project-dir` then can't find their dependencies, because they've moved into the project directory and away from the starting directory.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
