### PR TITLE
Feature/schema versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - dbt will compare configurations using the un-rendered form of the config block in dbt_project.yml ([#2713](https://github.com/fishtown-analytics/dbt/issues/2713), [#2735](https://github.com/fishtown-analytics/dbt/pull/2735))
 - Added state and defer arguments to the RPC client, matching the CLI ([#2678](https://github.com/fishtown-analytics/dbt/issues/2678), [#2736](https://github.com/fishtown-analytics/dbt/pull/2736))
+- Added schema and dbt versions to JSON artifacts ([#2670](https://github.com/fishtown-analytics/dbt/issues/2670), [#2767](https://github.com/fishtown-analytics/dbt/pull/2767))
 
 ## dbt 0.18.1 (Release TBD)
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -22,7 +22,7 @@ from dbt.contracts.graph.parsed import (
 )
 from dbt.contracts.files import SourceFile
 from dbt.contracts.util import (
-    Readable, Writable, Replaceable, MacroKey, SourceKey
+    VersionedSchema, Replaceable, MacroKey, SourceKey, SchemaVersion
 )
 from dbt.exceptions import (
     raise_duplicate_resource_name, raise_compiler_error, warn_or_error,
@@ -924,7 +924,9 @@ class Manifest:
 
 
 @dataclass
-class WritableManifest(JsonSchemaMixin, Writable, Readable):
+class WritableManifest(VersionedSchema):
+    dbt_schema_version = SchemaVersion('manifest', 1)
+
     nodes: Mapping[UniqueID, ManifestNode] = field(
         metadata=dict(description=(
             'The nodes defined in the dbt project and its dependencies'

--- a/core/dbt/contracts/results.py
+++ b/core/dbt/contracts/results.py
@@ -3,7 +3,9 @@ from dbt.contracts.graph.unparsed import (
     Time, FreshnessStatus, FreshnessThreshold
 )
 from dbt.contracts.graph.parsed import ParsedSourceDefinition
-from dbt.contracts.util import Writable, Replaceable
+from dbt.contracts.util import (
+    Writable, VersionedSchema, Replaceable, SchemaVersion
+)
 from dbt.exceptions import InternalException
 from dbt.logger import (
     TimingProcessor,
@@ -86,7 +88,8 @@ class RunModelResult(WritableRunModelResult):
 
 
 @dataclass
-class ExecutionResult(JsonSchemaMixin, Writable):
+class ExecutionResult(VersionedSchema):
+    dbt_schema_version = SchemaVersion('run-results', 1)
     results: List[Union[WritableRunModelResult, PartialResult]]
     generated_at: datetime
     elapsed_time: float
@@ -140,7 +143,8 @@ class FreshnessMetadata(JsonSchemaMixin):
 
 
 @dataclass
-class FreshnessExecutionResult(FreshnessMetadata):
+class FreshnessExecutionResult(VersionedSchema, FreshnessMetadata):
+    dbt_schema_version = SchemaVersion('sources', 1)
     results: List[Union[PartialResult, SourceFreshnessResult]]
 
     def write(self, path, omit_none=True):
@@ -293,7 +297,8 @@ class CatalogTable(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class CatalogResults(JsonSchemaMixin, Writable):
+class CatalogResults(VersionedSchema):
+    dbt_schema_version = SchemaVersion('catalog', 1)
     nodes: Dict[str, CatalogTable]
     sources: Dict[str, CatalogTable]
     generated_at: datetime

--- a/core/dbt/contracts/state.py
+++ b/core/dbt/contracts/state.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from .graph.manifest import WritableManifest
 from typing import Optional
+from dbt.exceptions import IncompatibleSchemaException
 
 
 class PreviousState:
@@ -10,4 +11,8 @@ class PreviousState:
 
         manifest_path = self.path / 'manifest.json'
         if manifest_path.exists() and manifest_path.is_file():
-            self.manifest = WritableManifest.read(str(manifest_path))
+            try:
+                self.manifest = WritableManifest.read(str(manifest_path))
+            except IncompatibleSchemaException as exc:
+                exc.add_filename(str(manifest_path))
+                raise

--- a/core/dbt/contracts/util.py
+++ b/core/dbt/contracts/util.py
@@ -1,9 +1,10 @@
 import dataclasses
-from typing import List, Tuple
+from typing import List, Tuple, ClassVar, Type, TypeVar, Dict, Any
 
 from dbt.clients.system import write_json, read_json
-from dbt.exceptions import RuntimeException
-
+from dbt.exceptions import RuntimeException, IncompatibleSchemaException
+from dbt.version import __version__
+from hologram import JsonSchemaMixin
 
 MacroKey = Tuple[str, str]
 SourceKey = Tuple[str, str]
@@ -94,3 +95,71 @@ class Readable:
             ) from exc
 
         return cls.from_dict(data)  # type: ignore
+
+
+T = TypeVar('T', bound='VersionedSchema')
+
+
+BASE_SCHEMAS_URL = 'https://schemas.getdbt.com/dbt/{name}/v{version}.json'
+
+
+@dataclasses.dataclass
+class SchemaVersion:
+    name: str
+    version: int
+
+    def __str__(self) -> str:
+        return BASE_SCHEMAS_URL.format(
+            name=self.name,
+            version=self.version,
+        )
+
+
+DBT_VERSION_KEY = 'dbt_version'
+SCHEMA_VERSION_KEY = 'dbt_schema_version'
+
+
+@dataclasses.dataclass
+class VersionedSchema(JsonSchemaMixin, Readable, Writable):
+    dbt_schema_version: ClassVar[SchemaVersion]
+
+    def to_dict(
+        self, omit_none: bool = True, validate: bool = False
+    ) -> Dict[str, Any]:
+        dct = super().to_dict(omit_none=omit_none, validate=validate)
+        dct[SCHEMA_VERSION_KEY] = str(self.dbt_schema_version)
+        dct[DBT_VERSION_KEY] = __version__
+        return dct
+
+    @classmethod
+    def from_dict(
+        cls: Type[T], data: Dict[str, Any], validate: bool = True
+    ) -> T:
+        if validate:
+            expected = str(cls.dbt_schema_version)
+            found = data.get(SCHEMA_VERSION_KEY)
+            if found != expected:
+                raise IncompatibleSchemaException(expected, found)
+
+        return super().from_dict(data=data, validate=validate)
+
+    @classmethod
+    def _collect_json_schema(
+        cls, definitions: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        result = super()._collect_json_schema(definitions)
+        result['properties'][SCHEMA_VERSION_KEY] = {
+            'const': str(cls.dbt_schema_version)
+        }
+        result['properties'][DBT_VERSION_KEY] = {'type': 'string'}
+        result['required'].extend([SCHEMA_VERSION_KEY, DBT_VERSION_KEY])
+        return result
+
+    @classmethod
+    def json_schema(cls, embeddable: bool = False) -> Dict[str, Any]:
+        result = super().json_schema(embeddable=embeddable)
+        # it would be nice to do this in hologram!
+        # in the schema itself, include the version url as $id
+        if not embeddable:
+            result['$id'] = str(cls.dbt_schema_version)
+        return result

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -276,7 +276,8 @@ class IncompatibleSchemaException(RuntimeException):
 
         msg = (
             f'Expected a schema version of "{self.expected}" in '
-            f'{self.filename}, but found {found_str}'
+            f'{self.filename}, but found {found_str}. Are you running with a '
+            f'different version of dbt?'
         )
         return msg
 

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -257,6 +257,33 @@ class JSONValidationException(ValidationException):
         return (JSONValidationException, (self.typename, self.errors))
 
 
+class IncompatibleSchemaException(RuntimeException):
+    def __init__(self, expected: str, found: Optional[str]):
+        self.expected = expected
+        self.found = found
+        self.filename = 'input file'
+
+        super().__init__(self.get_message())
+
+    def add_filename(self, filename: str):
+        self.filename = filename
+        self.msg = self.get_message()
+
+    def get_message(self) -> str:
+        found_str = 'nothing'
+        if self.found is not None:
+            found_str = f'"{self.found}"'
+
+        msg = (
+            f'Expected a schema version of "{self.expected}" in '
+            f'{self.filename}, but found {found_str}'
+        )
+        return msg
+
+    CODE = 10014
+    MESSAGE = "Incompatible Schema"
+
+
 class JinjaRenderingException(CompilationException):
     pass
 

--- a/core/dbt/rpc/builtins.py
+++ b/core/dbt/rpc/builtins.py
@@ -21,7 +21,7 @@ from dbt.contracts.rpc import (
     RemoteRunResult,
     RemoteCompileResult,
     RemoteCatalogResults,
-    RemoteEmptyResult,
+    RemoteDepsResult,
     RemoteRunOperationResult,
     PollParameters,
     PollResult,
@@ -158,7 +158,7 @@ def poll_complete(
         cls = PollCompileCompleteResult
     elif isinstance(result, RemoteCatalogResults):
         cls = PollCatalogCompleteResult
-    elif isinstance(result, RemoteEmptyResult):
+    elif isinstance(result, RemoteDepsResult):
         cls = PollRemoteEmptyCompleteResult
     elif isinstance(result, RemoteRunOperationResult):
         cls = PollRunOperationCompleteResult

--- a/core/dbt/task/rpc/deps.py
+++ b/core/dbt/task/rpc/deps.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from dbt.contracts.rpc import (
-    RPCNoParameters, RemoteEmptyResult, RemoteMethodFlags,
+    RPCDepsParameters, RemoteDepsResult, RemoteMethodFlags,
 )
 from dbt.rpc.method import RemoteMethod
 from dbt.task.deps import DepsTask
@@ -15,7 +15,7 @@ def _clean_deps(config):
 
 
 class RemoteDepsTask(
-    RemoteMethod[RPCNoParameters, RemoteEmptyResult],
+    RemoteMethod[RPCDepsParameters, RemoteDepsResult],
     DepsTask,
 ):
     METHOD_NAME = 'deps'
@@ -26,10 +26,10 @@ class RemoteDepsTask(
             RemoteMethodFlags.RequiresManifestReloadAfter
         )
 
-    def set_args(self, params: RPCNoParameters):
+    def set_args(self, params: RPCDepsParameters):
         pass
 
-    def handle_request(self) -> RemoteEmptyResult:
+    def handle_request(self) -> RemoteDepsResult:
         _clean_deps(self.config)
         self.run()
-        return RemoteEmptyResult([])
+        return RemoteDepsResult([])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       dockerfile: Dockerfile
       args:
         # Run `make .env` to set $USER_ID and $GROUP_ID
-        USER_ID: ${USER_ID}
-        GROUP_ID: ${GROUP_ID}
+        USER_ID: ${USER_ID:-}
+        GROUP_ID: ${GROUP_ID:-}
     command: "/root/.virtualenvs/dbt/bin/pytest"
     env_file:
       - ./test.env

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -12,6 +12,7 @@ from pytest import mark
 from test.integration.base import DBTIntegrationTest, use_profile, AnyFloat, \
     AnyString, AnyStringWith, normalize, Normalized
 
+import dbt.version
 from dbt.exceptions import CompilationException
 
 
@@ -376,6 +377,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
         }
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/catalog/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
                     'unique_id': 'model.test.model',
@@ -507,6 +510,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
         }
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/catalog/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'seed.test.seed': {
                     'unique_id': 'seed.test.seed',
@@ -686,6 +691,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         }
 
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/catalog/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.clustered': {
                     'unique_id': 'model.test.clustered',
@@ -771,6 +778,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
         role = self.get_role()
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/catalog/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
                     'unique_id': 'model.test.model',
@@ -1033,6 +1042,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         unrendered_test_config = self.unrendered_tst_config()
 
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
                     'build_path': Normalized('target/compiled/test/models/model.sql'),
@@ -1436,6 +1447,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'tags': [],
                     'unique_id': 'source.test.my_source.my_table',
                     'fqn': ['test', 'my_source', 'my_table'],
+                    'unrendered_config': {},
                 },
             },
             'reports': {
@@ -1544,6 +1556,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         seed_path = self.dir('seed/seed.csv')
 
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.ephemeral_copy': {
                     'alias': 'ephemeral_copy',
@@ -1969,6 +1983,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         my_schema_name = self.unique_schema()
 
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.clustered': {
                     'alias': 'clustered',
@@ -2386,6 +2402,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         seed_path = self.dir('seed/seed.csv')
 
         return {
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+            'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
                     'build_path': Normalized('target/compiled/test/rs_models/model.sql'),
@@ -2573,7 +2591,7 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         manifest_keys = frozenset({
             'nodes', 'sources', 'macros', 'parent_map', 'child_map', 'generated_at',
-            'docs', 'metadata', 'docs', 'disabled', 'reports'
+            'docs', 'metadata', 'docs', 'disabled', 'reports', 'dbt_schema_version', 'dbt_version',
         })
 
         self.assertEqual(frozenset(manifest), manifest_keys)
@@ -3336,7 +3354,13 @@ class TestDocsGenerate(DBTIntegrationTest):
         )
         # sort the results so we can make reasonable assertions
         run_result['results'].sort(key=lambda r: r['node']['unique_id'])
-        self.assertEqual(run_result['results'], expected_run_results)
+        assert run_result['results'] == expected_run_results
+        assert run_result['dbt_schema_version'] == 'https://schemas.getdbt.com/dbt/run-results/v1.json'
+        assert run_result['dbt_version'] == dbt.version.__version__
+        set(run_result) == {
+            'generated_at', 'elapsed_time', 'results', 'dbt_schema_version',
+            'dbt_version'
+        }
 
     @use_profile('postgres')
     def test__postgres__run_and_generate_no_compile(self):

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import pytest
 
 import dbt.flags
+import dbt.version
 from dbt import tracking
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.manifest import Manifest, ManifestMetadata
@@ -219,6 +220,8 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(
             manifest.writable_manifest().to_dict(),
             {
+                'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+                'dbt_version': dbt.version.__version__,
                 'nodes': {},
                 'sources': {},
                 'macros': {},
@@ -347,6 +350,8 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual(
             manifest.writable_manifest().to_dict(),
             {
+                'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+                'dbt_version': dbt.version.__version__,
                 'nodes': {},
                 'sources': {},
                 'macros': {},
@@ -581,6 +586,8 @@ class MixedManifestTest(unittest.TestCase):
         self.assertEqual(
             manifest.writable_manifest().to_dict(),
             {
+                'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v1.json',
+                'dbt_version': dbt.version.__version__,
                 'nodes': {},
                 'macros': {},
                 'sources': {},


### PR DESCRIPTION
resolves #2670 

### Description
Add schema versions and dbt versions dbt's artifact output.

Long-term, these belong in the `metadata` field described in #2761.

I think I would like to get some automated mechanism for this into either hologram or the class, rather than this method of manually inserting things.

We can definitely change the name to something better, I don't love `dbt_schema_version`.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
