### PR TITLE
Feature/defer tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add support for impersonating a service account using `impersonate_service_account` in the BigQuery profile configuration ([#2677](https://github.com/fishtown-analytics/dbt/issues/2677)) ([docs](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation))
 - Macros in the current project can override internal dbt macros that are called through `execute_macros`. ([#2301](https://github.com/fishtown-analytics/dbt/issues/2301), [#2686](https://github.com/fishtown-analytics/dbt/pull/2686))
 - Add state:modified and state:new selectors ([#2641](https://github.com/fishtown-analytics/dbt/issues/2641), [#2695](https://github.com/fishtown-analytics/dbt/pull/2695))
+- Added `--defer` flag for `dbt test` as well. ([#2701](https://github.com/fishtown-analytics/dbt/issues/2701), [#2706](https://github.com/fishtown-analytics/dbt/pull/2706))
 
 Contributors:
 - [@bbhoss](https://github.com/bbhoss) ([#2677](https://github.com/fishtown-analytics/dbt/pull/2677))

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -444,6 +444,21 @@ def _build_snapshot_subparser(subparsers, base_subparser):
     return sub
 
 
+def _add_defer_argument(*subparsers):
+    for sub in subparsers:
+        sub.add_optional_argument_inverse(
+            '--defer',
+            enable_help='''
+            If set, defer to the state variable for resolving unselected nodes.
+            ''',
+            disable_help='''
+            If set, do not defer to the state variable for resolving unselected
+            nodes.
+            ''',
+            default=flags.DEFER_MODE,
+        )
+
+
 def _build_run_subparser(subparsers, base_subparser):
     run_sub = subparsers.add_parser(
         'run',
@@ -459,19 +474,6 @@ def _build_run_subparser(subparsers, base_subparser):
         help='''
         Stop execution upon a first failure.
         '''
-    )
-
-    # this is a "dbt run"-only thing, for now
-    run_sub.add_optional_argument_inverse(
-        '--defer',
-        enable_help='''
-        If set, defer to the state variable for resolving unselected nodes.
-        ''',
-        disable_help='''
-        If set, do not defer to the state variable for resolving unselected
-        nodes.
-        ''',
-        default=flags.DEFER_MODE,
     )
 
     run_sub.set_defaults(cls=run_task.RunTask, which='run', rpc_method='run')
@@ -987,6 +989,8 @@ def parse_args(args, cls=DBTArgumentParser):
     # list_sub sets up its own arguments.
     _add_selection_arguments(run_sub, compile_sub, generate_sub, test_sub)
     _add_selection_arguments(snapshot_sub, seed_sub, models_name='select')
+    # --defer
+    _add_defer_argument(run_sub, test_sub)
     # --full-refresh
     _add_table_mutability_arguments(run_sub, compile_sub)
 

--- a/core/dbt/task/seed.py
+++ b/core/dbt/task/seed.py
@@ -37,6 +37,10 @@ class SeedRunner(ModelRunner):
 
 
 class SeedTask(RunTask):
+    def defer_to_manifest(self, selected_uids):
+        # seeds don't defer
+        return
+
     def raise_on_first_error(self):
         return False
 

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -22,6 +22,10 @@ class SnapshotTask(RunTask):
     def raise_on_first_error(self):
         return False
 
+    def defer_to_manifest(self, selected_uids):
+        # snapshots don't defer
+        return
+
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:
             raise InternalException(


### PR DESCRIPTION
resolves #2701 


### Description
Support deferred tests. 

I also prevented --defer from doing anything on snapshots/seeds more explicitly. I think the CLI argument will default to not being set regardless of the environment variable, but it's even easier to be sure if we just disable that code path entirely for snapshots and seeds.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
