### PR TITLE
On bigquery, persist docs for seeds as well as tables/views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Hash name of local packages ([#2600](https://github.com/fishtown-analytics/dbt/pull/2600))
+- On bigquery, also persist docs for seeds ([#2598](https://github.com/fishtown-analytics/dbt/issues/2598), [#2601](https://github.com/fishtown-analytics/dbt/pull/2601))
 
 ## dbt 0.17.1rc2 (June 25, 2020)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -616,7 +616,9 @@ class BigQueryAdapter(BaseAdapter):
         conn.handle.update_table(new_table, ['schema'])
 
     @available.parse_none
-    def update_table_description(self, database, schema, identifier, description):
+    def update_table_description(
+        self, database: str, schema: str, identifier: str, description: str
+    ):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -616,6 +616,21 @@ class BigQueryAdapter(BaseAdapter):
         conn.handle.update_table(new_table, ['schema'])
 
     @available.parse_none
+    def update_table_description(self, database, schema, identifier, description):
+        conn = self.connections.get_thread_connection()
+        client = conn.handle
+
+        table_ref = self.connections.table_ref(
+            database,
+            schema,
+            identifier,
+            conn
+        )
+        table = client.get_table(table_ref)
+        table.description = description
+        client.update_table(table, ['description'])
+
+    @available.parse_none
     def alter_table_add_columns(self, relation, columns):
 
         logger.debug('Adding columns ({}) to table {}".'.format(

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/seed.sql
@@ -12,5 +12,8 @@
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'],
   							agate_table, column_override) }}
+  {% if config.persist_relation_docs() and 'description' in model %}
 
+  	{{ adapter.update_table_description(model['database'], model['schema'], model['alias'], model['description']) }}
+  {% endif %}
 {% endmacro %}

--- a/test/integration/060_persist_docs_tests/data/seed.csv
+++ b/test/integration/060_persist_docs_tests/data/seed.csv
@@ -1,0 +1,3 @@
+id,name
+1,Alice
+2,Bob

--- a/test/integration/060_persist_docs_tests/models/schema.yml
+++ b/test/integration/060_persist_docs_tests/models/schema.yml
@@ -43,3 +43,28 @@ models:
           --
           /* comment */
           Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+
+seeds:
+  - name: seed
+    description: |
+      Seed model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+      - name: name
+        description: |
+          Some stuff here and then a call to
+          {{ doc('my_fun_doc')}}


### PR DESCRIPTION
resolves #2598 


### Description
I added a method, made it available, and called it from the code that creates seeds.

I added a test that runs `dbt seed` and makes sure the values are persisted properly.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
