### PR TITLE
preserve empty strings in native env templating

### DIFF
--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -524,6 +524,9 @@ def get_rendered(
         _HAS_RENDER_CHARS_PAT.search(string) is None
     ):
         return string
+    elif string == '':
+        return string
+
     template = get_template(
         string,
         ctx,


### PR DESCRIPTION
### Do not merge this PR

Just wanted to call out another issue we're seeing with the Jinja NativeEnv implementation introduced in 0.17.1. This PR fixes a problem where the empty string `''` is converted to `None`.

Example:
```
version: 2

models:
  - name: debug

    columns:
      - name: id
        tests:
          - accepted_values:
              values: ['', 'a']
```

Here, the test compiles to `....where id not in ('None', 'a')`.

I think the number of holes to plug in our current approach to native env rendering is exceeding the number of thumbs we have available to us. Let's regroup and figure out a long-term sustainable approach to type inference for yaml+jinja.