### PR TITLE
add environment variables for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt 0.17.2b1 (Release TBD)
+
+### Features
+- Added environment variables for debug-level logging ([#2633](https://github.com/fishtown-analytics/dbt/issues/2633), [#2635](https://github.com/fishtown-analytics/dbt/pull/2635))
+
 ## dbt 0.17.1 (July 20, 2020)
 
 ## dbt 0.17.1rc4 (July 08, 2020)

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -597,15 +597,28 @@ class ListLogHandler(LogMessageHandler):
         self.records.append(as_dict)
 
 
-# we still need to use logging to suppress these or pytest captures them
-logging.getLogger('botocore').setLevel(logging.ERROR)
-logging.getLogger('requests').setLevel(logging.ERROR)
-logging.getLogger('urllib3').setLevel(logging.ERROR)
-logging.getLogger('google').setLevel(logging.ERROR)
-logging.getLogger('snowflake.connector').setLevel(logging.ERROR)
+def _env_log_level(var_name: str) -> int:
+    # convert debugging environment variable name to a log level
+    if dbt.flags.env_set_truthy(var_name):
+        return logging.DEBUG
+    else:
+        return logging.ERROR
+
+
+LOG_LEVEL_GOOGLE = _env_log_level('DBT_GOOGLE_DEBUG_LOGGING')
+LOG_LEVEL_SNOWFLAKE = _env_log_level('DBT_SNOWFLAKE_CONNECTOR_DEBUG_LOGGING')
+LOG_LEVEL_BOTOCORE = _env_log_level('DBT_BOTOCORE_DEBUG_LOGGING')
+LOG_LEVEL_HTTP = _env_log_level('DBT_HTTP_DEBUG_LOGGING')
+LOG_LEVEL_WERKZEUG = _env_log_level('DBT_WERKZEUG_DEBUG_LOGGING')
+
+logging.getLogger('botocore').setLevel(LOG_LEVEL_BOTOCORE)
+logging.getLogger('requests').setLevel(LOG_LEVEL_HTTP)
+logging.getLogger('urllib3').setLevel(LOG_LEVEL_HTTP)
+logging.getLogger('google').setLevel(LOG_LEVEL_GOOGLE)
+logging.getLogger('snowflake.connector').setLevel(LOG_LEVEL_SNOWFLAKE)
+
 logging.getLogger('parsedatetime').setLevel(logging.ERROR)
-# want to see werkzeug logs about errors
-logging.getLogger('werkzeug').setLevel(logging.ERROR)
+logging.getLogger('werkzeug').setLevel(LOG_LEVEL_WERKZEUG)
 
 
 def list_handler(


### PR DESCRIPTION
resolves #2633 

### Description
The snowflake log data shows up in the debug log file, but not stdout/stderr (even if you run with `--debug`). I didn't want to spend a lot of time figuring out why, because that actually seems pretty great to me. Let me know if I'm wrong and it should go to stdout, if so I'll dig into it.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
