### PR TITLE
Port the adapter macro to python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.18.0 (Release TBD)
 
+### Breaking changes
+- `adapter_macro` is no longer a macro, instead it is a builtin context method. Any custom macros that intercepted it by going through `context['dbt']` will need to instead access it via `context['builtins']` ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2673](https://github.com/fishtown-analytics/dbt/pull/2673))
+
 ## dbt 0.18.0b2 (July 30, 2020)
 
 ### Features

--- a/core/dbt/adapters/base/query_headers.py
+++ b/core/dbt/adapters/base/query_headers.py
@@ -3,7 +3,7 @@ from typing import Optional, Callable, Dict, Any
 
 from dbt.clients.jinja import QueryStringGenerator
 
-from dbt.context.configured import generate_query_header_context
+from dbt.context.manifest import generate_query_header_context
 from dbt.contracts.connection import AdapterRequiredConfig, QueryComment
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -1,16 +1,11 @@
-from typing import Any, Dict, Iterable, Union, Optional, List
+from typing import Any, Dict
 
-from dbt.clients.jinja import MacroGenerator, MacroStack
 from dbt.contracts.connection import AdapterRequiredConfig
-from dbt.contracts.graph.manifest import Manifest
-from dbt.contracts.graph.parsed import ParsedMacro
-from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
 from dbt.node_types import NodeType
 from dbt.utils import MultiDict
 
 from dbt.context.base import contextproperty, Var
 from dbt.context.target import TargetContext
-from dbt.exceptions import raise_duplicate_macro_name
 
 
 class ConfiguredContext(TargetContext):
@@ -79,150 +74,6 @@ class SchemaYamlContext(ConfiguredContext):
         return ConfiguredVar(
             self._ctx, self.config, self._project_name
         )
-
-
-FlatNamespace = Dict[str, MacroGenerator]
-NamespaceMember = Union[FlatNamespace, MacroGenerator]
-FullNamespace = Dict[str, NamespaceMember]
-
-
-class MacroNamespace:
-    def __init__(
-        self,
-        root_package: str,
-        search_package: str,
-        thread_ctx: MacroStack,
-        internal_packages: List[str],
-        node: Optional[Any] = None,
-    ) -> None:
-        self.root_package = root_package
-        self.search_package = search_package
-        self.internal_package_names = set(internal_packages)
-        self.internal_package_names_order = internal_packages
-        self.globals: FlatNamespace = {}
-        self.locals: FlatNamespace = {}
-        self.internal_packages: Dict[str, FlatNamespace] = {}
-        self.packages: Dict[str, FlatNamespace] = {}
-        self.thread_ctx = thread_ctx
-        self.node = node
-
-    def _add_macro_to(
-        self,
-        heirarchy: Dict[str, FlatNamespace],
-        macro: ParsedMacro,
-        macro_func: MacroGenerator,
-    ):
-        if macro.package_name in heirarchy:
-            namespace = heirarchy[macro.package_name]
-        else:
-            namespace = {}
-            heirarchy[macro.package_name] = namespace
-
-        if macro.name in namespace:
-            raise_duplicate_macro_name(
-                macro_func.macro, macro, macro.package_name
-            )
-        heirarchy[macro.package_name][macro.name] = macro_func
-
-    def add_macro(self, macro: ParsedMacro, ctx: Dict[str, Any]):
-        macro_name: str = macro.name
-
-        macro_func: MacroGenerator = MacroGenerator(
-            macro, ctx, self.node, self.thread_ctx
-        )
-
-        # internal macros (from plugins) will be processed separately from
-        # project macros, so store them in a different place
-        if macro.package_name in self.internal_package_names:
-            self._add_macro_to(self.internal_packages, macro, macro_func)
-        else:
-            self._add_macro_to(self.packages, macro, macro_func)
-
-            if macro.package_name == self.search_package:
-                self.locals[macro_name] = macro_func
-            elif macro.package_name == self.root_package:
-                self.globals[macro_name] = macro_func
-
-    def add_macros(self, macros: Iterable[ParsedMacro], ctx: Dict[str, Any]):
-        for macro in macros:
-            self.add_macro(macro, ctx)
-
-    def get_macro_dict(self) -> FullNamespace:
-        root_namespace: FullNamespace = {}
-
-        # add everything in the 'dbt' namespace to the root namespace
-        # overwriting any duplicates. Iterate in reverse-order because the
-        # packages that are first in the list are the ones we want to "win".
-        global_project_namespace = {}
-        for pkg in reversed(self.internal_package_names_order):
-            macros = self.internal_packages.get(pkg, {})
-            global_project_namespace.update(macros)
-            # these can then be overwitten by globals/locals
-            root_namespace.update(macros)
-
-        root_namespace[GLOBAL_PROJECT_NAME] = global_project_namespace
-        root_namespace.update(self.packages)
-        root_namespace.update(self.globals)
-        root_namespace.update(self.locals)
-
-        return root_namespace
-
-
-class ManifestContext(ConfiguredContext):
-    """The Macro context has everything in the target context, plus the macros
-    in the manifest.
-
-    The given macros can override any previous context values, which will be
-    available as if they were accessed relative to the package name.
-    """
-    def __init__(
-        self,
-        config: AdapterRequiredConfig,
-        manifest: Manifest,
-        search_package: str,
-    ) -> None:
-        super().__init__(config)
-        self.manifest = manifest
-        self.search_package = search_package
-        self.macro_stack = MacroStack()
-
-    def _get_namespace(self):
-        # avoid an import loop
-        from dbt.adapters.factory import get_adapter_package_names
-        internal_packages = get_adapter_package_names(
-            self.config.credentials.type
-        )
-        return MacroNamespace(
-            self.config.project_name,
-            self.search_package,
-            self.macro_stack,
-            internal_packages,
-            None,
-        )
-
-    def get_macros(self) -> Dict[str, Any]:
-        nsp = self._get_namespace()
-        nsp.add_macros(self.manifest.macros.values(), self._ctx)
-        return nsp.get_macro_dict()
-
-    def to_dict(self) -> Dict[str, Any]:
-        dct = super().to_dict()
-        dct.update(self.get_macros())
-        return dct
-
-
-class QueryHeaderContext(ManifestContext):
-    def __init__(
-        self, config: AdapterRequiredConfig, manifest: Manifest
-    ) -> None:
-        super().__init__(config, manifest, config.project_name)
-
-
-def generate_query_header_context(
-    config: AdapterRequiredConfig, manifest: Manifest
-):
-    ctx = QueryHeaderContext(config, manifest)
-    return ctx.to_dict()
 
 
 def generate_schema_yml(

--- a/core/dbt/context/macros.py
+++ b/core/dbt/context/macros.py
@@ -43,15 +43,6 @@ class MacroNamespace(Mapping):
             keys.update(search)
         return keys
 
-    def to_dict(self) -> FullNamespace:
-        root_namespace: FullNamespace = {}
-        root_namespace.update(self.global_project_namespace)
-        root_namespace[GLOBAL_PROJECT_NAME] = self.global_project_namespace
-        root_namespace.update(self.packages)
-        root_namespace.update(self.global_namespace)
-        root_namespace.update(self.local_namespace)
-        return root_namespace
-
     def __iter__(self) -> Iterator[str]:
         for key in self._keys():
             yield key

--- a/core/dbt/context/macros.py
+++ b/core/dbt/context/macros.py
@@ -1,0 +1,162 @@
+from typing import (
+    Any, Dict, Iterable, Union, Optional, List, Iterator, Mapping, Set
+)
+
+from dbt.clients.jinja import MacroGenerator, MacroStack
+from dbt.contracts.graph.parsed import ParsedMacro
+from dbt.include.global_project import PROJECT_NAME as GLOBAL_PROJECT_NAME
+from dbt.exceptions import (
+    raise_duplicate_macro_name, raise_compiler_error
+)
+
+
+FlatNamespace = Dict[str, MacroGenerator]
+NamespaceMember = Union[FlatNamespace, MacroGenerator]
+FullNamespace = Dict[str, NamespaceMember]
+
+
+class MacroNamespace(Mapping):
+    def __init__(
+        self,
+        global_namespace: FlatNamespace,
+        local_namespace: FlatNamespace,
+        global_project_namespace: FlatNamespace,
+        packages: Dict[str, FlatNamespace],
+    ):
+        self.global_namespace: FlatNamespace = global_namespace
+        self.local_namespace: FlatNamespace = local_namespace
+        self.packages: Dict[str, FlatNamespace] = packages
+        self.global_project_namespace: FlatNamespace = global_project_namespace
+
+    def _search_order(self) -> Iterable[Union[FullNamespace, FlatNamespace]]:
+        yield self.local_namespace
+        yield self.global_namespace
+        yield self.packages
+        yield {
+            GLOBAL_PROJECT_NAME: self.global_project_namespace,
+        }
+        yield self.global_project_namespace
+
+    def _keys(self) -> Set[str]:
+        keys: Set[str] = set()
+        for search in self._search_order():
+            keys.update(search)
+        return keys
+
+    def to_dict(self) -> FullNamespace:
+        root_namespace: FullNamespace = {}
+        root_namespace.update(self.global_project_namespace)
+        root_namespace[GLOBAL_PROJECT_NAME] = self.global_project_namespace
+        root_namespace.update(self.packages)
+        root_namespace.update(self.global_namespace)
+        root_namespace.update(self.local_namespace)
+        return root_namespace
+
+    def __iter__(self) -> Iterator[str]:
+        for key in self._keys():
+            yield key
+
+    def __len__(self):
+        return len(self._keys())
+
+    def __getitem__(self, key: str) -> NamespaceMember:
+        for dct in self._search_order():
+            if key in dct:
+                return dct[key]
+        raise KeyError(key)
+
+    def get_from_package(
+        self, package_name: Optional[str], name: str
+    ) -> Optional[MacroGenerator]:
+        pkg: FlatNamespace
+        if package_name is None:
+            return self.get(name)
+        elif package_name == GLOBAL_PROJECT_NAME:
+            return self.global_project_namespace.get(name)
+        elif package_name in self.packages:
+            return self.packages[package_name].get(name)
+        else:
+            raise_compiler_error(
+                f"Could not find package '{package_name}'"
+            )
+
+
+class MacroNamespaceBuilder:
+    def __init__(
+        self,
+        root_package: str,
+        search_package: str,
+        thread_ctx: MacroStack,
+        internal_packages: List[str],
+        node: Optional[Any] = None,
+    ) -> None:
+        self.root_package = root_package
+        self.search_package = search_package
+        self.internal_package_names = set(internal_packages)
+        self.internal_package_names_order = internal_packages
+        self.globals: FlatNamespace = {}
+        self.locals: FlatNamespace = {}
+        self.internal_packages: Dict[str, FlatNamespace] = {}
+        self.packages: Dict[str, FlatNamespace] = {}
+        self.thread_ctx = thread_ctx
+        self.node = node
+
+    def _add_macro_to(
+        self,
+        heirarchy: Dict[str, FlatNamespace],
+        macro: ParsedMacro,
+        macro_func: MacroGenerator,
+    ):
+        if macro.package_name in heirarchy:
+            namespace = heirarchy[macro.package_name]
+        else:
+            namespace = {}
+            heirarchy[macro.package_name] = namespace
+
+        if macro.name in namespace:
+            raise_duplicate_macro_name(
+                macro_func.macro, macro, macro.package_name
+            )
+        heirarchy[macro.package_name][macro.name] = macro_func
+
+    def add_macro(self, macro: ParsedMacro, ctx: Dict[str, Any]):
+        macro_name: str = macro.name
+
+        macro_func: MacroGenerator = MacroGenerator(
+            macro, ctx, self.node, self.thread_ctx
+        )
+
+        # internal macros (from plugins) will be processed separately from
+        # project macros, so store them in a different place
+        if macro.package_name in self.internal_package_names:
+            self._add_macro_to(self.internal_packages, macro, macro_func)
+        else:
+            self._add_macro_to(self.packages, macro, macro_func)
+
+            if macro.package_name == self.search_package:
+                self.locals[macro_name] = macro_func
+            elif macro.package_name == self.root_package:
+                self.globals[macro_name] = macro_func
+
+    def add_macros(self, macros: Iterable[ParsedMacro], ctx: Dict[str, Any]):
+        for macro in macros:
+            self.add_macro(macro, ctx)
+
+    def build_namespace(
+        self, macros: Iterable[ParsedMacro], ctx: Dict[str, Any]
+    ) -> MacroNamespace:
+        self.add_macros(macros, ctx)
+
+        # Iterate in reverse-order and overwrite: the packages that are first
+        # in the list are the ones we want to "win".
+        global_project_namespace: FlatNamespace = {}
+        for pkg in reversed(self.internal_package_names_order):
+            if pkg in self.internal_packages:
+                global_project_namespace.update(self.internal_packages[pkg])
+
+        return MacroNamespace(
+            global_namespace=self.globals,
+            local_namespace=self.locals,
+            global_project_namespace=global_project_namespace,
+            packages=self.packages,
+        )

--- a/core/dbt/context/manifest.py
+++ b/core/dbt/context/manifest.py
@@ -1,0 +1,66 @@
+from typing import List
+
+from dbt.clients.jinja import MacroStack
+from dbt.contracts.connection import AdapterRequiredConfig
+from dbt.contracts.graph.manifest import Manifest
+
+
+from .configured import ConfiguredContext
+from .macros import MacroNamespaceBuilder
+
+
+class ManifestContext(ConfiguredContext):
+    """The Macro context has everything in the target context, plus the macros
+    in the manifest.
+
+    The given macros can override any previous context values, which will be
+    available as if they were accessed relative to the package name.
+    """
+    def __init__(
+        self,
+        config: AdapterRequiredConfig,
+        manifest: Manifest,
+        search_package: str,
+    ) -> None:
+        super().__init__(config)
+        self.manifest = manifest
+        self.search_package = search_package
+        self.macro_stack = MacroStack()
+        builder = self._get_namespace_builder()
+        self.namespace = builder.build_namespace(
+            self.manifest.macros.values(),
+            self._ctx,
+        )
+
+    def _get_namespace_builder(self) -> MacroNamespaceBuilder:
+        # avoid an import loop
+        from dbt.adapters.factory import get_adapter_package_names
+        internal_packages: List[str] = get_adapter_package_names(
+            self.config.credentials.type
+        )
+        return MacroNamespaceBuilder(
+            self.config.project_name,
+            self.search_package,
+            self.macro_stack,
+            internal_packages,
+            None,
+        )
+
+    def to_dict(self):
+        dct = super().to_dict()
+        dct.update(self.namespace)
+        return dct
+
+
+class QueryHeaderContext(ManifestContext):
+    def __init__(
+        self, config: AdapterRequiredConfig, manifest: Manifest
+    ) -> None:
+        super().__init__(config, manifest, config.project_name)
+
+
+def generate_query_header_context(
+    config: AdapterRequiredConfig, manifest: Manifest
+):
+    ctx = QueryHeaderContext(config, manifest)
+    return ctx.to_dict()

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -12,17 +12,21 @@ from dbt.adapters.factory import get_adapter, get_adapter_package_names
 from dbt.clients import agate_helper
 from dbt.clients.jinja import get_rendered
 from dbt.config import RuntimeConfig, Project
-from dbt.context.base import (
-    contextmember, contextproperty, Var
-)
-from dbt.context.configured import ManifestContext, MacroNamespace, FQNLookup
-from dbt.context.context_config import ContextConfigType
+from .base import contextmember, contextproperty, Var
+from .configured import FQNLookup
+from .context_config import ContextConfigType
+from .macros import MacroNamespaceBuilder
+from .manifest import ManifestContext
 from dbt.contracts.graph.manifest import Manifest, Disabled
 from dbt.contracts.graph.compiled import (
-    NonSourceNode, CompiledSeedNode, CompiledResource
+    CompiledResource,
+    CompiledSeedNode,
+    NonSourceNode,
 )
 from dbt.contracts.graph.parsed import (
-    ParsedMacro, ParsedSourceDefinition, ParsedSeedNode
+    ParsedMacro,
+    ParsedSeedNode,
+    ParsedSourceDefinition,
 )
 from dbt.exceptions import (
     CompilationException,
@@ -564,19 +568,19 @@ class ProviderContext(ManifestContext):
             )
         # mypy appeasement - we know it'll be a RuntimeConfig
         self.config: RuntimeConfig
+        self.model: Union[ParsedMacro, NonSourceNode] = model
         super().__init__(config, manifest, model.package_name)
         self.sql_results: Dict[str, AttrDict] = {}
-        self.model: Union[ParsedMacro, NonSourceNode] = model
         self.context_config: Optional[ContextConfigType] = context_config
         self.provider: Provider = provider
         self.adapter = get_adapter(self.config)
         self.db_wrapper = self.provider.DatabaseWrapper(self.adapter)
 
-    def _get_namespace(self):
+    def _get_namespace_builder(self):
         internal_packages = get_adapter_package_names(
             self.config.credentials.type
         )
-        return MacroNamespace(
+        return MacroNamespaceBuilder(
             self.config.project_name,
             self.search_package,
             self.macro_stack,
@@ -1040,6 +1044,81 @@ class ProviderContext(ManifestContext):
     @contextproperty
     def sql_now(self) -> str:
         return self.adapter.date_function()
+
+    def _get_adapter_macro_prefixes(self) -> List[str]:
+        # a future version of this could have plugins automatically call fall
+        # back to their dependencies' dependencies by using
+        # `get_adapter_type_names` instead of `[self.config.credentials.type]`
+        search_prefixes = [self.config.credentials.type, 'default']
+        return search_prefixes
+
+    @contextmember
+    def adapter_macro(self, name: str, *args, **kwargs):
+        """Find the most appropriate macro for the name, considering the
+        adapter type currently in use, and call that with the given arguments.
+
+        If the name has a `.` in it, the first section before the `.` is
+        interpreted as a package name, and the remainder as a macro name.
+
+        If no adapter is faund, raise a compiler exception. If an invalid
+        package name is specified, raise a compiler exception.
+
+
+        Some examples:
+
+            {# dbt will call this macro by name, providing any arguments #}
+            {% macro create_table_as(temporary, relation, sql) -%}
+
+              {# dbt will dispatch the macro call to the relevant macro #}
+              {{ adapter_macro('create_table_as', temporary, relation, sql) }}
+            {%- endmacro %}
+
+
+            {#
+                If no macro matches the specified adapter, "default" will be
+                used
+            #}
+            {% macro default__create_table_as(temporary, relation, sql) -%}
+               ...
+            {%- endmacro %}
+
+
+
+            {# Example which defines special logic for Redshift #}
+            {% macro redshift__create_table_as(temporary, relation, sql) -%}
+               ...
+            {%- endmacro %}
+
+
+
+            {# Example which defines special logic for BigQuery #}
+            {% macro bigquery__create_table_as(temporary, relation, sql) -%}
+               ...
+            {%- endmacro %}
+        """
+        original_name: str = name
+        package_name: Optional[str] = None
+        if '.' in name:
+            package_name, name = name.split('.', 1)
+
+        for prefix in self._get_adapter_macro_prefixes():
+            search_name = f'{prefix}__{name}'
+            try:
+                macro = self.namespace.get_from_package(
+                    package_name, search_name
+                )
+            except CompilationException as exc:
+                raise CompilationException(
+                    f'In adapter_macro: {exc.msg}, original name '
+                    f"'{original_name}'"
+                ) from exc
+            if macro is not None:
+                return macro(*args, **kwargs)
+
+        raise_compiler_error(
+            f"In adapter_macro: No macro named '{name}' found "
+            f"(original name: '{original_name}')"
+        )
 
 
 class MacroContext(ProviderContext):

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -1,33 +1,3 @@
-{% macro adapter_macro(name) -%}
-{% set original_name = name %}
-  {% if '.' in name %}
-    {% set package_name, name = name.split(".", 1) %}
-  {% else %}
-    {% set package_name = none %}
-  {% endif %}
-
-  {% if package_name is none %}
-    {% set package_context = context %}
-  {% elif package_name in context %}
-    {% set package_context = context[package_name] %}
-  {% else %}
-    {% set error_msg %}
-        In adapter_macro: could not find package '{{package_name}}', called with '{{original_name}}'
-    {% endset %}
-    {{ exceptions.raise_compiler_error(error_msg | trim) }}
-  {% endif %}
-
-  {%- set separator = '__' -%}
-  {%- set search_name = adapter.type() + separator + name -%}
-  {%- set default_name = 'default' + separator + name -%}
-
-  {%- if package_context.get(search_name) is not none -%}
-    {{ return(package_context[search_name](*varargs, **kwargs)) }}
-  {%- else -%}
-    {{ return(package_context[default_name](*varargs, **kwargs)) }}
-  {%- endif -%}
-{%- endmacro %}
-
 {% macro get_columns_in_query(select_sql) -%}
   {{ return(adapter_macro('get_columns_in_query', select_sql)) }}
 {% endmacro %}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,7 +9,7 @@ six>=1.14.0
 ipdb
 pytest-xdist>=1.28.0,<2
 flaky>=3.5.3,<4
-mypy==0.761
+mypy==0.782
 wheel
 twine
 pytest-logbook>=1.2.0,<1.3

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-mypy_path = ./third-party-stubs,./core
+mypy_path = ./third-party-stubs
 namespace_packages = True

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -448,7 +448,6 @@ def test_macro_namespace(config, manifest_fx):
 
     namespace = mn.build_namespace(all_macros, {})
     dct = dict(namespace)
-    assert dct == namespace.to_dict()
     for result in [dct, namespace]:
         assert 'dbt' in result
         assert 'root' in result


### PR DESCRIPTION
resolves part of #2302 

### Description
This ports `adapter_macro` to python, which involved some cleanup of the node selection logic.

I split the macros and manifest+query header contexts out from the `configured` context as that file was getting too busy.

I made no change to actual behavior, so the real test here is that all the existing integration tests pass.

I added a `get_adapter_type_names` to the adapter factory to handle an inheritance-style lookup, but that looked like it broke things. I rolled that back but would like to keep the adapter factory changes as I think they're probably for the best.

In the future, we should consider changing it so redshift automatically tries the postgres version of a macro when there's no redshift version before falling back to the default, but let's keep the breaking changes to a minimum for now.

A future PR will implement the `dispatch` name and additional arguments.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
