### PR TITLE
Create adapter.dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Breaking changes
 - `adapter_macro` is no longer a macro, instead it is a builtin context method. Any custom macros that intercepted it by going through `context['dbt']` will need to instead access it via `context['builtins']` ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2673](https://github.com/fishtown-analytics/dbt/pull/2673))
+- `adapter_macro` is now deprecated. Use `adapter.dispatch` instead.
+
+### Features
+- Added a `dispatch` method to the context adapter and deprecated `adapter_macro`. ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2679](https://github.com/fishtown-analytics/dbt/pull/2679))
 
 ## dbt 0.18.0b2 (July 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,9 @@ Contributors:
 - dbt compile and ls no longer create schemas if they don't already exist ([#2525](https://github.com/fishtown-analytics/dbt/issues/2525), [#2528](https://github.com/fishtown-analytics/dbt/pull/2528))
 - `dbt deps` now respects the `--project-dir` flag, so using `dbt deps --project-dir=/some/path` and then `dbt run --project-dir=/some/path` will properly find dependencies ([#2519](https://github.com/fishtown-analytics/dbt/issues/2519), [#2534](https://github.com/fishtown-analytics/dbt/pull/2534))
 - `packages.yml` revision/version fields can be float-like again (`revision: '1.0'` is valid). ([#2518](https://github.com/fishtown-analytics/dbt/issues/2518), [#2535](https://github.com/fishtown-analytics/dbt/pull/2535))
-<<<<<<< HEAD
 - dbt again respects config aliases in config() calls ([#2557](https://github.com/fishtown-analytics/dbt/issues/2557), [#2559](https://github.com/fishtown-analytics/dbt/pull/2559))
 
 
-=======
 - Parallel RPC requests no longer step on each others' arguments ([[#2484](https://github.com/fishtown-analytics/dbt/issues/2484), [#2554](https://github.com/fishtown-analytics/dbt/pull/2554)])
 - `persist_docs` now takes into account descriptions for nested columns in bigquery ([#2549](https://github.com/fishtown-analytics/dbt/issues/2549), [#2550](https://github.com/fishtown-analytics/dbt/pull/2550))
 - On windows (depending upon OS support), dbt no longer fails with errors when writing artifacts ([#2558](https://github.com/fishtown-analytics/dbt/issues/2558), [#2566](https://github.com/fishtown-analytics/dbt/pull/2566))
@@ -141,7 +139,6 @@ Contributors:
 
 Contributors:
  - [@bodschut](https://github.com/bodschut) ([#2550](https://github.com/fishtown-analytics/dbt/pull/2550))
->>>>>>> dev/0.17.1
 
 ## dbt 0.17.0 (June 08, 2020)
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1149,6 +1149,7 @@ class ProviderContext(ManifestContext):
             {%- endmacro %}
         """
         deprecations.warn('adapter-macro', macro_name=name)
+        original_name = name
         package_names: Optional[List[str]] = None
         if '.' in name:
             package_name, name = name.split('.', 1)
@@ -1161,7 +1162,7 @@ class ProviderContext(ManifestContext):
         except CompilationException as exc:
             raise CompilationException(
                 f'In adapter_macro: {exc.msg}\n'
-                f"    Original name: '{name}'",
+                f"    Original name: '{original_name}'",
                 node=self.model
             ) from exc
         return macro(*args, **kwargs)

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -124,6 +124,11 @@ class BaseDatabaseWrapper:
 
         if packages is None:
             search_packages = [None]
+        elif isinstance(packages, str):
+            raise CompilationException(
+                f'In adapter.dispatch, got a string packages argument '
+                f'("{packages}"), but packages should be None or a list.'
+            )
         else:
             search_packages = packages
 

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -111,6 +111,17 @@ class BaseDatabaseWrapper:
         self, macro_name: str, packages: Optional[List[str]] = None
     ) -> MacroGenerator:
         search_packages: List[Optional[str]]
+
+        if '.' in macro_name:
+            suggest_package, suggest_macro_name = macro_name.split('.', 1)
+            msg = (
+                f'In adapter.dispatch, got a macro name of "{macro_name}", '
+                f'but "." is not a valid macro name component. Did you mean '
+                f'`adapter.dispatch("{suggest_macro_name}", '
+                f'packages=["{suggest_package}"])`?'
+            )
+            raise CompilationException(msg)
+
         if packages is None:
             search_packages = [None]
         else:
@@ -139,10 +150,11 @@ class BaseDatabaseWrapper:
                     return macro
 
         searched = ', '.join(repr(a) for a in attempts)
-        raise CompilationException(
-            f"In dispatch: No macro named '{macro_name}' found\n",
+        msg = (
+            f"In dispatch: No macro named '{macro_name}' found\n"
             f"    Searched for: {searched}"
         )
+        raise CompilationException(msg)
 
 
 class BaseResolver(metaclass=abc.ABCMeta):

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -116,6 +116,15 @@ class ExecuteMacrosReleaseDeprecation(DBTDeprecation):
     '''
 
 
+class AdapterMacroDeprecation(DBTDeprecation):
+    _name = 'adapter-macro'
+    _description = '''\
+    The "adapter_macro" macro has been deprecated. Instead, use the
+    `adapter.dispatch` method to find a macro and call the result.
+    adapter_macro was called for: {macro_name}
+    '''
+
+
 _adapter_renamed_description = """\
 The adapter function `adapter.{old_name}` is deprecated and will be removed in
 a future release of dbt. Please use `adapter.{new_name}` instead.
@@ -160,6 +169,7 @@ deprecations_list: List[DBTDeprecation] = [
     ModelsKeyNonModelDeprecation(),
     DbtProjectYamlDeprecation(),
     ExecuteMacrosReleaseDeprecation(),
+    AdapterMacroDeprecation(),
 ]
 
 deprecations: Dict[str, DBTDeprecation] = {

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -1,5 +1,5 @@
 {% macro get_columns_in_query(select_sql) -%}
-  {{ return(adapter_macro('get_columns_in_query', select_sql)) }}
+  {{ return(adapter.dispatch('get_columns_in_query')(select_sql)) }}
 {% endmacro %}
 
 {% macro default__get_columns_in_query(select_sql) %}
@@ -15,7 +15,7 @@
 {% endmacro %}
 
 {% macro create_schema(relation) -%}
-  {{ adapter_macro('create_schema', relation) }}
+  {{ adapter.dispatch('create_schema')(relation) }}
 {% endmacro %}
 
 {% macro default__create_schema(relation) -%}
@@ -25,7 +25,7 @@
 {% endmacro %}
 
 {% macro drop_schema(relation) -%}
-  {{ adapter_macro('drop_schema', relation) }}
+  {{ adapter.dispatch('drop_schema')(relation) }}
 {% endmacro %}
 
 {% macro default__drop_schema(relation) -%}
@@ -35,7 +35,7 @@
 {% endmacro %}
 
 {% macro create_table_as(temporary, relation, sql) -%}
-  {{ adapter_macro('create_table_as', temporary, relation, sql) }}
+  {{ adapter.dispatch('create_table_as')(temporary, relation, sql) }}
 {%- endmacro %}
 
 {% macro default__create_table_as(temporary, relation, sql) -%}
@@ -52,7 +52,7 @@
 {% endmacro %}
 
 {% macro create_view_as(relation, sql) -%}
-  {{ adapter_macro('create_view_as', relation, sql) }}
+  {{ adapter.dispatch('create_view_as')(relation, sql) }}
 {%- endmacro %}
 
 {% macro default__create_view_as(relation, sql) -%}
@@ -66,7 +66,7 @@
 
 
 {% macro get_catalog(information_schema, schemas) -%}
-  {{ return(adapter_macro('get_catalog', information_schema, schemas)) }}
+  {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
 {%- endmacro %}
 
 {% macro default__get_catalog(information_schema, schemas) -%}
@@ -81,7 +81,7 @@
 
 
 {% macro get_columns_in_relation(relation) -%}
-  {{ return(adapter_macro('get_columns_in_relation', relation)) }}
+  {{ return(adapter.dispatch('get_columns_in_relation')(relation)) }}
 {% endmacro %}
 
 {% macro sql_convert_columns_in_relation(table) -%}
@@ -98,13 +98,13 @@
 {% endmacro %}
 
 {% macro alter_column_type(relation, column_name, new_column_type) -%}
-  {{ return(adapter_macro('alter_column_type', relation, column_name, new_column_type)) }}
+  {{ return(adapter.dispatch('alter_column_type')(relation, column_name, new_column_type)) }}
 {% endmacro %}
 
 
 
 {% macro alter_column_comment(relation, column_dict) -%}
-  {{ return(adapter_macro('alter_column_comment', relation, column_dict)) }}
+  {{ return(adapter.dispatch('alter_column_comment')(relation, column_dict)) }}
 {% endmacro %}
 
 {% macro default__alter_column_comment(relation, column_dict) -%}
@@ -113,7 +113,7 @@
 {% endmacro %}
 
 {% macro alter_relation_comment(relation, relation_comment) -%}
-  {{ return(adapter_macro('alter_relation_comment', relation, relation_comment)) }}
+  {{ return(adapter.dispatch('alter_relation_comment')(relation, relation_comment)) }}
 {% endmacro %}
 
 {% macro default__alter_relation_comment(relation, relation_comment) -%}
@@ -122,7 +122,7 @@
 {% endmacro %}
 
 {% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}
-  {{ return(adapter_macro('persist_docs', relation, model, for_relation, for_columns)) }}
+  {{ return(adapter.dispatch('persist_docs')(relation, model, for_relation, for_columns)) }}
 {% endmacro %}
 
 {% macro default__persist_docs(relation, model, for_relation, for_columns) -%}
@@ -157,7 +157,7 @@
 
 
 {% macro drop_relation(relation) -%}
-  {{ return(adapter_macro('drop_relation', relation)) }}
+  {{ return(adapter.dispatch('drop_relation')(relation)) }}
 {% endmacro %}
 
 
@@ -168,7 +168,7 @@
 {% endmacro %}
 
 {% macro truncate_relation(relation) -%}
-  {{ return(adapter_macro('truncate_relation', relation)) }}
+  {{ return(adapter.dispatch('truncate_relation')(relation)) }}
 {% endmacro %}
 
 
@@ -179,7 +179,7 @@
 {% endmacro %}
 
 {% macro rename_relation(from_relation, to_relation) -%}
-  {{ return(adapter_macro('rename_relation', from_relation, to_relation)) }}
+  {{ return(adapter.dispatch('rename_relation')(from_relation, to_relation)) }}
 {% endmacro %}
 
 {% macro default__rename_relation(from_relation, to_relation) -%}
@@ -191,7 +191,7 @@
 
 
 {% macro information_schema_name(database) %}
-  {{ return(adapter_macro('information_schema_name', database)) }}
+  {{ return(adapter.dispatch('information_schema_name')(database)) }}
 {% endmacro %}
 
 {% macro default__information_schema_name(database) -%}
@@ -204,7 +204,7 @@
 
 
 {% macro list_schemas(database) -%}
-  {{ return(adapter_macro('list_schemas', database)) }}
+  {{ return(adapter.dispatch('list_schemas')(database)) }}
 {% endmacro %}
 
 {% macro default__list_schemas(database) -%}
@@ -218,7 +218,7 @@
 
 
 {% macro check_schema_exists(information_schema, schema) -%}
-  {{ return(adapter_macro('check_schema_exists', information_schema, schema)) }}
+  {{ return(adapter.dispatch('check_schema_exists')(information_schema, schema)) }}
 {% endmacro %}
 
 {% macro default__check_schema_exists(information_schema, schema) -%}
@@ -233,7 +233,7 @@
 
 
 {% macro list_relations_without_caching(schema_relation) %}
-  {{ return(adapter_macro('list_relations_without_caching', schema_relation)) }}
+  {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}
 {% endmacro %}
 
 
@@ -244,7 +244,7 @@
 
 
 {% macro current_timestamp() -%}
-  {{ adapter_macro('current_timestamp') }}
+  {{ adapter.dispatch('current_timestamp')() }}
 {%- endmacro %}
 
 
@@ -255,7 +255,7 @@
 
 
 {% macro collect_freshness(source, loaded_at_field, filter) %}
-  {{ return(adapter_macro('collect_freshness', source, loaded_at_field, filter))}}
+  {{ return(adapter.dispatch('collect_freshness')(source, loaded_at_field, filter))}}
 {% endmacro %}
 
 
@@ -273,7 +273,7 @@
 {% endmacro %}
 
 {% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}
-  {{ return(adapter_macro('make_temp_relation', base_relation, suffix))}}
+  {{ return(adapter.dispatch('make_temp_relation')(base_relation, suffix))}}
 {% endmacro %}
 
 {% macro default__make_temp_relation(base_relation, suffix) %}

--- a/core/dbt/include/global_project/macros/etc/get_custom_database.sql
+++ b/core/dbt/include/global_project/macros/etc/get_custom_database.sql
@@ -14,7 +14,7 @@
 
 #}
 {% macro generate_database_name(custom_database_name=none, node=none) -%}
-    {% do return(adapter_macro('generate_database_name', custom_database_name, node)) %}
+    {% do return(adapter.dispatch('generate_database_name')(custom_database_name, node)) %}
 {%- endmacro %}
 
 {% macro default__generate_database_name(custom_database_name=none, node=none) -%}

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -1,17 +1,17 @@
 
 
 {% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}
-  {{ adapter_macro('get_merge_sql', target, source, unique_key, dest_columns, predicates) }}
+  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}
 {%- endmacro %}
 
 
 {% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}
-  {{ adapter_macro('get_delete_insert_merge_sql', target, source, unique_key, dest_columns) }}
+  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns) }}
 {%- endmacro %}
 
 
 {% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}
-  {{ adapter_macro('get_insert_overwrite_merge_sql', target, source, dest_columns, predicates, include_sql_header) }}
+  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}
 {%- endmacro %}
 
 
@@ -97,7 +97,7 @@
     merge into {{ target }} as DBT_INTERNAL_DEST
         using {{ source }} as DBT_INTERNAL_SOURCE
         on FALSE
-    
+
     when not matched by source
         {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}
         then delete

--- a/core/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -1,14 +1,14 @@
 
 {% macro create_csv_table(model, agate_table) -%}
-  {{ adapter_macro('create_csv_table', model, agate_table) }}
+  {{ adapter.dispatch('create_csv_table')(model, agate_table) }}
 {%- endmacro %}
 
 {% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}
-  {{ adapter_macro('reset_csv_table', model, full_refresh, old_relation, agate_table) }}
+  {{ adapter.dispatch('reset_csv_table')(model, full_refresh, old_relation, agate_table) }}
 {%- endmacro %}
 
 {% macro load_csv_rows(model, agate_table) -%}
-  {{ adapter_macro('load_csv_rows', model, agate_table) }}
+  {{ adapter.dispatch('load_csv_rows')(model, agate_table) }}
 {%- endmacro %}
 
 {% macro default__create_csv_table(model, agate_table) %}

--- a/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
@@ -2,7 +2,7 @@
     Add new columns to the table if applicable
 #}
 {% macro create_columns(relation, columns) %}
-  {{ adapter_macro('create_columns', relation, columns) }}
+  {{ adapter.dispatch('create_columns')(relation, columns) }}
 {% endmacro %}
 
 {% macro default__create_columns(relation, columns) %}
@@ -15,7 +15,7 @@
 
 
 {% macro post_snapshot(staging_relation) %}
-  {{ adapter_macro('post_snapshot', staging_relation) }}
+  {{ adapter.dispatch('post_snapshot')(staging_relation) }}
 {% endmacro %}
 
 {% macro default__post_snapshot(staging_relation) %}

--- a/core/dbt/include/global_project/macros/materializations/snapshot/snapshot_merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/snapshot_merge.sql
@@ -1,6 +1,6 @@
 
 {% macro snapshot_merge_sql(target, source, insert_cols) -%}
-  {{ adapter_macro('snapshot_merge_sql', target, source, insert_cols) }}
+  {{ adapter.dispatch('snapshot_merge_sql')(target, source, insert_cols) }}
 {%- endmacro %}
 
 

--- a/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/strategies.sql
@@ -36,7 +36,7 @@
     Create SCD Hash SQL fields cross-db
 #}
 {% macro snapshot_hash_arguments(args) -%}
-  {{ adapter_macro('snapshot_hash_arguments', args) }}
+  {{ adapter.dispatch('snapshot_hash_arguments')(args) }}
 {%- endmacro %}
 
 
@@ -52,7 +52,7 @@
     Get the current time cross-db
 #}
 {% macro snapshot_get_time() -%}
-  {{ adapter_macro('snapshot_get_time') }}
+  {{ adapter.dispatch('snapshot_get_time')() }}
 {%- endmacro %}
 
 {% macro default__snapshot_get_time() -%}
@@ -92,7 +92,7 @@
 
 
 {% macro snapshot_string_as_time(timestamp) -%}
-    {{ adapter_macro('snapshot_string_as_time', timestamp) }}
+    {{ adapter.dispatch('snapshot_string_as_time')(timestamp) }}
 {%- endmacro %}
 
 

--- a/core/dbt/include/global_project/macros/materializations/view/create_or_replace_view.sql
+++ b/core/dbt/include/global_project/macros/materializations/view/create_or_replace_view.sql
@@ -1,6 +1,6 @@
 
 {% macro handle_existing_table(full_refresh, old_relation) %}
-    {{ adapter_macro("dbt.handle_existing_table", full_refresh, old_relation) }}
+    {{ adapter.dispatch("handle_existing_table", packages=['dbt'])(full_refresh, old_relation) }}
 {% endmacro %}
 
 {% macro default__handle_existing_table(full_refresh, old_relation) %}

--- a/test/integration/004_simple_snapshot_test/macros/test_no_overlaps.sql
+++ b/test/integration/004_simple_snapshot_test/macros/test_no_overlaps.sql
@@ -1,5 +1,5 @@
 {% macro get_snapshot_unique_id() -%}
-    {{ return(adapter_macro('get_snapshot_unique_id', )) }}
+    {{ return(adapter.dispatch('get_snapshot_unique_id')()) }}
 {%- endmacro %}
 
 {% macro default__get_snapshot_unique_id() -%}

--- a/test/integration/012_deprecation_tests/adapter-macro-macros/macros.sql
+++ b/test/integration/012_deprecation_tests/adapter-macro-macros/macros.sql
@@ -1,0 +1,17 @@
+{% macro some_macro(arg1, arg2) -%}
+    {{ adapter_macro('some_macro', arg1, arg2) }}
+{%- endmacro %}
+
+
+{% macro default__some_macro(arg1, arg2) %}
+    {% do exceptions.raise_compiler_error('not allowed') %}
+{% endmacro %}
+
+{% macro postgres__some_macro(arg1, arg2) -%}
+    {{ arg1 }}{{ arg2 }}
+{%- endmacro %}
+
+
+{% macro some_other_macro(arg1, arg2) -%}
+	{{ adapter_macro('test.some_macro', arg1, arg2) }}
+{%- endmacro %}

--- a/test/integration/012_deprecation_tests/adapter-macro-models-package/model.sql
+++ b/test/integration/012_deprecation_tests/adapter-macro-models-package/model.sql
@@ -1,0 +1,4 @@
+{% if some_other_macro('foo', 'bar') != 'foobar' %}
+  {% do exceptions.raise_compiler_error('invalid foobar') %}
+{% endif %}
+select 1 as id

--- a/test/integration/012_deprecation_tests/adapter-macro-models/model.sql
+++ b/test/integration/012_deprecation_tests/adapter-macro-models/model.sql
@@ -1,0 +1,4 @@
+{% if some_macro('foo', 'bar') != 'foobar' %}
+  {% do exceptions.raise_compiler_error('invalid foobar') %}
+{% endif %}
+select 1 as id

--- a/test/integration/012_deprecation_tests/test_deprecations.py
+++ b/test/integration/012_deprecation_tests/test_deprecations.py
@@ -104,3 +104,77 @@ class TestDbtProjectYamlV1Deprecation(BaseTestDeprecations):
         self.run_dbt(strict=False)
         expected = {'dbt-project-yaml-v1'}
         self.assertEqual(expected, deprecations.active_deprecations)
+
+
+class TestAdapterMacroDeprecation(BaseTestDeprecations):
+    @property
+    def models(self):
+        return self.dir('adapter-macro-models')
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': [self.dir('adapter-macro-macros')]
+        }
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        self.run_dbt(strict=False)
+        expected = {'adapter-macro'}
+        self.assertEqual(expected, deprecations.active_deprecations)
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro_fail(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            self.run_dbt(strict=True)
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        assert 'The "adapter_macro" macro has been deprecated' in exc_str
+
+    @use_profile('redshift')
+    def test_redshift_adapter_macro(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        # picked up the default -> error
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            self.run_dbt(strict=False, expect_pass=False)
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        assert 'not allowed' in exc_str  # we saw the default macro
+
+
+class TestAdapterMacroDeprecationPackages(BaseTestDeprecations):
+    @property
+    def models(self):
+        return self.dir('adapter-macro-models-package')
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': [self.dir('adapter-macro-macros')]
+        }
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro_pkg(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        self.run_dbt(strict=False)
+        expected = {'adapter-macro'}
+        self.assertEqual(expected, deprecations.active_deprecations)
+
+    @use_profile('postgres')
+    def test_postgres_adapter_macro_pkg_fail(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            self.run_dbt(strict=True)
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        assert 'The "adapter_macro" macro has been deprecated' in exc_str
+
+    @use_profile('redshift')
+    def test_redshift_adapter_macro_pkg(self):
+        self.assertEqual(deprecations.active_deprecations, set())
+        # picked up the default -> error
+        with self.assertRaises(dbt.exceptions.CompilationException) as exc:
+            self.run_dbt(strict=False, expect_pass=False)
+        exc_str = ' '.join(str(exc.exception).split())  # flatten all whitespace
+        assert 'not allowed' in exc_str  # we saw the default macro

--- a/test/integration/016_macro_tests/fail-missing-macro-models/model.sql
+++ b/test/integration/016_macro_tests/fail-missing-macro-models/model.sql
@@ -1,0 +1,2 @@
+{{ dispatch_to_nowhere() }}
+select 1 as id

--- a/test/integration/016_macro_tests/macros/my_macros.sql
+++ b/test/integration/016_macro_tests/macros/my_macros.sql
@@ -13,3 +13,10 @@
     {{ ref('table_model') }}
 
 {% endmacro %}
+
+
+{# there is no no default__dispatch_to_nowhere! #}
+{% macro dispatch_to_nowhere() %}
+	{% set macro = adapter.dispatch('dispatch_to_nowhere') %}
+	{{ macro() }}
+{% endmacro %}

--- a/test/integration/026_aliases_test/macros/cast.sql
+++ b/test/integration/026_aliases_test/macros/cast.sql
@@ -1,7 +1,7 @@
 
 
 {% macro string_literal(s) -%}
-  {{ adapter_macro('test.string_literal', s) }}
+  {{ adapter.dispatch('string_literal', packages=['test'])(s) }}
 {%- endmacro %}
 
 {% macro default__string_literal(s) %}

--- a/test/integration/043_custom_aliases_test/macros-configs/macros.sql
+++ b/test/integration/043_custom_aliases_test/macros-configs/macros.sql
@@ -9,7 +9,7 @@
 {%- endmacro %}
 
 {% macro string_literal(s) -%}
-  {{ adapter_macro('test.string_literal', s) }}
+  {{ adapter.dispatch('string_literal', packages=['test'])(s) }}
 {%- endmacro %}
 
 {% macro default__string_literal(s) %}

--- a/test/integration/043_custom_aliases_test/macros/macros.sql
+++ b/test/integration/043_custom_aliases_test/macros/macros.sql
@@ -9,7 +9,7 @@
 
 
 {% macro string_literal(s) -%}
-  {{ adapter_macro('test.string_literal', s) }}
+  {{ adapter.dispatch('string_literal', packages=['test'])(s) }}
 {%- endmacro %}
 
 {% macro default__string_literal(s) %}

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -121,6 +121,13 @@ def inject_adapter(value, plugin):
     FACTORY.adapters[key] = value
 
 
+def clear_plugin(plugin):
+    from dbt.adapters.factory import FACTORY
+    key = plugin.adapter.type()
+    FACTORY.plugins.pop(key, None)
+    FACTORY.adapters.pop(key, None)
+
+
 class ContractTestCase(TestCase):
     ContractType = None
 


### PR DESCRIPTION
resolves #2302 (the rest of it)


### Description
This is a follow-up to #2675.

This PR adds the `adapter.dispatch` described in #2302, and marked `adapter_macro` as deprecated. This is a pretty straightforward PR. The dispatch method happens on the "database wrapper" rather than the actual adapter, as adapters themselves don't know about manifests/namespacing. The adapter_macro context method now calls into dispatch.

I had to massage some of the error messaging, but I think it's ok.


A large part of this PR is just converting `adapter_macro(foo, *args, **kwargs)` calls into `adapter.dispatch(foo)(*args, **kwargs)`.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
