### PR TITLE
backport aliases in config fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `packages.yml` revision/version fields can be float-like again (`revision: '1.0'` is valid). ([#2518](https://github.com/fishtown-analytics/dbt/issues/2518), [#2535](https://github.com/fishtown-analytics/dbt/pull/2535))
 - Parallel RPC requests no longer step on each others' arguments ([[#2484](https://github.com/fishtown-analytics/dbt/issues/2484), [#2554](https://github.com/fishtown-analytics/dbt/pull/2554)])
 - On windows (depending upon OS support), dbt no longer fails with errors when writing artifacts ([#2558](https://github.com/fishtown-analytics/dbt/issues/2558), [#2566](https://github.com/fishtown-analytics/dbt/pull/2566))
-- dbt again respects config aliases in config() calls ([#2557](https://github.com/fishtown-analytics/dbt/issues/2557), [#2559](https://github.com/fishtown-analytics/dbt/pull/2559))
+- dbt again respects config aliases in config() calls and dbt_project.yml ([#2557](https://github.com/fishtown-analytics/dbt/issues/2557), [#2559](https://github.com/fishtown-analytics/dbt/pull/2559), [#2575](https://github.com/fishtown-analytics/dbt/pull/2575))
 
 ## dbt 0.17.0 (June 08, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `packages.yml` revision/version fields can be float-like again (`revision: '1.0'` is valid). ([#2518](https://github.com/fishtown-analytics/dbt/issues/2518), [#2535](https://github.com/fishtown-analytics/dbt/pull/2535))
 - Parallel RPC requests no longer step on each others' arguments ([[#2484](https://github.com/fishtown-analytics/dbt/issues/2484), [#2554](https://github.com/fishtown-analytics/dbt/pull/2554)])
 - On windows (depending upon OS support), dbt no longer fails with errors when writing artifacts ([#2558](https://github.com/fishtown-analytics/dbt/issues/2558), [#2566](https://github.com/fishtown-analytics/dbt/pull/2566))
+- dbt again respects config aliases in config() calls ([#2557](https://github.com/fishtown-analytics/dbt/issues/2557), [#2559](https://github.com/fishtown-analytics/dbt/pull/2559))
 
 ## dbt 0.17.0 (June 08, 2020)
 

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -131,8 +131,9 @@ class ContextConfigGenerator:
     def _update_from_config(
         self, result: T, partial: Dict[str, Any], validate: bool = False
     ) -> T:
+        translated = self.active_project.credentials.translate_aliases(partial)
         return result.update_from(
-            partial,
+            translated,
             self.active_project.credentials.type,
             validate=validate
         )

--- a/test/integration/040_override_database_test/models/view_2.sql
+++ b/test/integration/040_override_database_test/models/view_2.sql
@@ -1,4 +1,6 @@
-{{
-    config(database=var('alternate_db'))
-}}
+{%- if target.type == 'bigquery' -%}
+  {{ config(project=var('alternate_db')) }}
+{%- else -%}
+  {{ config(database=var('alternate_db')) }}
+{%- endif -%}
 select * from {{ ref('seed') }}

--- a/test/integration/040_override_database_test/test_override_database.py
+++ b/test/integration/040_override_database_test/test_override_database.py
@@ -99,13 +99,44 @@ class TestModelOverride(BaseOverrideDatabase):
         self.run_database_override()
 
 
-class TestProjectModelOverride(BaseOverrideDatabase):
+class BaseTestProjectModelOverride(BaseOverrideDatabase):
+    # this is janky, but I really want to access self.default_database in
+    # project_config
+    @property
+    def default_database(self):
+        target = self._profile_config['test']['target']
+        profile = self._profile_config['test']['outputs'][target]
+        for key in ['database', 'project', 'dbname']:
+            if key in profile:
+                database = profile[key]
+                if self.adapter_type == 'snowflake':
+                    return database.upper()
+                return database
+        assert False, 'No profile database found!'
+
     def run_database_override(self):
+        self.run_dbt_notstrict(['seed'])
+        self.assertEqual(len(self.run_dbt_notstrict(['run'])), 4)
+        self.assertExpectedRelations()
+
+    def assertExpectedRelations(self):
         if self.adapter_type == 'snowflake':
             func = lambda x: x.upper()
         else:
             func = lambda x: x
 
+        self.assertManyRelationsEqual([
+            (func('seed'), self.unique_schema(), self.default_database),
+            (func('view_2'), self.unique_schema(), self.alternative_database),
+            (func('view_1'), self.unique_schema(), self.alternative_database),
+            (func('view_3'), self.unique_schema(), self.default_database),
+            (func('view_4'), self.unique_schema(), self.alternative_database),
+        ])
+
+
+class TestProjectModelOverride(BaseTestProjectModelOverride):
+    @property
+    def project_config(self):
         self.use_default_project({
             'config-version': 2,
             'vars': {
@@ -120,16 +151,6 @@ class TestProjectModelOverride(BaseOverrideDatabase):
                 }
             },
         })
-        self.run_dbt_notstrict(['seed'])
-
-        self.assertEqual(len(self.run_dbt_notstrict(['run'])), 4)
-        self.assertManyRelationsEqual([
-            (func('seed'), self.unique_schema(), self.default_database),
-            (func('view_2'), self.unique_schema(), self.alternative_database),
-            (func('view_1'), self.unique_schema(), self.alternative_database),
-            (func('view_3'), self.unique_schema(), self.default_database),
-            (func('view_4'), self.unique_schema(), self.alternative_database),
-        ])
 
     @use_profile('bigquery')
     def test_bigquery_database_override(self):
@@ -137,6 +158,29 @@ class TestProjectModelOverride(BaseOverrideDatabase):
 
     @use_profile('snowflake')
     def test_snowflake_database_override(self):
+        self.run_database_override()
+
+
+class TestProjectModelAliasOverride(BaseTestProjectModelOverride):
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'vars': {
+                'alternate_db': self.alternative_database,
+            },
+            'models': {
+                'project': self.alternative_database,
+                'test': {
+                    'subfolder': {
+                        'project': self.default_database,
+                    }
+                }
+            },
+        }
+
+    @use_profile('bigquery')
+    def test_bigquery_project_override(self):
         self.run_database_override()
 
 

--- a/test/integration/040_override_database_test/test_override_database.py
+++ b/test/integration/040_override_database_test/test_override_database.py
@@ -137,7 +137,7 @@ class BaseTestProjectModelOverride(BaseOverrideDatabase):
 class TestProjectModelOverride(BaseTestProjectModelOverride):
     @property
     def project_config(self):
-        self.use_default_project({
+        return {
             'config-version': 2,
             'vars': {
                 'alternate_db': self.alternative_database,
@@ -150,7 +150,17 @@ class TestProjectModelOverride(BaseTestProjectModelOverride):
                     }
                 }
             },
-        })
+            'data-paths': ['data'],
+            'vars': {
+                'alternate_db': self.alternative_database,
+            },
+            'quoting': {
+                'database': True,
+            },
+            'seeds': {
+                'quote_columns': False,
+            }
+        }
 
     @use_profile('bigquery')
     def test_bigquery_database_override(self):
@@ -177,6 +187,16 @@ class TestProjectModelAliasOverride(BaseTestProjectModelOverride):
                     }
                 }
             },
+            'data-paths': ['data'],
+            'vars': {
+                'alternate_db': self.alternative_database,
+            },
+            'quoting': {
+                'database': True,
+            },
+            'seeds': {
+                'quote_columns': False,
+            }
         }
 
     @use_profile('bigquery')

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -1024,6 +1024,8 @@ class DBTIntegrationTest(unittest.TestCase):
         first_columns = None
         for relation in specs:
             key = (relation.database, relation.schema, relation.identifier)
+            # get a good error here instead of a hard-to-diagnose KeyError
+            self.assertIn(key, column_specs, f'No columns found for {key}')
             columns = column_specs[key]
             if first_columns is None:
                 first_columns = columns


### PR DESCRIPTION
resolves #2559 
resolves #2562 

### Description
This backports the fix for aliasing in `config()` calls that I accidentally opened against `dev/marian-anderson`. In addition, it adds a test demonstrating that you can use this patch to set `project` in a `dbt_project.yml` (note that this is only on `config-version: 2`).

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
