### PR TITLE
added option --adapter to dbt init, to create sample profiles.yml bas…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+dbt_env/
 build/
 develop-eggs/
 dist/
@@ -83,3 +84,11 @@ target/
 
 # pycharm
 .idea/
+
+# AWS credentials
+.aws/
+
+.DS_Store
+
+# vscode
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Previously, dbt put macros from all installed plugins into the namespace. This version of dbt will not include adapter plugin macros unless they are from the currently-in-use adapter or one of its dependencies [#2590](https://github.com/fishtown-analytics/dbt/pull/2590)
 
 ### Features
+- Added option "--adapter" to `dbt init` to create a sample `profiles.yml` based on the chosen adapter ([#2533](https://github.com/fishtown-analytics/dbt/issues/2533), [#2594](https://github.com/fishtown-analytics/dbt/pull/2594))
 - Added support for Snowflake query tags at the connection and model level ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030), [#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
 - Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437), [#2581](https://github.com/fishtown-analytics/dbt/pull/2581))
 
@@ -11,7 +12,7 @@
 - Adapter plugins can once again override plugins defined in core ([#2548](https://github.com/fishtown-analytics/dbt/issues/2548), [#2590](https://github.com/fishtown-analytics/dbt/pull/2590))
 
 Contributors:
-- [@brunomurino](https://github.com/brunomurino) ([#2437](https://github.com/fishtown-analytics/dbt/pull/2581))
+- [@brunomurino](https://github.com/brunomurino) ([#2581](https://github.com/fishtown-analytics/dbt/pull/2581), [#2594](https://github.com/fishtown-analytics/dbt/pull/2594))
 - [@DrMcTaco](https://github.com/DrMcTaco) ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030)),[#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
 
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -317,6 +317,14 @@ def _build_init_subparser(subparsers, base_subparser):
         Name of the new project
         ''',
     )
+    sub.add_argument(
+        '--adapter',
+        default='redshift',
+        type=str,
+        help='''
+        Write sample profiles.yml for which adapter
+        ''',
+    )
     sub.set_defaults(cls=init_task.InitTask, which='init', rpc_method=None)
     return sub
 

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -1,8 +1,11 @@
 import os
+import shutil
 
 import dbt.config
 import dbt.clients.git
 import dbt.clients.system
+from dbt.adapters.factory import load_plugin, get_include_paths
+from dbt.exceptions import RuntimeException
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -11,12 +14,12 @@ from dbt.task.base import BaseTask
 STARTER_REPO = 'https://github.com/fishtown-analytics/dbt-starter-project.git'
 STARTER_BRANCH = 'dbt-yml-config-version-2'
 DOCS_URL = 'https://docs.getdbt.com/docs/configure-your-profile'
-SAMPLE_PROFILES_YML_FILE = 'https://docs.getdbt.com/docs/profile'  # noqa
 
 ON_COMPLETE_MESSAGE = """
 Your new dbt project "{project_name}" was created! If this is your first time
-using dbt, you'll need to set up your profiles.yml file -- this file will
-tell dbt how to connect to your database. You can find this file by running:
+using dbt, you'll need to set up your profiles.yml file (we've created a sample
+file for you to connect to {sample_adapter}) -- this file will tell dbt how
+to connect to your database. You can find this file by running:
 
   {open_cmd} {profiles_path}
 
@@ -30,34 +33,6 @@ One more thing:
 Need help? Don't hesitate to reach out to us via GitHub issues or on Slack --
 There's a link to our Slack group in the GitHub Readme. Happy modeling!
 """
-
-
-STARTER_PROFILE = """
-# For more information on how to configure this file, please see:
-# {profiles_sample}
-
-default:
-  outputs:
-    dev:
-      type: redshift
-      threads: 1
-      host: 127.0.0.1
-      port: 5439
-      user: alice
-      pass: pa55word
-      dbname: warehouse
-      schema: dbt_alice
-    prod:
-      type: redshift
-      threads: 1
-      host: 127.0.0.1
-      port: 5439
-      user: alice
-      pass: pa55word
-      dbname: warehouse
-      schema: analytics
-  target: dev
-""".format(profiles_sample=SAMPLE_PROFILES_YML_FILE)
 
 
 class InitTask(BaseTask):
@@ -76,33 +51,47 @@ class InitTask(BaseTask):
             return True
         return False
 
-    def create_profiles_file(self, profiles_file):
+    def create_profiles_file(self, profiles_file, sample_adapter):
+        # Line below raises an exception if the specified adapter is not found
+        load_plugin(sample_adapter)
+        adapter_path = get_include_paths(sample_adapter)[0]
+        sample_profiles_path = adapter_path / 'sample_profiles.yml'
+
+        if not sample_profiles_path.exists():
+            raise RuntimeException(f'No sample profile for {sample_adapter}')
+
         if not os.path.exists(profiles_file):
-            dbt.clients.system.make_file(profiles_file, STARTER_PROFILE)
+            shutil.copyfile(sample_profiles_path, profiles_file)
             return True
+
         return False
 
-    def get_addendum(self, project_name, profiles_path):
+    def get_addendum(self, project_name, profiles_path, sample_adapter):
         open_cmd = dbt.clients.system.open_dir_cmd()
 
         return ON_COMPLETE_MESSAGE.format(
             open_cmd=open_cmd,
             project_name=project_name,
+            sample_adapter=sample_adapter,
             profiles_path=profiles_path,
             docs_url=DOCS_URL
         )
 
     def run(self):
         project_dir = self.args.project_name
+        sample_adapter = self.args.adapter
 
         profiles_dir = dbt.config.PROFILES_DIR
         profiles_file = os.path.join(profiles_dir, 'profiles.yml')
 
-        self.create_profiles_dir(profiles_dir)
-        self.create_profiles_file(profiles_file)
-
         msg = "Creating dbt configuration folder at {}"
         logger.info(msg.format(profiles_dir))
+
+        msg = "With sample profiles.yml for {}"
+        logger.info(msg.format(sample_adapter))
+
+        self.create_profiles_dir(profiles_dir)
+        self.create_profiles_file(profiles_file, sample_adapter)
 
         if os.path.exists(project_dir):
             raise RuntimeError("directory {} already exists!".format(
@@ -111,5 +100,5 @@ class InitTask(BaseTask):
 
         self.clone_starter_repo(project_dir)
 
-        addendum = self.get_addendum(project_dir, profiles_dir)
+        addendum = self.get_addendum(project_dir, profiles_dir, sample_adapter)
         logger.info(addendum)

--- a/plugins/bigquery/dbt/include/bigquery/sample_profiles.yml
+++ b/plugins/bigquery/dbt/include/bigquery/sample_profiles.yml
@@ -1,7 +1,18 @@
-my-bigquery-db:
-  target: dev
+default:
   outputs:
+
     dev:
+      type: bigquery
+      method: oauth
+      project: [GCP project id]
+      dataset: [the name of your dbt dataset] # You can also use "schema" here
+      threads: [1 or more]
+      timeout_seconds: 300
+      location: US # Optional, one of US or EU
+      priority: interactive
+      retries: 1
+
+    prod:
       type: bigquery
       method: service-account
       project: [GCP project id]
@@ -11,3 +22,5 @@ my-bigquery-db:
       timeout_seconds: 300
       priority: interactive
       retries: 1
+
+  target: dev

--- a/plugins/bigquery/dbt/include/bigquery/sample_profiles.yml
+++ b/plugins/bigquery/dbt/include/bigquery/sample_profiles.yml
@@ -1,0 +1,13 @@
+my-bigquery-db:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: service-account
+      project: [GCP project id]
+      dataset: [the name of your dbt dataset]
+      threads: [1 or more]
+      keyfile: [/path/to/bigquery/keyfile.json]
+      timeout_seconds: 300
+      priority: interactive
+      retries: 1

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -34,6 +34,7 @@ setup(
     package_data={
         'dbt': [
             'include/bigquery/dbt_project.yml',
+            'include/bigquery/sample_profiles.yml',
             'include/bigquery/macros/*.sql',
             'include/bigquery/macros/**/*.sql',
         ]

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -1,21 +1,24 @@
 default:
   outputs:
+
     dev:
       type: postgres
       threads: 1
       host: 127.0.0.1
       port: 5439
-      user: alice
-      pass: pa55word
+      user: [dev_username]
+      pass: [dev_password]
       dbname: warehouse
-      schema: dbt_alice
+      schema: [dev_schema]
+
     prod:
       type: postgres
       threads: 1
       host: 127.0.0.1
       port: 5439
-      user: alice
-      pass: pa55word
+      user: [prod_username]
+      pass: [prod_password]
       dbname: warehouse
-      schema: analytics
+      schema: [prod_schema]
+
   target: dev

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -18,7 +18,7 @@ default:
       port: [port]
       user: [prod_username]
       pass: [prod_password]
-      dbname: warehouse
+      dbname: [dbname]
       schema: [prod_schema]
 
   target: dev

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -8,7 +8,7 @@ default:
       port: [port]
       user: [dev_username]
       pass: [dev_password]
-      dbname: warehouse
+      dbname: [dbname]
       schema: [dev_schema]
 
     prod:

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -3,9 +3,9 @@ default:
 
     dev:
       type: postgres
-      threads: 1
-      host: 127.0.0.1
-      port: 5439
+      threads: [1 or more]
+      host: [host]
+      port: [port]
       user: [dev_username]
       pass: [dev_password]
       dbname: warehouse

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -13,9 +13,9 @@ default:
 
     prod:
       type: postgres
-      threads: 1
-      host: 127.0.0.1
-      port: 5439
+      threads: [1 or more]
+      host: [host]
+      port: [port]
       user: [prod_username]
       pass: [prod_password]
       dbname: warehouse

--- a/plugins/postgres/dbt/include/postgres/sample_profiles.yml
+++ b/plugins/postgres/dbt/include/postgres/sample_profiles.yml
@@ -1,0 +1,21 @@
+default:
+  outputs:
+    dev:
+      type: postgres
+      threads: 1
+      host: 127.0.0.1
+      port: 5439
+      user: alice
+      pass: pa55word
+      dbname: warehouse
+      schema: dbt_alice
+    prod:
+      type: postgres
+      threads: 1
+      host: 127.0.0.1
+      port: 5439
+      user: alice
+      pass: pa55word
+      dbname: warehouse
+      schema: analytics
+  target: dev

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -57,6 +57,7 @@ setup(
     package_data={
         'dbt': [
             'include/postgres/dbt_project.yml',
+            'include/postgres/sample_profiles.yml',
             'include/postgres/macros/*.sql',
             'include/postgres/macros/**/*.sql',
         ]

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -5,7 +5,7 @@ default:
       type: redshift
       threads: [1 or more]
       host: [host]
-      port: 5439
+      port: [port]
       user: [dev_username]
       pass: [dev_password]
       dbname: [dbname]

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -1,21 +1,25 @@
 default:
   outputs:
+
     dev:
       type: redshift
       threads: 1
       host: 127.0.0.1
       port: 5439
-      user: alice
-      pass: pa55word
+      user: [dev_username]
+      pass: [dev_password]
       dbname: warehouse
-      schema: dbt_alice
+      schema: [dev_schema]
+
     prod:
       type: redshift
+      method: iam
+      cluster_id: [cluster_id]
       threads: 1
       host: 127.0.0.1
       port: 5439
-      user: alice
-      pass: pa55word
+      user: [prod_user]
       dbname: warehouse
-      schema: analytics
+      schema: [prod_schema]
+
   target: dev

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -17,7 +17,7 @@ default:
       cluster_id: [cluster_id]
       threads: [1 or more]
       host: [host]
-      port: 5439
+      port: [port]
       user: [prod_user]
       dbname: [dbname]
       schema: [prod_schema]

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -4,11 +4,11 @@ default:
     dev:
       type: redshift
       threads: 1
-      host: 127.0.0.1
+      host: [host]
       port: 5439
       user: [dev_username]
       pass: [dev_password]
-      dbname: warehouse
+      dbname: [dbname]
       schema: [dev_schema]
 
     prod:
@@ -16,10 +16,10 @@ default:
       method: iam
       cluster_id: [cluster_id]
       threads: 1
-      host: 127.0.0.1
+      host: [host]
       port: 5439
       user: [prod_user]
-      dbname: warehouse
+      dbname: [dbname]
       schema: [prod_schema]
 
   target: dev

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -3,7 +3,7 @@ default:
 
     dev:
       type: redshift
-      threads: 1
+      threads: [1 or more]
       host: [host]
       port: 5439
       user: [dev_username]
@@ -15,7 +15,7 @@ default:
       type: redshift
       method: iam
       cluster_id: [cluster_id]
-      threads: 1
+      threads: [1 or more]
       host: [host]
       port: 5439
       user: [prod_user]

--- a/plugins/redshift/dbt/include/redshift/sample_profiles.yml
+++ b/plugins/redshift/dbt/include/redshift/sample_profiles.yml
@@ -1,0 +1,21 @@
+default:
+  outputs:
+    dev:
+      type: redshift
+      threads: 1
+      host: 127.0.0.1
+      port: 5439
+      user: alice
+      pass: pa55word
+      dbname: warehouse
+      schema: dbt_alice
+    prod:
+      type: redshift
+      threads: 1
+      host: 127.0.0.1
+      port: 5439
+      user: alice
+      pass: pa55word
+      dbname: warehouse
+      schema: analytics
+  target: dev

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -34,6 +34,7 @@ setup(
     package_data={
         'dbt': [
             'include/redshift/dbt_project.yml',
+            'include/redshift/sample_profiles.yml',
             'include/redshift/macros/*.sql',
             'include/redshift/macros/**/*.sql',
         ]

--- a/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
+++ b/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
@@ -1,0 +1,17 @@
+my-snowflake-db:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: [account id]
+
+      # User/password auth
+      user: [username]
+      password: [password]
+
+      role: [user role]
+      database: [database name]
+      warehouse: [warehouse name]
+      schema: [dbt schema]
+      threads: [1 or more]
+      client_session_keep_alive: False

--- a/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
+++ b/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
@@ -3,7 +3,7 @@ default:
 
     dev: # User-Password config
       type: snowflake
-      account: [account id]
+      account: [account id + region (if applicable)]
       user: [username]
       password: [password]
       role: [user role]
@@ -15,7 +15,7 @@ default:
 
     prod: # Keypair config
       type: snowflake
-      account: [account id]
+      account: [account id + region (if applicable)]
       user: [username]
       role: [user role]
       private_key_path: [path/to/private.key]

--- a/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
+++ b/plugins/snowflake/dbt/include/snowflake/sample_profiles.yml
@@ -1,17 +1,29 @@
-my-snowflake-db:
-  target: dev
+default:
   outputs:
-    dev:
+
+    dev: # User-Password config
       type: snowflake
       account: [account id]
-
-      # User/password auth
       user: [username]
       password: [password]
-
       role: [user role]
       database: [database name]
       warehouse: [warehouse name]
       schema: [dbt schema]
       threads: [1 or more]
       client_session_keep_alive: False
+
+    prod: # Keypair config
+      type: snowflake
+      account: [account id]
+      user: [username]
+      role: [user role]
+      private_key_path: [path/to/private.key]
+      private_key_passphrase: [passphrase for the private key, if key is encrypted]
+      database: [database name]
+      warehouse: [warehouse name]
+      schema: [dbt schema]
+      threads: [1 or more]
+      client_session_keep_alive: False
+  
+  target: dev

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -34,6 +34,7 @@ setup(
     package_data={
         'dbt': [
             'include/snowflake/dbt_project.yml',
+            'include/snowflake/sample_profiles.yml',
             'include/snowflake/macros/*.sql',
             'include/snowflake/macros/**/*.sql',
         ]

--- a/test/integration/040_init_test/test_init.py
+++ b/test/integration/040_init_test/test_init.py
@@ -28,7 +28,7 @@ class TestInit(DBTIntegrationTest):
     @use_profile('postgres')
     def test_postgres_init_task(self):
         project_name = self.get_project_name()
-        self.run_dbt(['init', project_name])
+        self.run_dbt(['init', project_name, '--adapter', 'postgres'])
 
         assert os.path.exists(project_name)
         project_file = os.path.join(project_name, 'dbt_project.yml')


### PR DESCRIPTION
resolves [#2533](https://github.com/fishtown-analytics/dbt/issues/2533)


### Description

Added option '--adapter' to `dbt init`, to create sample profiles.yml based on chosen adapter.

It gets the sample profiles.yml from the adapter 'includes' folder

Related PRs:
* https://github.com/fishtown-analytics/dbt-presto/pull/26
* https://github.com/fishtown-analytics/dbt-spark/pull/98



### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
