### PR TITLE
Suppress docker-compose arg warnings.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Run `make .env` to set $USER_ID and $GROUP_ID
-        USER_ID: ${USER_ID}
-        GROUP_ID: ${GROUP_ID}
+        # Run `make .env` to set $USER_ID and $GROUP_ID for Linux
+        USER_ID: ${USER_ID:-0}
+        GROUP_ID: ${GROUP_ID:-0}
     command: "/root/.virtualenvs/dbt/bin/pytest"
     env_file:
       - ./test.env


### PR DESCRIPTION
If the user has not created a .env file, then they see warnings like
this when running `docker-compose`:

```
WARNING: The USER_ID variable is not set. Defaulting to a blank string.
WARNING: The GROUP_ID variable is not set. Defaulting to a blank string.
```

This fix provides defaults to docker-compose.yml to suppress this
warning.

resolves #2739
Follow-on to https://github.com/fishtown-analytics/dbt/pull/2741