### PR TITLE
Add better error messages for yaml selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added state and defer arguments to the RPC client, matching the CLI ([#2678](https://github.com/fishtown-analytics/dbt/issues/2678), [#2736](https://github.com/fishtown-analytics/dbt/pull/2736))
 - Added schema and dbt versions to JSON artifacts ([#2670](https://github.com/fishtown-analytics/dbt/issues/2670), [#2767](https://github.com/fishtown-analytics/dbt/pull/2767))
 - Added ability to snapshot hard-deleted records (opt-in with `invalidate_hard_deletes` config option). ([#249](https://github.com/fishtown-analytics/dbt/issues/249), [#2749](https://github.com/fishtown-analytics/dbt/pull/2749))
+- Improved error messages for YAML selectors ([#2700](https://github.com/fishtown-analytics/dbt/issues/2700), [#2781](https://github.com/fishtown-analytics/dbt/pull/2781))
 
 Contributors:
 - [@joelluijmes](https://github.com/joelluijmes) ([#2749](https://github.com/fishtown-analytics/dbt/pull/2749))

--- a/core/dbt/graph/selector_spec.py
+++ b/core/dbt/graph/selector_spec.py
@@ -93,7 +93,9 @@ class SelectionCriteria:
         try:
             method_name = MethodName(method_parts[0])
         except ValueError as exc:
-            raise InvalidSelectorException(method_parts[0]) from exc
+            raise InvalidSelectorException(
+                f"'{method_parts[0]}' is not a valid method name"
+            ) from exc
 
         method_arguments: List[str] = method_parts[1:]
 

--- a/test/unit/test_selector_errors.py
+++ b/test/unit/test_selector_errors.py
@@ -1,0 +1,179 @@
+import dbt.exceptions
+import textwrap
+import yaml
+import unittest
+from dbt.config.selectors import (
+    selector_config_from_data
+)
+
+from dbt.config.selectors import SelectorConfig
+
+
+def get_selector_dict(txt: str) -> dict:
+    txt = textwrap.dedent(txt)
+    dct = yaml.safe_load(txt)
+    return dct
+
+
+class SelectorUnitTest(unittest.TestCase):
+
+    def test_parse_multiple_excludes(self):
+        dct = get_selector_dict('''\
+            selectors:
+                - name: mult_excl
+                  definition:
+                    union:
+                      - method: tag
+                        value: nightly
+                      - exclude:
+                         - method: tag
+                           value: hourly
+                      - exclude:
+                         - method: tag
+                           value: daily
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                'cannot provide multiple exclude arguments'
+        ):
+            selector_config_from_data(dct)
+
+    def test_parse_set_op_plus(self):
+        dct = get_selector_dict('''\
+            selectors:
+                - name: union_plus
+                  definition:
+                    - union:
+                       - method: tag
+                         value: nightly
+                       - exclude:
+                          - method: tag
+                            value: hourly
+                    - method: tag
+                      value: foo
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                'Valid root-level selector definitions'
+        ):
+            selector_config_from_data(dct)
+
+    def test_parse_multiple_methods(self):
+        dct = get_selector_dict('''\
+            selectors:
+                - name: mult_methods
+                  definition:
+                    - tag:hourly
+                    - tag:nightly
+                    - fqn:start
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                'Valid root-level selector definitions'
+        ):
+            selector_config_from_data(dct)
+
+    def test_parse_set_with_method(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: mixed_syntaxes
+                    definition:
+                      key: value
+                      method: tag
+                      value: foo
+                      union:
+                        - method: tag
+                          value: m1234
+                        - exclude:
+                          - method: tag
+                            value: m5678
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                "Only a single 'union' or 'intersection' key is allowed"
+        ):
+            selector_config_from_data(dct)
+
+    def test_complex_sector(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: nightly_diet_snowplow
+                    definition:
+                      union:
+                        - intersection:
+                            - method: source
+                              value: snowplow
+                              childrens_parents: true
+                            - method: tag
+                              value: nightly
+                        - method: path
+                          value: models/export
+                        - exclude:
+                            - intersection:
+                                - method: package
+                                  value: snowplow
+                                - method: config.materialized
+                                  value: incremental
+                            - method: fqn
+                              value: export_performance_timing
+            ''')
+        selectors = selector_config_from_data(dct)
+        assert(isinstance(selectors, SelectorConfig))
+
+    def test_exclude_not_list(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: summa_exclude
+                    definition:
+                      union:
+                        - method: tag
+                          value: nightly
+                        - exclude:
+                            method: tag
+                            value: daily
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                "Expected a list"
+        ):
+            selector_config_from_data(dct)
+
+    def test_invalid_key(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: summa_nothing
+                    definition:
+                      method: tag
+                      key: nightly
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                "Expected either 1 key"
+        ):
+            selector_config_from_data(dct)
+
+    def test_invalid_single_def(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: summa_nothing
+                    definition:
+                      fubar: tag
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                "not a valid method name"
+        ):
+            selector_config_from_data(dct)
+
+    def test_method_no_value(self):
+        dct = get_selector_dict('''\
+                selectors:
+                  - name: summa_nothing
+                    definition:
+                      method: tag
+            ''')
+        with self.assertRaisesRegex(
+                dbt.exceptions.DbtSelectorsError,
+                "not a valid method name"
+        ):
+            selector_config_from_data(dct)


### PR DESCRIPTION
resolves #2700


### Description

Changed hologram to provide more information in the exceptions, and modified selector error messages to include yaml output and more information.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
