### PR TITLE
remove length check + catch any exceptions on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Hash name of local packages ([#2600](https://github.com/fishtown-analytics/dbt/pull/2600))
+- Swallow all file-writing related errors on Windows, regardless of path length or exception type. ([#2603](https://github.com/fishtown-analytics/dbt/pull/2603))
 
 ## dbt 0.17.1rc2 (June 25, 2020)
 

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -154,8 +154,8 @@ def write_file(path: str, contents: str = '') -> bool:
             # all our hard work and the path was still too long. Log and
             # continue.
             logger.debug(
-                f'Could not write to path {path}: {reason} '
-                f'({len(path)} characters)'
+                f'Could not write to path {path}({len(path)} characters): '
+                f'{reason}\nexception: {exc}'
             )
         else:
             raise

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -135,11 +135,14 @@ def write_file(path: str, contents: str = '') -> bool:
         make_directory(os.path.dirname(path))
         with open(path, 'w', encoding='utf-8') as f:
             f.write(str(contents))
-    except FileNotFoundError as exc:
-        if (
-            os.name == 'nt' and
-            len(path) >= 260
-        ):
+    except Exception as exc:
+        # note that you can't just catch FileNotFound, because sometimes
+        # windows apparently raises something else.
+        # It's also not sufficient to look at the path length, because
+        # sometimes windows fails to write paths that are less than the length
+        # limit. So on windows, suppress all errors that happen from writing
+        # to disk.
+        if os.name == 'nt':
             # sometimes we get a winerror of 3 which means the path was
             # definitely too long, but other times we don't and it means the
             # path was just probably too long. This is probably based on the


### PR DESCRIPTION
resolves #2602 


### Description
Ok, I give up - on windows, swallow all exceptions we receive about writing files to disk unconditionally.

No tests, I have not run this locally because I still can't reproduce anything like this.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
