### PR TITLE
DO NOT MERGE: Synapse incompatibility with dbt-adapter-tests suite

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1142,7 +1142,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         # default. A lot of searching has lead me to believe that the
         # '+ interval' syntax used in postgres/redshift is relatively common
         # and might even be the SQL standard's intention.
-        return f"{add_to} + interval '{number} {interval}'"
+        return f"DATEADD({interval},{number},{add_to})'"
 
     def string_add_sql(
         self, add_to: str, value: str, location='append',

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -1211,7 +1211,7 @@ select
     row_count_diff.difference as row_count_difference,
     diff_count.num_missing as num_mismatched
 from row_count_diff
-join diff_count using (id)
+join diff_count on row_count_diff.id = diff_count.id
 '''.strip()
 
 


### PR DESCRIPTION
opening this to highlight some incompatibility that [`dbt-sqlserver` ](https://github.com/mikaelene/dbt-sqlserver) and [`dbt-synapse`](https://github.com/swanderz/dbt-synapse) has when trying to implement [`dbt-adapter-tests`](https://github.com/fishtown-analytics/dbt-adapter-tests).

1. `interval`: this isn't supported by any MSFT/T-SQL product (SQL Server, Azure SQL, Azure Synapse)
2. `using`: this isn't supported by Azure Synapse.



### Description

This is just a draft PR to highlight the incompatibilities we've found (so far). Would love some advice!


### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
