### PR TITLE
When column config says quote, use quotes in SQL to add comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt 0.18.1 (Release TBD)
+
+### Under the hood
+- If column config says quote, use quoting in SQL for adding a comment. ([#2539](https://github.com/fishtown-analytics/dbt/issues/2539), [#2733](https://github.com/fishtown-analytics/dbt/pull/2733))
+
 ## dbt 0.18.0 (September 03, 2020)
 
 ## dbt 0.18.0rc2 (September 03, 2020)
@@ -7,7 +12,7 @@
 ### Under the hood
 - Added 3 more adapter methods that the new dbt-adapter-test suite can use for testing. ([#2492](https://github.com/fishtown-analytics/dbt/issues/2492), [#2721](https://github.com/fishtown-analytics/dbt/pull/2721))
 - It is now an error to attempt installing `dbt` with a Python version less than 3.6. (resolves [#2347](https://github.com/fishtown-analytics/dbt/issues/2347))
-- Check for Postgres relation names longer than 63 and throw exception. ([#2197](https://github.com/fishtown-analytics/dbt/issues/2197))
+- Check for Postgres relation names longer than 63 and throw exception. ([#2197](https://github.com/fishtown-analytics/dbt/issues/2197), [#2727](https://github.com/fishtown-analytics/dbt/pull/2727))
 
 
 ### Fixes

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -57,6 +57,7 @@ class ColumnInfo(
     description: str = ''
     meta: Dict[str, Any] = field(default_factory=dict)
     data_type: Optional[str] = None
+    quote: Optional[bool] = None
     tags: List[str] = field(default_factory=list)
     _extra: Dict[str, Any] = field(default_factory=dict)
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -95,12 +95,18 @@ class ParserRef:
     ):
         tags: List[str] = []
         tags.extend(getattr(column, 'tags', ()))
+        quote: Optional[bool]
+        if isinstance(column, UnparsedColumn):
+            quote = column.quote
+        else:
+            quote = None
         self.column_info[column.name] = ColumnInfo(
             name=column.name,
             description=description,
             data_type=data_type,
             meta=meta,
             tags=tags,
+            quote=quote,
             _extra=column.extra
         )
 

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -155,6 +155,6 @@
   {% for column_name in column_dict %}
     {% set comment = column_dict[column_name]['description'] %}
     {% set escaped_comment = postgres_escape_comment(comment) %}
-    comment on column {{ relation }}.{{ column_name }} is {{ escaped_comment }};
+    comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};
   {% endfor %}
 {% endmacro %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql
@@ -157,7 +157,7 @@
 {% macro snowflake__alter_column_comment(relation, column_dict) -%}
     alter {{ relation.type }} {{ relation }} alter
     {% for column_name in column_dict %}
-        {{ column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$ {{ ',' if not loop.last else ';' }}
+        {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$ {{ ',' if not loop.last else ';' }}
     {% endfor %}
 {% endmacro %}
 

--- a/plugins/snowflake/dbt/include/snowflake/macros/catalog.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/catalog.sql
@@ -7,6 +7,7 @@
               table_schema as "table_schema",
               table_name as "table_name",
               table_type as "table_type",
+              comment as "table_comment",
 
               -- note: this is the _role_ that owns the table
               table_owner as "table_owner",
@@ -36,12 +37,11 @@
               table_catalog as "table_database",
               table_schema as "table_schema",
               table_name as "table_name",
-              null as "table_comment",
 
               column_name as "column_name",
               ordinal_position as "column_index",
               data_type as "column_type",
-              null as "column_comment"
+              comment as "column_comment"
 
           from {{ information_schema }}.columns
       )

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -980,6 +980,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -987,6 +988,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -994,6 +996,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -1001,6 +1004,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -1008,6 +1012,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1048,6 +1053,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -1055,6 +1061,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -1062,6 +1069,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -1069,6 +1077,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -1076,6 +1085,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1135,6 +1145,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -1142,6 +1153,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -1149,6 +1161,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -1156,6 +1169,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -1163,6 +1177,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1459,6 +1474,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ct': {
@@ -1466,6 +1482,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ct',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1528,6 +1545,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ct': {
@@ -1535,6 +1553,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ct',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1596,6 +1615,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -1603,6 +1623,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -1610,6 +1631,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -1617,6 +1639,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -1624,6 +1647,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1679,6 +1703,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         }
                     },
@@ -1906,6 +1931,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'email',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -1913,6 +1939,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'id': {
@@ -1920,6 +1947,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -1927,6 +1955,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ip_address',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -1934,6 +1963,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'updated_at',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -1990,6 +2020,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'email',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -1997,6 +2028,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'id': {
@@ -2004,6 +2036,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2011,6 +2044,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ip_address',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2018,6 +2052,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'updated_at',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -2075,6 +2110,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The first field',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'field_2': {
@@ -2082,6 +2118,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The second field',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'field_3': {
@@ -2089,6 +2126,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The third field',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'nested_field.field_4': {
@@ -2096,6 +2134,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The first nested field',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'nested_field.field_5': {
@@ -2103,6 +2142,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The second nested field',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -2211,6 +2251,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2218,6 +2259,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2225,6 +2267,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2232,6 +2275,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2239,6 +2283,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -2360,6 +2405,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2367,6 +2413,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2374,6 +2421,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2381,6 +2429,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2388,6 +2437,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -2445,6 +2495,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2452,6 +2503,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2459,6 +2511,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2466,6 +2519,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2473,6 +2527,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -2617,6 +2672,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2624,6 +2680,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2631,6 +2688,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'email',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2638,6 +2696,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ip_address',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2645,6 +2704,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'updated_at',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         }
                     },
@@ -2700,6 +2760,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2707,6 +2768,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2714,6 +2776,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'email',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2721,6 +2784,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ip_address',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2728,6 +2792,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'updated_at',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         }
                     },
@@ -2781,6 +2846,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'id',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -2788,6 +2854,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -2795,6 +2862,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'email',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -2802,6 +2870,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ip_address',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -2809,6 +2878,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'updated_at',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         }
                     },
@@ -3112,6 +3182,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ct': {
@@ -3119,6 +3190,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ct',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -3198,6 +3270,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'first_name',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ct': {
@@ -3205,6 +3278,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'name': 'ct',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },
@@ -3279,6 +3353,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': 'The user ID number',
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'first_name': {
@@ -3286,6 +3361,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's first name",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'email': {
@@ -3293,6 +3369,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's email",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'ip_address': {
@@ -3300,6 +3377,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The user's IP address",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                         'updated_at': {
@@ -3307,6 +3385,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'description': "The last time this user's email was updated",
                             'data_type': None,
                             'meta': {},
+                            'quote': None,
                             'tags': [],
                         },
                     },

--- a/test/integration/035_docs_blocks/test_docs_blocks.py
+++ b/test/integration/035_docs_blocks/test_docs_blocks.py
@@ -38,6 +38,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': 'The user ID number',
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['id']
@@ -48,6 +49,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': "The user's first name",
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['first_name']
@@ -59,6 +61,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': "The user's last name",
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['last_name']
@@ -86,6 +89,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': 'The user ID number with alternative text',
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['id']
@@ -96,6 +100,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': "The user's first name",
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['first_name']
@@ -107,6 +112,7 @@ class TestGoodDocsBlocks(DBTIntegrationTest):
                 'description': "The user's last name in this other file",
                 'data_type': None,
                 'meta': {},
+                'quote': None,
                 'tags': [],
             },
             model_data['columns']['last_name']

--- a/test/integration/060_persist_docs_tests/test_persist_docs.py
+++ b/test/integration/060_persist_docs_tests/test_persist_docs.py
@@ -99,6 +99,26 @@ class TestPersistDocs(BasePersistDocsTest):
     def test_redshift_comments(self):
         self.run_has_comments_pglike()
 
+    @use_profile('snowflake')
+    def test_snowflake_comments(self):
+        self.run_dbt()
+        self.run_dbt(['docs', 'generate'])
+        with open('target/catalog.json') as fp:
+            catalog_data = json.load(fp)
+        assert 'nodes' in catalog_data
+        assert len(catalog_data['nodes']) == 3
+        table_node = catalog_data['nodes']['model.test.table_model']
+        table_comment = table_node['metadata']['comment']
+        assert table_comment.startswith('Table model description')
+
+        table_id_comment = table_node['columns']['ID']['comment']
+        assert table_id_comment.startswith('id Column description')
+
+        table_name_comment = table_node['columns']['NAME']['comment']
+        assert table_name_comment.startswith(
+            'Some stuff here and then a call to')
+
+
 
 class TestPersistDocsLateBinding(BasePersistDocsTest):
     @property

--- a/test/integration/064_column_comments_tests/models/quote_model.sql
+++ b/test/integration/064_column_comments_tests/models/quote_model.sql
@@ -1,0 +1,1 @@
+select 1 as {{ adapter.quote("2id") }}

--- a/test/integration/064_column_comments_tests/models/schema.yml
+++ b/test/integration/064_column_comments_tests/models/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+models:
+  - name: quote_model
+    description: "model to test column quotes and comments" 
+    columns:
+      - name: 2id
+        description: "XXX My description"
+        quote: true
+

--- a/test/integration/064_column_comments_tests/test_column_comments.py
+++ b/test/integration/064_column_comments_tests/test_column_comments.py
@@ -1,0 +1,56 @@
+from test.integration.base import DBTIntegrationTest, use_profile
+import os
+
+import json
+
+
+class TestColumnComment(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "column_comment_060"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'models': {
+                'test': {
+                    'materialized': 'table',
+                    '+persist_docs': {
+                        "relation": True,
+                        "columns": True,
+                    },
+                }
+            }
+        }
+
+    def run_has_comments(self):
+        self.run_dbt()
+        self.run_dbt(['docs', 'generate'])
+        with open('target/catalog.json') as fp:
+            catalog_data = json.load(fp)
+        assert 'nodes' in catalog_data
+        assert len(catalog_data['nodes']) == 1
+        column_node = catalog_data['nodes']['model.test.quote_model']
+        column_comment = column_node['columns']['2id']['comment']
+        assert column_comment.startswith('XXX')
+
+
+    @use_profile('postgres')
+    def test_postgres_comments(self):
+        self.run_has_comments()
+
+    @use_profile('redshift')
+    def test_redshift_comments(self):
+        self.run_has_comments()
+
+    @use_profile('snowflake')
+    def test_snowflake_comments(self):
+        self.run_has_comments()
+
+
+


### PR DESCRIPTION
resolves #2539

### Description
When 'persist_docs' was turned on, an error occurred if a column had config 'quote: true' because the DDL to add the comment did not quote the column name. This fix passes the column quote config on to the ColumnInfo object and checks that config when constructing the SQL to add a comment.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
