### PR TITLE
Fix: dbt clean without profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 
 ### Fixes
-- fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644))
+- fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644), [#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
+- `dbt clean` no longer requries a profile ([#2620](https://github.com/fishtown-analytics/dbt/issues/2620), [#2649](https://github.com/fishtown-analytics/dbt/pull/2649))
 
 Contributors:
  - [@joshpeng-quibi](https://github.com/joshpeng-quibi) ([#2646](https://github.com/fishtown-analytics/dbt/pull/2646))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixes
 - fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644), [#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
-- `dbt clean` no longer requries a profile ([#2620](https://github.com/fishtown-analytics/dbt/issues/2620), [#2649](https://github.com/fishtown-analytics/dbt/pull/2649))
+- `dbt clean` no longer requires a profile ([#2620](https://github.com/fishtown-analytics/dbt/issues/2620), [#2649](https://github.com/fishtown-analytics/dbt/pull/2649))
 
 Contributors:
  - [@joshpeng-quibi](https://github.com/joshpeng-quibi) ([#2646](https://github.com/fishtown-analytics/dbt/pull/2646))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,13 @@ jobs:
       Set-Service -InputObject $serviceName -StartupType Automatic
       Start-Service -InputObject $serviceName
 
-      createdb.exe -U postgres dbt
-      psql.exe  -U postgres -c "CREATE ROLE root WITH PASSWORD 'password';"
-      psql.exe  -U postgres -c "ALTER ROLE root WITH LOGIN;"
-      psql.exe  -U postgres -c "GRANT CREATE, CONNECT ON DATABASE dbt TO root WITH GRANT OPTION;"
-      psql.exe  -U postgres -c "CREATE ROLE noaccess WITH PASSWORD 'password' NOSUPERUSER;"
-      psql.exe  -U postgres -c "ALTER ROLE noaccess WITH LOGIN;"
-      psql.exe  -U postgres -c "GRANT CONNECT ON DATABASE dbt TO noaccess;"
+      & $env:PGBIN\createdb.exe -U postgres dbt
+      & $env:PGBIN\psql.exe  -U postgres -c "CREATE ROLE root WITH PASSWORD 'password';"
+      & $env:PGBIN\psql.exe  -U postgres -c "ALTER ROLE root WITH LOGIN;"
+      & $env:PGBIN\psql.exe  -U postgres -c "GRANT CREATE, CONNECT ON DATABASE dbt TO root WITH GRANT OPTION;"
+      & $env:PGBIN\psql.exe  -U postgres -c "CREATE ROLE noaccess WITH PASSWORD 'password' NOSUPERUSER;"
+      & $env:PGBIN\psql.exe  -U postgres -c "ALTER ROLE noaccess WITH LOGIN;"
+      & $env:PGBIN\psql.exe  -U postgres -c "GRANT CONNECT ON DATABASE dbt TO noaccess;"
     displayName: Install postgresql and set up database
 
   - task: UsePythonVersion@0

--- a/core/dbt/task/clean.py
+++ b/core/dbt/task/clean.py
@@ -2,11 +2,13 @@ import os.path
 import os
 import shutil
 
-from dbt.task.base import ConfiguredTask
+from dbt.task.base import BaseTask
 from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.config import UnsetProfileConfig
 
 
-class CleanTask(ConfiguredTask):
+class CleanTask(BaseTask):
+    ConfigType = UnsetProfileConfig
 
     def __is_project_path(self, path):
         proj_path = os.path.abspath('.')


### PR DESCRIPTION
resolves #2620 

### Description

Fix `dbt clean` to work without a profile, like `dbt deps`.

I also backported the azure pipelines fix from dev/marian-anderson, I'm tired of that Windows tests failing!


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
