### PR TITLE
Update minimum python version

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -86,5 +86,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-    python_requires=">=3.6.2",
+    python_requires=">=3.6.3",
 )


### PR DESCRIPTION
resolves #2536

### Description
Python 3.6.2 has a typing bug that dbt/hologram handle poorly. I assume it's either the second or third entry [here](https://docs.python.org/3.6/whatsnew/changelog.html#id71). Both of those entries point to the same very long bug page that contains multiple prs/commits that span a large number of python releases (including multiple 3.6.x releases!). Nothing else in 3.6.3 jumps out at me as a likely cause.

We already require `python >=3.6.2` for `typing.NoReturn`, so I just incremented that by 1.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
