### PR TITLE
add all exports from python re module

### DIFF
--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -42,12 +42,14 @@ def get_datetime_module_context() -> Dict[str, Any]:
         name: getattr(datetime, name) for name in context_exports
     }
 
+
 def get_re_module_context() -> Dict[str, Any]:
     context_exports = re.__all__
 
     return {
       name: getattr(re, name) for name in context_exports
     }
+
 
 def get_context_modules() -> Dict[str, Dict[str, Any]]:
     return {

--- a/core/dbt/context/base.py
+++ b/core/dbt/context/base.py
@@ -18,6 +18,7 @@ import yaml
 # approaches which will extend well to potentially many modules
 import pytz
 import datetime
+import re
 
 
 def get_pytz_module_context() -> Dict[str, Any]:
@@ -41,11 +42,18 @@ def get_datetime_module_context() -> Dict[str, Any]:
         name: getattr(datetime, name) for name in context_exports
     }
 
+def get_re_module_context() -> Dict[str, Any]:
+    context_exports = re.__all__
+
+    return {
+      name: getattr(re, name) for name in context_exports
+    }
 
 def get_context_modules() -> Dict[str, Dict[str, Any]]:
     return {
         'pytz': get_pytz_module_context(),
         'datetime': get_datetime_module_context(),
+        're': get_re_module_context(),
     }
 
 


### PR DESCRIPTION
resolves #1755 

### Description

**Describe the feature**
This is a follow-up PR for the same exact feature posted by @whisperstream at #1755 . Descriptions below will almost exactly match.

I have a case where I'd like to be able to do a regex in a jinja template for matching a particular set of values. It would be handier to have a access to python's re module than having to use normal string manipulation and matching

**Describe alternatives you've considered**
Similar to the original issue, I have used the following to workaround not having RegEx
1. for loops
2. string replacement and splitting + array indexing
3. IF and NOT statements

**Additional context**
Same as original issue. Not database specific, would apply to all jinja templates in the same way that datetime and pytz modules are made available. I checked the list of exported functions from the native `re` module and they do not introduce any unsafe behaviour with respect to database connections, exposed secrets, etc:
https://github.com/python/cpython/blob/83c86cf54b36a7325f615f5adf22b28e48f0e72d/Lib/re.py#L135-L141
```
__all__ = [
    "match", "fullmatch", "search", "sub", "subn", "split",
    "findall", "finditer", "compile", "purge", "template", "escape",
    "error", "Pattern", "Match", "A", "I", "L", "M", "S", "X", "U",
    "ASCII", "IGNORECASE", "LOCALE", "MULTILINE", "DOTALL", "VERBOSE",
    "UNICODE",
]
```

**Who will this benefit?**
Anybody who wants to do more complex string manipulation and string checking in a more straight-foward way than is possible today. For us, this comes up often when an **input array of strings to a macro** are "dirty" and need to be cleaned via RegEx. Or if we are looking for certain string occurrences that might decide the logical flow of our macros.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
