### PR TITLE
Fix prefixing support to not render "+pre-hook"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt 0.17.1 (Release TBD)
 
+
+### Fixes
+- dbt config-version: 2 now properly defers rendering `+pre-hook` and `+post-hook` fields. ([#2583](https://github.com/fishtown-analytics/dbt/issues/2583), [#2854](https://github.com/fishtown-analytics/dbt/pull/2854))
+
+
 ## dbt 0.17.1rc1 (June 19, 2020)
 
 
@@ -16,7 +21,7 @@
 
 Contributors:
  - [@bodschut](https://github.com/bodschut) ([#2550](https://github.com/fishtown-analytics/dbt/pull/2550))
- 
+
 ## dbt 0.17.0 (June 08, 2020)
 
 ### Fixes

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -78,7 +78,7 @@ class DbtProjectYamlRenderer(BaseRenderer):
         if first in {'on-run-start', 'on-run-end', 'query-comment'}:
             return False
         # models have two things to avoid
-        if first in {'seeds', 'models', 'snapshots', 'seeds'}:
+        if first in {'seeds', 'models', 'snapshots'}:
             # model-level hooks
             if 'pre-hook' in keypath or 'post-hook' in keypath:
                 return False

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -102,11 +102,12 @@ class DbtProjectYamlRenderer(BaseRenderer):
             return False
 
         if first in {'seeds', 'models', 'snapshots', 'seeds'}:
+            keypath_parts = {
+                (k.lstrip('+') if isinstance(k, str) else k)
+                for k in keypath
+            }
             # model-level hooks
-            if 'pre-hook' in keypath or 'post-hook' in keypath:
-                return False
-            # model-level 'vars' declarations
-            if 'vars' in keypath:
+            if 'pre-hook' in keypath_parts or 'post-hook' in keypath_parts:
                 return False
 
         return True

--- a/test/integration/014_hook_tests/test_model_hooks.py
+++ b/test/integration/014_hook_tests/test_model_hooks.py
@@ -226,6 +226,23 @@ class TestPrePostModelHooksOnSeeds(DBTIntegrationTest):
         self.assertEqual(len(res), 1, 'Expected exactly one item')
 
 
+class TestPrePostModelHooksOnSeedsPlusPrefixed(TestPrePostModelHooksOnSeeds):
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'data-paths': ['data'],
+            'models': {},
+            'seeds': {
+                '+post-hook': [
+                    'alter table {{ this }} add column new_col int',
+                    'update {{ this }} set new_col = 1'
+                ],
+                'quote_columns': False,
+            },
+        }
+
+
 class TestPrePostModelHooksOnSnapshots(DBTIntegrationTest):
     @property
     def schema(self):

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -66,7 +66,7 @@ class ServerProcess(dbt.flags.MP_CONTEXT.Process):
 
     def start(self):
         super().start()
-        for _ in range(30):
+        for _ in range(60):
             if self.is_up():
                 break
             time.sleep(0.5)


### PR DESCRIPTION
resolves #2583 

### Description
Handle `+` prefixes in the renderer. Note that top-level `+` prefixes aren't supported. We'd have to change the schema of the `dbt_project.yml` to support that.

I also removed the logic that deferred rendering for `vars` blocks inside of configuration blocks - that's a v1-only construct and including it was a bug.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
