### PR TITLE
Feature/add debug query method

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -30,6 +30,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         - commit
         - clear_transaction
         - execute
+        - debug_query
 
     You must also set the 'TYPE' class attribute with a class-unique constant
     string.
@@ -287,6 +288,14 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             return sql
         return self.query_header.add(sql)
 
+    def debug_query(self, sql: str):
+        if sql is None:
+            self.execute('select 1 as id')
+        else:
+            self.execute(sql)
+        
+
+
     @abc.abstractmethod
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
@@ -303,3 +312,4 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         raise dbt.exceptions.NotImplementedException(
             '`execute` is not implemented for this adapter!'
         )
+

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -334,7 +334,7 @@ class DebugTask(BaseTask):
         adapter = get_adapter(profile)
         try:
             with adapter.connection_named('debug'):
-                adapter.execute('select 1 as id')
+                adapter.debug_query()
         except Exception as exc:
             return COULD_NOT_CONNECT_MESSAGE.format(
                 err=str(exc),


### PR DESCRIPTION
resolves #2751

### Description
In the base debug task, there was a hard-coded test query that wouldn't work in some databases (e.g. Oracle). This new debug_query method on the base adapter allows plugin authors to specify their own debug query.



### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
