### PR TITLE
remove double underscore from cte prefix ephemeral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ target/
 
 # pycharm
 .idea/
+
+# vscode 
+.history/

--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -130,11 +130,11 @@ def _inject_ctes_into_sql(sql: str, ctes: List[InjectedCTE]) -> str:
         [
             InjectedCTE(
                 id="cte_id_1",
-                sql="__dbt__CTE__ephemeral as (select * from table)",
+                sql="dbt__CTE__ephemeral as (select * from table)",
             ),
             InjectedCTE(
                 id="cte_id_2",
-                sql="__dbt__CTE__events as (select id, type from events)",
+                sql="dbt__CTE__events as (select id, type from events)",
             ),
         ]
 
@@ -145,8 +145,8 @@ def _inject_ctes_into_sql(sql: str, ctes: List[InjectedCTE]) -> str:
 
     This will spit out:
 
-      "with __dbt__CTE__ephemeral as (select * from table),
-            __dbt__CTE__events as (select id, type from events),
+      "with dbt__CTE__ephemeral as (select * from table),
+            dbt__CTE__events as (select id, type from events),
             with internal_cte as (select * from sessions)
        select * from internal_cte"
 

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -297,7 +297,7 @@ def filter_null_values(input: Dict[K_T, Optional[V_T]]) -> Dict[K_T, V_T]:
 
 
 def add_ephemeral_model_prefix(s: str) -> str:
-    return '__dbt__CTE__{}'.format(s)
+    return 'dbt__CTE__{}'.format(s)
 
 
 def timestring() -> str:

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2755,17 +2755,17 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
         ephemeral_compiled_sql = (
             '\n\nselect first_name, count(*) as ct from '
-            '__dbt__CTE__ephemeral_copy\ngroup by first_name\n'
+            'dbt__CTE__ephemeral_copy\ngroup by first_name\n'
             'order by first_name asc'
         )
 
         cte_sql = (
-            ' __dbt__CTE__ephemeral_copy as (\n\n\nselect * from {}."{}"."seed"\n)'
+            ' dbt__CTE__ephemeral_copy as (\n\n\nselect * from {}."{}"."seed"\n)'
         ).format(self.default_database, my_schema_name)
 
         ephemeral_injected_sql = (
             '\n\nwith{}select first_name, count(*) as ct from '
-            '__dbt__CTE__ephemeral_copy\ngroup by first_name\n'
+            'dbt__CTE__ephemeral_copy\ngroup by first_name\n'
             'order by first_name asc'
         ).format(cte_sql)
 

--- a/test/integration/048_rpc_test/test_rpc.py
+++ b/test/integration/048_rpc_test/test_rpc.py
@@ -87,11 +87,11 @@ def query_url(url, query):
     return requests.post(url, headers=headers, data=json.dumps(query))
 
 
-_select_from_ephemeral = '''with __dbt__CTE__ephemeral_model as (
+_select_from_ephemeral = '''with dbt__CTE__ephemeral_model as (
 
 
 select 1 as id
-)select * from __dbt__CTE__ephemeral_model'''
+)select * from dbt__CTE__ephemeral_model'''
 
 
 def addr_in_use(err, *args):

--- a/test/unit/test_compiler.py
+++ b/test/unit/test_compiler.py
@@ -39,7 +39,7 @@ class CompilerTest(unittest.TestCase):
 
         def mock_generate_runtime_model_context(model, config, manifest):
             def ref(name):
-                result = f'__dbt__CTE__{name}'
+                result = f'dbt__CTE__{name}'
                 unique_id = f'model.root.{name}'
                 model.extra_ctes.append(InjectedCTE(id=unique_id, sql=None))
                 return result
@@ -80,7 +80,7 @@ class CompilerTest(unittest.TestCase):
                     injected_sql='',
                     compiled_sql=(
                         'with cte as (select * from something_else) '
-                        'select * from __dbt__CTE__ephemeral')
+                        'select * from dbt__CTE__ephemeral')
                 ),
                 'model.root.ephemeral': CompiledModelNode(
                     name='ephemeral',
@@ -126,10 +126,10 @@ class CompilerTest(unittest.TestCase):
         self.assertEqual(result.extra_ctes_injected, True)
         self.assertEqualIgnoreWhitespace(
             result.injected_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with dbt__CTE__ephemeral as ('
              'select * from source_table'
              '), cte as (select * from something_else) '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from dbt__CTE__ephemeral'))
 
         self.assertEqual(
             manifest.nodes['model.root.ephemeral'].extra_ctes_injected,
@@ -254,7 +254,7 @@ class CompilerTest(unittest.TestCase):
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql='select * from source_table')],
                     injected_sql='',
-                    compiled_sql='select * from __dbt__CTE__ephemeral'
+                    compiled_sql='select * from dbt__CTE__ephemeral'
                 ),
                 'model.root.ephemeral': CompiledModelNode(
                     name='ephemeral',
@@ -301,10 +301,10 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.injected_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with dbt__CTE__ephemeral as ('
              'select * from source_table'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from dbt__CTE__ephemeral'))
 
         self.assertTrue(manifest.nodes['model.root.ephemeral'].extra_ctes_injected)
 
@@ -378,7 +378,7 @@ class CompilerTest(unittest.TestCase):
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql='select * from source_table')],
                     injected_sql='',
-                    compiled_sql='select * from __dbt__CTE__ephemeral'
+                    compiled_sql='select * from dbt__CTE__ephemeral'
                 ),
                 'model.root.ephemeral': parsed_ephemeral,
             },
@@ -407,10 +407,10 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.injected_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with dbt__CTE__ephemeral as ('
              'select * from source_table'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from dbt__CTE__ephemeral'))
 
         self.assertTrue(manifest.nodes['model.root.ephemeral'].extra_ctes_injected)
 
@@ -442,7 +442,7 @@ class CompilerTest(unittest.TestCase):
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql=None)],
                     injected_sql=None,
-                    compiled_sql='select * from __dbt__CTE__ephemeral'
+                    compiled_sql='select * from dbt__CTE__ephemeral'
                 ),
                 'model.root.ephemeral': ParsedModelNode(
                     name='ephemeral',
@@ -503,12 +503,12 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.injected_sql,
-            ('with __dbt__CTE__ephemeral_level_two as ('
+            ('with dbt__CTE__ephemeral_level_two as ('
              'select * from source_table'
-             '), __dbt__CTE__ephemeral as ('
-             'select * from __dbt__CTE__ephemeral_level_two'
+             '), dbt__CTE__ephemeral as ('
+             'select * from dbt__CTE__ephemeral_level_two'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from dbt__CTE__ephemeral'))
 
         self.assertTrue(manifest.nodes['model.root.ephemeral'].compiled)
         self.assertTrue(manifest.nodes['model.root.ephemeral_level_two'].compiled)


### PR DESCRIPTION
resolves #2660

### Descriptione-->
Basically just removed double underscore from ephemeral CTE prefix in order to support dbt-exasol adapter.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
