### PR TITLE
Run all integration tests on PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,33 +132,24 @@ workflows:
       - integration-redshift-py36:
           requires:
             - integration-postgres-py36
-          filters: &no_forks
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
       - integration-bigquery-py36:
           requires:
             - integration-postgres-py36
-          filters: *no_forks
       - integration-snowflake-py36:
           requires:
             - integration-postgres-py36
-          filters: *no_forks
       - integration-postgres-py38:
           requires:
             - unit
       - integration-redshift-py38:
           requires:
             - integration-postgres-py38
-          filters: *no_forks
       - integration-bigquery-py38:
           requires:
             - integration-postgres-py38
-          filters: *no_forks
       - integration-snowflake-py38:
           requires:
             - integration-postgres-py38
-          filters: *no_forks
       - build-wheels:
           requires:
             - unit
@@ -170,4 +161,3 @@ workflows:
             - integration-redshift-py38
             - integration-bigquery-py38
             - integration-snowflake-py38
-          filters: *no_forks

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-unit:
 
 test-integration:
 	@echo "Integration test run starting..."
-	@time docker-compose run test tox -e integration-postgres-py36integration-redshift-py36,integration-snowflake-py36,integration-bigquery-py36
+	@time docker-compose run test tox -e integration-postgres-py36,integration-redshift-py36,integration-snowflake-py36,integration-bigquery-py36
 
 test-quick:
 	@echo "Integration test run starting..."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   dependsOn: PostgresIntegrationTest
-  condition: and(succeeded(), ne(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true'))
+  condition: succeeded()
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -92,7 +92,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   dependsOn: PostgresIntegrationTest
-  condition: and(succeeded(), ne(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true'))
+  condition: succeeded()
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -109,7 +109,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   dependsOn: PostgresIntegrationTest
-  condition: and(succeeded(), ne(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true'))
+  condition: succeeded()
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -137,7 +137,7 @@ jobs:
     - RedshiftIntegrationTest
     - SnowflakeIntegrationTest
     - BigQueryIntegrationTest
-  condition: and(succeeded(), ne(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true'))
+  condition: succeeded()
   steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
resolves #2444

### Description

I just swapped out the environment variables in CircleCI and Azure to point to sandboxed, cost-controlled instances of Redshift, Snowflake, and BigQuery. Once all tests are passing, we can enable integration tests to automatically run on PRs from forks.