### PR TITLE
move the sql for getting different rows into dbt proper

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1107,6 +1107,64 @@ class BaseAdapter(metaclass=AdapterMeta):
         """
         pass
 
+    def get_rows_different_sql(
+        self,
+        relation_a: BaseRelation,
+        relation_b: BaseRelation,
+        column_names: Optional[List[str]] = None,
+        except_operator: str = 'EXCEPT',
+    ) -> str:
+        """Generate SQL for a query that returns a single row with a two
+        columns: the number of rows that are different between the two
+        relations and the number of mismatched rows.
+        """
+        # This method only really exists for test reasons.
+        names: List[str]
+        if column_names is None:
+            columns = self.get_columns_in_relation(relation_a)
+            names = sorted((self.quote(c.name) for c in columns))
+        else:
+            names = sorted((self.quote(n) for n in column_names))
+        columns_csv = ', '.join(names)
+
+        sql = COLUMNS_EQUAL_SQL.format(
+            columns=columns_csv,
+            relation_a=str(relation_a),
+            relation_b=str(relation_b),
+            except_op=except_operator,
+        )
+
+        return sql
+
+
+COLUMNS_EQUAL_SQL = '''
+with diff_count as (
+    SELECT
+        1 as id,
+        COUNT(*) as num_missing FROM (
+            (SELECT {columns} FROM {relation_a} {except_op}
+             SELECT {columns} FROM {relation_b})
+             UNION ALL
+            (SELECT {columns} FROM {relation_b} {except_op}
+             SELECT {columns} FROM {relation_a})
+        ) as a
+), table_a as (
+    SELECT COUNT(*) as num_rows FROM {relation_a}
+), table_b as (
+    SELECT COUNT(*) as num_rows FROM {relation_b}
+), row_count_diff as (
+    select
+        1 as id,
+        table_a.num_rows - table_b.num_rows as difference
+    from table_a, table_b
+)
+select
+    row_count_diff.difference as row_count_difference,
+    diff_count.num_missing as num_mismatched
+from row_count_diff
+join diff_count using (id)
+'''.strip()
+
 
 def catch_as_completed(
     futures  # typing: List[Future[agate.Table]]

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -51,6 +51,10 @@ class BaseRelation(FakeAPIObject, Hashable):
     def get_default_quote_policy(cls) -> Policy:
         return cls._get_field_named('quote_policy').default
 
+    @classmethod
+    def get_default_include_policy(cls) -> Policy:
+        return cls._get_field_named('include_policy').default
+
     def get(self, key, default=None):
         """Override `.get` to return a metadata object so we don't break
         dbt_utils.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 freezegun==0.3.12
-pytest==4.4.0
+pytest==5.4.3
 flake8>=3.5.0
 pytz==2017.2
 bumpversion==0.5.3

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -738,3 +738,17 @@ class BigQueryAdapter(BaseAdapter):
         access_entries.append(AccessEntry(role, entity_type, entity))
         dataset.access_entries = access_entries
         client.update_dataset(dataset, ['access_entries'])
+
+    def get_rows_different_sql(
+        self,
+        relation_a: BigQueryRelation,
+        relation_b: BigQueryRelation,
+        column_names: Optional[List[str]] = None,
+        except_operator='EXCEPT DISTINCT'
+    ) -> str:
+        return super().get_rows_different_sql(
+            relation_a=relation_a,
+            relation_b=relation_b,
+            column_names=column_names,
+            except_operator=except_operator,
+        )


### PR DESCRIPTION
This doesn't resolve, but is a prerequisite for #2492 

### Description
Move a method that generates a sql query comparing two relations from the test suite to adapters. This is one of the big missing pieces for a test suite for third-party adapters that isn't tangled into dbt's ball of mud that we call an integration test suite. I changed the behavior of the method a bit to make it a bit more dbt-ish.

No changelog update as this is an internal feature.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
