### PR TITLE
added option to specify profile when connecting to redshift via IAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Next
+- Added option to specify profile when connecting to Redshift via IAM
+
+
 ## dbt 0.18.0 (Release TBD)
 
 ## dbt 0.18.0b1 (June 08, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-### Next
-- Added option to specify profile when connecting to Redshift via IAM
-
-
 ## dbt 0.18.0 (Release TBD)
+
+### Features
+- Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437))
+
+Contributors:
+- [@brunomurino](https://github.com/brunomurino) ([#2437](https://github.com/fishtown-analytics/dbt/pull/2581))
+
 
 ## dbt 0.18.0b1 (June 08, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt 0.18.0 (Release TBD)
 
 ### Features
-- Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437))
+- Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437), [#2581](https://github.com/fishtown-analytics/dbt/pull/2581))
 
 Contributors:
 - [@brunomurino](https://github.com/brunomurino) ([#2437](https://github.com/fishtown-analytics/dbt/pull/2581))

--- a/plugins/redshift/dbt/adapters/redshift/connections.py
+++ b/plugins/redshift/dbt/adapters/redshift/connections.py
@@ -57,7 +57,12 @@ class RedshiftCredentials(PostgresCredentials):
 
     def _connection_keys(self):
         keys = super()._connection_keys()
-        return keys + ('method', 'cluster_id', 'iam_profile', 'iam_duration_seconds')
+        return keys + (
+            'method',
+            'cluster_id',
+            'iam_profile',
+            'iam_duration_seconds'
+        )
 
 
 class RedshiftConnectionManager(PostgresConnectionManager):
@@ -87,15 +92,17 @@ class RedshiftConnectionManager(PostgresConnectionManager):
             self.begin()
 
     @classmethod
-    def fetch_cluster_credentials(cls, db_user, db_name, cluster_id, iam_profile,
-                                  duration_s, autocreate, db_groups):
+    def fetch_cluster_credentials(cls, db_user, db_name, cluster_id,
+                                iam_profile, duration_s, autocreate,
+                                db_groups):
         """Fetches temporary login credentials from AWS. The specified user
         must already exist in the database, or else an error will occur"""
 
         if iam_profile is None:
             boto_client = boto3.client('redshift')
         else:
-            logger.debug(f"Connecting to Redshift using 'IAM' with profile {iam_profile}")
+            logger.debug("Connecting to Redshift using 'IAM'"
+                        + f"with profile {iam_profile}")
             boto_session = boto3.Session(
                 profile_name=iam_profile,
                 region_name='eu-west-1'

--- a/plugins/redshift/dbt/adapters/redshift/connections.py
+++ b/plugins/redshift/dbt/adapters/redshift/connections.py
@@ -93,16 +93,16 @@ class RedshiftConnectionManager(PostgresConnectionManager):
 
     @classmethod
     def fetch_cluster_credentials(cls, db_user, db_name, cluster_id,
-                                iam_profile, duration_s, autocreate,
-                                db_groups):
+                                  iam_profile, duration_s, autocreate,
+                                  db_groups):
         """Fetches temporary login credentials from AWS. The specified user
         must already exist in the database, or else an error will occur"""
 
         if iam_profile is None:
             boto_client = boto3.client('redshift')
         else:
-            logger.debug("Connecting to Redshift using 'IAM'"
-                        + f"with profile {iam_profile}")
+            logger.debug("Connecting to Redshift using 'IAM'" +
+                         f"with profile {iam_profile}")
             boto_session = boto3.Session(
                 profile_name=iam_profile,
                 region_name='eu-west-1'

--- a/plugins/redshift/dbt/adapters/redshift/connections.py
+++ b/plugins/redshift/dbt/adapters/redshift/connections.py
@@ -104,8 +104,7 @@ class RedshiftConnectionManager(PostgresConnectionManager):
             logger.debug("Connecting to Redshift using 'IAM'" +
                          f"with profile {iam_profile}")
             boto_session = boto3.Session(
-                profile_name=iam_profile,
-                region_name='eu-west-1'
+                profile_name=iam_profile
             )
             boto_client = boto_session.client('redshift')
 


### PR DESCRIPTION
resolves #2437 
### Description

Added option to specify profile when connecting to redshift via IAM


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
