### PR TITLE
new node selectors (#2425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 - Added support for Snowflake query tags at the connection and model level ([#1030](https://github.com/fishtown-analytics/dbt/issues/1030), [#2555](https://github.com/fishtown-analytics/dbt/pull/2555/))
+- Added new node selector methods (`config`, `test_type`, `test_name`, `package`) ([#2425](https://github.com/fishtown-analytics/dbt/issues/2425), [#2629](https://github.com/fishtown-analytics/dbt/pull/2629))
 - Added option to specify profile when connecting to Redshift via IAM ([#2437](https://github.com/fishtown-analytics/dbt/issues/2437), [#2581](https://github.com/fishtown-analytics/dbt/pull/2581))
 
 ### Fixes

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -120,6 +120,7 @@ def insensitive_patterns(*patterns: str):
 
 
 Severity = NewType('Severity', str)
+
 register_pattern(Severity, insensitive_patterns('warn', 'error'))
 
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -393,6 +393,12 @@ class InvalidConnectionException(RuntimeException):
         )
 
 
+class InvalidSelectorException(RuntimeException):
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(name)
+
+
 def raise_compiler_error(msg, node=None) -> NoReturn:
     raise CompilationException(msg, node)
 

--- a/core/dbt/graph/__init__.py
+++ b/core/dbt/graph/__init__.py
@@ -9,6 +9,9 @@ from .selector import (  # noqa: F401
     ResourceTypeSelector,
     NodeSelector,
 )
-from .cli import parse_difference  # noqa: F401
+from .cli import (  # noqa: F401
+    parse_difference,
+    parse_test_selectors,
+)
 from .queue import GraphQueue  # noqa: F401
 from .graph import Graph, UniqueId  # noqa: F401

--- a/core/dbt/graph/cli.py
+++ b/core/dbt/graph/cli.py
@@ -17,6 +17,8 @@ INTERSECTION_DELIMITER = ','
 
 DEFAULT_INCLUDES: List[str] = ['fqn:*', 'source:*']
 DEFAULT_EXCLUDES: List[str] = []
+DATA_TEST_SELECTOR: str = 'test_type:data'
+SCHEMA_TEST_SELECTOR: str = 'test_type:schema'
 
 
 def parse_union(
@@ -64,3 +66,34 @@ def parse_difference(
     included = parse_union_from_default(include, DEFAULT_INCLUDES)
     excluded = parse_union_from_default(exclude, DEFAULT_EXCLUDES)
     return SelectionDifference(components=[included, excluded])
+
+
+def parse_test_selectors(
+    data: bool, schema: bool, base: SelectionSpec
+) -> SelectionSpec:
+    union_components = []
+
+    if data:
+        union_components.append(
+            SelectionCriteria.from_single_spec(DATA_TEST_SELECTOR)
+        )
+    if schema:
+        union_components.append(
+            SelectionCriteria.from_single_spec(SCHEMA_TEST_SELECTOR)
+        )
+
+    intersect_with: SelectionSpec
+    if not union_components:
+        return base
+    elif len(union_components) == 1:
+        intersect_with = union_components[0]
+    else:  # data and schema tests
+        intersect_with = SelectionUnion(
+            components=union_components,
+            expect_exists=True,
+            raw=[DATA_TEST_SELECTOR, SCHEMA_TEST_SELECTOR],
+        )
+
+    return SelectionIntersection(
+        components=[base, intersect_with], expect_exists=True
+    )

--- a/core/dbt/graph/selector_methods.py
+++ b/core/dbt/graph/selector_methods.py
@@ -1,15 +1,43 @@
 import abc
 from itertools import chain
 from pathlib import Path
-from typing import Set, List
+from typing import Set, List, Dict, Iterator, Tuple, Any, Union, Type
 
 from hologram.helpers import StrEnum
 
-from dbt.exceptions import RuntimeException
 from .graph import UniqueId
+
+from dbt.contracts.graph.compiled import (
+    CompiledDataTestNode,
+    CompiledSchemaTestNode,
+    NonSourceNode,
+)
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.parsed import (
+    HasTestMetadata,
+    ParsedDataTestNode,
+    ParsedSchemaTestNode,
+    ParsedSourceDefinition,
+)
+from dbt.exceptions import (
+    InternalException,
+    RuntimeException,
+)
+
 
 SELECTOR_GLOB = '*'
 SELECTOR_DELIMITER = ':'
+
+
+class MethodName(StrEnum):
+    FQN = 'fqn'
+    Tag = 'tag'
+    Source = 'source'
+    Path = 'path'
+    Package = 'package'
+    Config = 'config'
+    TestName = 'test_name'
+    TestType = 'test_type'
 
 
 def is_selected_node(real_node, node_selector):
@@ -38,24 +66,49 @@ def is_selected_node(real_node, node_selector):
     return True
 
 
-class SelectorMethod(metaclass=abc.ABCMeta):
-    def __init__(self, manifest):
-        self.manifest = manifest
+SelectorTarget = Union[ParsedSourceDefinition, NonSourceNode]
 
-    def parsed_nodes(self, included_nodes):
-        for unique_id, node in self.manifest.nodes.items():
+
+class SelectorMethod(metaclass=abc.ABCMeta):
+    def __init__(self, manifest: Manifest, arguments: List[str]):
+        self.manifest: Manifest = manifest
+        self.arguments: List[str] = arguments
+
+    def parsed_nodes(
+        self,
+        included_nodes: Set[UniqueId]
+    ) -> Iterator[Tuple[UniqueId, NonSourceNode]]:
+
+        for key, node in self.manifest.nodes.items():
+            unique_id = UniqueId(key)
             if unique_id not in included_nodes:
                 continue
             yield unique_id, node
 
-    def source_nodes(self, included_nodes):
-        for unique_id, source in self.manifest.sources.items():
+    def source_nodes(
+        self,
+        included_nodes: Set[UniqueId]
+    ) -> Iterator[Tuple[UniqueId, ParsedSourceDefinition]]:
+
+        for key, source in self.manifest.sources.items():
+            unique_id = UniqueId(key)
             if unique_id not in included_nodes:
                 continue
             yield unique_id, source
 
+    def all_nodes(
+        self,
+        included_nodes: Set[UniqueId]
+    ) -> Iterator[Tuple[UniqueId, SelectorTarget]]:
+        yield from chain(self.parsed_nodes(included_nodes),
+                         self.source_nodes(included_nodes))
+
     @abc.abstractmethod
-    def search(self, included_nodes: Set[UniqueId], selector: str):
+    def search(
+        self,
+        included_nodes: Set[UniqueId],
+        selector: str,
+    ) -> Iterator[UniqueId]:
         raise NotImplementedError('subclasses should implement this')
 
 
@@ -88,7 +141,9 @@ class QualifiedNameSelectorMethod(SelectorMethod):
 
         return False
 
-    def search(self, included_nodes, selector):
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
         """Yield all nodes in the graph that match the selector.
 
         :param str selector: The selector or node name
@@ -106,18 +161,20 @@ class QualifiedNameSelectorMethod(SelectorMethod):
 
 
 class TagSelectorMethod(SelectorMethod):
-    def search(self, included_nodes, selector):
-        """ yields nodes from graph that have the specified tag """
-        search = chain(self.parsed_nodes(included_nodes),
-                       self.source_nodes(included_nodes))
-        for node, real_node in search:
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        """ yields nodes from included that have the specified tag """
+        for node, real_node in self.all_nodes(included_nodes):
             if selector in real_node.tags:
                 yield node
 
 
 class SourceSelectorMethod(SelectorMethod):
-    def search(self, included_nodes, selector):
-        """yields nodes from graph are the specified source."""
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        """yields nodes from included are the specified source."""
         parts = selector.split('.')
         target_package = SELECTOR_GLOB
         if len(parts) == 1:
@@ -145,17 +202,16 @@ class SourceSelectorMethod(SelectorMethod):
 
 
 class PathSelectorMethod(SelectorMethod):
-    def search(self, included_nodes, selector):
-        """Yield all nodes in the graph that match the given path.
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        """Yields nodes from inclucded that match the given path.
 
-        :param str selector: The path selector
         """
         # use '.' and not 'root' for easy comparison
         root = Path.cwd()
         paths = set(p.relative_to(root) for p in root.glob(selector))
-        search = chain(self.parsed_nodes(included_nodes),
-                       self.source_nodes(included_nodes))
-        for node, real_node in search:
+        for node, real_node in self.all_nodes(included_nodes):
             if Path(real_node.root_path) != root:
                 continue
             ofp = Path(real_node.original_file_path)
@@ -165,8 +221,111 @@ class PathSelectorMethod(SelectorMethod):
                 yield node
 
 
-class MethodName(StrEnum):
-    FQN = 'fqn'
-    Tag = 'tag'
-    Source = 'source'
-    Path = 'path'
+class PackageSelectorMethod(SelectorMethod):
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        """Yields nodes from included that have the specified package"""
+        for node, real_node in self.all_nodes(included_nodes):
+            if real_node.package_name == selector:
+                yield node
+
+
+def _getattr_descend(obj: Any, attrs: List[str]) -> Any:
+    value = obj
+    for attr in attrs:
+        value = getattr(value, attr)
+    return value
+
+
+class CaseInsensitive(str):
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.upper() == other.upper()
+        else:
+            return self.upper() == other
+
+
+class ConfigSelectorMethod(SelectorMethod):
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        parts = self.arguments
+        # special case: if the user wanted to compoare test severity,
+        # make the comparison case-insensitive
+        if parts == ['severity']:
+            selector = CaseInsensitive(selector)
+
+        # search sources is kind of useless now source configs only have
+        # 'enabled', which you can't really filter on anyway, but maybe we'll
+        # add more someday, so search them anyway.
+        for node, real_node in self.all_nodes(included_nodes):
+            try:
+                value = _getattr_descend(real_node.config, parts)
+            except AttributeError:
+                continue
+            else:
+                # the selector can only be a str, so call str() on the value.
+                # of course, if one wished to render the selector in the jinja
+                # native env, this would no longer be true
+
+                if selector == str(value):
+                    yield node
+
+
+class TestNameSelectorMethod(SelectorMethod):
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        for node, real_node in self.parsed_nodes(included_nodes):
+            if isinstance(real_node, HasTestMetadata):
+                if real_node.test_metadata.name == selector:
+                    yield node
+
+
+class TestTypeSelectorMethod(SelectorMethod):
+    def search(
+        self, included_nodes: Set[UniqueId], selector: str
+    ) -> Iterator[UniqueId]:
+        search_types: Tuple[Type, ...]
+        if selector == 'schema':
+            search_types = (ParsedSchemaTestNode, CompiledSchemaTestNode)
+        elif selector == 'data':
+            search_types = (ParsedDataTestNode, CompiledDataTestNode)
+        else:
+            raise RuntimeException(
+                f'Invalid test type selector {selector}: expected "data" or '
+                '"schema"'
+            )
+
+        for node, real_node in self.parsed_nodes(included_nodes):
+            if isinstance(real_node, search_types):
+                yield node
+
+
+class MethodManager:
+    SELECTOR_METHODS: Dict[MethodName, Type[SelectorMethod]] = {
+        MethodName.FQN: QualifiedNameSelectorMethod,
+        MethodName.Tag: TagSelectorMethod,
+        MethodName.Source: SourceSelectorMethod,
+        MethodName.Path: PathSelectorMethod,
+        MethodName.Package: PackageSelectorMethod,
+        MethodName.Config: ConfigSelectorMethod,
+        MethodName.TestName: TestNameSelectorMethod,
+        MethodName.TestType: TestTypeSelectorMethod,
+    }
+
+    def __init__(self, manifest: Manifest):
+        self.manifest = manifest
+
+    def get_method(
+        self, method: MethodName, method_arguments: List[str]
+    ) -> SelectorMethod:
+
+        if method not in self.SELECTOR_METHODS:
+            raise InternalException(
+                f'Method name "{method}" is a valid node selection '
+                f'method name, but it is not handled'
+            )
+        cls: Type[SelectorMethod] = self.SELECTOR_METHODS[method]
+        return cls(self.manifest, method_arguments)

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -1,7 +1,11 @@
 import json
 from typing import Type
 
-from dbt.graph import ResourceTypeSelector, parse_difference, SelectionSpec
+from dbt.graph import (
+    parse_difference,
+    ResourceTypeSelector,
+    SelectionSpec,
+)
 from dbt.task.runnable import GraphRunnableTask, ManifestTask
 from dbt.task.test import TestSelector
 from dbt.node_types import NodeType
@@ -158,8 +162,6 @@ class ListTask(GraphRunnableTask):
             return TestSelector(
                 graph=self.graph,
                 manifest=self.manifest,
-                schema=True,
-                data=True
             )
         else:
             return ResourceTypeSelector(

--- a/test/integration/007_graph_selection_tests/models/schema.yml
+++ b/test/integration/007_graph_selection_tests/models/schema.yml
@@ -4,7 +4,8 @@ models:
   columns:
   - name: email
     tests:
-    - unique
+    - not_null:
+        severity: warn
 - name: users
   columns:
   - name: id

--- a/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
+++ b/test/integration/007_graph_selection_tests/test_schema_test_graph_selection.py
@@ -47,7 +47,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             None,
-            ['unique_emails_email',
+            ['not_null_emails_email',
              'unique_table_model_id',
              'unique_users_id',
              'unique_users_rollup_gender']
@@ -83,7 +83,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['tag:base+'],
             None,
-            ['unique_emails_email',
+            ['not_null_emails_email',
              'unique_users_id',
              'unique_users_rollup_gender']
         )
@@ -109,7 +109,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             ['users_rollup'],
-            ['unique_emails_email', 'unique_table_model_id', 'unique_users_id']
+            ['not_null_emails_email', 'unique_table_model_id', 'unique_users_id']
         )
 
     @use_profile('postgres')
@@ -127,7 +127,7 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             ['*'],
             ['users'],
-            ['unique_emails_email', 'unique_table_model_id', 'unique_users_rollup_gender']
+            ['not_null_emails_email', 'unique_table_model_id', 'unique_users_rollup_gender']
         )
 
     @use_profile('postgres')
@@ -151,5 +151,5 @@ class TestSchemaTestGraphSelection(DBTIntegrationTest):
         self.run_schema_and_assert(
             None,
             ['dbt_integration_project'],
-            ['unique_emails_email', 'unique_users_id', 'unique_users_rollup_gender']
+            ['not_null_emails_email', 'unique_users_id', 'unique_users_rollup_gender']
         )

--- a/test/integration/007_graph_selection_tests/test_tag_selection.py
+++ b/test/integration/007_graph_selection_tests/test_tag_selection.py
@@ -73,3 +73,20 @@ class TestGraphSelection(DBTIntegrationTest):
             {'users', 'users_rollup', 'emails_alt', 'users_rollup_dependency'},
             models_run
         )
+
+        # just the users/users_rollup tests
+        results = self.run_dbt(['test', '--models', '@tag:users'])
+        self.assertEqual(len(results), 2)
+        assert sorted(r.node.name for r in results) == ['unique_users_id', 'unique_users_rollup_gender']
+        # just the email test
+        results = self.run_dbt(['test', '--models', 'tag:base,config.materialized:ephemeral'])
+        self.assertEqual(len(results), 1)
+        assert results[0].node.name == 'not_null_emails_email'
+        # also just the email test
+        results = self.run_dbt(['test', '--models', 'config.severity:warn'])
+        self.assertEqual(len(results), 1)
+        assert results[0].node.name == 'not_null_emails_email'
+        # all 3 tests
+        results = self.run_dbt(['test', '--models', '@tag:users tag:base,config.materialized:ephemeral'])
+        self.assertEqual(len(results), 3)
+        assert sorted(r.node.name for r in results) == ['not_null_emails_email', 'unique_users_id', 'unique_users_rollup_gender']

--- a/test/integration/047_dbt_ls_test/models/incremental.sql
+++ b/test/integration/047_dbt_ls_test/models/incremental.sql
@@ -1,0 +1,12 @@
+{{
+  config(
+    materialized = "incremental",
+    incremental_strategy = "delete+insert",
+  )
+}}
+
+select * from {{ ref('seed') }}
+
+{% if is_incremental() %}
+    where a > (select max(a) from {{this}})
+{% endif %}

--- a/test/unit/test_graph_selection.py
+++ b/test/unit/test_graph_selection.py
@@ -7,6 +7,7 @@ import string
 import dbt.exceptions
 import dbt.graph.selector as graph_selector
 import dbt.graph.cli as graph_cli
+from dbt.node_types import NodeType
 
 import networkx as nx
 
@@ -28,7 +29,13 @@ def _get_manifest(graph):
     for unique_id in graph:
         fqn = unique_id.split('.')
         node = mock.MagicMock(
-            unique_id=unique_id, fqn=fqn, package_name=fqn[0], tags=[]
+            unique_id=unique_id,
+            fqn=fqn,
+            package_name=fqn[0],
+            tags=[],
+            resource_type=NodeType.Model,
+            empty=False,
+            config=mock.MagicMock(enabled=True),
         )
         nodes[unique_id] = node
 
@@ -111,11 +118,9 @@ run_specs = [
 def test_run_specs(include, exclude, expected):
     graph = _get_graph()
     manifest = _get_manifest(graph)
-    # we can use the same graph twice.
     selector = graph_selector.NodeSelector(graph, manifest)
     spec = graph_cli.parse_difference(include, exclude)
-    subgraph = graph.subgraph(set(graph.nodes()))
-    selected = selector.select_nodes(subgraph, spec)
+    selected = selector.select_nodes(spec)
 
     assert selected == expected
 

--- a/test/unit/test_graph_selector_methods.py
+++ b/test/unit/test_graph_selector_methods.py
@@ -1,0 +1,543 @@
+import pytest
+
+from datetime import datetime
+
+from dbt.contracts.graph.parsed import (
+    DependsOn,
+    NodeConfig,
+    ParsedModelNode,
+    ParsedSeedNode,
+    ParsedSnapshotNode,
+    ParsedDataTestNode,
+    ParsedSchemaTestNode,
+    ParsedSourceDefinition,
+    TestConfig,
+    TestMetadata,
+)
+from dbt.contracts.graph.manifest import Manifest
+from dbt.node_types import NodeType
+from dbt.graph.selector_methods import (
+    MethodManager,
+    QualifiedNameSelectorMethod,
+    TagSelectorMethod,
+    SourceSelectorMethod,
+    PathSelectorMethod,
+    PackageSelectorMethod,
+    ConfigSelectorMethod,
+    TestNameSelectorMethod,
+    TestTypeSelectorMethod,
+)
+
+
+def make_model(pkg, name, sql, refs=None, sources=None, tags=None, path=None, alias=None, config_kwargs=None, fqn_extras=None):
+    if refs is None:
+        refs = []
+    if sources is None:
+        sources = []
+    if tags is None:
+        tags = []
+    if path is None:
+        path = f'{name}.sql'
+    if alias is None:
+        alias = name
+    if config_kwargs is None:
+        config_kwargs = {}
+
+    if fqn_extras is None:
+        fqn_extras = []
+
+    fqn = [pkg] + fqn_extras + [name]
+
+    depends_on_nodes = []
+    source_values = []
+    ref_values = []
+    for ref in refs:
+        ref_values.append([ref.name])
+        depends_on_nodes.append(ref.unique_id)
+    for src in sources:
+        source_values.append([src.source_name, src.name])
+        depends_on_nodes.append(src.unique_id)
+
+    return ParsedModelNode(
+        raw_sql=sql,
+        database='dbt',
+        schema='dbt_schema',
+        alias=alias,
+        name=name,
+        fqn=fqn,
+        unique_id=f'model.{pkg}.{name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=path,
+        original_file_path=f'models/{path}',
+        config=NodeConfig(**config_kwargs),
+        tags=tags,
+        refs=ref_values,
+        sources=source_values,
+        depends_on=DependsOn(nodes=depends_on_nodes),
+        resource_type=NodeType.Model,
+    )
+
+
+def make_seed(pkg, name, path=None, loader=None, alias=None, tags=None, fqn_extras=None):
+    if alias is None:
+        alias = name
+    if tags is None:
+        tags = []
+    if path is None:
+        path = f'{name}.csv'
+
+    if fqn_extras is None:
+        fqn_extras = []
+
+    fqn = [pkg] + fqn_extras + [name]
+    return ParsedSeedNode(
+        raw_sql='',
+        database='dbt',
+        schema='dbt_schema',
+        alias=alias,
+        name=name,
+        fqn=fqn,
+        unique_id=f'seed.{pkg}.{name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=path,
+        original_file_path=f'data/{path}',
+        tags=tags,
+        resource_type=NodeType.Seed,
+    )
+
+
+def make_source(pkg, source_name, table_name, path=None, loader=None, identifier=None, fqn_extras=None):
+    if path is None:
+        path = 'models/schema.yml'
+    if loader is None:
+        loader = 'my_loader'
+    if identifier is None:
+        identifier = table_name
+
+    if fqn_extras is None:
+        fqn_extras = []
+
+    fqn = [pkg] + fqn_extras + [source_name, table_name]
+
+    return ParsedSourceDefinition(
+        fqn=fqn,
+        database='dbt',
+        schema='dbt_schema',
+        unique_id=f'source.{pkg}.{source_name}.{table_name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=path,
+        original_file_path=path,
+        name=table_name,
+        source_name=source_name,
+        loader='my_loader',
+        identifier=identifier,
+        resource_type=NodeType.Source,
+        loaded_at_field='loaded_at',
+        tags=[],
+        source_description='',
+    )
+
+
+def make_unique_test(pkg, test_model, column_name, path=None, refs=None, sources=None, tags=None):
+    return make_schema_test(pkg, 'unique', test_model, {}, column_name=column_name)
+
+
+def make_not_null_test(pkg, test_model, column_name, path=None, refs=None, sources=None, tags=None):
+    return make_schema_test(pkg, 'not_null', test_model, {}, column_name=column_name)
+
+
+def make_schema_test(pkg, test_name, test_model, test_kwargs, path=None, refs=None, sources=None, tags=None, column_name=None):
+    kwargs = test_kwargs.copy()
+    ref_values = []
+    source_values = []
+    # this doesn't really have to be correct
+    if isinstance(test_model, ParsedSourceDefinition):
+        kwargs['model'] = "{{ source('" + test_model.source_name + "', '" + test_model.name + "') }}"
+        source_values.append([test_model.source_name, test_model.name])
+    else:
+        kwargs['model'] = "{{ ref('" + test_model.name + "')}}"
+        ref_values.append([test_model.name])
+    if column_name is not None:
+        kwargs['column_name'] = column_name
+
+    # whatever
+    args_name = test_model.search_name.replace(".", "_")
+    if column_name is not None:
+        args_name += '_' + column_name
+    node_name = f'{test_name}_{args_name}'
+    raw_sql = '{{ config(severity="ERROR") }}{{ test_' + test_name + '(**dbt_schema_test_kwargs) }}'
+    name_parts = test_name.split('.')
+
+    if len(name_parts) == 2:
+        namespace, test_name = name_parts
+        macro_depends = f'model.{namespace}.{test_name}'
+    elif len(name_parts) == 1:
+        namespace = None
+        macro_depends = f'model.dbt.{test_name}'
+    else:
+        assert False, f'invalid test name: {test_name}'
+
+    if path is None:
+        path = 'schema.yml'
+    if tags is None:
+        tags = ['schema']
+
+    if refs is None:
+        refs = []
+    if sources is None:
+        sources = []
+
+    depends_on_nodes = []
+    for ref in refs:
+        ref_values.append([ref.name])
+        depends_on_nodes.append(ref.unique_id)
+
+    for source in sources:
+        source_values.append([source.source_name, source.name])
+        depends_on_nodes.append(source.unique_id)
+
+    return ParsedSchemaTestNode(
+        raw_sql=raw_sql,
+        test_metadata=TestMetadata(
+            namespace=namespace,
+            name=test_name,
+            kwargs=kwargs,
+        ),
+        database='dbt',
+        schema='dbt_postgres',
+        name=node_name,
+        alias=node_name,
+        fqn=['minimal', 'schema_test', node_name],
+        unique_id=f'test.{pkg}.{node_name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=f'schema_test/{node_name}.sql',
+        original_file_path=f'models/{path}',
+        resource_type=NodeType.Test,
+        tags=tags,
+        refs=ref_values,
+        sources=[],
+        depends_on=DependsOn(
+            macros=[macro_depends],
+            nodes=['model.minimal.view_model']
+        ),
+        column_name=column_name,
+    )
+
+
+def make_data_test(pkg, name, sql, refs=None, sources=None, tags=None, path=None, config_kwargs=None):
+
+    if refs is None:
+        refs = []
+    if sources is None:
+        sources = []
+    if tags is None:
+        tags = ['data']
+    if path is None:
+        path = f'{name}.sql'
+
+    if config_kwargs is None:
+        config_kwargs = {}
+
+    fqn = ['minimal', 'data_test', name]
+
+    depends_on_nodes = []
+    source_values = []
+    ref_values = []
+    for ref in refs:
+        ref_values.append([ref.name])
+        depends_on_nodes.append(ref.unique_id)
+    for src in sources:
+        source_values.append([src.source_name, src.name])
+        depends_on_nodes.append(src.unique_id)
+
+    return ParsedDataTestNode(
+        raw_sql=sql,
+        database='dbt',
+        schema='dbt_schema',
+        name=name,
+        alias=name,
+        fqn=fqn,
+        unique_id=f'test.{pkg}.{name}',
+        package_name=pkg,
+        root_path='/usr/dbt/some-project',
+        path=path,
+        original_file_path=f'tests/{path}',
+        config=TestConfig(**config_kwargs),
+        tags=tags,
+        refs=ref_values,
+        sources=source_values,
+        depends_on=DependsOn(nodes=depends_on_nodes),
+        resource_type=NodeType.Test,
+    )
+
+
+@pytest.fixture
+def seed():
+    return make_seed(
+        'pkg',
+        'seed'
+    )
+
+
+@pytest.fixture
+def source():
+    return make_source(
+        'pkg',
+        'raw',
+        'seed',
+        identifier='seed'
+    )
+
+
+@pytest.fixture
+def ephemeral_model(source):
+    return make_model(
+        'pkg',
+        'ephemeral_model',
+        'select * from {{ source("raw", "seed") }}',
+        config_kwargs={'materialized': 'ephemeral'},
+        sources=[source],
+    )
+
+
+@pytest.fixture
+def view_model(ephemeral_model):
+    return make_model(
+        'pkg',
+        'view_model',
+        'select * from {{ ref("ephemeral_model") }}',
+        config_kwargs={'materialized': 'view'},
+        refs=[ephemeral_model],
+        tags=['uses_ephemeral'],
+    )
+
+
+@pytest.fixture
+def table_model(ephemeral_model):
+    return make_model(
+        'pkg',
+        'table_model',
+        'select * from {{ ref("ephemeral_model") }}',
+        config_kwargs={'materialized': 'table'},
+        refs=[ephemeral_model],
+        tags=['uses_ephemeral'],
+        path='subdirectory/table_model.sql'
+    )
+
+
+@pytest.fixture
+def ext_source():
+    return make_source(
+        'ext',
+        'ext_raw',
+        'ext_source',
+    )
+
+
+@pytest.fixture
+def ext_source_2():
+    return make_source(
+        'ext',
+        'ext_raw',
+        'ext_source_2',
+    )
+
+
+@pytest.fixture
+def ext_source_other():
+    return make_source(
+        'ext',
+        'raw',
+        'ext_source',
+    )
+
+
+@pytest.fixture
+def ext_source_other_2():
+    return make_source(
+        'ext',
+        'raw',
+        'ext_source_2',
+    )
+
+
+@pytest.fixture
+def ext_model(ext_source):
+    return make_model(
+        'ext',
+        'ext_model',
+        'select * from {{ source("ext_raw", "ext_source") }}',
+        sources=[ext_source],
+    )
+
+
+@pytest.fixture
+def union_model(seed, ext_source):
+    return make_model(
+        'pkg',
+        'union_model',
+        'select * from {{ ref("seed") }} union all select * from {{ source("ext_raw", "ext_source") }}',
+        config_kwargs={'materialized': 'table'},
+        refs=[seed],
+        sources=[ext_source],
+        fqn_extras=['unions'],
+        path='subdirectory/union_model.sql',
+        tags=['unions'],
+    )
+
+
+@pytest.fixture
+def table_id_unique(table_model):
+    return make_unique_test('pkg', table_model, 'id')
+
+
+@pytest.fixture
+def table_id_not_null(table_model):
+    return make_not_null_test('pkg', table_model, 'id')
+
+
+@pytest.fixture
+def view_id_unique(view_model):
+    return make_unique_test('pkg', view_model, 'id')
+
+
+@pytest.fixture
+def ext_source_id_unique(ext_source):
+    return make_unique_test('ext', ext_source, 'id')
+
+
+@pytest.fixture
+def view_test_nothing(view_model):
+    return make_data_test('pkg', 'view_test_nothing', 'select * from {{ ref("view_model") }} limit 0', refs=[view_model])
+
+
+@pytest.fixture
+def manifest(seed, source, ephemeral_model, view_model, table_model, ext_source, ext_model, union_model, ext_source_2, ext_source_other, ext_source_other_2, table_id_unique, table_id_not_null, view_id_unique, ext_source_id_unique, view_test_nothing):
+    nodes = [seed, ephemeral_model, view_model, table_model, union_model, ext_model, table_id_unique, table_id_not_null, view_id_unique, ext_source_id_unique, view_test_nothing]
+    sources = [source, ext_source, ext_source_2, ext_source_other, ext_source_other_2]
+    manifest = Manifest(
+        nodes={n.unique_id: n for n in nodes},
+        sources={s.unique_id: s for s in sources},
+        macros={},
+        docs={},
+        files={},
+        generated_at=datetime.utcnow(),
+        disabled=[],
+    )
+    return manifest
+
+
+def search_manifest_using_method(manifest, method, selection):
+    selected = method.search(set(manifest.nodes) | set(manifest.sources), selection)
+    results = {manifest.expect(uid).search_name for uid in selected}
+    return results
+
+
+def test_select_fqn(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('fqn', [])
+    assert isinstance(method, QualifiedNameSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(manifest, method, 'pkg.unions') == {'union_model'}
+    assert not search_manifest_using_method(manifest, method, 'ext.unions')
+    # sources don't show up, because selection pretends they have no FQN. Should it?
+    assert search_manifest_using_method(manifest, method, 'pkg') == {'union_model', 'table_model', 'view_model', 'ephemeral_model', 'seed'}
+    assert search_manifest_using_method(manifest, method, 'ext') == {'ext_model'}
+
+
+def test_select_tag(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('tag', [])
+    assert isinstance(method, TagSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(manifest, method, 'uses_ephemeral') == {'view_model', 'table_model'}
+    assert not search_manifest_using_method(manifest, method, 'missing')
+
+
+def test_select_source(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('source', [])
+    assert isinstance(method, SourceSelectorMethod)
+    assert method.arguments == []
+
+    # the lookup is based on how many components you provide: source, source.table, package.source.table
+    assert search_manifest_using_method(manifest, method, 'raw') == {'raw.seed', 'raw.ext_source', 'raw.ext_source_2'}
+    assert search_manifest_using_method(manifest, method, 'raw.seed') == {'raw.seed'}
+    assert search_manifest_using_method(manifest, method, 'pkg.raw.seed') == {'raw.seed'}
+    assert search_manifest_using_method(manifest, method, 'pkg.*.*') == {'raw.seed'}
+    assert search_manifest_using_method(manifest, method, 'raw.*') == {'raw.seed', 'raw.ext_source', 'raw.ext_source_2'}
+    assert search_manifest_using_method(manifest, method, 'ext.raw.*') == {'raw.ext_source', 'raw.ext_source_2'}
+    assert not search_manifest_using_method(manifest, method, 'missing')
+    assert not search_manifest_using_method(manifest, method, 'raw.missing')
+    assert not search_manifest_using_method(manifest, method, 'missing.raw.seed')
+
+    assert search_manifest_using_method(manifest, method, 'ext.*.*') == {'ext_raw.ext_source', 'ext_raw.ext_source_2', 'raw.ext_source', 'raw.ext_source_2'}
+    assert search_manifest_using_method(manifest, method, 'ext_raw') == {'ext_raw.ext_source', 'ext_raw.ext_source_2'}
+    assert search_manifest_using_method(manifest, method, 'ext.ext_raw.*') == {'ext_raw.ext_source', 'ext_raw.ext_source_2'}
+    assert not search_manifest_using_method(manifest, method, 'pkg.ext_raw.*')
+
+
+# TODO: this requires writing out files
+@pytest.mark.skip('TODO: write manifest files to disk')
+def test_select_path(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('path', [])
+    assert isinstance(method, PathSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(manifest, method, 'subdirectory/*.sql') == {'union_model', 'table_model'}
+    assert search_manifest_using_method(manifest, method, 'subdirectory/union_model.sql') == {'union_model'}
+    assert search_manifest_using_method(manifest, method, 'models/*.sql') == {'view_model', 'ephemeral_model'}
+    assert not search_manifest_using_method(manifest, method, 'missing')
+    assert not search_manifest_using_method(manifest, method, 'models/missing.sql')
+    assert not search_manifest_using_method(manifest, method, 'models/missing*')
+
+
+def test_select_package(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('package', [])
+    assert isinstance(method, PackageSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(manifest, method, 'pkg') == {'union_model', 'table_model', 'view_model', 'ephemeral_model', 'seed', 'raw.seed', 'unique_table_model_id', 'not_null_table_model_id', 'unique_view_model_id', 'view_test_nothing'}
+    assert search_manifest_using_method(manifest, method, 'ext') == {'ext_model', 'ext_raw.ext_source', 'ext_raw.ext_source_2', 'raw.ext_source', 'raw.ext_source_2', 'unique_ext_raw_ext_source_id'}
+
+    assert not search_manifest_using_method(manifest, method, 'missing')
+
+
+def test_select_config_materialized(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('config', ['materialized'])
+    assert isinstance(method, ConfigSelectorMethod)
+    assert method.arguments == ['materialized']
+
+    # yes, technically tests are "views"
+    assert search_manifest_using_method(manifest, method, 'view') == {'view_model', 'ext_model', 'unique_table_model_id', 'not_null_table_model_id', 'unique_view_model_id', 'unique_ext_raw_ext_source_id', 'view_test_nothing'}
+    assert search_manifest_using_method(manifest, method, 'table') == {'table_model', 'union_model'}
+
+
+def test_select_test_name(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('test_name', [])
+    assert isinstance(method, TestNameSelectorMethod)
+    assert method.arguments == []
+
+    assert search_manifest_using_method(manifest, method, 'unique') == {'unique_table_model_id', 'unique_view_model_id', 'unique_ext_raw_ext_source_id'}
+    assert search_manifest_using_method(manifest, method, 'not_null') == {'not_null_table_model_id'}
+    assert not search_manifest_using_method(manifest, method, 'notatest')
+
+
+def test_select_test_type(manifest):
+    methods = MethodManager(manifest)
+    method = methods.get_method('test_type', [])
+    assert isinstance(method, TestTypeSelectorMethod)
+    assert method.arguments == []
+    assert search_manifest_using_method(manifest, method, 'schema') == {'unique_table_model_id', 'not_null_table_model_id', 'unique_view_model_id', 'unique_ext_raw_ext_source_id'}
+    assert search_manifest_using_method(manifest, method, 'data') == {'view_test_nothing'}
+

--- a/test/unit/test_graph_selector_spec.py
+++ b/test/unit/test_graph_selector_spec.py
@@ -1,0 +1,151 @@
+import pytest
+
+from dbt.exceptions import RuntimeException
+from dbt.graph.selector_spec import (
+    SelectionCriteria,
+    SelectionIntersection,
+    SelectionDifference,
+    SelectionUnion,
+)
+from dbt.graph.selector_methods import MethodName
+import os
+
+
+def test_raw_parse_simple():
+    raw = 'asdf'
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.FQN
+    assert result.method_arguments == []
+    assert result.value == raw
+    assert not result.select_childrens_parents
+    assert not result.select_children
+    assert not result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_simple_infer_path():
+    raw = os.path.join('asdf', '*')
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.Path
+    assert result.method_arguments == []
+    assert result.value == raw
+    assert not result.select_childrens_parents
+    assert not result.select_children
+    assert not result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_simple_infer_path_modified():
+    raw = '@' + os.path.join('asdf', '*')
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.Path
+    assert result.method_arguments == []
+    assert result.value == raw[1:]
+    assert result.select_childrens_parents
+    assert not result.select_children
+    assert not result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_simple_infer_fqn_parents():
+    raw = '+asdf'
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.FQN
+    assert result.method_arguments == []
+    assert result.value == 'asdf'
+    assert not result.select_childrens_parents
+    assert not result.select_children
+    assert result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_simple_infer_fqn_children():
+    raw = 'asdf+'
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.FQN
+    assert result.method_arguments == []
+    assert result.value == 'asdf'
+    assert not result.select_childrens_parents
+    assert result.select_children
+    assert not result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_complex():
+    raw = '2+config.arg.secondarg:argument_value+4'
+    result = SelectionCriteria.from_single_spec(raw)
+    assert result.raw == raw
+    assert result.method == MethodName.Config
+    assert result.method_arguments == ['arg', 'secondarg']
+    assert result.value == 'argument_value'
+    assert not result.select_childrens_parents
+    assert result.select_children
+    assert result.select_parents
+    assert result.select_parents_max_depth == 2
+    assert result.select_children_max_depth == 4
+
+
+def test_raw_parse_weird():
+    # you can have an empty method name (defaults to FQN/path) and you can have
+    # an empty value, so you can also have this...
+    result = SelectionCriteria.from_single_spec('')
+    assert result.raw == ''
+    assert result.method == MethodName.FQN
+    assert result.method_arguments == []
+    assert result.value == ''
+    assert not result.select_childrens_parents
+    assert not result.select_children
+    assert not result.select_parents
+    assert result.select_parents_max_depth is None
+    assert result.select_children_max_depth is None
+
+
+def test_raw_parse_invalid():
+    with pytest.raises(RuntimeException):
+        SelectionCriteria.from_single_spec('invalid_method:something')
+
+    with pytest.raises(RuntimeException):
+        SelectionCriteria.from_single_spec('@foo+')
+
+
+def test_intersection():
+    fqn_a = SelectionCriteria.from_single_spec('fqn:model_a')
+    fqn_b = SelectionCriteria.from_single_spec('fqn:model_b')
+    intersection = SelectionIntersection(components=[fqn_a, fqn_b])
+    assert list(intersection) == [fqn_a, fqn_b]
+    combined = intersection.combine_selections([{'model_a', 'model_b', 'model_c'}, {'model_c', 'model_d'}])
+    assert combined == {'model_c'}
+
+
+def test_difference():
+    fqn_a = SelectionCriteria.from_single_spec('fqn:model_a')
+    fqn_b = SelectionCriteria.from_single_spec('fqn:model_b')
+    difference = SelectionDifference(components=[fqn_a, fqn_b])
+    assert list(difference) == [fqn_a, fqn_b]
+    combined = difference.combine_selections([{'model_a', 'model_b', 'model_c'}, {'model_c', 'model_d'}])
+    assert combined == {'model_a', 'model_b'}
+
+    fqn_c = SelectionCriteria.from_single_spec('fqn:model_c')
+    difference = SelectionDifference(components=[fqn_a, fqn_b, fqn_c])
+    assert list(difference) == [fqn_a, fqn_b, fqn_c]
+    combined = difference.combine_selections([{'model_a', 'model_b', 'model_c'}, {'model_c', 'model_d'}, {'model_a'}])
+    assert combined == {'model_b'}
+
+
+def test_union():
+    fqn_a = SelectionCriteria.from_single_spec('fqn:model_a')
+    fqn_b = SelectionCriteria.from_single_spec('fqn:model_b')
+    fqn_c = SelectionCriteria.from_single_spec('fqn:model_c')
+    difference = SelectionUnion(components=[fqn_a, fqn_b, fqn_c])
+    combined = difference.combine_selections([{'model_a', 'model_b'}, {'model_b', 'model_c'}, {'model_d'}])
+    assert combined == {'model_a', 'model_b', 'model_c', 'model_d'}

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -17,13 +17,12 @@ from dbt.contracts.graph.parsed import (
     NodeConfig,
     ParsedSeedNode,
     ParsedSourceDefinition,
-    ParsedDocumentation,
 )
 from dbt.contracts.graph.compiled import CompiledModelNode
 from dbt.node_types import NodeType
 import freezegun
 
-from .utils import MockMacro
+from .utils import MockMacro, MockDocumentation, MockSource, MockNode, MockMaterialization, MockGenerateMacro
 
 
 REQUIRED_PARSED_NODE_KEYS = frozenset({
@@ -663,62 +662,6 @@ class MixedManifestTest(unittest.TestCase):
 
 
 # Tests of the manifest search code (find_X_by_Y)
-def MockMaterialization(package, name='my_materialization', adapter_type=None, kwargs={}):
-    if adapter_type is None:
-        adapter_type = 'default'
-    kwargs['adapter_type'] = adapter_type
-    return MockMacro(package, f'materialization_{name}_{adapter_type}', kwargs)
-
-
-def MockGenerateMacro(package, component='some_component', kwargs={}):
-    name = f'generate_{component}_name'
-    return MockMacro(package, name=name, kwargs=kwargs)
-
-
-def MockSource(package, source_name, name, kwargs={}):
-    src = mock.MagicMock(
-        __class__=ParsedSourceDefinition,
-        resource_type=NodeType.Source,
-        source_name=source_name,
-        package_name=package,
-        unique_id=f'source.{package}.{source_name}.{name}',
-        search_name=f'{source_name}.{name}',
-        **kwargs
-    )
-    src.name = name
-    return src
-
-
-def MockNode(package, name, resource_type=NodeType.Model, kwargs={}):
-    if resource_type == NodeType.Model:
-        cls = ParsedModelNode
-    elif resource_type == NodeType.Seed:
-        cls = ParsedSeedNode
-    else:
-        raise ValueError(f'I do not know how to handle {resource_type}')
-    node = mock.MagicMock(
-        __class__=cls,
-        resource_type=resource_type,
-        package_name=package,
-        unique_id=f'{str(resource_type)}.{package}.{name}',
-        search_name=name,
-        **kwargs
-    )
-    node.name = name
-    return node
-
-
-def MockDocumentation(package, name, kwargs={}):
-    doc = mock.MagicMock(
-        __class__=ParsedDocumentation,
-        resource_type=NodeType.Documentation,
-        package_name=package,
-        search_name=name,
-        unique_id=f'{package}.{name}',
-    )
-    doc.name = name
-    return doc
-
 
 class TestManifestSearch(unittest.TestCase):
     _macros = []

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -26,60 +26,13 @@ from dbt.contracts.graph.model_config import (
     NodeConfig, TestConfig, TimestampSnapshotConfig, SnapshotStrategy,
 )
 from dbt.contracts.graph.parsed import (
-    ParsedModelNode, ParsedMacro, ParsedNodePatch, ParsedSourceDefinition,
-    DependsOn, ColumnInfo, ParsedDataTestNode, ParsedSnapshotNode,
-    ParsedAnalysisNode, ParsedDocumentation, UnpatchedSourceDefinition,
-    ParsedSeedNode
+    ParsedModelNode, ParsedMacro, ParsedNodePatch, DependsOn, ColumnInfo,
+    ParsedDataTestNode, ParsedSnapshotNode, ParsedAnalysisNode,
+    UnpatchedSourceDefinition
 )
 from dbt.contracts.graph.unparsed import Docs
 
-from .utils import config_from_parts_or_dicts, normalize, generate_name_macros
-
-
-def MockSource(package, source_name, name, **kwargs):
-    src = mock.MagicMock(
-        __class__=ParsedSourceDefinition,
-        resource_type=NodeType.Source,
-        source_name=source_name,
-        package_name=package,
-        unique_id=f'source.{package}.{source_name}.{name}',
-        search_name=f'{source_name}.{name}',
-        **kwargs
-    )
-    src.name = name
-    return src
-
-
-def MockNode(package, name, resource_type=NodeType.Model, **kwargs):
-    if resource_type == NodeType.Model:
-        cls = ParsedModelNode
-    elif resource_type == NodeType.Seed:
-        cls = ParsedSeedNode
-    else:
-        raise ValueError(f'I do not know how to handle {resource_type}')
-    node = mock.MagicMock(
-        __class__=cls,
-        resource_type=resource_type,
-        package_name=package,
-        unique_id=f'{str(resource_type)}.{package}.{name}',
-        search_name=name,
-        **kwargs
-    )
-    node.name = name
-    return node
-
-
-def MockDocumentation(package, name, **kwargs):
-    doc = mock.MagicMock(
-        __class__=ParsedDocumentation,
-        resource_type=NodeType.Documentation,
-        package_name=package,
-        search_name=name,
-        unique_id=f'{package}.{name}',
-        **kwargs
-    )
-    doc.name = name
-    return doc
+from .utils import config_from_parts_or_dicts, normalize, generate_name_macros, MockNode, MockSource, MockDocumentation
 
 
 def get_abs_os_path(unix_path):

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -195,7 +195,7 @@ class TestAdapterConversions(TestCase):
         return table
 
 
-def MockMacro(package, name='my_macro', kwargs={}):
+def MockMacro(package, name='my_macro', **kwargs):
     from dbt.contracts.graph.parsed import ParsedMacro
     from dbt.node_types import NodeType
 
@@ -214,3 +214,69 @@ def MockMacro(package, name='my_macro', kwargs={}):
     )
     macro.name = name
     return macro
+
+
+def MockMaterialization(package, name='my_materialization', adapter_type=None, **kwargs):
+    if adapter_type is None:
+        adapter_type = 'default'
+    kwargs['adapter_type'] = adapter_type
+    return MockMacro(package, f'materialization_{name}_{adapter_type}', **kwargs)
+
+
+def MockGenerateMacro(package, component='some_component', **kwargs):
+    name = f'generate_{component}_name'
+    return MockMacro(package, name=name, **kwargs)
+
+
+def MockSource(package, source_name, name, **kwargs):
+    from dbt.node_types import NodeType
+    from dbt.contracts.graph.parsed import ParsedSourceDefinition
+    src = mock.MagicMock(
+        __class__=ParsedSourceDefinition,
+        resource_type=NodeType.Source,
+        source_name=source_name,
+        package_name=package,
+        unique_id=f'source.{package}.{source_name}.{name}',
+        search_name=f'{source_name}.{name}',
+        **kwargs
+    )
+    src.name = name
+    return src
+
+
+def MockNode(package, name, resource_type=None, **kwargs):
+    from dbt.node_types import NodeType
+    from dbt.contracts.graph.parsed import ParsedModelNode, ParsedSeedNode
+    if resource_type is None:
+        resource_type = NodeType.Model
+    if resource_type == NodeType.Model:
+        cls = ParsedModelNode
+    elif resource_type == NodeType.Seed:
+        cls = ParsedSeedNode
+    else:
+        raise ValueError(f'I do not know how to handle {resource_type}')
+    node = mock.MagicMock(
+        __class__=cls,
+        resource_type=resource_type,
+        package_name=package,
+        unique_id=f'{str(resource_type)}.{package}.{name}',
+        search_name=name,
+        **kwargs
+    )
+    node.name = name
+    return node
+
+
+def MockDocumentation(package, name, **kwargs):
+    from dbt.node_types import NodeType
+    from dbt.contracts.graph.parsed import ParsedDocumentation
+    doc = mock.MagicMock(
+        __class__=ParsedDocumentation,
+        resource_type=NodeType.Documentation,
+        package_name=package,
+        search_name=name,
+        unique_id=f'{package}.{name}',
+        **kwargs
+    )
+    doc.name = name
+    return doc


### PR DESCRIPTION
resolves #2425 

### Description

Add the node selectors discussed in #2425, except I used `test_type` for differentiating schema and data tests, and `test_name` to differentiate between schema test names.

There's obviously lots of room for new selectors in addition to these, but this felt like a nice start.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
