### PR TITLE
bump requirements, enable the token cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `adapter_macro` is no longer a macro, instead it is a builtin context method. Any custom macros that intercepted it by going through `context['dbt']` will need to instead access it via `context['builtins']` ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2673](https://github.com/fishtown-analytics/dbt/pull/2673))
 - `adapter_macro` is now deprecated. Use `adapter.dispatch` instead.
 
+
+### Under the hood
+- Upgraded snowflake-connector-python dependency to 2.2.10 and enabled the SSO token cache ([#2613](https://github.com/fishtown-analytics/dbt/issues/2613), [#2689](https://github.com/fishtown-analytics/dbt/issues/2689), [#2698](https://github.com/fishtown-analytics/dbt/pull/2698))
+
 ### Features
 - Added a `dispatch` method to the context adapter and deprecated `adapter_macro`. ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2679](https://github.com/fishtown-analytics/dbt/pull/2679))
 - The built-in schema tests now use `adapter.dispatch`, so they can be overridden for adapter plugins ([#2415](https://github.com/fishtown-analytics/dbt/issues/2415), [#2684](https://github.com/fishtown-analytics/dbt/pull/2684))

--- a/core/setup.py
+++ b/core/setup.py
@@ -68,9 +68,9 @@ setup(
         'logbook>=1.5,<1.6',
         'typing-extensions>=3.7.4,<3.8',
         # the following are all to match snowflake-connector-python
-        'requests>=2.18.0,<2.23.0',
-        'idna<2.9',
-        'cffi>=1.9,<1.14',
+        'requests>=2.18.0,<2.24.0',
+        'idna<2.10',
+        'cffi>=1.9,<1.15',
     ],
     zip_safe=False,
     classifiers=[

--- a/plugins/snowflake/dbt/adapters/snowflake/connections.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/connections.py
@@ -88,6 +88,8 @@ class SnowflakeCredentials(Credentials):
                     )
 
                 result['token'] = token
+            # enable the token cache
+            result['client_store_temporary_credential'] = True
         result['private_key'] = self._get_private_key()
         return result
 

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -41,9 +41,9 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'snowflake-connector-python==2.2.1',
+        'snowflake-connector-python==2.2.10',
         'azure-common<2.0.0',
-        'azure-storage-blob<12.0.0',
+        'azure-storage-blob>=12.0.0,<13.0.0',
         'urllib3>=1.20,<1.26.0',
         # this seems sufficiently broad
         'cryptography>=2,<3',

--- a/test/unit/test_snowflake_adapter.py
+++ b/test/unit/test_snowflake_adapter.py
@@ -302,7 +302,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse',
                 authenticator='test_sso_url', private_key=None,
-                application='dbt')
+                application='dbt', client_store_temporary_credential=True)
         ])
 
     def test_authenticator_externalbrowser_authentication(self):
@@ -320,7 +320,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='externalbrowser',
-                private_key=None, application='dbt')
+                private_key=None, application='dbt', client_store_temporary_credential=True)
         ])
 
     def test_authenticator_oauth_authentication(self):
@@ -339,7 +339,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='oauth', token='my-oauth-token',
-                private_key=None, application='dbt')
+                private_key=None, application='dbt', client_store_temporary_credential=True)
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')


### PR DESCRIPTION
resolves #2613 
resolves #2689 


### Description
Upgrade the snowflake-connector-python library and enable the token cache. We don't have a good way to test this currently, I think we'd need to set up a headless browser (I have no idea what the state of the art there is, I assume they still exist and it's not still selenium).

I did update the unit tests, but they won't save us if the library changes, so when we upgrade it we'll want to test this manually again.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
