### PR TITLE
convert tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 - Added a `dispatch` method to the context adapter and deprecated `adapter_macro`. ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2679](https://github.com/fishtown-analytics/dbt/pull/2679))
+- The built-in schema tests now use `adapter.dispatch`, so they can be overridden for adapter plugins ([#2415](https://github.com/fishtown-analytics/dbt/issues/2415), [#2684](https://github.com/fishtown-analytics/dbt/pull/2684))
 
 ## dbt 0.18.0b2 (July 30, 2020)
 

--- a/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/accepted_values.sql
@@ -1,5 +1,5 @@
 
-{% macro test_accepted_values(model, values) %}
+{% macro default__test_accepted_values(model, values) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('field')) %}
 {% set quote_values = kwargs.get('quote', True) %}
@@ -34,4 +34,10 @@ validation_errors as (
 select count(*) as validation_errors
 from validation_errors
 
+{% endmacro %}
+
+
+{% macro test_accepted_values(model, values) %}
+    {% set macro = adapter.dispatch('test_accepted_values') %}
+    {{ macro(model, values, **kwargs) }}
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/schema_tests/not_null.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/not_null.sql
@@ -1,5 +1,5 @@
 
-{% macro test_not_null(model) %}
+{% macro default__test_not_null(model) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
@@ -9,3 +9,9 @@ where {{ column_name }} is null
 
 {% endmacro %}
 
+
+
+{% macro test_not_null(model) %}
+    {% set macro = adapter.dispatch('test_not_null') %}
+    {{ macro(model, **kwargs) }}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/schema_tests/relationships.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/relationships.sql
@@ -1,5 +1,5 @@
 
-{% macro test_relationships(model, to, field) %}
+{% macro default__test_relationships(model, to, field) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
 
@@ -16,3 +16,9 @@ where child.id is not null
 
 {% endmacro %}
 
+
+
+{% macro test_relationships(model, to, field) %}
+    {% set macro = adapter.dispatch('test_relationships') %}
+    {{ macro(model, to, field, **kwargs) }}
+{% endmacro %}

--- a/core/dbt/include/global_project/macros/schema_tests/unique.sql
+++ b/core/dbt/include/global_project/macros/schema_tests/unique.sql
@@ -1,5 +1,5 @@
 
-{% macro test_unique(model) %}
+{% macro default__test_unique(model) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
@@ -16,4 +16,10 @@ from (
 
 ) validation_errors
 
+{% endmacro %}
+
+
+{% macro test_unique(model) %}
+    {% set macro = adapter.dispatch('test_unique') %}
+    {{ macro(model, **kwargs) }}
 {% endmacro %}


### PR DESCRIPTION
resolves #2415 

requires #2679 

### Description
The existing tests all still pass (a good start!). Locally I modified the postgres adapter to add an always-failing `postgres__test_not_null` and everything worked.

We don't really have a good way to write automated tests for adapter plugin behavior itself, unfortunately. I think the general case of it will be pretty hard to solve!

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
