### PR TITLE
Feature/add debug query method

### DIFF
--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -30,7 +30,6 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         - commit
         - clear_transaction
         - execute
-        - debug_query
 
     You must also set the 'TYPE' class attribute with a class-unique constant
     string.

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -288,14 +288,6 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             return sql
         return self.query_header.add(sql)
 
-    def debug_query(self, sql: str):
-        if sql is None:
-            self.execute('select 1 as id')
-        else:
-            self.execute(sql)
-        
-
-
     @abc.abstractmethod
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -30,6 +30,7 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         - commit
         - clear_transaction
         - execute
+        - debug_query
 
     You must also set the 'TYPE' class attribute with a class-unique constant
     string.
@@ -287,6 +288,14 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
             return sql
         return self.query_header.add(sql)
 
+    def debug_query(self, sql: str):
+        if sql is None:
+            self.execute('select 1 as id')
+        else:
+            self.execute(sql)
+        
+
+
     @abc.abstractmethod
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
@@ -303,3 +312,4 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         raise dbt.exceptions.NotImplementedException(
             '`execute` is not implemented for this adapter!'
         )
+

--- a/core/dbt/adapters/base/connections.py
+++ b/core/dbt/adapters/base/connections.py
@@ -303,4 +303,3 @@ class BaseConnectionManager(metaclass=abc.ABCMeta):
         raise dbt.exceptions.NotImplementedException(
             '`execute` is not implemented for this adapter!'
         )
-

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -180,6 +180,9 @@ class BaseAdapter(metaclass=AdapterMeta):
     def commit_if_has_connection(self) -> None:
         self.connections.commit_if_has_connection()
 
+    def debug_query(self):
+        self.execute('select 1 as id')
+
     def nice_connection_name(self) -> str:
         conn = self.connections.get_if_exists()
         if conn is None or conn.name is None:

--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -180,7 +180,7 @@ class BaseAdapter(metaclass=AdapterMeta):
     def commit_if_has_connection(self) -> None:
         self.connections.commit_if_has_connection()
 
-    def debug_query(self):
+    def debug_query(self) -> None:
         self.execute('select 1 as id')
 
     def nice_connection_name(self) -> str:

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -334,7 +334,7 @@ class DebugTask(BaseTask):
         adapter = get_adapter(profile)
         try:
             with adapter.connection_named('debug'):
-                adapter.execute('select 1 as id')
+                adapter.debug_query()
         except Exception as exc:
             return COULD_NOT_CONNECT_MESSAGE.format(
                 err=str(exc),


### PR DESCRIPTION
resolves #2811 

### Description

Adds a debug_query method to the base adapter that will allow for plugin authors to add their own debug query. Intended for all use cases where the database doesn't support 'select 1 as id' as a valid query.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
