### PR TITLE
Add more helpful error message for misconfiguration in profiles.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 - Added support for Snowflake query tags at the connection and model level ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030), [#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
 - Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437), [#2581](https://github.com/fishtown-analytics/dbt/pull/2581))
+- Add more helpful error message for misconfiguration in profiles.yml ([#2627](https://github.com/fishtown-analytics/dbt/issues/2569))
 
 ### Fixes
 - Adapter plugins can once again override plugins defined in core ([#2548](https://github.com/fishtown-analytics/dbt/issues/2548), [#2590](https://github.com/fishtown-analytics/dbt/pull/2590))
@@ -13,6 +14,7 @@
 Contributors:
 - [@brunomurino](https://github.com/brunomurino) ([#2437](https://github.com/fishtown-analytics/dbt/pull/2581))
 - [@DrMcTaco](https://github.com/DrMcTaco) ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030)),[#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
+- [@kning](https://github.com/kning) ([#2627](https://github.com/fishtown-analytics/dbt/issues/2569))
 
 
 ## dbt 0.18.0b1 (June 08, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,14 @@
 ### Features
 - Added support for Snowflake query tags at the connection and model level ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030), [#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
 - Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437), [#2581](https://github.com/fishtown-analytics/dbt/pull/2581))
-- Add more helpful error message for misconfiguration in profiles.yml ([#2627](https://github.com/fishtown-analytics/dbt/issues/2569))
-
+- Add more helpful error message for misconfiguration in profiles.yml ([#2569](https://github.com/fishtown-analytics/dbt/issues/2569), [#2627](https://github.com/fishtown-analytics/dbt/pull/2627))
 ### Fixes
 - Adapter plugins can once again override plugins defined in core ([#2548](https://github.com/fishtown-analytics/dbt/issues/2548), [#2590](https://github.com/fishtown-analytics/dbt/pull/2590))
 
 Contributors:
 - [@brunomurino](https://github.com/brunomurino) ([#2437](https://github.com/fishtown-analytics/dbt/pull/2581))
 - [@DrMcTaco](https://github.com/DrMcTaco) ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030)),[#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
-- [@kning](https://github.com/kning) ([#2627](https://github.com/fishtown-analytics/dbt/issues/2569))
+- [@kning](https://github.com/kning) ([#2627](https://github.com/fishtown-analytics/dbt/pull/2627))
 
 
 ## dbt 0.18.0b1 (June 08, 2020)

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -198,8 +198,11 @@ class Profile(HasCredentials):
             raise DbtProfileError(msg, result_type='invalid_target')
         profile_data = outputs[target_name]
 
-        if profile_data is None:
-            msg = (f"{target_name} is misconfigured in your profiles.yml")
+        if not isinstance(profile_data, dict):
+            msg = (
+                f"output '{target_name}' of profile '{profile_name}' is "
+                f"misconfigured in profiles.yml"
+            )
             raise DbtProfileError(msg, result_type='invalid_target')
 
         return profile_data

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -197,6 +197,11 @@ class Profile(HasCredentials):
                    .format(profile_name, target_name, outputs))
             raise DbtProfileError(msg, result_type='invalid_target')
         profile_data = outputs[target_name]
+
+        if profile_data is None:
+            msg = (f"{target_name} is misconfigured in your profiles.yml")
+            raise DbtProfileError(msg, result_type='invalid_target')
+
         return profile_data
 
     @classmethod

--- a/test/integration/049_dbt_debug_test/test_debug.py
+++ b/test/integration/049_dbt_debug_test/test_debug.py
@@ -41,7 +41,8 @@ class TestDebug(DBTIntegrationTest):
                 'pass': 'notmypassword',
                 'dbname': 'dbt',
                 'schema': self.unique_schema()
-            }
+            },
+            'none_target': None
         })
         return profile
 
@@ -72,6 +73,11 @@ class TestDebug(DBTIntegrationTest):
     def test_postgres_wronguser(self):
         self.run_dbt(['debug', '--target', 'wronguser'])
         self.assertGotValue(re.compile(r'\s+Connection test'), 'ERROR')
+
+    @use_profile('postgres')
+    def test_postgres_empty_target(self):
+        self.run_dbt(['debug', '--target', 'none_target'])
+        self.assertGotValue(re.compile(r"\s+output 'none_target'"), 'misconfigured')
 
 
 class TestDebugProfileVariable(TestDebug):


### PR DESCRIPTION
resolves [#2569](https://github.com/fishtown-analytics/dbt/issues/2569) 

### Description
Adds an additional catch for if the supplied target returns no data and returns a more helpful error message.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.  <-- not sure if this change warrants a mention quite yet but let me know if you'd like me to add.


### Further Validation
Additional screenshot of what the new terminal output looks like (tested against the example target referenced in the issue):
![image](https://user-images.githubusercontent.com/1820651/87601676-89244780-c6c3-11ea-9b41-4cacd500cfb5.png)
