### PR TITLE
make native env rendering opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt 0.17.1 (Release TBD)
 
+### Fixes
+- dbt native rendering now requires an opt-in with the `as_native` filter. Added `as_bool` and `as_number` filters, which are like `as_native` but also type-check. ([#2612](https://github.com/fishtown-analytics/dbt/issues/2612), [#2618](https://github.com/fishtown-analytics/dbt/pull/2618))
+
+
 ## dbt 0.17.1rc3 (July 01, 2020)
 
 

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -157,11 +157,11 @@ def quoted_native_concat(nodes):
         result = raw
     if isinstance(raw, BoolMarker) and not isinstance(result, bool):
         raise JinjaRenderingException(
-            f"Could not convert '{raw!s} into bool"
+            f"Could not convert value '{raw!s}' into type 'bool'"
         )
     if isinstance(raw, NumberMarker) and not _is_number(result):
         raise JinjaRenderingException(
-            f"Could not convert '{raw!s}' into number"
+            f"Could not convert value '{raw!s}' into type 'number'"
         )
 
     return result

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -8,6 +8,7 @@ from dbt.clients.system import load_file_contents
 from dbt.clients.yaml_helper import load_yaml_text
 from dbt.contracts.connection import Credentials, HasCredentials
 from dbt.contracts.project import ProfileConfig, UserConfig
+from dbt.exceptions import CompilationException
 from dbt.exceptions import DbtProfileError
 from dbt.exceptions import DbtProjectError
 from dbt.exceptions import ValidationException
@@ -268,7 +269,10 @@ class Profile(HasCredentials):
             raw_profile, profile_name, target_name
         )
 
-        profile_data = renderer.render_data(raw_profile_data)
+        try:
+            profile_data = renderer.render_data(raw_profile_data)
+        except CompilationException as exc:
+            raise DbtProfileError(str(exc)) from exc
         return target_name, profile_data
 
     @classmethod

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -256,6 +256,10 @@ class JSONValidationException(ValidationException):
         return (JSONValidationException, (self.typename, self.errors))
 
 
+class JinjaRenderingException(CompilationException):
+    pass
+
+
 class UnknownAsyncIDException(Exception):
     CODE = 10012
     MESSAGE = 'RPC server got an unknown async ID'

--- a/test/integration/039_config_test/test_configs.py
+++ b/test/integration/039_config_test/test_configs.py
@@ -110,9 +110,9 @@ class TestDisabledConfigs(DBTIntegrationTest):
                     'default2': {
                         'type': 'postgres',
                         # make sure you can do this and get an int out
-                        'threads': "{{ 1 + 3 }}",
+                        'threads': "{{ (1 + 3) | as_number }}",
                         'host': self.database_host,
-                        'port': "{{ 5400 + 32 }}",
+                        'port': "{{ (5400 + 32) | as_number }}",
                         'user': 'root',
                         'pass': 'password',
                         'dbname': 'dbt',
@@ -121,9 +121,9 @@ class TestDisabledConfigs(DBTIntegrationTest):
                     'disabled': {
                         'type': 'postgres',
                         # make sure you can do this and get an int out
-                        'threads': "{{ 1 + 3 }}",
+                        'threads': "{{ (1 + 3) | as_number }}",
                         'host': self.database_host,
-                        'port': "{{ 5400 + 32 }}",
+                        'port': "{{ (5400 + 32) | as_number }}",
                         'user': 'root',
                         'pass': 'password',
                         'dbname': 'dbt',
@@ -141,7 +141,7 @@ class TestDisabledConfigs(DBTIntegrationTest):
             'data-paths': ['data'],
             'models': {
                 'test': {
-                    'enabled': "{{ target.name == 'default2' }}",
+                    'enabled': "{{ (target.name == 'default2' | as_bool) }}",
                 },
             },
             # set the `var` result in schema.yml to be 'seed', so that the
@@ -155,7 +155,7 @@ class TestDisabledConfigs(DBTIntegrationTest):
                 'quote_columns': False,
                 'test': {
                     'seed': {
-                        'enabled': "{{ target.name == 'default2' }}",
+                        'enabled': "{{ (target.name == 'default2') | as_bool }}",
                     },
                 },
             },

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -184,7 +184,7 @@ class DBTIntegrationTest(unittest.TestCase):
                         'type': 'redshift',
                         'threads': 1,
                         'host': os.getenv('REDSHIFT_TEST_HOST'),
-                        'port': os.getenv('REDSHIFT_TEST_PORT'),
+                        'port': int(os.getenv('REDSHIFT_TEST_PORT')),
                         'user': os.getenv('REDSHIFT_TEST_USER'),
                         'pass': os.getenv('REDSHIFT_TEST_PASS'),
                         'dbname': os.getenv('REDSHIFT_TEST_DBNAME'),

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -131,7 +131,7 @@ class BaseConfigTest(unittest.TestCase):
                     'with-vars': {
                         'type': "{{ env_var('env_value_type') }}",
                         'host': "{{ env_var('env_value_host') }}",
-                        'port': "{{ env_var('env_value_port') }}",
+                        'port': "{{ env_var('env_value_port') | as_number }}",
                         'user': "{{ env_var('env_value_user') }}",
                         'pass': "{{ env_var('env_value_pass') }}",
                         'dbname': "{{ env_var('env_value_dbname') }}",
@@ -140,7 +140,7 @@ class BaseConfigTest(unittest.TestCase):
                     'cli-and-env-vars': {
                         'type': "{{ env_var('env_value_type') }}",
                         'host': "{{ var('cli_value_host') }}",
-                        'port': "{{ env_var('env_value_port') }}",
+                        'port': "{{ env_var('env_value_port') | as_number }}",
                         'user': "{{ env_var('env_value_user') }}",
                         'pass': "{{ env_var('env_value_pass') }}",
                         'dbname': "{{ env_var('env_value_dbname') }}",
@@ -367,7 +367,7 @@ class TestProfile(BaseConfigTest):
                     renderer,
                     target_override='with-vars'
                 )
-        self.assertIn("not of type 'integer'", str(exc.exception))
+        self.assertIn("Could not convert 'hello' into number", str(exc.exception))
 
 
 class TestProfileFile(BaseFileTest):
@@ -511,7 +511,7 @@ class TestProfileFile(BaseFileTest):
             with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
                 self.from_args()
 
-        self.assertIn("not of type 'integer'", str(exc.exception))
+        self.assertIn("Could not convert 'hello' into number", str(exc.exception))
 
     def test_cli_and_env_vars(self):
         self.args.target = 'cli-and-env-vars'

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -367,7 +367,7 @@ class TestProfile(BaseConfigTest):
                     renderer,
                     target_override='with-vars'
                 )
-        self.assertIn("Could not convert 'hello' into number", str(exc.exception))
+        self.assertIn("Could not convert value 'hello' into type 'number'", str(exc.exception))
 
 
 class TestProfileFile(BaseFileTest):
@@ -511,7 +511,7 @@ class TestProfileFile(BaseFileTest):
             with self.assertRaises(dbt.exceptions.DbtProfileError) as exc:
                 self.from_args()
 
-        self.assertIn("Could not convert 'hello' into number", str(exc.exception))
+        self.assertIn("Could not convert value 'hello' into type 'number'", str(exc.exception))
 
     def test_cli_and_env_vars(self):
         self.args.target = 'cli-and-env-vars'


### PR DESCRIPTION
resolves #2612 

### Description
Add `as_number`, `as_native`, and `as_bool` filters, which call literal_eval and (for number/bool) ensure the output type is valid.

The default behavior of `get_rendered` is to return whatever the input value is, which preserves expected behavior with Relations. Multiple nodes are converted to text. The `as_text` filter still calls `str()` on the result.

There is a non-obvious breaking change: Port numbers that are set via jinja evaluation (such as via `"{{ var(...) }}"` and `" {{ env_var(...) }}"`) require the `as_number` or `as_native` filter. Fixing this to behave the way it did in 0.16.x is going to be quite annoying, and hologram limitations make it tricky to allow string inputs for ports on that level: You can't define a field encoder whose json_schema is a `oneOf`, because hologram assumes that the schema for a given field will have a `type`.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
