### PR TITLE
Fix: require keyring on snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Feature
 - Added 'Last Modified' stat in snowflake catalog macro. Now should be available in docs. ([#2728](https://github.com/fishtown-analytics/dbt/issues/2728))
 
+### Under the hood
+- Require extra `snowflake-connector-python[secure-local-storage]` on all dbt-snowflake installations ([#2779](https://github.com/fishtown-analytics/dbt/issues/2779), [#2789](https://github.com/fishtown-analytics/dbt/pull/2789))
+
 Contributors:
 - [@Mr-Nobody99](https://github.com/Mr-Nobody99) ([#2732](https://github.com/fishtown-analytics/dbt/pull/2732))
 

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -47,8 +47,7 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'snowflake-connector-python==2.2.10',
-        'snowflake-connector-python[secure-local-storage]',
+        'snowflake-connector-python[secure-local-storage]==2.2.10',
         'azure-common<2.0.0',
         'azure-storage-blob>=12.0.0,<13.0.0',
         'urllib3>=1.20,<1.26.0',

--- a/plugins/snowflake/setup.py
+++ b/plugins/snowflake/setup.py
@@ -48,6 +48,7 @@ setup(
     install_requires=[
         'dbt-core=={}'.format(package_version),
         'snowflake-connector-python==2.2.10',
+        'snowflake-connector-python[secure-local-storage]',
         'azure-common<2.0.0',
         'azure-storage-blob>=12.0.0,<13.0.0',
         'urllib3>=1.20,<1.26.0',


### PR DESCRIPTION
resolves #2779

### Description

- Require extra dependency on all installations of `dbt-snowflake`: `snowflake-connector-python[secure-local-storage]`, which is really just `keyring`

### Alternatives

We could put `snowflake-connector-python[secure-local-storage]` under `extras_require` instead of `install_requires`, since it's only _really_ needed for external-browser auth. I opted for the more aggressive approach since:
- The version bound on `keyring` in `snowflake-connector-python` is quite permissive
- The goal is to avoid users running into surprising behavior (e.g. #2689) that's easily avoided by installing one extra package

I don't really know what I'm doing, though, when it comes to python deps!

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - ~I have run this code in development and it appears to resolve the stated issue~
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
