### PR TITLE
Track deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Under the hood
 - Upgraded snowflake-connector-python dependency to 2.2.10 and enabled the SSO token cache ([#2613](https://github.com/fishtown-analytics/dbt/issues/2613), [#2689](https://github.com/fishtown-analytics/dbt/issues/2689), [#2698](https://github.com/fishtown-analytics/dbt/pull/2698))
+- Add deprecation warnings to anonymous usage tracking ([#2688](https://github.com/fishtown-analytics/dbt/issues/2688), [#2710](https://github.com/fishtown-analytics/dbt/issues/2710))
 
 ### Features
 - Add better retry support when using the BigQuery adapter ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694), follow-up to [#1963](https://github.com/fishtown-analytics/dbt/pull/1963))

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -3,6 +3,8 @@ from typing import Optional, Set, List, Dict, ClassVar
 import dbt.exceptions
 from dbt import ui
 
+import dbt.tracking
+
 
 class DBTDeprecation:
     _name: ClassVar[Optional[str]] = None

--- a/core/dbt/deprecations.py
+++ b/core/dbt/deprecations.py
@@ -16,6 +16,11 @@ class DBTDeprecation:
             'name not implemented for {}'.format(self)
         )
 
+    def track_deprecation_warn(self) -> None:
+        dbt.tracking.track_deprecation_warn({
+            "deprecation_name": self.name
+        })
+
     @property
     def description(self) -> str:
         if self._description is not None:
@@ -31,6 +36,7 @@ class DBTDeprecation:
                 desc, prefix='* Deprecation Warning: '
             )
             dbt.exceptions.warn_or_error(msg)
+            self.track_deprecation_warn()
             active_deprecations.add(self.name)
 
 

--- a/core/dbt/tracking.py
+++ b/core/dbt/tracking.py
@@ -26,6 +26,7 @@ RUN_MODEL_SPEC = 'iglu:com.dbt/run_model/jsonschema/1-0-1'
 INVOCATION_ENV_SPEC = 'iglu:com.dbt/invocation_env/jsonschema/1-0-0'
 PACKAGE_INSTALL_SPEC = 'iglu:com.dbt/package_install/jsonschema/1-0-0'
 RPC_REQUEST_SPEC = 'iglu:com.dbt/rpc_request/jsonschema/1-0-1'
+DEPRECATION_WARN_SPEC = 'iglu:com.dbt/deprecation_warn/jsonschema/1-0-0'
 
 DBT_INVOCATION_ENV = 'DBT_INVOCATION_ENV'
 
@@ -317,6 +318,25 @@ def track_package_install(config, args, options):
         action='package',
         label=active_user.invocation_id,
         property_='install',
+        context=context
+    )
+
+
+def track_deprecation_warn(options):
+
+    assert active_user is not None, \
+        'Cannot track deprecation warnings when active user is None'
+
+    context = [
+        SelfDescribingJson(DEPRECATION_WARN_SPEC, options)
+    ]
+
+    track(
+        active_user,
+        category="dbt",
+        action='deprecation',
+        label=active_user.invocation_id,
+        property_='warn',
         context=context
     )
 


### PR DESCRIPTION
resolves #2688 

### Description

* Fire one event per distinct deprecation per invocation
* For now, we're just tracking the deprecation name, it's easy to add more later

### Validation

In the warehouse:

SE_CATEGORY | SE_ACTION | SE_LABEL | SE_PROPERTY | CONTEXTS | COLLECTOR_TSTAMP
-- | -- | -- | -- | -- | --
dbt | deprecation | f8fdf25e-82ff-4769-963e-15727b3c51b1 | warn | {"data": [{"data": {"deprecation_name": "dbt-project-yaml-v1"},"schema": "iglu:com.dbt/deprecation_warn/jsonschema/1-0-0"}],"schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1"} | 2020-08-17 20:15:05
dbt | deprecation | f8fdf25e-82ff-4769-963e-15727b3c51b1 | warn | {"data": [{"data": {"deprecation_name": "models-key-mismatch"},"schema": "iglu:com.dbt/deprecation_warn/jsonschema/1-0-0"}],"schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1"} | 2020-08-17 20:15:05

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - ~This PR includes tests, or tests are not required/relevant for this PR~ I don't think we need a test, but let me know if you disagree!
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
