### PR TITLE
include project macros in the manifest the adapter stores locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Features
 - Add support for impersonating a service account using `impersonate_service_account` in the BigQuery profile configuration ([#2677](https://github.com/fishtown-analytics/dbt/issues/2677)) ([docs](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation))
+- Macros in the current project can override internal dbt macros that are called through `execute_macros`. ([#2301](https://github.com/fishtown-analytics/dbt/issues/2301), [#2686](https://github.com/fishtown-analytics/dbt/pull/2686))
 
 
 ### Breaking changes

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -158,7 +158,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self.config = config
         self.cache = RelationsCache()
         self.connections = self.ConnectionManager(config)
-        self._internal_manifest_lazy: Optional[Manifest] = None
+        self._macro_manifest_lazy: Optional[Manifest] = None
 
     ###
     # Methods that pass through to the connection manager
@@ -239,24 +239,26 @@ class BaseAdapter(metaclass=AdapterMeta):
         return cls.ConnectionManager.TYPE
 
     @property
-    def _internal_manifest(self) -> Manifest:
-        if self._internal_manifest_lazy is None:
-            return self.load_internal_manifest()
-        return self._internal_manifest_lazy
+    def _macro_manifest(self) -> Manifest:
+        if self._macro_manifest_lazy is None:
+            return self.load_macro_manifest()
+        return self._macro_manifest_lazy
 
-    def check_internal_manifest(self) -> Optional[Manifest]:
+    def check_macro_manifest(self) -> Optional[Manifest]:
         """Return the internal manifest (used for executing macros) if it's
         been initialized, otherwise return None.
         """
-        return self._internal_manifest_lazy
+        return self._macro_manifest_lazy
 
-    def load_internal_manifest(self) -> Manifest:
-        if self._internal_manifest_lazy is None:
+    def load_macro_manifest(self) -> Manifest:
+        if self._macro_manifest_lazy is None:
             # avoid a circular import
-            from dbt.parser.manifest import load_internal_manifest
-            manifest = load_internal_manifest(self.config)
-            self._internal_manifest_lazy = manifest
-        return self._internal_manifest_lazy
+            from dbt.parser.manifest import load_macro_manifest
+            manifest = load_macro_manifest(
+                self.config, self.connections.set_query_header
+            )
+            self._macro_manifest_lazy = manifest
+        return self._macro_manifest_lazy
 
     ###
     # Caching methods
@@ -941,7 +943,7 @@ class BaseAdapter(metaclass=AdapterMeta):
             context_override = {}
 
         if manifest is None:
-            manifest = self._internal_manifest
+            manifest = self._macro_manifest
 
         macro = manifest.find_macro_by_name(
             macro_name, self.config.project_name, project

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -260,6 +260,10 @@ class BaseAdapter(metaclass=AdapterMeta):
             self._macro_manifest_lazy = manifest
         return self._macro_manifest_lazy
 
+    def clear_macro_manifest(self):
+        if self._macro_manifest_lazy is not None:
+            self._macro_manifest_lazy = None
+
     ###
     # Caching methods
     ###

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -355,6 +355,9 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             self.dependencies = all_projects
         return self.dependencies
 
+    def clear_dependencies(self):
+        self.dependencies = None
+
     def load_projects(
         self, paths: Iterable[Path]
     ) -> Iterator[Tuple[str, 'RuntimeConfig']]:

--- a/core/dbt/perf_utils.py
+++ b/core/dbt/perf_utils.py
@@ -7,7 +7,11 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt.config import RuntimeConfig
 
 
-def get_full_manifest(config: RuntimeConfig) -> Manifest:
+def get_full_manifest(
+    config: RuntimeConfig,
+    *,
+    reset: bool = False,
+) -> Manifest:
     """Load the full manifest, using the adapter's internal manifest if it
     exists to skip parsing internal (dbt + plugins) macros a second time.
 
@@ -15,6 +19,10 @@ def get_full_manifest(config: RuntimeConfig) -> Manifest:
     attached to the adapter for any methods that need it.
     """
     adapter = get_adapter(config)  # type: ignore
+    if reset:
+        config.clear_dependencies()
+        adapter.clear_macro_manifest()
+
     internal: Manifest = adapter.load_macro_manifest()
 
     return load_manifest(

--- a/core/dbt/perf_utils.py
+++ b/core/dbt/perf_utils.py
@@ -15,9 +15,10 @@ def get_full_manifest(config: RuntimeConfig) -> Manifest:
     attached to the adapter for any methods that need it.
     """
     adapter = get_adapter(config)  # type: ignore
-    internal: Manifest = adapter.load_internal_manifest()
+    internal: Manifest = adapter.load_macro_manifest()
 
-    def set_header(manifest: Manifest) -> None:
-        adapter.connections.set_query_header(manifest)
-
-    return load_manifest(config, internal, set_header)
+    return load_manifest(
+        config,
+        internal,
+        adapter.connections.set_query_header,
+    )

--- a/core/dbt/rpc/task_manager.py
+++ b/core/dbt/rpc/task_manager.py
@@ -8,6 +8,7 @@ from typing import (
 
 import dbt.exceptions
 import dbt.flags as flags
+from dbt.adapters.factory import reset_adapters, register_adapter
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.rpc import (
     LastParse,
@@ -126,6 +127,8 @@ class TaskManager:
     def reload_config(self):
         config = self.config.from_args(self.args)
         self.config = config
+        reset_adapters()
+        register_adapter(config)
         return config
 
     def add_request(self, request_handler: TaskHandlerProtocol):
@@ -184,7 +187,7 @@ class TaskManager:
         return True
 
     def parse_manifest(self) -> None:
-        self.manifest = get_full_manifest(self.config)
+        self.manifest = get_full_manifest(self.config, reset=True)
 
     def set_compile_exception(self, exc, logs=List[LogMessage]) -> None:
         assert self.last_parse.state == ManifestStatus.Compiling, \
@@ -227,6 +230,7 @@ class TaskManager:
             return None
 
         task = self.rpc_task(method)
+
         return task
 
     def task_table(self) -> List[TaskRow]:

--- a/core/dbt/task/rpc/cli.py
+++ b/core/dbt/task/rpc/cli.py
@@ -104,7 +104,9 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
         if dumped != self.args.vars:
             self.real_task.args.vars = dumped
             if isinstance(self.real_task, RemoteManifestMethod):
-                self.real_task.manifest = get_full_manifest(self.config)
+                self.real_task.manifest = get_full_manifest(
+                    self.config, reset=True
+                )
 
         # we parsed args from the cli, so we're set on that front
         return self.real_task.handle_request()

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -320,7 +320,7 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(obj, 'to_dict'):
             # if we have a to_dict we should try to serialize the result of
             # that!
-            obj = obj.to_dict()
+            return obj.to_dict()
         return super().default(obj)
 
 

--- a/test/integration/016_macro_tests/override-get-columns-macros/macros.sql
+++ b/test/integration/016_macro_tests/override-get-columns-macros/macros.sql
@@ -1,0 +1,3 @@
+{% macro get_columns_in_relation(relation) %}
+	{{ return('a string') }}
+{% endmacro %}

--- a/test/integration/016_macro_tests/override-get-columns-models/model.sql
+++ b/test/integration/016_macro_tests/override-get-columns-models/model.sql
@@ -1,0 +1,5 @@
+{% set result = adapter.get_columns_in_relation(this) %}
+{% if execute and result != 'a string' %}
+  {% do exceptions.raise_compiler_error('overriding get_columns_in_relation failed') %}
+{% endif %}
+select 1 as id

--- a/test/integration/016_macro_tests/test_macros.py
+++ b/test/integration/016_macro_tests/test_macros.py
@@ -93,3 +93,27 @@ class TestAdapterMacroNoDestination(DBTIntegrationTest):
             self.run_dbt(['run'])
 
         assert "In dispatch: No macro named 'dispatch_to_nowhere' found" in str(exc.value)
+
+
+class TestMacroOverrideBuiltin(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "test_macros_016"
+
+    @property
+    def models(self):
+        return 'override-get-columns-models'
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'macro-paths': ['override-get-columns-macros'],
+        }
+
+
+    @use_profile('postgres')
+    def test_postgres_overrides(self):
+        # the first time, the model doesn't exist
+        self.run_dbt()
+        self.run_dbt()

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -104,7 +104,7 @@ class GraphTest(unittest.TestCase):
         self.mock_source_file = self.load_source_file_patcher.start()
         self.mock_source_file.side_effect = lambda path: [n for n in self.mock_models if n.path == path][0]
 
-        self.internal_manifest = Manifest.from_macros(macros={
+        self.macro_manifest = Manifest.from_macros(macros={
             n.unique_id: n for n in generate_name_macros('test_models_compile')
         })
 
@@ -161,7 +161,7 @@ class GraphTest(unittest.TestCase):
 
     def load_manifest(self, config):
         loader = dbt.parser.manifest.ManifestLoader(config, {config.project_name: config})
-        loader.load(internal_manifest=self.internal_manifest)
+        loader.load(macro_manifest=self.macro_manifest)
         return loader.create_manifest()
 
     def test__single_model(self):
@@ -319,7 +319,7 @@ class GraphTest(unittest.TestCase):
         config = self.get_config()
 
         loader = dbt.parser.manifest.ManifestLoader(config, {config.project_name: config})
-        loader.load(internal_manifest=self.internal_manifest)
+        loader.load(macro_manifest=self.macro_manifest)
         loader.create_manifest()
         results = loader.results
 

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -14,7 +14,7 @@ from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.parser.results import ParseResult
 from snowflake import connector as snowflake_connector
 
-from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection, TestAdapterConversions
+from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection, TestAdapterConversions, load_internal_manifest_macros
 
 
 class TestSnowflakeAdapter(unittest.TestCase):
@@ -65,8 +65,8 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
         self.snowflake.return_value = self.handle
         self.adapter = SnowflakeAdapter(self.config)
-
-        self.adapter.connections.query_header = MacroQueryStringSetter(self.config, mock.MagicMock(macros={}))
+        self.adapter._macro_manifest_lazy = load_internal_manifest_macros(self.config)
+        self.adapter.connections.query_header = MacroQueryStringSetter(self.config, self.adapter._macro_manifest_lazy)
 
         self.qh_patch = mock.patch.object(self.adapter.connections.query_header, 'add')
         self.mock_query_header_add = self.qh_patch.start()

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -289,3 +289,12 @@ def MockDocumentation(package, name, **kwargs):
     )
     doc.name = name
     return doc
+
+
+def load_internal_manifest_macros(config, macro_hook = lambda m: None):
+    from dbt.adapters.factory import get_include_paths
+    from dbt.parser.manifest import ManifestLoader
+    paths = get_include_paths(config.credentials.type)
+    projects = {k: v for k, v in config.load_dependencies().items() if k.startswith('dbt')}
+    loader = ManifestLoader(config, projects, macro_hook)
+    return loader.load_only_macros()


### PR DESCRIPTION
resolves #2301

### Description
Macros defined in core and called via the adapter's `execute_macro` method will now accept local overrides.

Previously, if you wanted to override a macro in dbt that was used for internal purposes (listing schemas, creating schemas, dropping schemas, getting columns in a relation, ...), the only way to do so was in an adapter plugin itself. This is because the adapter uses a special internal manifest that doesn't require any non-macros. Previously, the adapter's internal manifest only looked at macros defined in dbt core and any active adapter plugins. Now, we search the entire project (including dependencies) for macros and use that for the manifest.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
