### PR TITLE
Feature: Change project-level warning color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 
 ### Features
+- Made project-level warnings more apparent ([#2545](https://github.com/fishtown-analytics/dbt/issues/2545))
 - Added a `full_refresh` config item that overrides the behavior of the `--full-refresh` flag ([#1009](https://github.com/fishtown-analytics/dbt/issues/1009), [#2348](https://github.com/fishtown-analytics/dbt/pull/2348))
 - Added a "docs" field to macros, with a "show" subfield to allow for hiding macros from the documentation site ([#2430](https://github.com/fishtown-analytics/dbt/issues/2430))
 - Added intersection syntax for model selector ([#2167](https://github.com/fishtown-analytics/dbt/issues/2167), [#2417](https://github.com/fishtown-analytics/dbt/pull/2417))

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -317,8 +317,8 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             len(unused),
             '\n'.join('- {}'.format('.'.join(u)) for u in unused)
         )
-        
-        warn_or_error(msg, log_fmt = printer.warning_tag('{}'))
+
+        warn_or_error(msg, log_fmt=printer.warning_tag('{}'))
 
     def load_dependencies(self) -> Mapping[str, 'RuntimeConfig']:
         if self.dependencies is None:

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -314,8 +314,8 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             return
 
         msg = UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE.format(
-            printer.red(len(unused)),
-            '\n'.join('\t\t- {}'.format('.'.join(u)) for u in unused)
+            len(unused),
+            '\n'.join('- {}'.format('.'.join(u)) for u in unused)
         )
         
         warn_or_error(msg, log_fmt = printer.warning_tag('{}'))
@@ -551,8 +551,9 @@ class UnsetProfileConfig(RuntimeConfig):
 
 UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE = """\
 Configuration paths exist in your dbt_project.yml file which do not \
-apply to any resources. 
-\t     There are {} unused configuration paths:\n{}
+apply to any resources.
+There are {} unused configuration paths:
+{}
 """
 
 

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -314,10 +314,11 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             return
 
         msg = UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE.format(
-            len(unused),
-            '\n'.join('- {}'.format('.'.join(u)) for u in unused)
+            printer.red(len(unused)),
+            '\n'.join('\t\t- {}'.format('.'.join(u)) for u in unused)
         )
-        warn_or_error(msg, log_fmt=printer.yellow('{}'))
+        
+        warn_or_error(msg, log_fmt = printer.warning_tag('{}'))
 
     def load_dependencies(self) -> Mapping[str, 'RuntimeConfig']:
         if self.dependencies is None:
@@ -549,9 +550,9 @@ class UnsetProfileConfig(RuntimeConfig):
 
 
 UNUSED_RESOURCE_CONFIGURATION_PATH_MESSAGE = """\
-WARNING: Configuration paths exist in your dbt_project.yml file which do not \
-apply to any resources.
-There are {} unused configuration paths:\n{}
+Configuration paths exist in your dbt_project.yml file which do not \
+apply to any resources. 
+\t     There are {} unused configuration paths:\n{}
 """
 
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -105,6 +105,7 @@ class DbtProjectYamlDeprecation(DBTDeprecation):
     For upgrading instructions, consult the documentation:
 
       https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-17-0
+      
     '''
 
 

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -105,7 +105,7 @@ class DbtProjectYamlDeprecation(DBTDeprecation):
     For upgrading instructions, consult the documentation:
 
       https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-17-0
-      
+
     '''
 
 

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -1,12 +1,9 @@
 import textwrap
 import time
 from typing import Dict, Optional, Tuple
-
 from dbt.logger import GLOBAL_LOGGER as logger, DbtStatusMessage, TextOnly
 from dbt.node_types import NodeType
-from dbt.tracking import InvocationProcessor
 import dbt.ui.colors
-
 
 USE_COLORS = False
 
@@ -368,6 +365,9 @@ def print_end_of_run_summary(
 
 
 def print_run_end_messages(results, keyboard_interrupt: bool = False) -> None:
+    # Prevent import loop from happening by importing tracking here.
+    from dbt.tracking import InvocationProcessor #noqa
+
     errors = [r for r in results if r.error is not None or r.fail]
     warnings = [r for r in results if r.warn]
     with DbtStatusMessage(), InvocationProcessor():

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -366,7 +366,7 @@ def print_end_of_run_summary(
 
 def print_run_end_messages(results, keyboard_interrupt: bool = False) -> None:
     # Prevent import loop from happening by importing tracking here.
-    from dbt.tracking import InvocationProcessor #noqa
+    from dbt.tracking import InvocationProcessor  # noqa
 
     errors = [r for r in results if r.error is not None or r.fail]
     warnings = [r for r in results if r.warn]

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -405,7 +405,7 @@ def line_wrap_message(
     chunks = msg.split(splitter)
     return '\n'.join(textwrap.fill(chunk, width=width) for chunk in chunks)
 
+
 def warning_tag(msg: str) -> str:
     warning_tag = warning_tag = '[' + yellow('WARNING') + ']: '
     return warning_tag + msg
-    

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -406,5 +406,6 @@ def line_wrap_message(
     return '\n'.join(textwrap.fill(chunk, width=width) for chunk in chunks)
 
 def warning_tag(msg: str) -> str:
-    warning_tag = warning_tag = '[ ' + yellow('WARNING') + ' ]: '
+    warning_tag = warning_tag = '[' + yellow('WARNING') + ']: '
     return warning_tag + msg
+    

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -404,3 +404,7 @@ def line_wrap_message(
     splitter = '\r\n\r\n' if '\r\n\r\n' in msg else '\n\n'
     chunks = msg.split(splitter)
     return '\n'.join(textwrap.fill(chunk, width=width) for chunk in chunks)
+
+def warning_tag(msg: str) -> str:
+    warning_tag = warning_tag = '[ ' + yellow('WARNING') + ' ]: '
+    return warning_tag + msg

--- a/core/dbt/ui/printer.py
+++ b/core/dbt/ui/printer.py
@@ -407,5 +407,4 @@ def line_wrap_message(
 
 
 def warning_tag(msg: str) -> str:
-    warning_tag = warning_tag = '[' + yellow('WARNING') + ']: '
-    return warning_tag + msg
+    return f'[{yellow("WARNING")}]: {msg}'

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -306,14 +306,13 @@ def invalid_ref_fail_unless_test(node, target_model_name,
         msg = dbt.exceptions.get_target_not_found_or_disabled_msg(
             node, target_model_name, target_model_package, disabled
         )
-        
-        
         if disabled:
             logger.debug(printer.warning_tag(msg))
-            
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt = printer.warning_tag('{}'))
-
+            dbt.exceptions.warn_or_error(
+                msg, 
+                log_fmt=printer.warning_tag('{}')
+            )
     else:
         dbt.exceptions.ref_target_not_found(
             node,
@@ -326,18 +325,14 @@ def invalid_ref_fail_unless_test(node, target_model_name,
 def invalid_source_fail_unless_test(
     node, target_name, target_table_name, disabled
 ):    
-
     if node.resource_type == NodeType.Test:
         msg = dbt.exceptions.get_source_not_found_or_disabled_msg(
             node, target_name, target_table_name, disabled
         )
-        
         if disabled:
-            logger.debug(printer.warning_tag(msg))
-            
+            logger.debug(printer.warning_tag(msg))    
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt = warning_tag + '{}')
-            
+            dbt.exceptions.warn_or_error(msg, log_fmt=warning_tag + '{}')
     else:
         dbt.exceptions.source_target_not_found(
             node,

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -20,6 +20,7 @@ import dbt.exceptions
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.node_types import NodeType
 from dbt.clients import yaml_helper
+from dbt.ui import printer
 
 DECIMALS: Tuple[Type[Any], ...]
 try:
@@ -300,14 +301,18 @@ class memoized:
 
 def invalid_ref_fail_unless_test(node, target_model_name,
                                  target_model_package, disabled):
+
     if node.resource_type == NodeType.Test:
         msg = dbt.exceptions.get_target_not_found_or_disabled_msg(
             node, target_model_name, target_model_package, disabled
         )
+        
+        
         if disabled:
-            logger.debug(f'WARNING: {msg}')
+            logger.debug(printer.warning_tag(msg))
+            
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt='WARNING: {}')
+            dbt.exceptions.warn_or_error(msg, log_fmt = printer.warning_tag('{}'))
 
     else:
         dbt.exceptions.ref_target_not_found(
@@ -320,15 +325,19 @@ def invalid_ref_fail_unless_test(node, target_model_name,
 
 def invalid_source_fail_unless_test(
     node, target_name, target_table_name, disabled
-):
+):    
+
     if node.resource_type == NodeType.Test:
         msg = dbt.exceptions.get_source_not_found_or_disabled_msg(
             node, target_name, target_table_name, disabled
         )
+        
         if disabled:
-            logger.debug(f'WARNING: {msg}')
+            logger.debug(printer.warning_tag(msg))
+            
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt='WARNING: {}')
+            dbt.exceptions.warn_or_error(msg, log_fmt = warning_tag + '{}')
+            
     else:
         dbt.exceptions.source_target_not_found(
             node,

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -332,7 +332,7 @@ def invalid_source_fail_unless_test(
         if disabled:
             logger.debug(printer.warning_tag(msg))    
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt=warning_tag + '{}')
+            dbt.exceptions.warn_or_error(msg, log_fmt=printer.warning_tag('{}'))
     else:
         dbt.exceptions.source_target_not_found(
             node,

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -310,7 +310,7 @@ def invalid_ref_fail_unless_test(node, target_model_name,
             logger.debug(printer.warning_tag(msg))
         else:
             dbt.exceptions.warn_or_error(
-                msg, 
+                msg,
                 log_fmt=printer.warning_tag('{}')
             )
     else:
@@ -324,15 +324,18 @@ def invalid_ref_fail_unless_test(node, target_model_name,
 
 def invalid_source_fail_unless_test(
     node, target_name, target_table_name, disabled
-):    
+):
     if node.resource_type == NodeType.Test:
         msg = dbt.exceptions.get_source_not_found_or_disabled_msg(
             node, target_name, target_table_name, disabled
         )
         if disabled:
-            logger.debug(printer.warning_tag(msg))    
+            logger.debug(printer.warning_tag(msg))
         else:
-            dbt.exceptions.warn_or_error(msg, log_fmt=printer.warning_tag('{}'))
+            dbt.exceptions.warn_or_error(
+                msg,
+                log_fmt=printer.warning_tag('{}')
+        )
     else:
         dbt.exceptions.source_target_not_found(
             node,

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -335,7 +335,7 @@ def invalid_source_fail_unless_test(
             dbt.exceptions.warn_or_error(
                 msg,
                 log_fmt=printer.warning_tag('{}')
-        )
+            )
     else:
         dbt.exceptions.source_target_not_found(
             node,


### PR DESCRIPTION
resolves https://github.com/fishtown-analytics/dbt/issues/2545

### Description
Warnings for project-level configurations were not apparent enough when running dbt.
Changes:
- printer.py:
   - Added a function to wrap a string with a colored warning label
- exceptions.py:
   - `invalid_ref_fail_unless_test()` and `invalid_source_fail_unless_test`: 
      - `msg` strings were wrapped with `printer.warning_tag()`
- runtime.py:
   - Configuration warning wrapped with `print.warning_tag()`
- deprecations.py
   - Whitespace added at the end of 0.17.0 deprecation warning message

### Checklist
 - [x ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x ] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
      - Unsure of additional tests I may need to run for this one outside of testing this with a dbt run.
 - [x ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
      - Not sure if I put this in the right section
