### PR TITLE
Fix: close connections after use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## dbt 0.17.2 (Release TBD)
 
 
+### Breaking changes (for plugins)
+- The `release` argument to adapter.execute_macro no longer has any effect. It will be removed in a future release of dbt (likely 0.18.0) ([#2650](https://github.com/fishtown-analytics/dbt/pull/2650))
+
+
 ### Fixes
 - fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644), [#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
 - `dbt clean` no longer requires a profile ([#2620](https://github.com/fishtown-analytics/dbt/issues/2620), [#2649](https://github.com/fishtown-analytics/dbt/pull/2649))
@@ -8,6 +12,8 @@
 
 Contributors:
  - [@joshpeng-quibi](https://github.com/joshpeng-quibi) ([#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
+
+
 ## dbt 0.17.2b1 (July 21, 2020)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixes
 - fast-fail option with adapters that don't support cancelling queries will now passthrough the original error messages ([#2644](https://github.com/fishtown-analytics/dbt/issues/2644), [#2646](https://github.com/fishtown-analytics/dbt/pull/2646))
 - `dbt clean` no longer requires a profile ([#2620](https://github.com/fishtown-analytics/dbt/issues/2620), [#2649](https://github.com/fishtown-analytics/dbt/pull/2649))
+- Close all connections so snowflake's keepalive thread will exit. ([#2645](https://github.com/fishtown-analytics/dbt/issues/2645), [#2650](https://github.com/fishtown-analytics/dbt/pull/2650))
 
 Contributors:
  - [@joshpeng-quibi](https://github.com/joshpeng-quibi) ([#2646](https://github.com/fishtown-analytics/dbt/pull/2646))

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -179,8 +179,8 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             if conn.state == 'open':
                 if conn.transaction_open is True:
                     self._rollback(conn)
-            else:
-                self.close(conn)
+            # always close the connection
+            self.close(conn)
         except Exception:
             # if rollback or close failed, remove our busted connection
             self.clear_thread_connection()

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -88,6 +88,11 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             self.begin()
             self.commit()
 
+    def rollback_if_open(self) -> None:
+        conn = self.get_if_exists()
+        if conn is not None and conn.handle and conn.transaction_open:
+            self._rollback(conn)
+
     @abc.abstractmethod
     def exception_handler(self, sql: str) -> ContextManager:
         """Create a context manager that handles exceptions caused by database
@@ -176,10 +181,8 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
                 return
 
         try:
-            if conn.state == 'open':
-                if conn.transaction_open is True:
-                    self._rollback(conn)
-            # always close the connection
+            # always close the connection. close() calls _rollback() if there
+            # is an open transaction
             self.close(conn)
         except Exception:
             # if rollback or close failed, remove our busted connection
@@ -230,11 +233,10 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         """Perform the actual close operation."""
         # On windows, sometimes connection handles don't have a close() attr.
         if hasattr(connection.handle, 'close'):
-            logger.debug('On {}: Close'.format(connection.name))
+            logger.debug(f'On {connection.name}: Close')
             connection.handle.close()
         else:
-            logger.debug('On {}: No close available on handle'
-                         .format(connection.name))
+            logger.debug(f'On {connection.name}: No close available on handle')
 
     @classmethod
     def _rollback(cls, connection: Connection) -> None:
@@ -247,10 +249,11 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
 
         if connection.transaction_open is False:
             raise dbt.exceptions.InternalException(
-                'Tried to rollback transaction on connection "{}", but '
-                'it does not have one open!'.format(connection.name))
+                f'Tried to rollback transaction on connection '
+                f'"{connection.name}", but it does not have one open!'
+            )
 
-        logger.debug('On {}: ROLLBACK'.format(connection.name))
+        logger.debug(f'On {connection.name}: ROLLBACK')
         cls._rollback_handle(connection)
 
         connection.transaction_open = False
@@ -268,6 +271,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             return connection
 
         if connection.transaction_open and connection.handle:
+            logger.debug('On {}: ROLLBACK'.format(connection.name))
             cls._rollback_handle(connection)
         connection.transaction_open = False
 

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -312,13 +312,6 @@ class BaseAdapter(metaclass=AdapterMeta):
         # databases
         return info_schema_name_map
 
-    def _list_relations_get_connection(
-        self, schema_relation: BaseRelation
-    ) -> List[BaseRelation]:
-        name = f'list_{schema_relation.database}_{schema_relation.schema}'
-        with self.connection_named(name):
-            return self.list_relations_without_caching(schema_relation)
-
     def _relations_cache_for_schemas(self, manifest: Manifest) -> None:
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
@@ -328,10 +321,16 @@ class BaseAdapter(metaclass=AdapterMeta):
 
         cache_schemas = self._get_cache_schemas(manifest)
         with executor(self.config) as tpe:
-            futures: List[Future[List[BaseRelation]]] = [
-                tpe.submit(self._list_relations_get_connection, cache_schema)
-                for cache_schema in cache_schemas
-            ]
+            futures: List[Future[List[BaseRelation]]] = []
+            for cache_schema in cache_schemas:
+                fut = tpe.submit_connected(
+                    self,
+                    f'list_{cache_schema.database}_{cache_schema.schema}',
+                    self.list_relations_without_caching,
+                    cache_schema
+                )
+                futures.append(fut)
+
             for future in as_completed(futures):
                 # if we can't read the relations we need to just raise anyway,
                 # so just call future.result() and let that raise on failure
@@ -1001,24 +1000,18 @@ class BaseAdapter(metaclass=AdapterMeta):
         manifest: Manifest,
     ) -> agate.Table:
 
-        name = '.'.join([
-            str(information_schema.database),
-            'information_schema'
-        ])
-
-        with self.connection_named(name):
-            kwargs = {
-                'information_schema': information_schema,
-                'schemas': schemas
-            }
-            table = self.execute_macro(
-                GET_CATALOG_MACRO_NAME,
-                kwargs=kwargs,
-                release=True,
-                # pass in the full manifest so we get any local project
-                # overrides
-                manifest=manifest,
-            )
+        kwargs = {
+            'information_schema': information_schema,
+            'schemas': schemas
+        }
+        table = self.execute_macro(
+            GET_CATALOG_MACRO_NAME,
+            kwargs=kwargs,
+            release=False,
+            # pass in the full manifest so we get any local project
+            # overrides
+            manifest=manifest,
+        )
 
         results = self._catalog_filter_table(table, manifest)
         return results
@@ -1029,10 +1022,21 @@ class BaseAdapter(metaclass=AdapterMeta):
         schema_map = self._get_catalog_schemas(manifest)
 
         with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = [
-                tpe.submit(self._get_one_catalog, info, schemas, manifest)
-                for info, schemas in schema_map.items() if len(schemas) > 0
-            ]
+            futures: List[Future[agate.Table]] = []
+            for info, schemas in schema_map.items():
+                if len(schemas) == 0:
+                    continue
+                name = '.'.join([
+                    str(info.database),
+                    'information_schema'
+                ])
+
+                fut = tpe.submit_connected(
+                    self, name,
+                    self._get_one_catalog, info, schemas, manifest
+                )
+                futures.append(fut)
+
             catalogs, exceptions = catch_as_completed(futures)
 
         return catalogs, exceptions
@@ -1059,7 +1063,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         table = self.execute_macro(
             FRESHNESS_MACRO_NAME,
             kwargs=kwargs,
-            release=True,
+            release=False,
             manifest=manifest
         )
         # now we have a 1-row table of the maximum `loaded_at_field` value and

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -934,8 +934,10 @@ class BaseAdapter(metaclass=AdapterMeta):
             execution context.
         :param kwargs: An optional dict of keyword args used to pass to the
             macro.
-        :param release: If True, release the connection after executing.
+        :param release: Ignored.
         """
+        if release is not False:
+            deprecations.warn('execute-macro-release')
         if kwargs is None:
             kwargs = {}
         if context_override is None:
@@ -971,11 +973,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         macro_function = MacroGenerator(macro, macro_context)
 
         with self.connections.exception_handler(f'macro {macro_name}'):
-            try:
-                result = macro_function(**kwargs)
-            finally:
-                if release:
-                    self.release_connection()
+            result = macro_function(**kwargs)
         return result
 
     @classmethod
@@ -1007,7 +1005,6 @@ class BaseAdapter(metaclass=AdapterMeta):
         table = self.execute_macro(
             GET_CATALOG_MACRO_NAME,
             kwargs=kwargs,
-            release=False,
             # pass in the full manifest so we get any local project
             # overrides
             manifest=manifest,
@@ -1063,7 +1060,6 @@ class BaseAdapter(metaclass=AdapterMeta):
         table = self.execute_macro(
             FRESHNESS_MACRO_NAME,
             kwargs=kwargs,
-            release=False,
             manifest=manifest
         )
         # now we have a 1-row table of the maximum `loaded_at_field` value and

--- a/core/dbt/adapters/sql/connections.py
+++ b/core/dbt/adapters/sql/connections.py
@@ -6,7 +6,7 @@ import agate
 
 import dbt.clients.agate_helper
 import dbt.exceptions
-from dbt.contracts.connection import Connection
+from dbt.contracts.connection import Connection, ConnectionState
 from dbt.adapters.base import BaseConnectionManager
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -37,7 +37,10 @@ class SQLConnectionManager(BaseConnectionManager):
 
                 # if the connection failed, the handle will be None so we have
                 # nothing to cancel.
-                if connection.handle is not None:
+                if (
+                    connection.handle is not None and
+                    connection.state == ConnectionState.OPEN
+                ):
                     self.cancel(connection)
                 if connection.name is not None:
                     names.append(connection.name)

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -108,6 +108,15 @@ class DbtProjectYamlDeprecation(DBTDeprecation):
     '''
 
 
+class ExecuteMacrosReleaseDeprecation(DBTDeprecation):
+    _name = 'execute-macro-release'
+    _description = '''\
+    The "release" argument to execute_macro is now ignored, and will be removed
+    in a future relase of dbt. At that time, providing a `release` argument
+    will result in an error.
+    '''
+
+
 _adapter_renamed_description = """\
 The adapter function `adapter.{old_name}` is deprecated and will be removed in
 a future release of dbt. Please use `adapter.{new_name}` instead.
@@ -151,6 +160,7 @@ deprecations_list: List[DBTDeprecation] = [
     ColumnQuotingDeprecation(),
     ModelsKeyNonModelDeprecation(),
     DbtProjectYamlDeprecation(),
+    ExecuteMacrosReleaseDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -297,13 +297,15 @@ class GraphRunnableTask(ManifestTask):
             dbt.ui.printer.print_timestamped_line(msg, yellow)
 
         else:
-            for conn_name in adapter.cancel_open_connections():
-                if self.manifest is not None:
-                    node = self.manifest.nodes.get(conn_name)
-                    if node is not None and node.is_ephemeral_model:
-                        continue
-                # if we don't have a manifest/don't have a node, print anyway.
-                dbt.ui.printer.print_cancel_line(conn_name)
+            with adapter.connection_named('master'):
+                for conn_name in adapter.cancel_open_connections():
+                    if self.manifest is not None:
+                        node = self.manifest.nodes.get(conn_name)
+                        if node is not None and node.is_ephemeral_model:
+                            continue
+                    # if we don't have a manifest/don't have a node, print
+                    # anyway.
+                    dbt.ui.printer.print_cancel_line(conn_name)
 
         pool.join()
 
@@ -457,18 +459,15 @@ class GraphRunnableTask(ManifestTask):
             db_lowercase = dbt.utils.lowercase(db_only.database)
             if db_only.database is None:
                 database_quoted = None
-                conn_name = 'list_schemas'
             else:
                 database_quoted = str(db_only)
-                conn_name = f'list_{db_only.database}'
 
-            with adapter.connection_named(conn_name):
-                # we should never create a null schema, so just filter them out
-                return [
-                    (db_lowercase, s.lower())
-                    for s in adapter.list_schemas(database_quoted)
-                    if s is not None
-                ]
+            # we should never create a null schema, so just filter them out
+            return [
+                (db_lowercase, s.lower())
+                for s in adapter.list_schemas(database_quoted)
+                if s is not None
+            ]
 
         def create_schema(relation: BaseRelation) -> None:
             db = relation.database or ''
@@ -480,9 +479,13 @@ class GraphRunnableTask(ManifestTask):
         create_futures = []
 
         with dbt.utils.executor(self.config) as tpe:
-            list_futures = [
-                tpe.submit(list_schemas, db) for db in required_databases
-            ]
+            for req in required_databases:
+                if req.database is None:
+                    name = 'list_schemas'
+                else:
+                    name = f'list_{req.database}'
+                fut = tpe.submit_connected(adapter, name, list_schemas, req)
+                list_futures.append(fut)
 
             for ls_future in as_completed(list_futures):
                 existing_schemas_lowered.update(ls_future.result())
@@ -499,9 +502,12 @@ class GraphRunnableTask(ManifestTask):
                 db_schema = (db_lower, schema.lower())
                 if db_schema not in existing_schemas_lowered:
                     existing_schemas_lowered.add(db_schema)
-                    create_futures.append(
-                        tpe.submit(create_schema, info)
+
+                    fut = tpe.submit_connected(
+                        adapter, f'create_{info.database or ""}_{info.schema}',
+                        create_schema, info
                     )
+                    create_futures.append(fut)
 
             for create_future in as_completed(create_futures):
                 # trigger/re-raise any excceptions while creating schemas

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -10,6 +10,7 @@ from google.oauth2 import service_account
 
 from dbt.utils import format_bytes
 from dbt.clients import agate_helper, gcloud
+from dbt.contracts.connection import ConnectionState
 from dbt.exceptions import (
     FailedToConnectException, RuntimeException, DatabaseException
 )
@@ -111,7 +112,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
     @classmethod
     def close(cls, connection):
-        connection.state = 'closed'
+        connection.state = ConnectionState.CLOSED
 
         return connection
 

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -49,8 +49,7 @@ class PostgresConnectionManager(SQLConnectionManager):
             logger.debug('Postgres error: {}'.format(str(e)))
 
             try:
-                # attempt to release the connection
-                self.release()
+                self.rollback_if_open()
             except psycopg2.Error:
                 logger.debug("Failed to release connection!")
                 pass
@@ -60,7 +59,7 @@ class PostgresConnectionManager(SQLConnectionManager):
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
-            self.release()
+            self.rollback_if_open()
             if isinstance(e, dbt.exceptions.RuntimeException):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -165,7 +165,6 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             if 'Empty SQL statement' in msg:
                 logger.debug("got empty sql statement, moving on")
             elif 'This session does not have a current database' in msg:
-                self.release()
                 raise FailedToConnectException(
                     ('{}\n\nThis error sometimes occurs when invalid '
                      'credentials are provided, or when your default role '
@@ -173,7 +172,6 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                      'Please double check your profile and try again.')
                     .format(msg))
             else:
-                self.release()
                 raise DatabaseException(msg)
         except Exception as e:
             if isinstance(e, snowflake.connector.errors.Error):
@@ -181,7 +179,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
 
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
-            self.release()
+            self.rollback_if_open()
             if isinstance(e, RuntimeException):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
@@ -328,7 +326,6 @@ class SnowflakeConnectionManager(SQLConnectionManager):
         """On snowflake, rolling back the handle of an aborted session raises
         an exception.
         """
-        logger.debug('initiating rollback')
         try:
             connection.handle.rollback()
         except snowflake.connector.errors.ProgrammingError as e:

--- a/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
+++ b/test/integration/048_rpc_test/test_execute_fetch_and_serialize.py
@@ -33,7 +33,8 @@ class TestRpcExecuteReturnsResults(DBTIntegrationTest):
         with open(file_path) as fh:
             query = fh.read()
 
-        status, table = self.adapter.execute(query, auto_begin=False, fetch=True)
+        with self.adapter.connection_named('master'):
+            status, table = self.adapter.execute(query, auto_begin=False, fetch=True)
         self.assertTrue(len(table.columns) > 0, "agate table had no columns")
         self.assertTrue(len(table.rows) > 0, "agate table had no rows")
 

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -35,12 +35,11 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_configure(config):
-    config.addinivalue_line('markers', 'supported(: Marks postgres-only tests')
+    # the '(plugin, ...)' part isn't really important: any positional arguments
+    # to `pytest.mark.supported` will be consumed as plugin names.
+    helptxt = 'Marks supported test types ("postgres", "snowflake", "any")'
     config.addinivalue_line(
-        'markers', 'snowflake: Mark snowflake-only tests'
-    )
-    config.addinivalue_line(
-        'markers', 'any: Mark '
+        'markers', f'supported(plugin, ...): {helptxt}'
     )
 
 

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -2,9 +2,46 @@ import os
 import pytest
 import random
 import time
-from typing import Dict, Any
+from typing import Dict, Any, Set
 
 import yaml
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--profile', default='postgres', help='Use the postgres profile',
+    )
+
+
+def _get_item_profiles(item) -> Set[str]:
+    supported = set()
+    for mark in item.iter_markers(name='supported'):
+        supported.update(mark.args)
+    return supported
+
+
+def pytest_collection_modifyitems(config, items):
+    selected_profile = config.getoption('profile')
+
+    to_remove = []
+
+    for item in items:
+        item_profiles = _get_item_profiles(item)
+        if selected_profile not in item_profiles and 'any' not in item_profiles:
+            to_remove.append(item)
+
+    for item in to_remove:
+        items.remove(item)
+
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'supported(: Marks postgres-only tests')
+    config.addinivalue_line(
+        'markers', 'snowflake: Mark snowflake-only tests'
+    )
+    config.addinivalue_line(
+        'markers', 'any: Mark '
+    )
 
 
 @pytest.fixture
@@ -22,7 +59,6 @@ def project_root(tmpdir):
     return tmpdir.mkdir('project')
 
 
-@pytest.fixture
 def postgres_profile_data(unique_schema):
     return {
         'config': {
@@ -46,9 +82,55 @@ def postgres_profile_data(unique_schema):
     }
 
 
+def snowflake_profile_data(unique_schema):
+    return {
+        'config': {
+            'send_anonymous_usage_stats': False
+        },
+        'test': {
+            'outputs': {
+                'default': {
+                    'type': 'snowflake',
+                    'threads': 4,
+                    'account': os.getenv('SNOWFLAKE_TEST_ACCOUNT'),
+                    'user': os.getenv('SNOWFLAKE_TEST_USER'),
+                    'password': os.getenv('SNOWFLAKE_TEST_PASSWORD'),
+                    'database': os.getenv('SNOWFLAKE_TEST_DATABASE'),
+                    'schema': unique_schema,
+                    'warehouse': os.getenv('SNOWFLAKE_TEST_WAREHOUSE'),
+                },
+                'keepalives': {
+                    'type': 'snowflake',
+                    'threads': 4,
+                    'account': os.getenv('SNOWFLAKE_TEST_ACCOUNT'),
+                    'user': os.getenv('SNOWFLAKE_TEST_USER'),
+                    'password': os.getenv('SNOWFLAKE_TEST_PASSWORD'),
+                    'database': os.getenv('SNOWFLAKE_TEST_DATABASE'),
+                    'schema': unique_schema,
+                    'warehouse': os.getenv('SNOWFLAKE_TEST_WAREHOUSE'),
+                    'client_session_keep_alive': True,
+                },
+            },
+            'target': 'default',
+        },
+    }
+
+
 @pytest.fixture
-def postgres_profile(profiles_root, postgres_profile_data) -> Dict[str, Any]:
+def dbt_profile_data(unique_schema, pytestconfig):
+    profile_name = pytestconfig.getoption('profile')
+    if profile_name == 'postgres':
+        return postgres_profile_data(unique_schema)
+    elif profile_name == 'snowflake':
+        return snowflake_profile_data(unique_schema)
+    else:
+        print(f'Bad profile name {profile_name}!')
+        return {}
+
+
+@pytest.fixture
+def dbt_profile(profiles_root, dbt_profile_data) -> Dict[str, Any]:
     path = os.path.join(profiles_root, 'profiles.yml')
     with open(path, 'w') as fp:
-        fp.write(yaml.safe_dump(postgres_profile_data))
-    return postgres_profile_data
+        fp.write(yaml.safe_dump(dbt_profile_data))
+    return dbt_profile_data

--- a/test/rpc/test_compile.py
+++ b/test/rpc/test_compile.py
@@ -1,3 +1,4 @@
+import pytest
 from .util import (
     assert_has_threads,
     get_querier,
@@ -5,8 +6,9 @@ from .util import (
 )
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_compile_threads(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}

--- a/test/rpc/test_concurrency.py
+++ b/test/rpc/test_concurrency.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import pytest
 
 from .util import (
     get_querier,
@@ -15,8 +16,9 @@ def _compile_poll_for_result(querier, id: int):
     assert compile_sql_result['results'][0]['compiled_sql'] == sql
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_compile_sql_concurrency(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}

--- a/test/rpc/test_deps.py
+++ b/test/rpc/test_deps.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .util import (
     get_querier,
     ProjectDefinition,
@@ -70,7 +72,8 @@ def deps_with_packages(packages, bad_packages, project_dir, profiles_dir, schema
         querier.is_result(querier.async_wait(tok1))
 
 
-def test_rpc_deps_packages(project_root, profiles_root, postgres_profile, unique_schema):
+@pytest.mark.supported('postgres')
+def test_rpc_deps_packages(project_root, profiles_root, dbt_profile, unique_schema):
     packages = [{
         'package': 'fishtown-analytics/dbt_utils',
         'version': '0.2.1',
@@ -82,7 +85,8 @@ def test_rpc_deps_packages(project_root, profiles_root, postgres_profile, unique
     deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
 
 
-def test_rpc_deps_git(project_root, profiles_root, postgres_profile, unique_schema):
+@pytest.mark.supported('postgres')
+def test_rpc_deps_git(project_root, profiles_root, dbt_profile, unique_schema):
     packages = [{
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
         'revision': '0.2.1'

--- a/test/rpc/test_management.py
+++ b/test/rpc/test_management.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 from .util import (
     get_querier,
@@ -5,8 +6,9 @@ from .util import (
 )
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_basics(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
@@ -62,7 +64,8 @@ sources:
 '''
 
 
-def test_rpc_status_error(project_root, profiles_root, postgres_profile, unique_schema):
+@pytest.mark.supported('postgres')
+def test_rpc_status_error(project_root, profiles_root, dbt_profile, unique_schema):
     project = ProjectDefinition(
         models={
             'descendant_model.sql': 'select * from {{ source("test_source", "test_table") }}',
@@ -130,7 +133,8 @@ def test_rpc_status_error(project_root, profiles_root, postgres_profile, unique_
         querier.is_result(querier.compile_sql('select 1 as id'))
 
 
-def test_gc_change_interval(project_root, profiles_root, postgres_profile, unique_schema):
+@pytest.mark.supported('postgres')
+def test_gc_change_interval(project_root, profiles_root, dbt_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
     )
@@ -176,7 +180,8 @@ def test_gc_change_interval(project_root, profiles_root, postgres_profile, uniqu
         assert len(result['rows']) == 2
 
 
-def test_ps_poll_output_match(project_root, profiles_root, postgres_profile, unique_schema):
+@pytest.mark.supported('postgres')
+def test_ps_poll_output_match(project_root, profiles_root, dbt_profile, unique_schema):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
     )
@@ -248,8 +253,9 @@ def wait_for_log_ordering(querier, token, attempts, *messages) -> int:
     assert False, msg
 
 
+@pytest.mark.supported('postgres')
 def test_get_status(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'},
@@ -294,8 +300,9 @@ def test_get_status(
         assert len(result['logs']) == 0
 
 
+@pytest.mark.supported('postgres')
 def test_missing_tag_sighup(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={
@@ -333,8 +340,9 @@ def test_missing_tag_sighup(
         assert querier.wait_for_status('ready') is True
 
 
+@pytest.mark.supported('postgres')
 def test_get_manifest(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={

--- a/test/rpc/test_run.py
+++ b/test/rpc/test_run.py
@@ -1,3 +1,4 @@
+import pytest
 from .util import (
     assert_has_threads,
     get_querier,
@@ -5,8 +6,9 @@ from .util import (
 )
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_run_threads(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'}
@@ -28,8 +30,9 @@ def test_rpc_run_threads(
         assert_has_threads(results, 7)
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_run_vars(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={
@@ -50,8 +53,9 @@ def test_rpc_run_vars(
         assert results['results'][0]['node']['compiled_sql'] == 'select 100 as id'
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_run_vars_compiled(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={

--- a/test/rpc/test_run_operation.py
+++ b/test/rpc/test_run_operation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .util import (
     get_querier,
     ProjectDefinition,
@@ -16,8 +18,9 @@ macros_data = '''
 '''
 
 
+@pytest.mark.supported('postgres')
 def test_run_operation(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'},
@@ -62,8 +65,9 @@ def test_run_operation(
         assert poll_result['success'] is True
 
 
+@pytest.mark.supported('postgres')
 def test_run_operation_cli(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         models={'my_model.sql': 'select 1 as id'},

--- a/test/rpc/test_run_sql.py
+++ b/test/rpc/test_run_sql.py
@@ -1,0 +1,43 @@
+import pytest
+
+from .util import (
+    get_querier,
+    ProjectDefinition,
+)
+
+
+@pytest.mark.supported('any')
+def test_rpc_run_sql_nohang(
+    project_root, profiles_root, dbt_profile, unique_schema
+):
+    project = ProjectDefinition(
+        models={'my_model.sql': 'select 1 as id'}
+    )
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
+    )
+    with querier_ctx as querier:
+        querier.async_wait_for_result(querier.run_sql('select 1 as id'))
+
+
+@pytest.mark.supported('snowflake')
+def test_snowflake_rpc_run_sql_keepalive_nohang(
+    project_root, profiles_root, dbt_profile, unique_schema
+):
+    project = ProjectDefinition(
+        models={'my_model.sql': 'select 1 as id'}
+    )
+    querier_ctx = get_querier(
+        project_def=project,
+        project_dir=project_root,
+        profiles_dir=profiles_root,
+        schema=unique_schema,
+        test_kwargs={},
+        target='keepalives',
+    )
+    with querier_ctx as querier:
+        querier.async_wait_for_result(querier.run_sql('select 1 as id'))

--- a/test/rpc/test_seed.py
+++ b/test/rpc/test_seed.py
@@ -1,3 +1,4 @@
+import pytest
 from .util import (
     assert_has_threads,
     get_querier,
@@ -5,8 +6,9 @@ from .util import (
 )
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_seed_threads(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         project_data={'seeds': {'config': {'quote_columns': False}}},
@@ -30,8 +32,9 @@ def test_rpc_seed_threads(
         assert_has_threads(results, 7)
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_seed_include_exclude(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         project_data={'seeds': {'config': {'quote_columns': False}}},

--- a/test/rpc/test_snapshots.py
+++ b/test/rpc/test_snapshots.py
@@ -1,3 +1,4 @@
+import pytest
 from .util import (
     assert_has_threads,
     get_querier,
@@ -22,8 +23,9 @@ snapshot_data = '''
 '''
 
 
+@pytest.mark.supported('postgres')
 def test_snapshots(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         snapshots={'my_snapshots.sql': snapshot_data},
@@ -50,8 +52,9 @@ def test_snapshots(
         assert len(results['results']) == 1
 
 
+@pytest.mark.supported('postgres')
 def test_snapshots_cli(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         snapshots={'my_snapshots.sql': snapshot_data},
@@ -81,8 +84,9 @@ def test_snapshots_cli(
         assert len(results['results']) == 1
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_snapshot_threads(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     project = ProjectDefinition(
         snapshots={'my_snapshots.sql': snapshot_data},

--- a/test/rpc/test_source_freshness.py
+++ b/test/rpc/test_source_freshness.py
@@ -1,3 +1,4 @@
+import pytest
 from datetime import datetime, timedelta
 from .util import (
     get_querier,
@@ -21,8 +22,9 @@ sources:
 '''
 
 
+@pytest.mark.supported('postgres')
 def test_source_freshness(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     start_time = datetime.utcnow()
     warn_me = start_time - timedelta(hours=18)

--- a/test/rpc/test_test.py
+++ b/test/rpc/test_test.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 from .util import (
     assert_has_threads,
@@ -6,8 +7,9 @@ from .util import (
 )
 
 
+@pytest.mark.supported('postgres')
 def test_rpc_test_threads(
-    project_root, profiles_root, postgres_profile, unique_schema
+    project_root, profiles_root, dbt_profile, unique_schema
 ):
     schema_yaml = {
         'version': 2,

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -30,9 +30,10 @@ class Obj:
     single_threaded = False
 
 
-def mock_connection(name):
+def mock_connection(name, state='open'):
     conn = mock.MagicMock()
     conn.name = name
+    conn.state = state
     return conn
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=snowflake test/rpc'
 deps =
     ./core
     ./plugins/snowflake
@@ -128,6 +129,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=snowflake test/rpc'
 deps =
     ./core
     ./plugins/snowflake
@@ -204,6 +206,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_snowflake {posargs} -n4 test/integration/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=snowflake test/rpc'
 deps =
     ./core
     ./plugins/snowflake

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*'
-           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/rpc/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=postgres test/rpc'
 deps =
     ./core
     ./plugins/postgres
@@ -116,7 +116,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*' && \
-           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/rpc/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=postgres test/rpc'
 deps =
     ./core
     ./plugins/postgres
@@ -192,7 +192,7 @@ passenv = *
 setenv =
     HOME=/home/tox
 commands = /bin/bash -c '{envpython} -m pytest --durations 0 -v -m profile_postgres {posargs} -n4 test/integration/*'
-           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 test/rpc/*'
+           /bin/bash -c '{envpython} -m pytest --durations 0 -v {posargs} -n4 --profile=postgres test/rpc'
 deps =
     ./core
     ./plugins/postgres


### PR DESCRIPTION
resolves #2645 

### Description
To make the snowflake thread exit, we need to actually close open connections. We should have been doing this before!

Fixing that caused some fallout with connection management, especially in single-threaded mode but also in a couple other places that were relying on open connections not being closed. I think this is all set now.

In order to test this, I had to modify the rpc integration tests to support snowflake. I think the way I did it is pretty good. Of note, I only enabled two snowflake tests (one snowflake-specific one) - the snowflake tests are just way too slow for us to reasonably run the full suite, IMO. Snowflake already takes an eternity.

I anticipate this will make it a bit easier to add RPC tests for other adapter-specific issues we find.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
