### PR TITLE
Feature: adapter cte generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ### Breaking changes
 - `adapter_macro` is no longer a macro, instead it is a builtin context method. Any custom macros that intercepted it by going through `context['dbt']` will need to instead access it via `context['builtins']` ([#2302](https://github.com/fishtown-analytics/dbt/issues/2302), [#2673](https://github.com/fishtown-analytics/dbt/pull/2673))
 - `adapter_macro` is now deprecated. Use `adapter.dispatch` instead.
+- Data tests are now written as CTEs instead of subqueries. Adapter plugins for adapters that don't support CTEs may require modification. ([#2712](https://github.com/fishtown-analytics/dbt/pull/2712))
 
 
 ### Under the hood
 - Upgraded snowflake-connector-python dependency to 2.2.10 and enabled the SSO token cache ([#2613](https://github.com/fishtown-analytics/dbt/issues/2613), [#2689](https://github.com/fishtown-analytics/dbt/issues/2689), [#2698](https://github.com/fishtown-analytics/dbt/pull/2698))
 - Add deprecation warnings to anonymous usage tracking ([#2688](https://github.com/fishtown-analytics/dbt/issues/2688), [#2710](https://github.com/fishtown-analytics/dbt/issues/2710))
+- Data tests now behave like dbt CTEs ([#2609](https://github.com/fishtown-analytics/dbt/issues/2609), [#2712](https://github.com/fishtown-analytics/dbt/pull/2712))
+- Adapter plugins can now override the CTE prefix by overriding their `Relation` attribute with a class that has a custom `add_ephemeral_prefix` implementation. ([#2660](https://github.com/fishtown-analytics/dbt/issues/2660), [#2712](https://github.com/fishtown-analytics/dbt/pull/2712))
 
 ### Features
 - Add better retry support when using the BigQuery adapter ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694), follow-up to [#1963](https://github.com/fishtown-analytics/dbt/pull/1963))
@@ -16,6 +19,7 @@
 - Add support for impersonating a service account using `impersonate_service_account` in the BigQuery profile configuration ([#2677](https://github.com/fishtown-analytics/dbt/issues/2677)) ([docs](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#service-account-impersonation))
 - Macros in the current project can override internal dbt macros that are called through `execute_macros`. ([#2301](https://github.com/fishtown-analytics/dbt/issues/2301), [#2686](https://github.com/fishtown-analytics/dbt/pull/2686))
 - Add state:modified and state:new selectors ([#2641](https://github.com/fishtown-analytics/dbt/issues/2641), [#2695](https://github.com/fishtown-analytics/dbt/pull/2695))
+
 
 ### Fixes
 - Fix Redshift table size estimation; e.g. 44 GB tables are no longer reported as 44 KB. [#2702](https://github.com/fishtown-analytics/dbt/issues/2702)

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -25,7 +25,9 @@ from dbt.adapters.protocol import (
 )
 from dbt.clients.agate_helper import empty_table, merge_tables, table_from_rows
 from dbt.clients.jinja import MacroGenerator
-from dbt.contracts.graph.compiled import CompileResultNode, CompiledSeedNode
+from dbt.contracts.graph.compiled import (
+    CompileResultNode, CompiledSeedNode
+)
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.parsed import ParsedSeedNode
 from dbt.exceptions import warn_or_error
@@ -289,7 +291,10 @@ class BaseAdapter(metaclass=AdapterMeta):
         return {
             self.Relation.create_from(self.config, node).without_identifier()
             for node in manifest.nodes.values()
-            if node.resource_type in NodeType.executable()
+            if (
+                node.resource_type in NodeType.executable() and
+                not node.is_ephemeral_model
+            )
         }
 
     def _get_catalog_schemas(self, manifest: Manifest) -> SchemaSearchMap:
@@ -1141,6 +1146,10 @@ class BaseAdapter(metaclass=AdapterMeta):
         )
 
         return sql
+
+    def get_compiler(self):
+        from dbt.compilation import Compiler
+        return Compiler(self.config)
 
 
 COLUMNS_EQUAL_SQL = '''

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -201,6 +201,23 @@ class BaseRelation(FakeAPIObject, Hashable):
             **kwargs
         )
 
+    @staticmethod
+    def add_ephemeral_prefix(name: str):
+        return f'__dbt__CTE__{name}'
+
+    @classmethod
+    def create_ephemeral_from_node(
+        cls: Type[Self],
+        config: HasQuoting,
+        node: Union[ParsedNode, CompiledNode],
+    ) -> Self:
+        # Note that ephemeral models are based on the name.
+        identifier = cls.add_ephemeral_prefix(node.name)
+        return cls.create(
+            type=cls.CTE,
+            identifier=identifier,
+        ).quote(identifier=False)
+
     @classmethod
     def create_from_node(
         cls: Type[Self],

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -318,7 +318,7 @@ class Compiler:
 
         return Graph(linker.graph)
 
-    def _write_node(self, node: NonSourceNode) -> NonSourceNode:
+    def _write_node(self, node: NonSourceCompiledNode) -> NonSourceNode:
         if not _is_writable(node):
             return node
         logger.debug(f'Writing injected SQL for node "{node.unique_id}"')

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -105,39 +105,39 @@ class Var:
         cli_vars: Mapping[str, Any],
         node: Optional[CompiledResource] = None
     ) -> None:
-        self.context: Mapping[str, Any] = context
-        self.cli_vars: Mapping[str, Any] = cli_vars
-        self.node: Optional[CompiledResource] = node
-        self.merged: Mapping[str, Any] = self._generate_merged()
+        self._context: Mapping[str, Any] = context
+        self._cli_vars: Mapping[str, Any] = cli_vars
+        self._node: Optional[CompiledResource] = node
+        self._merged: Mapping[str, Any] = self._generate_merged()
 
     def _generate_merged(self) -> Mapping[str, Any]:
-        return self.cli_vars
+        return self._cli_vars
 
     @property
     def node_name(self):
-        if self.node is not None:
-            return self.node.name
+        if self._node is not None:
+            return self._node.name
         else:
             return '<Configuration>'
 
     def get_missing_var(self, var_name):
-        dct = {k: self.merged[k] for k in self.merged}
+        dct = {k: self._merged[k] for k in self._merged}
         pretty_vars = json.dumps(dct, sort_keys=True, indent=4)
         msg = self.UndefinedVarError.format(
             var_name, self.node_name, pretty_vars
         )
-        raise_compiler_error(msg, self.node)
+        raise_compiler_error(msg, self._node)
 
     def has_var(self, var_name: str):
-        return var_name in self.merged
+        return var_name in self._merged
 
     def get_rendered_var(self, var_name):
-        raw = self.merged[var_name]
+        raw = self._merged[var_name]
         # if bool/int/float/etc are passed in, don't compile anything
         if not isinstance(raw, str):
             return raw
 
-        return get_rendered(raw, self.context)
+        return get_rendered(raw, self._context)
 
     def __call__(self, var_name, default=_VAR_NOTSET):
         if self.has_var(var_name):

--- a/core/dbt/context/configured.py
+++ b/core/dbt/context/configured.py
@@ -36,23 +36,23 @@ class ConfiguredVar(Var):
         project_name: str,
     ):
         super().__init__(context, config.cli_vars)
-        self.config = config
-        self.project_name = project_name
+        self._config = config
+        self._project_name = project_name
 
     def __call__(self, var_name, default=Var._VAR_NOTSET):
-        my_config = self.config.load_dependencies()[self.project_name]
+        my_config = self._config.load_dependencies()[self._project_name]
 
         # cli vars > active project > local project
-        if var_name in self.config.cli_vars:
-            return self.config.cli_vars[var_name]
+        if var_name in self._config.cli_vars:
+            return self._config.cli_vars[var_name]
 
-        if self.config.config_version == 2 and my_config.config_version == 2:
-            adapter_type = self.config.credentials.type
-            lookup = FQNLookup(self.project_name)
-            active_vars = self.config.vars.vars_for(lookup, adapter_type)
+        if self._config.config_version == 2 and my_config.config_version == 2:
+            adapter_type = self._config.credentials.type
+            lookup = FQNLookup(self._project_name)
+            active_vars = self._config.vars.vars_for(lookup, adapter_type)
             all_vars = MultiDict([active_vars])
 
-            if self.config.project_name != my_config.project_name:
+            if self._config.project_name != my_config.project_name:
                 all_vars.add(my_config.vars.vars_for(lookup, adapter_type))
 
             if var_name in all_vars:

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -523,37 +523,37 @@ class ModelConfiguredVar(Var):
         config: RuntimeConfig,
         node: CompiledResource,
     ) -> None:
-        self.node: CompiledResource
-        self.config: RuntimeConfig = config
+        self._node: CompiledResource
+        self._config: RuntimeConfig = config
         super().__init__(context, config.cli_vars, node=node)
 
     def packages_for_node(self) -> Iterable[Project]:
-        dependencies = self.config.load_dependencies()
-        package_name = self.node.package_name
+        dependencies = self._config.load_dependencies()
+        package_name = self._node.package_name
 
-        if package_name != self.config.project_name:
+        if package_name != self._config.project_name:
             if package_name not in dependencies:
                 # I don't think this is actually reachable
                 raise_compiler_error(
                     f'Node package named {package_name} not found!',
-                    self.node
+                    self._node
                 )
             yield dependencies[package_name]
-        yield self.config
+        yield self._config
 
     def _generate_merged(self) -> Mapping[str, Any]:
         search_node: IsFQNResource
-        if isinstance(self.node, IsFQNResource):
-            search_node = self.node
+        if isinstance(self._node, IsFQNResource):
+            search_node = self._node
         else:
-            search_node = FQNLookup(self.node.package_name)
+            search_node = FQNLookup(self._node.package_name)
 
-        adapter_type = self.config.credentials.type
+        adapter_type = self._config.credentials.type
 
         merged = MultiDict()
         for project in self.packages_for_node():
             merged.add(project.vars.vars_for(search_node, adapter_type))
-        merged.add(self.cli_vars)
+        merged.add(self._cli_vars)
         return merged
 
 

--- a/core/dbt/rpc/node_runners.py
+++ b/core/dbt/rpc/node_runners.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from typing import Generic, TypeVar
 
 import dbt.exceptions
-from dbt.compilation import compile_node
 from dbt.contracts.rpc import (
     RemoteCompileResult, RemoteRunResult, ResultTable,
 )
@@ -38,8 +37,8 @@ class GenericRPCRunner(CompileRunner, Generic[RPCSQLResult]):
         pass
 
     def compile(self, manifest):
-        return compile_node(self.adapter, self.config, self.node, manifest, {},
-                            write=False)
+        compiler = self.adapter.get_compiler()
+        return compiler.compile_node(self.node, manifest, {}, write=False)
 
     @abstractmethod
     def execute(self, compiled_node, manifest) -> RPCSQLResult:

--- a/core/dbt/task/compile.py
+++ b/core/dbt/task/compile.py
@@ -1,7 +1,6 @@
 from .runnable import GraphRunnableTask
 from .base import BaseRunner
 
-from dbt.compilation import compile_node
 from dbt.contracts.results import RunModelResult
 from dbt.exceptions import InternalException
 from dbt.graph import ResourceTypeSelector, SelectionSpec, parse_difference
@@ -20,7 +19,8 @@ class CompileRunner(BaseRunner):
         return RunModelResult(compiled_node)
 
     def compile(self, manifest):
-        return compile_node(self.adapter, self.config, self.node, manifest, {})
+        compiler = self.adapter.get_compiler()
+        return compiler.compile_node(self.node, manifest, {})
 
 
 class CompileTask(GraphRunnableTask):

--- a/core/dbt/task/rpc/sql_commands.py
+++ b/core/dbt/task/rpc/sql_commands.py
@@ -7,7 +7,6 @@ from typing import Dict, Any
 from dbt import flags
 from dbt.adapters.factory import get_adapter
 from dbt.clients.jinja import extract_toplevel_blocks
-from dbt.compilation import compile_manifest
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.graph.parsed import ParsedRPCNode
@@ -129,7 +128,9 @@ class RemoteRunSQLTask(RPCTask[RPCExecParameters]):
         )
 
         # don't write our new, weird manifest!
-        self.graph = compile_manifest(self.config, self.manifest, write=False)
+        adapter = get_adapter(self.config)
+        compiler = adapter.get_compiler()
+        self.graph = compiler.compile(self.manifest, write=False)
         # previously, this compiled the ancestors, but they are compiled at
         # runtime now.
         return rpc_node

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -18,7 +18,6 @@ from dbt import tracking
 from dbt import utils
 from dbt.adapters.base import BaseRelation
 from dbt.clients.jinja import MacroGenerator
-from dbt.compilation import compile_node
 from dbt.context.providers import generate_runtime_model
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import WritableManifest
@@ -254,8 +253,8 @@ class RunTask(CompileTask):
         return False
 
     def get_hook_sql(self, adapter, hook, idx, num_hooks, extra_context):
-        compiled = compile_node(adapter, self.config, hook, self.manifest,
-                                extra_context)
+        compiler = adapter.get_compiler()
+        compiled = compiler.compile_node(hook, self.manifest, extra_context)
         statement = compiled.injected_sql
         hook_index = hook.index or num_hooks
         hook_obj = get_hook(statement, index=hook_index)

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -26,7 +26,6 @@ from dbt.logger import (
     NodeCount,
     print_timestamped_line,
 )
-from dbt.compilation import compile_manifest
 
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
@@ -71,7 +70,9 @@ class ManifestTask(ConfiguredTask):
             raise InternalException(
                 'compile_manifest called before manifest was loaded'
             )
-        self.graph = compile_manifest(self.config, self.manifest)
+        adapter = get_adapter(self.config)
+        compiler = adapter.get_compiler()
+        self.graph = compiler.compile(self.manifest)
 
     def _runtime_initialize(self):
         self.load_manifest()

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -41,10 +41,12 @@ class TestRunner(CompileRunner):
         print_start_line(description, self.node_index, self.num_nodes)
 
     def execute_data_test(self, test: CompiledDataTestNode):
-        sql = (
-            f'select count(*) as errors from (\n{test.injected_sql}\n) sbq'
+        # sql = (
+        #     f'select count(*) as errors from (\n{test.injected_sql}\n) sbq'
+        # )
+        res, table = self.adapter.execute(
+            test.injected_sql, auto_begin=True, fetch=True
         )
-        res, table = self.adapter.execute(sql, auto_begin=True, fetch=True)
 
         num_rows = len(table.rows)
         if num_rows != 1:

--- a/core/dbt/task/test.py
+++ b/core/dbt/task/test.py
@@ -41,9 +41,6 @@ class TestRunner(CompileRunner):
         print_start_line(description, self.node_index, self.num_nodes)
 
     def execute_data_test(self, test: CompiledDataTestNode):
-        # sql = (
-        #     f'select count(*) as errors from (\n{test.injected_sql}\n) sbq'
-        # )
         res, table = self.adapter.execute(
             test.injected_sql, auto_begin=True, fetch=True
         )

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -367,7 +367,6 @@ def get_include_paths():
 def config():
     return config_from_parts_or_dicts(PROJECT_DATA, PROFILE_DATA)
 
-
 @pytest.fixture
 def manifest_fx(config):
     return mock_manifest(config)

--- a/test/unit/test_postgres_adapter.py
+++ b/test/unit/test_postgres_adapter.py
@@ -16,7 +16,7 @@ from dbt.parser.results import ParseResult
 from psycopg2 import extensions as psycopg2_extensions
 from psycopg2 import DatabaseError
 
-from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection, TestAdapterConversions, load_internal_manifest_macros
+from .utils import config_from_parts_or_dicts, inject_adapter, mock_connection, TestAdapterConversions, load_internal_manifest_macros, clear_plugin
 
 
 class TestPostgresAdapter(unittest.TestCase):
@@ -297,6 +297,7 @@ class TestConnectingPostgresAdapter(unittest.TestCase):
         self.qh_patch.stop()
         self.patcher.stop()
         self.load_patch.stop()
+        clear_plugin(PostgresPlugin)
 
     def test_quoting_on_drop_schema(self):
         relation = self.adapter.Relation.create(

--- a/test/unit/test_source_config.py
+++ b/test/unit/test_source_config.py
@@ -172,6 +172,6 @@ class LegacyContextConfigTest(TestCase):
         model = mock.MagicMock(resource_type=NodeType.Model, fqn=['root', 'x'], project_name='root')
 
         with self.assertRaises(dbt.exceptions.CompilationException) as exc:
-            cfg.updater.get_project_config(model, self.root_project_config)
+            cfg._updater.get_project_config(model, self.root_project_config)
 
         self.assertIn('must be a dict', str(exc.exception))

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -112,6 +112,14 @@ def inject_plugin(plugin):
     FACTORY.plugins[key] = plugin
 
 
+def inject_plugin_for(config):
+    # from dbt.adapters.postgres import Plugin, PostgresAdapter
+    from dbt.adapters.factory import FACTORY
+    FACTORY.load_plugin(config.credentials.type)
+    adapter = FACTORY.get_adapter(config)
+    return adapter
+
+
 def inject_adapter(value, plugin):
     """Inject the given adapter into the adapter factory, so your hand-crafted
     artisanal adapter will be available from get_adapter() as if dbt loaded it.

--- a/third-party-stubs/sqlparse/__init__.pyi
+++ b/third-party-stubs/sqlparse/__init__.pyi
@@ -1,0 +1,7 @@
+from typing import Tuple
+from . import sql
+from . import tokens
+
+
+def parse(sql: str) -> Tuple[sql.Statement]:
+    ...

--- a/third-party-stubs/sqlparse/sql.pyi
+++ b/third-party-stubs/sqlparse/sql.pyi
@@ -1,0 +1,32 @@
+from typing import Tuple, Iterable
+
+
+class Token:
+    def __init__(self, ttype, value):
+        ...
+
+    is_keyword: bool
+    normalized: str
+
+
+class TokenList(Token):
+    tokens: Tuple[Token]
+
+    def __getitem__(self, key) -> Token:
+        ...
+
+    def __iter__(self) -> Iterable[Token]:
+        ...
+
+    def insert_before(self, where, token, skip_ws=True):
+        ...
+
+    def insert_after(self, where, token, skip_ws=True):
+        ...
+
+    def token_first(self) -> Token:
+        ...
+
+
+class Statement(TokenList):
+    ...

--- a/third-party-stubs/sqlparse/tokens.pyi
+++ b/third-party-stubs/sqlparse/tokens.pyi
@@ -1,0 +1,6 @@
+
+class _TokenType(tuple):
+    ...
+
+Keyword: _TokenType = _TokenType()
+Punctuation: _TokenType = _TokenType()


### PR DESCRIPTION
resolves #2660 (well, makes it feasible)
resolves #2609 


### Description
This PR makes it possible for the exasol plugin (or any others) to override their `Relation` class with one that has a custom `add_ephemeral_prefix` method. For the basic case, this should solve cte-naming issues.

The adapter class is further modified: It now provides a `get_compiler` method that returns a `Compiler` instance, so plugins can provide plugin-specific compilation changes.

In particular, it should now be possible to override how dbt creates ephemeral models. No promises, of course, but this should make it feasible for adapters that support subqueries but not CTEs to make their own "ephemeral" models. This is definitely left as an exercise to the plugin author, but overriding the handy `_insert_ctes` method should help. Note that `_insert_ctes` also does special work for making data tests work, so authors will need to re-implement that. Which is because...

This PR also makes data tests behave _much_ more like CTEs. Instead of performing a subquery, dbt inserts a custom CTE at the end of the CTE chain that includes the test body, and then the final select clause is a `select count(*) from` the CTE. Adapters that need to override CTE generation will need to do this as well, but I think that's ok. My understanding is that this will make #2609  work as it should out of the box.

Most adapters should not need to change anything. Any adapters that don't support CTEs but do support subqueries might break here. We should be able tof come up with a backwards-compatibility behavior here if we need to, and make only our adapters use this behavior.

Finally, while I was working on this I found that we were not properly excluding some things from the sandbox. This isn't a huge deal, but as a matter of hygiene we should be prefixing more attributes of objects in the context with `_` so jinja won't allow access.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
