### PR TITLE
Add invocation_id to BigQuery jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added schema and dbt versions to JSON artifacts ([#2670](https://github.com/fishtown-analytics/dbt/issues/2670), [#2767](https://github.com/fishtown-analytics/dbt/pull/2767))
 - Added ability to snapshot hard-deleted records (opt-in with `invalidate_hard_deletes` config option). ([#249](https://github.com/fishtown-analytics/dbt/issues/249), [#2749](https://github.com/fishtown-analytics/dbt/pull/2749))
 - Improved error messages for YAML selectors ([#2700](https://github.com/fishtown-analytics/dbt/issues/2700), [#2781](https://github.com/fishtown-analytics/dbt/pull/2781))
+- Added dbt_invocation_id for each BigQuery job to enable performance analysis ([#2483](https://github.com/fishtown-analytics/dbt/issues/2483))
 
 ### Under the hood
 - Added strategy-specific validation to improve the relevancy of compilation errors for the `timestamp` and `check` snapshot strategies. (([#2787](https://github.com/fishtown-analytics/dbt/issues/2787), [#2791](https://github.com/fishtown-analytics/dbt/pull/2791))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added schema and dbt versions to JSON artifacts ([#2670](https://github.com/fishtown-analytics/dbt/issues/2670), [#2767](https://github.com/fishtown-analytics/dbt/pull/2767))
 - Added ability to snapshot hard-deleted records (opt-in with `invalidate_hard_deletes` config option). ([#249](https://github.com/fishtown-analytics/dbt/issues/249), [#2749](https://github.com/fishtown-analytics/dbt/pull/2749))
 - Improved error messages for YAML selectors ([#2700](https://github.com/fishtown-analytics/dbt/issues/2700), [#2781](https://github.com/fishtown-analytics/dbt/pull/2781))
-- Added dbt_invocation_id for each BigQuery job to enable performance analysis ([#2483](https://github.com/fishtown-analytics/dbt/issues/2483))
+- Added dbt_invocation_id for each BigQuery job to enable performance analysis ([#2808](https://github.com/fishtown-analytics/dbt/issues/2808))
 
 ### Under the hood
 - Added strategy-specific validation to improve the relevancy of compilation errors for the `timestamp` and `check` snapshot strategies. (([#2787](https://github.com/fishtown-analytics/dbt/issues/2787), [#2791](https://github.com/fishtown-analytics/dbt/pull/2791))

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -13,6 +13,7 @@ from google.oauth2 import service_account
 
 from dbt.utils import format_bytes, format_rows_number
 from dbt.clients import agate_helper, gcloud
+from dbt.tracking import active_user
 from dbt.contracts.connection import ConnectionState
 from dbt.exceptions import (
     FailedToConnectException, RuntimeException, DatabaseException
@@ -249,7 +250,12 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         logger.debug('On {}: {}', conn.name, sql)
 
-        job_params = {'use_legacy_sql': False}
+        job_params = {
+            'use_legacy_sql': False,
+            'labels': {
+                'dbt_invocation_id': active_user.invocation_id,
+            },
+        }
 
         priority = conn.credentials.priority
         if priority == Priority.Batch:

--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -252,10 +252,12 @@ class BigQueryConnectionManager(BaseConnectionManager):
 
         job_params = {
             'use_legacy_sql': False,
-            'labels': {
-                'dbt_invocation_id': active_user.invocation_id,
-            },
         }
+
+        if active_user:
+            job_params['labels'] = {
+                'dbt_invocation_id': active_user.invocation_id
+            }
 
         priority = conn.credentials.priority
         if priority == Priority.Batch:

--- a/scripts/build-sdists.sh
+++ b/scripts/build-sdists.sh
@@ -13,11 +13,11 @@ for SUBPATH in core plugins/postgres plugins/redshift plugins/bigquery plugins/s
 do
     rm -rf "$DBT_PATH"/"$SUBPATH"/dist
     cd "$DBT_PATH"/"$SUBPATH"
-    python3 setup.py sdist
+    python setup.py sdist
     cp -r "$DBT_PATH"/"$SUBPATH"/dist/* "$DBT_PATH"/dist/
 done
 
 cd "$DBT_PATH"
-python3 setup.py sdist
+python setup.py sdist
 
 set +x

--- a/scripts/build-sdists.sh
+++ b/scripts/build-sdists.sh
@@ -13,11 +13,11 @@ for SUBPATH in core plugins/postgres plugins/redshift plugins/bigquery plugins/s
 do
     rm -rf "$DBT_PATH"/"$SUBPATH"/dist
     cd "$DBT_PATH"/"$SUBPATH"
-    python setup.py sdist
+    python3 setup.py sdist
     cp -r "$DBT_PATH"/"$SUBPATH"/dist/* "$DBT_PATH"/dist/
 done
 
 cd "$DBT_PATH"
-python setup.py sdist
+python3 setup.py sdist
 
 set +x


### PR DESCRIPTION
This resolves #2808.

### Description

It adds the invocation_id into every label for a BigQuery job. The reason this is preferrable is because the labels have a 128 byte limit, and using the query comment could easily breach this limit.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
