### PR TITLE
Experiment/use mashumaro

### DIFF
--- a/core/dbt/adapters/base/column.py
+++ b/core/dbt/adapters/base/column.py
@@ -5,10 +5,11 @@ from hologram import JsonSchemaMixin
 from dbt.exceptions import RuntimeException
 
 from typing import Dict, ClassVar, Any, Optional
+from dbt.contracts.jsonschema import dbtClassMixin
 
 
 @dataclass
-class Column(JsonSchemaMixin):
+class Column(dbtClassMixin):
     TYPE_LABELS: ClassVar[Dict[str, str]] = {
         'STRING': 'TEXT',
         'TIMESTAMP': 'TIMESTAMP',

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -47,13 +47,16 @@ class BaseRelation(FakeAPIObject, Hashable):
             return False
         return self.to_dict() == other.to_dict()
 
+    # TODO : Unclear why we're leveraging a type system to implement inheritance?
     @classmethod
     def get_default_quote_policy(cls) -> Policy:
-        return cls._get_field_named('quote_policy').default
+        #return cls._get_field_named('quote_policy').default
+        return Policy()
 
     @classmethod
     def get_default_include_policy(cls) -> Policy:
-        return cls._get_field_named('include_policy').default
+        #return cls._get_field_named('include_policy').default
+        return Policy()
 
     def get(self, key, default=None):
         """Override `.get` to return a metadata object so we don't break

--- a/core/dbt/config/profile.py
+++ b/core/dbt/config/profile.py
@@ -137,7 +137,7 @@ class Profile(HasCredentials):
     def validate(self):
         try:
             if self.credentials:
-                self.credentials.to_dict(validate=True)
+                self.credentials.serialize(validate=True)
             ProfileConfig.from_dict(
                 self.to_profile_info(serialize_credentials=True)
             )

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -306,7 +306,7 @@ class PartialProject(RenderComponents):
         )
 
         try:
-            cfg = ProjectContract.from_dict(rendered.project_dict)
+            cfg = ProjectContract.deserialize(rendered.project_dict)
         except ValidationError as e:
             raise DbtProjectError(validator_error_message(e)) from e
         # name/version are required in the Project definition, so we can assume
@@ -586,7 +586,9 @@ class Project:
 
     def validate(self):
         try:
-            ProjectContract.from_dict(self.to_project_config())
+            # TODO : Jank; need to do this to handle aliasing between hyphens and underscores
+            as_dict = self.to_project_config()
+            ProjectContract.deserialize(as_dict)
         except ValidationError as e:
             raise DbtProjectError(validator_error_message(e)) from e
 

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -174,7 +174,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         :raises DbtProjectError: If the configuration fails validation.
         """
         try:
-            Configuration.from_dict(self.serialize())
+            Configuration.deserialize(self.serialize())
         except ValidationError as e:
             raise DbtProjectError(validator_error_message(e)) from e
 

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -165,7 +165,9 @@ class ContextConfigGenerator(BaseContextConfigGenerator[C]):
         # Calculate the defaults. We don't want to validate the defaults,
         # because it might be invalid in the case of required config members
         # (such as on snapshots!)
-        result = config_cls.from_dict({}, validate=False)
+        result = config_cls.from_dict({})
+        # TODO - why validate here?
+        # result.validate()
         return result
 
     def _update_from_config(

--- a/core/dbt/contracts/connection.py
+++ b/core/dbt/contracts/connection.py
@@ -17,22 +17,12 @@ from dbt.utils import translate_aliases
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
-from dbt.contracts.jsonschema import dbtClassMixin
+from dbt.contracts.jsonschema import dbtClassMixin, ValidatedStringMixin
 from mashumaro.types import SerializableType
 
-Identifier = NewType('Identifier', str)
-register_pattern(Identifier, r'^[A-Za-z_][A-Za-z0-9_]+$')
 
-# TODO?
-class Identifier(str, SerializableType):
-    @classmethod
-    def _deserialize(cls, value: str) -> 'Identifier':
-        # TODO : Validate here?
-        return Identifier(value)
-
-    def _serialize(self) -> str:
-        # TODO : Validate here?
-        return self
+class Identifier(ValidatedStringMixin):
+    ValidationRegex = r'^[A-Za-z_][A-Za-z0-9_]+$'
 
 
 class ConnectionState(StrEnum):

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -9,13 +9,15 @@ from dbt.exceptions import InternalException
 
 from .util import MacroKey, SourceKey
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 MAXIMUM_SEED_SIZE = 1 * 1024 * 1024
 MAXIMUM_SEED_SIZE_NAME = '1MB'
 
 
 @dataclass
-class FilePath(JsonSchemaMixin):
+class FilePath(dbtClassMixin):
     searched_path: str
     relative_path: str
     project_root: str
@@ -51,7 +53,7 @@ class FilePath(JsonSchemaMixin):
 
 
 @dataclass
-class FileHash(JsonSchemaMixin):
+class FileHash(dbtClassMixin):
     name: str  # the hash type name
     checksum: str  # the hashlib.hash_type().hexdigest() of the file contents
 
@@ -91,7 +93,7 @@ class FileHash(JsonSchemaMixin):
 
 
 @dataclass
-class RemoteFile(JsonSchemaMixin):
+class RemoteFile(dbtClassMixin):
     @property
     def searched_path(self) -> str:
         return 'from remote system'
@@ -110,7 +112,7 @@ class RemoteFile(JsonSchemaMixin):
 
 
 @dataclass
-class SourceFile(JsonSchemaMixin):
+class SourceFile(dbtClassMixin):
     """Define a source file in dbt"""
     path: Union[FilePath, RemoteFile]  # the path information
     checksum: FileHash

--- a/core/dbt/contracts/graph/compiled.py
+++ b/core/dbt/contracts/graph/compiled.py
@@ -23,15 +23,17 @@ from hologram import JsonSchemaMixin
 from dataclasses import dataclass, field
 from typing import Optional, List, Union, Dict, Type
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 @dataclass
-class InjectedCTE(JsonSchemaMixin, Replaceable):
+class InjectedCTE(dbtClassMixin, Replaceable):
     id: str
     sql: str
 
 
 @dataclass
-class CompiledNodeMixin(JsonSchemaMixin):
+class CompiledNodeMixin(dbtClassMixin):
     # this is a special mixin class to provide a required argument. If a node
     # is missing a `compiled` flag entirely, it must not be a CompiledNode.
     compiled: bool
@@ -179,7 +181,8 @@ def parsed_instance_for(compiled: CompiledNode) -> ParsedResource:
                          .format(compiled.resource_type))
 
     # validate=False to allow extra keys from compiling
-    return cls.from_dict(compiled.to_dict(), validate=False)
+    # TODO : This is probably not going to do the right thing....
+    return cls.deserialize(compiled.to_dict(), validate=False)
 
 
 NonSourceCompiledNode = Union[

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -508,10 +508,10 @@ class Manifest:
         """
         self.flat_graph = {
             'nodes': {
-                k: v.to_dict(omit_none=False) for k, v in self.nodes.items()
+                k: v.serialize(omit_none=False) for k, v in self.nodes.items()
             },
             'sources': {
-                k: v.to_dict(omit_none=False) for k, v in self.sources.items()
+                k: v.serialize(omit_none=False) for k, v in self.sources.items()
             }
         }
 
@@ -764,7 +764,7 @@ class Manifest:
         )
 
     def to_dict(self, omit_none=True, validate=False):
-        return self.writable_manifest().to_dict(
+        return self.writable_manifest().serialize(
             omit_none=omit_none, validate=validate
         )
 

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -16,9 +16,11 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Optional, List, Union, Dict, Any, Sequence
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 @dataclass
-class UnparsedBaseNode(JsonSchemaMixin, Replaceable):
+class UnparsedBaseNode(dbtClassMixin, Replaceable):
     package_name: str
     root_path: str
     path: str
@@ -66,18 +68,20 @@ class UnparsedRunHook(UnparsedNode):
 
 
 @dataclass
-class Docs(JsonSchemaMixin, Replaceable):
+class Docs(dbtClassMixin, Replaceable):
     show: bool = True
 
 
+# TODO : This should have AdditionalPropertiesMixin and ExtensibleJsonSchemaMixin
 @dataclass
-class HasDocs(AdditionalPropertiesMixin, ExtensibleJsonSchemaMixin,
-              Replaceable):
+class HasDocs(dbtClassMixin, Replaceable):
     name: str
     description: str = ''
     meta: Dict[str, Any] = field(default_factory=dict)
     data_type: Optional[str] = None
     docs: Docs = field(default_factory=Docs)
+
+    # TODO : How do we handle these additional fields with mashurmaro?
     _extra: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -100,7 +104,7 @@ class UnparsedColumn(HasTests):
 
 
 @dataclass
-class HasColumnDocs(JsonSchemaMixin, Replaceable):
+class HasColumnDocs(dbtClassMixin, Replaceable):
     columns: Sequence[HasDocs] = field(default_factory=list)
 
 
@@ -110,7 +114,7 @@ class HasColumnTests(HasColumnDocs):
 
 
 @dataclass
-class HasYamlMetadata(JsonSchemaMixin):
+class HasYamlMetadata(dbtClassMixin):
     original_file_path: str
     yaml_key: str
     package_name: str
@@ -127,7 +131,7 @@ class UnparsedNodeUpdate(HasColumnTests, HasTests, HasYamlMetadata):
 
 
 @dataclass
-class MacroArgument(JsonSchemaMixin):
+class MacroArgument(dbtClassMixin):
     name: str
     type: Optional[str] = None
     description: str = ''
@@ -148,7 +152,7 @@ class TimePeriod(StrEnum):
 
 
 @dataclass
-class Time(JsonSchemaMixin, Replaceable):
+class Time(dbtClassMixin, Replaceable):
     count: int
     period: TimePeriod
 
@@ -159,7 +163,7 @@ class Time(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class FreshnessThreshold(JsonSchemaMixin, Mergeable):
+class FreshnessThreshold(dbtClassMixin, Mergeable):
     warn_after: Optional[Time] = None
     error_after: Optional[Time] = None
     filter: Optional[str] = None
@@ -212,7 +216,7 @@ class ExternalTable(AdditionalPropertiesAllowed, Mergeable):
 
 
 @dataclass
-class Quoting(JsonSchemaMixin, Mergeable):
+class Quoting(dbtClassMixin, Mergeable):
     database: Optional[bool] = None
     schema: Optional[bool] = None
     identifier: Optional[bool] = None
@@ -231,14 +235,15 @@ class UnparsedSourceTableDefinition(HasColumnTests, HasTests):
     tags: List[str] = field(default_factory=list)
 
     def to_dict(self, omit_none=True, validate=False):
-        result = super().to_dict(omit_none=omit_none, validate=validate)
+        result = super().serialize(omit_none=omit_none, validate=validate)
+
         if omit_none and self.freshness is None:
             result['freshness'] = None
         return result
 
 
 @dataclass
-class UnparsedSourceDefinition(JsonSchemaMixin, Replaceable):
+class UnparsedSourceDefinition(dbtClassMixin, Replaceable):
     name: str
     description: str = ''
     meta: Dict[str, Any] = field(default_factory=dict)
@@ -258,14 +263,14 @@ class UnparsedSourceDefinition(JsonSchemaMixin, Replaceable):
         return 'sources'
 
     def to_dict(self, omit_none=True, validate=False):
-        result = super().to_dict(omit_none=omit_none, validate=validate)
+        result = super().serialize(omit_none=omit_none, validate=validate)
         if omit_none and self.freshness is None:
             result['freshness'] = None
         return result
 
 
 @dataclass
-class SourceTablePatch(JsonSchemaMixin):
+class SourceTablePatch(dbtClassMixin):
     name: str
     description: Optional[str] = None
     meta: Optional[Dict[str, Any]] = None
@@ -283,7 +288,7 @@ class SourceTablePatch(JsonSchemaMixin):
     columns: Optional[Sequence[UnparsedColumn]] = None
 
     def to_patch_dict(self) -> Dict[str, Any]:
-        dct = self.to_dict(omit_none=True)
+        dct = self.serialize(omit_none=True)
         remove_keys = ('name')
         for key in remove_keys:
             if key in dct:
@@ -296,7 +301,7 @@ class SourceTablePatch(JsonSchemaMixin):
 
 
 @dataclass
-class SourcePatch(JsonSchemaMixin, Replaceable):
+class SourcePatch(dbtClassMixin, Replaceable):
     name: str = field(
         metadata=dict(description='The name of the source to override'),
     )
@@ -320,7 +325,7 @@ class SourcePatch(JsonSchemaMixin, Replaceable):
     tags: Optional[List[str]] = None
 
     def to_patch_dict(self) -> Dict[str, Any]:
-        dct = self.to_dict(omit_none=True)
+        dct = self.serialize(omit_none=True)
         remove_keys = ('name', 'overrides', 'tables', 'path')
         for key in remove_keys:
             if key in dct:
@@ -340,7 +345,7 @@ class SourcePatch(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class UnparsedDocumentation(JsonSchemaMixin, Replaceable):
+class UnparsedDocumentation(dbtClassMixin, Replaceable):
     package_name: str
     root_path: str
     path: str
@@ -400,7 +405,7 @@ class MaturityType(StrEnum):
 
 
 @dataclass
-class ExposureOwner(JsonSchemaMixin, Replaceable):
+class ExposureOwner(dbtClassMixin, Replaceable):
     email: str
     name: Optional[str] = None
 

--- a/core/dbt/contracts/jsonschema.py
+++ b/core/dbt/contracts/jsonschema.py
@@ -1,0 +1,40 @@
+
+from dataclasses import dataclass, fields, Field
+from typing import (
+    Optional, TypeVar, Generic, Dict, get_type_hints, List, Tuple
+)
+from mashumaro import DataClassJSONMixin
+
+
+"""
+This is a throwaway shim to match the JsonSchemaMixin interface
+that downstream consumers (ie. PostgresRelation) is expecting. 
+I imagine that we would try to remove code that depends on this type
+reflection if we pursue an approach like the one shown here
+"""
+class JsonSchemaMixin(DataClassJSONMixin):
+    @classmethod
+    def field_mapping(cls) -> Dict[str, str]:
+        """Defines the mapping of python field names to JSON field names.
+
+        The main use-case is to allow JSON field names which are Python keywords
+        """
+        return {}
+
+    @classmethod
+    def _get_fields(cls) -> List[Tuple[Field, str]]:
+        mapped_fields = []
+        type_hints = get_type_hints(cls)
+
+        for f in fields(cls):
+            # Skip internal fields
+            if f.name.startswith("_"):
+                continue
+
+            # Note fields() doesn't resolve forward refs
+            f.type = type_hints[f.name]
+
+            mapped_fields.append((f, cls.field_mapping().get(f.name, f.name)))
+
+        return mapped_fields  # type: ignore
+

--- a/core/dbt/contracts/jsonschema.py
+++ b/core/dbt/contracts/jsonschema.py
@@ -3,16 +3,17 @@ from dataclasses import dataclass, fields, Field
 from typing import (
     Optional, TypeVar, Generic, Dict, get_type_hints, List, Tuple
 )
-from mashumaro import DataClassJSONMixin
+from mashumaro import DataClassDictMixin
 
 
 """
 This is a throwaway shim to match the JsonSchemaMixin interface
+
 that downstream consumers (ie. PostgresRelation) is expecting. 
 I imagine that we would try to remove code that depends on this type
 reflection if we pursue an approach like the one shown here
 """
-class JsonSchemaMixin(DataClassJSONMixin):
+class dbtClassMixin(DataClassDictMixin):
     @classmethod
     def field_mapping(cls) -> Dict[str, str]:
         """Defines the mapping of python field names to JSON field names.
@@ -21,20 +22,24 @@ class JsonSchemaMixin(DataClassJSONMixin):
         """
         return {}
 
+    def serialize(self, omit_none=False, validate=False, with_aliases: Optional[Dict[str, str]]=None):
+        dct = self.to_dict()
+
+        if with_aliases:
+            # TODO : Mutating these dicts is a TERRIBLE idea - remove this
+            for aliased_name, canonical_name in self._ALIASES.items():
+                if aliased_name in dct:
+                    dct[canonical_name] = dct.pop(aliased_name)
+
+        return dct
+
     @classmethod
-    def _get_fields(cls) -> List[Tuple[Field, str]]:
-        mapped_fields = []
-        type_hints = get_type_hints(cls)
+    def deserialize(cls, data, validate=False, with_aliases=False):
+        if with_aliases:
+            # TODO : Mutating these dicts is a TERRIBLE idea - remove this
+            for aliased_name, canonical_name in cls._ALIASES.items():
+                if aliased_name in data:
+                    data[canonical_name] = data.pop(aliased_name)
 
-        for f in fields(cls):
-            # Skip internal fields
-            if f.name.startswith("_"):
-                continue
-
-            # Note fields() doesn't resolve forward refs
-            f.type = type_hints[f.name]
-
-            mapped_fields.append((f, cls.field_mapping().get(f.name, f.name)))
-
-        return mapped_fields  # type: ignore
-
+        # TODO .... implement these?
+        return cls.from_dict(data)

--- a/core/dbt/contracts/jsonschema.py
+++ b/core/dbt/contracts/jsonschema.py
@@ -4,6 +4,8 @@ from typing import (
     Optional, TypeVar, Generic, Dict, get_type_hints, List, Tuple
 )
 from mashumaro import DataClassDictMixin
+from mashumaro.types import SerializableType
+import re
 
 
 """
@@ -43,3 +45,22 @@ class dbtClassMixin(DataClassDictMixin):
 
         # TODO .... implement these?
         return cls.from_dict(data)
+
+
+class ValidatedStringMixin(str, SerializableType):
+    ValidationRegex = None
+
+    @classmethod
+    def _deserialize(cls, value: str) -> 'ValidatedStringMixin':
+        cls.validate(value)
+        return ValidatedStringMixin(value)
+
+    def _serialize(self) -> str:
+        return str(self)
+
+    @classmethod
+    def validate(cls, value) -> str:
+        res = re.match(cls.ValidationRegex, value)
+
+        if res is None:
+            raise ValidationError(f"Invalid value: {value}") # TODO

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -12,25 +12,16 @@ from hologram.helpers import HyphenatedJsonSchemaMixin, register_pattern, \
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Union, Any, NewType
 
-from dbt.contracts.jsonschema import dbtClassMixin
+from dbt.contracts.jsonschema import dbtClassMixin, ValidatedStringMixin
 from mashumaro.types import SerializableType
 
 PIN_PACKAGE_URL = 'https://docs.getdbt.com/docs/package-management#section-specifying-package-versions' # noqa
 DEFAULT_SEND_ANONYMOUS_USAGE_STATS = True
 
 
-Name = NewType('Name', str)
-register_pattern(Name, r'^[^\d\W]\w*$')
+class Name(ValidatedStringMixin):
+    ValidationRegex = r'^[^\d\W]\w*$'
 
-# TODO : Validate
-# TODO : Make some sort of validated identifier class - couple other places we do this
-class Name(str, SerializableType):
-    def _serialize(self) -> str:
-        return self
-
-    @classmethod
-    def _deserialize(cls, value: str) -> 'Name':
-        return Name(value)
 
 # this does not support the full semver (does not allow a trailing -fooXYZ) and
 # is not restrictive enough for full semver, (allows '1.0'). But it's like

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -12,12 +12,25 @@ from hologram.helpers import HyphenatedJsonSchemaMixin, register_pattern, \
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Union, Any, NewType
 
+from dbt.contracts.jsonschema import dbtClassMixin
+from mashumaro.types import SerializableType
+
 PIN_PACKAGE_URL = 'https://docs.getdbt.com/docs/package-management#section-specifying-package-versions' # noqa
 DEFAULT_SEND_ANONYMOUS_USAGE_STATS = True
 
 
 Name = NewType('Name', str)
 register_pattern(Name, r'^[^\d\W]\w*$')
+
+# TODO : Validate
+# TODO : Make some sort of validated identifier class - couple other places we do this
+class Name(str, SerializableType):
+    def _serialize(self) -> str:
+        return self
+
+    @classmethod
+    def _deserialize(cls, value: str) -> 'Name':
+        return Name(value)
 
 # this does not support the full semver (does not allow a trailing -fooXYZ) and
 # is not restrictive enough for full semver, (allows '1.0'). But it's like
@@ -28,17 +41,26 @@ register_pattern(
     r'^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(\.(?:0|[1-9]\d*))?$',
 )
 
+class SemverString(str, SerializableType):
+    def _serialize(self) -> str:
+        return self
+
+    @classmethod
+    def _deserialize(cls, value: str) -> 'SemverString':
+        return SemverString(value)
+
 
 @dataclass
-class Quoting(JsonSchemaMixin, Mergeable):
-    identifier: Optional[bool]
-    schema: Optional[bool]
-    database: Optional[bool]
-    project: Optional[bool]
+class Quoting(dbtClassMixin, Mergeable):
+    identifier: Optional[bool] = None
+    schema: Optional[bool] = None
+    database: Optional[bool] = None
+    project: Optional[bool] = None
 
 
+# TODO .... hyphenation.... what.... why
 @dataclass
-class Package(Replaceable, HyphenatedJsonSchemaMixin):
+class Package(dbtClassMixin, Replaceable):
     pass
 
 
@@ -80,7 +102,7 @@ PackageSpec = Union[LocalPackage, GitPackage, RegistryPackage]
 
 
 @dataclass
-class PackageConfig(JsonSchemaMixin, Replaceable):
+class PackageConfig(dbtClassMixin, Replaceable):
     packages: List[PackageSpec]
 
 
@@ -96,13 +118,13 @@ class ProjectPackageMetadata:
 
 
 @dataclass
-class Downloads(ExtensibleJsonSchemaMixin, Replaceable):
+class Downloads(dbtClassMixin, Replaceable):
     tarball: str
 
 
 @dataclass
 class RegistryPackageMetadata(
-    ExtensibleJsonSchemaMixin,
+    dbtClassMixin,
     ProjectPackageMetadata,
 ):
     downloads: Downloads
@@ -153,7 +175,7 @@ BANNED_PROJECT_NAMES = {
 
 
 @dataclass
-class Project(HyphenatedJsonSchemaMixin, Replaceable):
+class Project(dbtClassMixin, Replaceable):
     name: Name
     version: Union[SemverString, float]
     config_version: int
@@ -189,9 +211,30 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
     packages: List[PackageSpec] = field(default_factory=list)
     query_comment: Optional[Union[QueryComment, NoValue, str]] = NoValue()
 
+    _ALIASES = {
+        'config-version': 'config_version',
+        'source-paths': 'source_paths',
+        'macro-paths': 'macro_paths',
+        'data-paths': 'data_paths',
+        'test-paths': 'test_paths',
+        'analysis-paths': 'analysis_paths',
+        'docs-paths': 'docs_paths',
+        'asset-paths': 'asset_paths',
+        'target-path': 'target_path',
+        'snapshot-paths': 'snapshot_paths',
+        'clean-targets': 'clean_targets',
+        'log-path': 'log_path',
+        'modules-path': 'modules_path',
+        'on-run-start': 'on_run_start',
+        'on-run-end': 'on_run_end',
+        'require-dbt-version': 'require_dbt_version',
+        'project-root': 'project_root',
+    }
+
     @classmethod
-    def from_dict(cls, data, validate=True) -> 'Project':
-        result = super().from_dict(data, validate=validate)
+    def deserialize(cls, data) -> 'Project':
+        # TODO : Deserialize this with aliases - right now, only implemented for serializer?
+        result = super().deserialize(data, with_aliases=True)
         if result.name in BANNED_PROJECT_NAMES:
             raise ValidationError(
                 f'Invalid project name: {result.name} is a reserved word'
@@ -200,8 +243,9 @@ class Project(HyphenatedJsonSchemaMixin, Replaceable):
         return result
 
 
+# TODO : Make extensible?
 @dataclass
-class UserConfig(ExtensibleJsonSchemaMixin, Replaceable, UserConfigContract):
+class UserConfig(dbtClassMixin, Replaceable, UserConfigContract):
     send_anonymous_usage_stats: bool = DEFAULT_SEND_ANONYMOUS_USAGE_STATS
     use_colors: Optional[bool] = None
     partial_parse: Optional[bool] = None
@@ -221,7 +265,7 @@ class UserConfig(ExtensibleJsonSchemaMixin, Replaceable, UserConfigContract):
 
 
 @dataclass
-class ProfileConfig(HyphenatedJsonSchemaMixin, Replaceable):
+class ProfileConfig(dbtClassMixin, Replaceable):
     profile_name: str = field(metadata={'preserve_underscore': True})
     target_name: str = field(metadata={'preserve_underscore': True})
     config: UserConfig
@@ -234,8 +278,8 @@ class ProfileConfig(HyphenatedJsonSchemaMixin, Replaceable):
 class ConfiguredQuoting(Quoting, Replaceable):
     identifier: bool
     schema: bool
-    database: Optional[bool]
-    project: Optional[bool]
+    database: Optional[bool] = None
+    project: Optional[bool] = None
 
 
 @dataclass
@@ -248,5 +292,5 @@ class Configuration(Project, ProfileConfig):
 
 
 @dataclass
-class ProjectList(JsonSchemaMixin):
+class ProjectList(dbtClassMixin):
     projects: Dict[str, Project]

--- a/core/dbt/contracts/relation.py
+++ b/core/dbt/contracts/relation.py
@@ -5,13 +5,14 @@ from typing import (
 )
 from typing_extensions import Protocol
 
-from dbt.contracts.jsonschema import JsonSchemaMixin
 from hologram.helpers import StrEnum
 
 from dbt import deprecations
 from dbt.contracts.util import Replaceable
 from dbt.exceptions import CompilationException
 from dbt.utils import deep_merge
+
+from dbt.contracts.jsonschema import dbtClassMixin
 
 
 class RelationType(StrEnum):
@@ -32,7 +33,7 @@ class HasQuoting(Protocol):
     quoting: Dict[str, bool]
 
 
-class FakeAPIObject(JsonSchemaMixin, Replaceable, Mapping):
+class FakeAPIObject(dbtClassMixin, Replaceable, Mapping):
     # override the mapping truthiness, len is always >1
     def __bool__(self):
         return True
@@ -63,6 +64,8 @@ mashumaro does not support generic types, so I just duplicated
 the generic type class that was here previously to get things
 working. We'd probably want to do this differently
 in the future
+
+TODO
 """
 
 @dataclass

--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -26,6 +26,8 @@ from dbt.exceptions import InternalException
 from dbt.logger import LogMessage
 from dbt.utils import restrict_to
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 TaskTags = Optional[Dict[str, Any]]
 TaskID = uuid.UUID
@@ -34,7 +36,7 @@ TaskID = uuid.UUID
 
 
 @dataclass
-class RPCParameters(JsonSchemaMixin):
+class RPCParameters(dbtClassMixin):
     timeout: Optional[float]
     task_tags: TaskTags
 
@@ -132,7 +134,7 @@ class StatusParameters(RPCParameters):
 
 
 @dataclass
-class GCSettings(JsonSchemaMixin):
+class GCSettings(dbtClassMixin):
     # start evicting the longest-ago-ended tasks here
     maxsize: int
     # start evicting all tasks before now - auto_reap_age when we have this
@@ -254,7 +256,7 @@ class RemoteExecutionResult(ExecutionResult, RemoteResult):
 
 
 @dataclass
-class ResultTable(JsonSchemaMixin):
+class ResultTable(dbtClassMixin):
     column_names: List[str]
     rows: List[Any]
 
@@ -411,7 +413,7 @@ class TaskHandlerState(StrEnum):
 
 
 @dataclass
-class TaskTiming(JsonSchemaMixin):
+class TaskTiming(dbtClassMixin):
     state: TaskHandlerState
     start: Optional[datetime]
     end: Optional[datetime]

--- a/core/dbt/contracts/selection.py
+++ b/core/dbt/contracts/selection.py
@@ -3,16 +3,18 @@ from hologram import JsonSchemaMixin
 
 from typing import List, Dict, Any, Union
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 @dataclass
-class SelectorDefinition(JsonSchemaMixin):
+class SelectorDefinition(dbtClassMixin):
     name: str
     definition: Union[str, Dict[str, Any]]
     description: str = ''
 
 
 @dataclass
-class SelectorFile(JsonSchemaMixin):
+class SelectorFile(dbtClassMixin):
     selectors: List[SelectorDefinition]
     version: int = 2
 

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -4,8 +4,20 @@ from typing import (
 import networkx as nx  # type: ignore
 
 from dbt.exceptions import InternalException
+from mashumaro.types import SerializableType
 
 UniqueId = NewType('UniqueId', str)
+
+# TODO?
+class UniqueId(str, SerializableType):
+    @classmethod
+    def _deserialize(cls, value: str) -> 'UniqueId':
+        # TODO : Validate here?
+        return UniqueId(value)
+
+    def _serialize(self) -> str:
+        # TODO : Validate here?
+        return self
 
 
 class Graph:

--- a/core/dbt/graph/graph.py
+++ b/core/dbt/graph/graph.py
@@ -4,20 +4,12 @@ from typing import (
 import networkx as nx  # type: ignore
 
 from dbt.exceptions import InternalException
+from dbt.contracts.jsonschema import ValidatedStringMixin
 from mashumaro.types import SerializableType
 
-UniqueId = NewType('UniqueId', str)
 
-# TODO?
-class UniqueId(str, SerializableType):
-    @classmethod
-    def _deserialize(cls, value: str) -> 'UniqueId':
-        # TODO : Validate here?
-        return UniqueId(value)
-
-    def _serialize(self) -> str:
-        # TODO : Validate here?
-        return self
+class UniqueId(ValidatedStringMixin):
+    ValidationRegex = '.+'
 
 
 class Graph:

--- a/core/dbt/logger.py
+++ b/core/dbt/logger.py
@@ -15,6 +15,8 @@ import colorama
 import logbook
 from hologram import JsonSchemaMixin
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 # Colorama needs some help on windows because we're using logger.info
 # intead of print(). If the Windows env doesn't have a TERM var set,
 # then we should override the logging stream to use the colorama
@@ -49,7 +51,7 @@ Extras = Dict[str, Any]
 
 
 @dataclass
-class LogMessage(JsonSchemaMixin):
+class LogMessage(dbtClassMixin):
     timestamp: datetime
     message: str
     channel: str
@@ -215,7 +217,7 @@ class TextOnly(logbook.Processor):
 
 
 class TimingProcessor(logbook.Processor):
-    def __init__(self, timing_info: Optional[JsonSchemaMixin] = None):
+    def __init__(self, timing_info: Optional[dbtClassMixin] = None):
         self.timing_info = timing_info
         super().__init__()
 

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -137,6 +137,7 @@ def main(args=None):
             exit_code = e.code
 
         except BaseException as e:
+            print(traceback.format_exc())
             logger.warning("Encountered an error:")
             logger.warning(str(e))
 

--- a/core/dbt/parser/analysis.py
+++ b/core/dbt/parser/analysis.py
@@ -13,7 +13,7 @@ class AnalysisParser(SimpleSQLParser[ParsedAnalysisNode]):
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedAnalysisNode:
-        return ParsedAnalysisNode.from_dict(dct, validate=validate)
+        return ParsedAnalysisNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/data_test.py
+++ b/core/dbt/parser/data_test.py
@@ -12,7 +12,7 @@ class DataTestParser(SimpleSQLParser[ParsedDataTestNode]):
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedDataTestNode:
-        return ParsedDataTestNode.from_dict(dct, validate=validate)
+        return ParsedDataTestNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/hooks.py
+++ b/core/dbt/parser/hooks.py
@@ -79,7 +79,7 @@ class HookParser(SimpleParser[HookBlock, ParsedHookNode]):
         return [path]
 
     def parse_from_dict(self, dct, validate=True) -> ParsedHookNode:
-        return ParsedHookNode.from_dict(dct, validate=validate)
+        return ParsedHookNode.deserialize(dct, validate=validate)
 
     @classmethod
     def get_compiled_path(cls, block: HookBlock):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -53,20 +53,22 @@ from dbt.version import __version__
 
 from hologram import JsonSchemaMixin
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 PARTIAL_PARSE_FILE_NAME = 'partial_parse.pickle'
 PARSING_STATE = DbtProcessState('parsing')
 DEFAULT_PARTIAL_PARSE = False
 
 
 @dataclass
-class ParserInfo(JsonSchemaMixin):
+class ParserInfo(dbtClassMixin):
     parser: str
     elapsed: float
     path_count: int = 0
 
 
 @dataclass
-class ProjectLoaderInfo(JsonSchemaMixin):
+class ProjectLoaderInfo(dbtClassMixin):
     project_name: str
     elapsed: float
     parsers: List[ParserInfo]
@@ -74,7 +76,7 @@ class ProjectLoaderInfo(JsonSchemaMixin):
 
 
 @dataclass
-class ManifestLoaderInfo(JsonSchemaMixin, Writable):
+class ManifestLoaderInfo(dbtClassMixin, Writable):
     path_count: int = 0
     is_partial_parse_enabled: Optional[bool] = None
     parse_project_elapsed: Optional[float] = None

--- a/core/dbt/parser/models.py
+++ b/core/dbt/parser/models.py
@@ -11,7 +11,7 @@ class ModelParser(SimpleSQLParser[ParsedModelNode]):
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedModelNode:
-        return ParsedModelNode.from_dict(dct, validate=validate)
+        return ParsedModelNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/results.py
+++ b/core/dbt/parser/results.py
@@ -3,6 +3,8 @@ from typing import TypeVar, MutableMapping, Mapping, Union, List
 
 from hologram import JsonSchemaMixin
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 from dbt.contracts.files import RemoteFile, FileHash, SourceFile
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.parsed import (
@@ -62,7 +64,7 @@ def dict_field():
 
 
 @dataclass
-class ParseResult(JsonSchemaMixin, Writable, Replaceable):
+class ParseResult(dbtClassMixin, Writable, Replaceable):
     vars_hash: FileHash
     profile_hash: FileHash
     project_hashes: MutableMapping[str, FileHash]

--- a/core/dbt/parser/rpc.py
+++ b/core/dbt/parser/rpc.py
@@ -26,7 +26,7 @@ class RPCCallParser(SimpleSQLParser[ParsedRPCNode]):
         return []
 
     def parse_from_dict(self, dct, validate=True) -> ParsedRPCNode:
-        return ParsedRPCNode.from_dict(dct, validate=validate)
+        return ParsedRPCNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -7,6 +7,7 @@ from typing import (
 )
 
 from hologram import ValidationError, JsonSchemaMixin
+from dbt.contracts.jsonschema import dbtClassMixin
 
 from dbt.adapters.factory import get_adapter
 from dbt.clients.jinja import get_rendered, add_rendered_test_kwargs
@@ -119,7 +120,8 @@ class ParserRef:
             meta=meta,
             tags=tags,
             quote=quote,
-            _extra=column.extra
+            # TODO
+            #_extra=column.extra
         )
 
     @classmethod
@@ -201,7 +203,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedSchemaTestNode:
-        return ParsedSchemaTestNode.from_dict(dct, validate=validate)
+        return ParsedSchemaTestNode.deserialize(dct, validate=validate)
 
     def _parse_format_version(
         self, yaml: YamlBlock
@@ -654,7 +656,7 @@ class YamlDocsReader(YamlReader):
         raise NotImplementedError('parse is abstract')
 
 
-T = TypeVar('T', bound=JsonSchemaMixin)
+T = TypeVar('T', bound=dbtClassMixin)
 
 
 class SourceParser(YamlDocsReader):

--- a/core/dbt/parser/seeds.py
+++ b/core/dbt/parser/seeds.py
@@ -13,7 +13,7 @@ class SeedParser(SimpleSQLParser[ParsedSeedNode]):
         )
 
     def parse_from_dict(self, dct, validate=True) -> ParsedSeedNode:
-        return ParsedSeedNode.from_dict(dct, validate=validate)
+        return ParsedSeedNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:

--- a/core/dbt/parser/snapshots.py
+++ b/core/dbt/parser/snapshots.py
@@ -26,7 +26,7 @@ class SnapshotParser(
         )
 
     def parse_from_dict(self, dct, validate=True) -> IntermediateSnapshotNode:
-        return IntermediateSnapshotNode.from_dict(dct, validate=validate)
+        return IntermediateSnapshotNode.deserialize(dct, validate=validate)
 
     @property
     def resource_type(self) -> NodeType:
@@ -66,6 +66,9 @@ class SnapshotParser(
 
     def transform(self, node: IntermediateSnapshotNode) -> ParsedSnapshotNode:
         try:
+            # TODO : This is not going to work at all
+            # TODO : We need to accept the config and turn that into a concrete
+            #        Snapshot node type
             parsed_node = ParsedSnapshotNode.from_dict(node.to_dict())
             self.set_snapshot_attributes(parsed_node)
             return parsed_node

--- a/core/dbt/rpc/logger.py
+++ b/core/dbt/rpc/logger.py
@@ -15,6 +15,9 @@ from dbt.contracts.rpc import (
 from dbt.exceptions import InternalException
 from dbt.utils import restrict_to
 
+from dbt.contracts.jsonschema import dbtClassMixin
+from mashumaro.types import SerializableType
+
 
 class QueueMessageType(StrEnum):
     Error = 'error'
@@ -26,8 +29,33 @@ class QueueMessageType(StrEnum):
 
 
 @dataclass
-class QueueMessage(JsonSchemaMixin):
+class QueueMessage(dbtClassMixin):
     message_type: QueueMessageType
+
+
+class SerializableLogRecord(logbook.LogRecord, SerializableType):
+    def _serialize(self):
+        # TODO
+        import ipdb; ipdb.set_trace()
+        pass
+
+    @classmethod
+    def _deserialize(cls, value):
+        # TODO
+        import ipdb; ipdb.set_trace()
+        pass
+
+class SerializableJSONRPCError(JSONRPCError, SerializableType):
+    def _serialize(self):
+        # TODO
+        import ipdb; ipdb.set_trace()
+        pass
+
+    @classmethod
+    def _deserialize(cls, value):
+        # TODO
+        import ipdb; ipdb.set_trace()
+        pass
 
 
 @dataclass
@@ -35,7 +63,7 @@ class QueueLogMessage(QueueMessage):
     message_type: QueueMessageType = field(
         metadata=restrict_to(QueueMessageType.Log)
     )
-    record: logbook.LogRecord
+    record: SerializableLogRecord
 
     @classmethod
     def from_record(cls, record: logbook.LogRecord):
@@ -50,7 +78,7 @@ class QueueErrorMessage(QueueMessage):
     message_type: QueueMessageType = field(
         metadata=restrict_to(QueueMessageType.Error)
     )
-    error: JSONRPCError
+    error: SerializableJSONRPCError
 
     @classmethod
     def from_error(cls, error: JSONRPCError):

--- a/core/dbt/rpc/method.py
+++ b/core/dbt/rpc/method.py
@@ -8,6 +8,8 @@ from hologram import JsonSchemaMixin, ValidationError
 from dbt.contracts.rpc import RPCParameters, RemoteResult, RemoteMethodFlags
 from dbt.exceptions import NotImplementedException, InternalException
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 Parameters = TypeVar('Parameters', bound=RPCParameters)
 Result = TypeVar('Result', bound=RemoteResult)
 
@@ -109,7 +111,7 @@ class RemoteBuiltinMethod(RemoteMethod[Parameters, Result]):
             'the run() method on builtins should never be called'
         )
 
-    def __call__(self, **kwargs: Dict[str, Any]) -> JsonSchemaMixin:
+    def __call__(self, **kwargs: Dict[str, Any]) -> dbtClassMixin:
         try:
             params = self.get_parameters().from_dict(kwargs)
         except ValidationError as exc:

--- a/core/dbt/rpc/response_manager.py
+++ b/core/dbt/rpc/response_manager.py
@@ -20,6 +20,8 @@ from dbt.rpc.task_handler import RequestTaskHandler
 from dbt.rpc.method import RemoteMethod
 from dbt.rpc.task_manager import TaskManager
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 def track_rpc_request(task):
     dbt.tracking.track_rpc_request({
@@ -90,11 +92,11 @@ class ResponseManager(JSONRPCResponseManager):
     @classmethod
     def _get_responses(cls, requests, dispatcher):
         for output in super()._get_responses(requests, dispatcher):
-            # if it's a result, check if it's a JsonSchemaMixin and if so call
+            # if it's a result, check if it's a dbtClassMixin and if so call
             # to_dict
             if hasattr(output, 'result'):
-                if isinstance(output.result, JsonSchemaMixin):
-                    output.result = output.result.to_dict(omit_none=False)
+                if isinstance(output.result, dbtClassMixin):
+                    output.result = output.result.serialize(omit_none=False)
             yield output
 
     @classmethod

--- a/core/dbt/rpc/task_handler.py
+++ b/core/dbt/rpc/task_handler.py
@@ -43,6 +43,9 @@ from dbt.rpc.method import RemoteMethod
 # we use this in typing only...
 from queue import Queue  # noqa
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
+
 
 def sigterm_handler(signum, frame):
     raise dbt.exceptions.RPCKilledException(signum)
@@ -283,7 +286,7 @@ class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
         #   - The actual thread that this represents, which writes its data to
         #     the result and logs. The atomicity of list.append() and item
         #     assignment means we don't need a lock.
-        self.result: Optional[JsonSchemaMixin] = None
+        self.result: Optional[dbtClassMixin] = None
         self.error: Optional[RPCException] = None
         self.state: TaskHandlerState = TaskHandlerState.NotStarted
         self.logs: List[LogMessage] = []

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -21,7 +21,6 @@ class Matchers(StrEnum):
 
 @dataclass
 class VersionSpecification(dbtClassMixin):
-    # TODO : Is it ok to initialize these as None?
     major: Optional[str] = None
     minor: Optional[str] = None
     patch: Optional[str] = None

--- a/core/dbt/semver.py
+++ b/core/dbt/semver.py
@@ -8,6 +8,8 @@ from hologram import JsonSchemaMixin
 from hologram.helpers import StrEnum
 from typing import Optional
 
+from dbt.contracts.jsonschema import dbtClassMixin
+
 
 class Matchers(StrEnum):
     GREATER_THAN = '>'
@@ -18,12 +20,13 @@ class Matchers(StrEnum):
 
 
 @dataclass
-class VersionSpecification(JsonSchemaMixin):
-    major: Optional[str]
-    minor: Optional[str]
-    patch: Optional[str]
-    prerelease: Optional[str]
-    build: Optional[str]
+class VersionSpecification(dbtClassMixin):
+    # TODO : Is it ok to initialize these as None?
+    major: Optional[str] = None
+    minor: Optional[str] = None
+    patch: Optional[str] = None
+    prerelease: Optional[str] = None
+    build: Optional[str] = None
     matcher: Matchers = Matchers.EXACT
 
 

--- a/core/dbt/task/list.py
+++ b/core/dbt/task/list.py
@@ -110,7 +110,7 @@ class ListTask(GraphRunnableTask):
         for node in self._iterate_selected_nodes():
             yield json.dumps({
                 k: v
-                for k, v in node.to_dict(omit_none=False).items()
+                for k, v in node.serialize(omit_none=False).items()
                 if k in self.ALLOWED_KEYS
             })
 

--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -16,13 +16,14 @@ from typing import Optional
 class PostgresCredentials(Credentials):
     host: str
     user: str
-    role: Optional[str]
     port: Port
     password: str  # on postgres the password is mandatory
+    role: Optional[str] = None
     search_path: Optional[str] = None
     keepalives_idle: int = 0  # 0 means to use the default value
     sslmode: Optional[str] = None
 
+    # TODO : Fix all instances of _ALIASES? Or include them in some base class?
     _ALIASES = {
         'dbname': 'database',
         'pass': 'password'


### PR DESCRIPTION
Draft PR - do not merge this.

Example script to assess perf gains:

```python
import dbt
import dbt.adapters.postgres.relation
import time

Relation = dbt.adapters.postgres.relation.PostgresRelation

N = 10000

t_create = 0
t_to_dict = 0
t_from_dict = 0
for i in range(N):
    step_1 = time.time()
    rel = Relation.create(database='debug', schema='debug', identifier='debug')
    step_2 = time.time()
    as_dict = rel.to_dict()
    step_3 = time.time()
    from_dict = Relation.from_dict(as_dict)
    step_4 = time.time()

    t_create += step_2 - step_1
    t_to_dict += step_3 - step_2
    t_from_dict += step_4 - step_3

total = t_create + t_to_dict + t_from_dict

print(f"create: {t_create:0.2f} ({t_create / N:0.4f} per node)")
print(f"to_dict: {t_to_dict:0.2f} ({t_to_dict / N:0.4f} per node)")
print(f"from_dict: {t_from_dict:0.2f} ({t_from_dict / N:0.4f} per node)")
print(f"total: {total:0.2f} ({total / N:0.4f} per node)")
```

Timing
| Branch | Cycles | Time |
| ------- | ------- | ----- |
| `experiment/use-mashumaro` | 100 | 0.00s |
| `experiment/use-mashumaro` | 1000 | 0.04s |
| `experiment/use-mashumaro` | 10000 | 0.23s |
| `kiyoshi-kuromiya` | 100 | 0.36s |
| `kiyoshi-kuromiya` | 1000 | 3.54s |
| `kiyoshi-kuromiya` | 10000 | 33.95s |


`kiyoshi-kuromiya avg`: 3.4ms / iteration
`experiment/use-mashumaro` avg: 0.023ms / iteration

So that's like a ~170x improvement :)