### PR TITLE
Add retry of additional errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
 - Add support for impersonating a service account using `impersonate_service_account` in the BigQuery profile configuration ([#2677](https://github.com/fishtown-analytics/dbt/issues/2677)) ([docs](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation))
 - Macros in the current project can override internal dbt macros that are called through `execute_macros`. ([#2301](https://github.com/fishtown-analytics/dbt/issues/2301), [#2686](https://github.com/fishtown-analytics/dbt/pull/2686))
+- Add better retry support when using the BigQuery adapter ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694), follow-up to [#1963](https://github.com/fishtown-analytics/dbt/pull/1963))
 
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 Contributors:
 - [@bbhoss](https://github.com/bbhoss) ([#2677](https://github.com/fishtown-analytics/dbt/pull/2677))
+- [@kconvey](https://github.com/kconvey) ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694))
 
 ## dbt 0.18.0b2 (July 30, 2020)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -404,7 +404,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
     def _retry_and_handle(self, msg, conn, fn):
         """retry a function call within the context of exception_handler."""
         def reopen_conn_on_error(error):
-            if isinstance(error, type):
+            if isinstance(error, REOPENABLE_ERRORS):
                 logger.warning('Reopening connection after {!r}', error)
                 self.close(conn)
                 self.open(conn)

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
+from requests.exceptions import ConnectionError
 from typing import Optional, Any, Dict
 
 import google.auth
@@ -24,6 +25,18 @@ from hologram.helpers import StrEnum
 
 
 BQ_QUERY_JOB_SPLIT = '-----Query Job SQL Follows-----'
+
+REOPENABLE_ERRORS = {
+    ConnectionResetError,
+    ConnectionError,
+}
+
+RETRYABLE_ERRORS = {
+    google.cloud.exceptions.ServerError,
+    google.cloud.exceptions.BadRequest,
+    ConnectionResetError,
+    ConnectionError,
+}
 
 
 class Priority(StrEnum):
@@ -390,12 +403,21 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
     def _retry_and_handle(self, msg, conn, fn):
         """retry a function call within the context of exception_handler."""
+        def reopen_conn_on_error(error):
+            for type in REOPENABLE_ERRORS:
+                if isinstance(error, type):
+                    logger.warning('Reopening connection after {!r}', error)
+                    self.close(conn)
+                    self.open(conn)
+                    return
+
         with self.exception_handler(msg):
             return retry.retry_target(
                 target=fn,
                 predicate=_ErrorCounter(self.get_retries(conn)).count_error,
                 sleep_generator=self._retry_generator(),
-                deadline=None)
+                deadline=None,
+                on_error=reopen_conn_on_error)
 
     def _retry_generator(self):
         """Generates retry intervals that exponentially back off."""
@@ -425,5 +447,8 @@ class _ErrorCounter(object):
 
 
 def _is_retryable(error):
-    """Return true for 500 level (retryable) errors."""
-    return isinstance(error, google.cloud.exceptions.ServerError)
+    """Return true for errors that are unlikely to occur again if retried."""
+    for error_type in RETRYABLE_ERRORS:
+        if isinstance(error, error_type):
+            return True
+    return False


### PR DESCRIPTION
resolves #1579

### Description

This is a follow-up to #1963 which I've been sitting on for a while, which adds a few more errors to the class of retryable errors in BigQuery, and re-opens a connection for some that involve a broken connection. Would love to get this out of our local patches :) 

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.