### PR TITLE
Bump version: 0.18.0 → 0.19.0a1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0
+current_version = 0.19.0a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -96,5 +96,5 @@ def _get_dbt_plugins_info():
         yield plugin_name, mod.version
 
 
-__version__ = '0.18.0'
+__version__ = '0.19.0a1'
 installed = get_installed_version()

--- a/core/setup.py
+++ b/core/setup.py
@@ -24,7 +24,7 @@ def read(fname):
 
 
 package_name = "dbt-core"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """dbt (data build tool) is a command line tool that helps \
 analysts and engineers transform data in their warehouse more effectively"""
 

--- a/plugins/bigquery/dbt/adapters/bigquery/__version__.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = '0.18.0'
+version = '0.19.0a1'

--- a/plugins/bigquery/setup.py
+++ b/plugins/bigquery/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 package_name = "dbt-bigquery"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """The bigquery adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/postgres/dbt/adapters/postgres/__version__.py
+++ b/plugins/postgres/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = '0.18.0'
+version = '0.19.0a1'

--- a/plugins/postgres/setup.py
+++ b/plugins/postgres/setup.py
@@ -41,7 +41,7 @@ def _dbt_psycopg2_name():
 
 
 package_name = "dbt-postgres"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """The postgres adpter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/redshift/dbt/adapters/redshift/__version__.py
+++ b/plugins/redshift/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = '0.18.0'
+version = '0.19.0a1'

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 package_name = "dbt-redshift"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """The redshift adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/plugins/snowflake/dbt/adapters/snowflake/__version__.py
+++ b/plugins/snowflake/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = '0.18.0'
+version = '0.19.0a1'

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 package_name = "dbt-snowflake"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """The snowflake adapter plugin for dbt (data build tool)"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt"
-package_version = "0.18.0"
+package_version = "0.19.0a1"
 description = """With dbt, data analysts and engineers can build analytics \
 the way engineers build applications."""
 


### PR DESCRIPTION
### Description
Version bump PR!

This bumps the dbt version to 0.19.0a1 for this branch. It merits neither tests nor a changelog update, this is just something we should do when we release a version as part of the new branch prep and I always, without fail, forget to do so until it's very inconvenient.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
