### PR TITLE
patch redshift table size estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@
 - Added a `dispatch` method to the context adapter and deprecated `adapter_macro`. ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2679](https://github.com/fishtown-analytics/dbt/pull/2679))
 - The built-in schema tests now use `adapter.dispatch`, so they can be overridden for adapter plugins ([#2415](https://github.com/fishtown-analytics/dbt/issues/2415), [#2684](https://github.com/fishtown-analytics/dbt/pull/2684))
 
+### Fixes
+- Fix Redshift table size estimation; e.g. 44 GB tables are no longer reported as 44 KB. [#2702](https://github.com/fishtown-analytics/dbt/issues/2702)
+
 Contributors:
 - [@bbhoss](https://github.com/bbhoss) ([#2677](https://github.com/fishtown-analytics/dbt/pull/2677))
 - [@kconvey](https://github.com/kconvey) ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694))
+- [@vogt4nick](https://github.com/vogt4nick) ([#2702](https://github.com/fishtown-analytics/dbt/issues/2702))
 
 ## dbt 0.18.0b2 (July 30, 2020)
 

--- a/plugins/redshift/dbt/include/redshift/macros/catalog.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/catalog.sql
@@ -147,7 +147,7 @@
         (sortkey_num > 0) as "stats:sortkey_num:include",
 
         'Approximate Size' as "stats:size:label",
-        size / 1000000.0 as "stats:size:value",
+        size * 1000000 as "stats:size:value",
         'Approximate size of the table, calculated from a count of 1MB blocks'::text as "stats:size:description",
         true as "stats:size:include",
 


### PR DESCRIPTION
resolves #2702

### Description

Root cause of #2702 seems to be size in MB is passed to `format_bytes` which expects amount in bytes. This PR estimates Redshift table size in bytes.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
