### PR TITLE
Fix a regression where dbt ignored aliases in config() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - dbt compile and ls no longer create schemas if they don't already exist ([#2525](https://github.com/fishtown-analytics/dbt/issues/2525), [#2528](https://github.com/fishtown-analytics/dbt/pull/2528))
 - `dbt deps` now respects the `--project-dir` flag, so using `dbt deps --project-dir=/some/path` and then `dbt run --project-dir=/some/path` will properly find dependencies ([#2519](https://github.com/fishtown-analytics/dbt/issues/2519), [#2534](https://github.com/fishtown-analytics/dbt/pull/2534))
 - `packages.yml` revision/version fields can be float-like again (`revision: '1.0'` is valid). ([#2518](https://github.com/fishtown-analytics/dbt/issues/2518), [#2535](https://github.com/fishtown-analytics/dbt/pull/2535))
+- dbt again respects config aliases in config() calls ([#2557](https://github.com/fishtown-analytics/dbt/issues/2557), [#2559](https://github.com/fishtown-analytics/dbt/pull/2559))
 
 ## dbt 0.17.0 (June 08, 2020)
 

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -131,8 +131,9 @@ class ContextConfigGenerator:
     def _update_from_config(
         self, result: T, partial: Dict[str, Any], validate: bool = False
     ) -> T:
+        translated = self.active_project.credentials.translate_aliases(partial)
         return result.update_from(
-            partial,
+            translated,
             self.active_project.credentials.type,
             validate=validate
         )

--- a/test/integration/040_override_database_test/models/view_2.sql
+++ b/test/integration/040_override_database_test/models/view_2.sql
@@ -1,4 +1,6 @@
-{{
-    config(database=var('alternate_db'))
-}}
+{%- if target.type == 'bigquery' -%}
+  {{ config(project=var('alternate_db')) }}
+{%- else -%}
+  {{ config(database=var('alternate_db')) }}
+{%- endif -%}
 select * from {{ ref('seed') }}

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1021,6 +1021,8 @@ class DBTIntegrationTest(unittest.TestCase):
         first_columns = None
         for relation in specs:
             key = (relation.database, relation.schema, relation.identifier)
+            # get a good error here instead of a hard-to-diagnose KeyError
+            self.assertIn(key, column_specs, f'No columns found for {key}')
             columns = column_specs[key]
             if first_columns is None:
                 first_columns = columns


### PR DESCRIPTION
resolves #2557 

### Description
The new `config()`-handling code just doesn't have the alias logic. This PR adds it back in.

I updated an existing test to catch this issue in the future.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
