### PR TITLE
Fix more jinja quoting sadness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## dbt 0.17.1 (Release TBD)
 
+### Fixes
+- dbt native rendering now avoids turning quoted strings into unqouted strings ([#2597](https://github.com/fishtown-analytics/dbt/issues/2597), [#2599](https://github.com/fishtown-analytics/dbt/pull/2599))
+
 ## dbt 0.17.1rc2 (June 25, 2020)
-
-
 
 ### Fixes
 - dbt config-version: 2 now properly defers rendering `+pre-hook` and `+post-hook` fields. ([#2583](https://github.com/fishtown-analytics/dbt/issues/2583), [#2854](https://github.com/fishtown-analytics/dbt/pull/2854))

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -133,6 +133,10 @@ def quoted_native_concat(nodes):
     except (ValueError, SyntaxError, MemoryError):
         return raw
 
+    # if it was a str and it still is a str, return it as-is.
+    if isinstance(result, str):
+        result = raw
+
     return result
 
 

--- a/test/unit/test_jinja.py
+++ b/test/unit/test_jinja.py
@@ -453,6 +453,8 @@ native_expected_behaviors = [
     ('''foo: "{{ a_int ~ 100 }}"''', 100100),
     ('''foo: "{{ a_str }}{{ a_str }}"''', 100100),
     ('''foo: "{{ a_int }}{{ a_int }}"''', 100100),
+    ('''foo: "'{{ a_int }}{{ a_int }}'"''', "'100100'"),
+
 ]
 
 


### PR DESCRIPTION
resolves #2597


### Description
Per Drew's suggestion, if the input to `ast.literal_eval` is a str and the output is a str, just return the initial value. I added some tests for the interaction of the native renderer with yaml to make sure they make sense.

As usual, we are kind of caught in a corner with `yaml` + `jinja` + `ast.literal_eval` together, and their slightly different interpretations of rendering. Note the irritating corner cases around differences between `true` and `True` and `1`: Getting an unquoted string value of `1` still requires `as_text`, but you can get a `true` or `True` out without it (frequently this requires some unintuitive formulations).

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
