### PR TITLE
fix the new makefile on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,13 @@ test-quick: .env
 # This rule creates a file named .env that is used by docker-compose for passing
 # the USER_ID and GROUP_ID arguments to the Docker image.
 .env:
+	@touch .env
+ifneq ($(OS),Windows_NT)
+ifneq ($(shell uname -s), Darwin)
 	@echo USER_ID=$(shell id -u) > .env
 	@echo GROUP_ID=$(shell id -g) >> .env
+endif
+endif
 	@time docker-compose build
 
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       dockerfile: Dockerfile
       args:
         # Run `make .env` to set $USER_ID and $GROUP_ID
-        USER_ID: ${USER_ID}
-        GROUP_ID: ${GROUP_ID}
+        USER_ID: ${USER_ID:-}
+        GROUP_ID: ${GROUP_ID:-}
     command: "/root/.virtualenvs/dbt/bin/pytest"
     env_file:
       - ./test.env


### PR DESCRIPTION
### Description
Have make touch `.env` before making it, and bypass making a .env file on macos (and Windows, though I doubt this works on Windows in general).

This also suppresses a related warning.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
