### PR TITLE
Fix fast-fail not logging original error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ### Fixes
 - fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644))
 
-
+Contributors:
+ - [@joshpeng-quibi](https://github.com/joshpeng-quibi) ([#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
 ## dbt 0.17.2b1 (July 21, 2020)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt 0.17.2 (Release TBD)
 
+
+### Fixes
+- fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644))
+
+
 ## dbt 0.17.2b1 (July 21, 2020)
 
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -295,15 +295,15 @@ class GraphRunnableTask(ManifestTask):
 
             yellow = dbt.ui.printer.COLOR_FG_YELLOW
             dbt.ui.printer.print_timestamped_line(msg, yellow)
-            raise
 
-        for conn_name in adapter.cancel_open_connections():
-            if self.manifest is not None:
-                node = self.manifest.nodes.get(conn_name)
-                if node is not None and node.is_ephemeral_model:
-                    continue
-            # if we don't have a manifest/don't have a node, print anyway.
-            dbt.ui.printer.print_cancel_line(conn_name)
+        if adapter.cancel_open_connections():
+            for conn_name in adapter.cancel_open_connections():
+                if self.manifest is not None:
+                    node = self.manifest.nodes.get(conn_name)
+                    if node is not None and node.is_ephemeral_model:
+                        continue
+                # if we don't have a manifest/don't have a node, print anyway.
+                dbt.ui.printer.print_cancel_line(conn_name)
 
         pool.join()
 

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -296,7 +296,7 @@ class GraphRunnableTask(ManifestTask):
             yellow = dbt.ui.printer.COLOR_FG_YELLOW
             dbt.ui.printer.print_timestamped_line(msg, yellow)
 
-        if adapter.cancel_open_connections():
+        else:
             for conn_name in adapter.cancel_open_connections():
                 if self.manifest is not None:
                     node = self.manifest.nodes.get(conn_name)


### PR DESCRIPTION
resolves #2644

### Description

The exception handling in `execute_nodes()` calls `_cancel_connections()`. For adapters that aren't cancellable, it goes down a code path that short-circuits the rest of the handling logic via a `raise`. This PR removes the short-circuit path which allows the handling to reach the `print_run_result_error()`. Prior behavior never reached there so it never printed the original error messages.

This PR also guards against iterating through a `NoneType` return from `adapter.cancel_open_connections()`. In BigQuery's case, it is always `None`.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.