### PR TITLE
set default `materialized` for test node configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add `unixodbc-dev` package to testing docker image ([#2859](https://github.com/fishtown-analytics/dbt/pull/2859))
 - Increased the supported relation name length in postgres from 29 to 51 ([#2850](https://github.com/fishtown-analytics/dbt/pull/2850))
 - dbt list command always return 0 as exit code ([#2886](https://github.com/fishtown-analytics/dbt/issues/2886), [#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
+- Set default `materialized` for test node configs to `test` ([#2806](https://github.com/fishtown-analytics/dbt/issues/2806), [#2902](https://github.com/fishtown-analytics/dbt/pull/2902))
 
 ### Under the hood
 - Bump hologram version to 0.0.11. Add scripts/dtr.py ([#2888](https://github.com/fishtown-analytics/dbt/issues/2840),[#2889](https://github.com/fishtown-analytics/dbt/pull/2889))

--- a/core/dbt/contracts/graph/model_config.py
+++ b/core/dbt/contracts/graph/model_config.py
@@ -450,6 +450,7 @@ class SeedConfig(NodeConfig):
 
 @dataclass
 class TestConfig(NodeConfig):
+    materialized: str = 'test'
     severity: Severity = Severity('ERROR')
 
 

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -91,7 +91,8 @@ class TestDocsGenerateEscapes(DBTIntegrationTest):
         self.assertEqual(len(manifest['nodes']), 1)
         self.assertIn('model.test.model', manifest['nodes'])
         self.assertIn('schema', manifest['nodes']['model.test.model'])
-        self.assertEqual('pg', manifest['nodes']['model.test.model']['schema'][:2])
+        self.assertEqual('pg', manifest['nodes']
+                         ['model.test.model']['schema'][:2])
 
 
 class TestDocsGenerate(DBTIntegrationTest):
@@ -116,7 +117,6 @@ class TestDocsGenerate(DBTIntegrationTest):
     def tearDown(self):
         super().tearDown()
         del os.environ['DBT_ENV_CUSTOM_ENV_env_key']
-
 
     @property
     def schema(self):
@@ -209,11 +209,11 @@ class TestDocsGenerate(DBTIntegrationTest):
                 "include": True
             },
             "diststyle": {
-              "id": "diststyle",
-              "label": "Dist Style",
-              "value": AnyStringWith('AUTO'),
-              "description": "Distribution style or distribution key column, if key distribution is defined.",
-              "include": True
+                "id": "diststyle",
+                "label": "Dist Style",
+                "value": AnyStringWith('AUTO'),
+                "description": "Distribution style or distribution key column, if key distribution is defined.",
+                "include": True
             },
             "max_varchar": {
                 "id": "max_varchar",
@@ -349,7 +349,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                           table_type, model_stats, seed_stats=None, case=None,
                           case_columns=False, model_database=None):
         if case is None:
-            case = lambda x: x
+            def case(x): return x
         col_case = case if case_columns else lambda x: x
 
         if seed_stats is None:
@@ -888,7 +888,8 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         assert set(catalog) == {'errors', 'metadata', 'nodes', 'sources'}
 
-        self.verify_metadata(catalog['metadata'], 'https://schemas.getdbt.com/dbt/catalog/v1.json')
+        self.verify_metadata(
+            catalog['metadata'], 'https://schemas.getdbt.com/dbt/catalog/v1.json')
         assert not catalog['errors']
 
         for key in 'nodes', 'sources':
@@ -988,7 +989,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         result = {
             'column_types': {},
             'enabled': True,
-            'materialized': 'view',
+            'materialized': 'test',
             'persist_docs': {},
             'post-hook': [],
             'pre-hook': [],
@@ -1071,10 +1072,13 @@ class TestDocsGenerate(DBTIntegrationTest):
             model_database = self.alternative_database
 
         model_config = self.rendered_model_config(database=model_database)
-        second_config = self.rendered_model_config(schema=self.alternate_schema[-4:])
+        second_config = self.rendered_model_config(
+            schema=self.alternate_schema[-4:])
 
-        unrendered_model_config = self.unrendered_model_config(database=model_database, materialized='view')
-        unrendered_second_config = self.unrendered_model_config(schema=self.alternate_schema[-4:], materialized='view')
+        unrendered_model_config = self.unrendered_model_config(
+            database=model_database, materialized='view')
+        unrendered_second_config = self.unrendered_model_config(
+            schema=self.alternate_schema[-4:], materialized='view')
 
         seed_config = self.rendered_seed_config()
         unrendered_seed_config = self.unrendered_seed_config()
@@ -2143,7 +2147,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'config': self.rendered_model_config(
                         cluster_by=['first_name'],
                         materialized='table',
-                        partition_by={'field': 'updated_at', 'data_type': 'date'},
+                        partition_by={'field': 'updated_at',
+                                      'data_type': 'date'},
                     ),
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
@@ -2219,7 +2224,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': self.unrendered_model_config(
                         cluster_by=['first_name'],
                         materialized='table',
-                        partition_by={'field': 'updated_at', 'data_type': 'date'},
+                        partition_by={'field': 'updated_at',
+                                      'data_type': 'date'},
                     ),
                 },
                 'model.test.multi_clustered': {
@@ -2228,7 +2234,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'config': self.rendered_model_config(
                         cluster_by=['first_name', 'email'],
                         materialized='table',
-                        partition_by={'field': 'updated_at', 'data_type': 'date'}
+                        partition_by={'field': 'updated_at',
+                                      'data_type': 'date'}
                     ),
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
@@ -2303,7 +2310,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': self.unrendered_model_config(
                         cluster_by=['first_name', 'email'],
                         materialized='table',
-                        partition_by={'field': 'updated_at', 'data_type': 'date'}
+                        partition_by={'field': 'updated_at',
+                                      'data_type': 'date'}
                     ),
                 },
                 'model.test.nested_view': {
@@ -2864,12 +2872,16 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         for key in manifest_keys:
             if key == 'macros':
-                self.verify_manifest_macros(manifest, expected_manifest.get('macros'))
+                self.verify_manifest_macros(
+                    manifest, expected_manifest.get('macros'))
             elif key == 'metadata':
                 metadata = manifest['metadata']
-                self.verify_metadata(metadata, 'https://schemas.getdbt.com/dbt/manifest/v1.json')
-                assert 'project_id' in metadata and metadata['project_id'] == '098f6bcd4621d373cade4e832627b4f6'
-                assert 'send_anonymous_usage_stats' in metadata and metadata['send_anonymous_usage_stats'] is False
+                self.verify_metadata(
+                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v1.json')
+                assert 'project_id' in metadata and metadata[
+                    'project_id'] == '098f6bcd4621d373cade4e832627b4f6'
+                assert 'send_anonymous_usage_stats' in metadata and metadata[
+                    'send_anonymous_usage_stats'] is False
                 assert 'user_id' in metadata and metadata['user_id'] is None
                 assert 'adapter_type' in metadata and metadata['adapter_type'] == self.adapter_type
             else:
@@ -2895,9 +2907,12 @@ class TestDocsGenerate(DBTIntegrationTest):
             model_database = self.alternative_database
 
         model_config = self.rendered_model_config(database=model_database)
-        second_model_config = self.rendered_model_config(schema=self.alternate_schema[-4:])
-        unrendered_model_config = self.unrendered_model_config(database=model_database, materialized='view')
-        unrendered_second_model_config = self.unrendered_model_config(schema=self.alternate_schema[-4:], materialized='view')
+        second_model_config = self.rendered_model_config(
+            schema=self.alternate_schema[-4:])
+        unrendered_model_config = self.unrendered_model_config(
+            database=model_database, materialized='view')
+        unrendered_second_model_config = self.unrendered_model_config(
+            schema=self.alternate_schema[-4:], materialized='view')
         schema = self.unique_schema()
 
         # we are selecting from the seed, which is always in the default db
@@ -3735,7 +3750,8 @@ class TestDocsGenerate(DBTIntegrationTest):
         run_results = _read_json('./target/run_results.json')
 
         assert 'metadata' in run_results
-        self.verify_metadata(run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v1.json')
+        self.verify_metadata(
+            run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v1.json')
         self.assertIn('elapsed_time', run_results)
         self.assertGreater(run_results['elapsed_time'], 0)
         self.assertTrue(
@@ -3752,7 +3768,8 @@ class TestDocsGenerate(DBTIntegrationTest):
 
     @use_profile('postgres')
     def test__postgres__run_and_generate_no_compile(self):
-        self.run_and_generate(alternate_db=self.default_database, args=['--no-compile'])
+        self.run_and_generate(
+            alternate_db=self.default_database, args=['--no-compile'])
         self.verify_catalog(self.expected_postgres_catalog())
         self.assertFalse(os.path.exists('./target/manifest.json'))
 
@@ -3777,12 +3794,14 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         self.verify_catalog(self.expected_postgres_references_catalog())
         self.verify_manifest(self.expected_postgres_references_manifest())
-        self.verify_run_results(self.expected_postgres_references_run_results())
+        self.verify_run_results(
+            self.expected_postgres_references_run_results())
 
     @use_profile('postgres')
     def test_postgres_asset_paths_copied(self):
         self.run_and_generate(
-            {'asset-paths': [self.dir('assets'), self.dir('non-existent-assets')]},
+            {'asset-paths': [self.dir('assets'),
+                             self.dir('non-existent-assets')]},
         )
 
         assert os.path.exists('./target/assets')
@@ -3823,7 +3842,8 @@ class TestDocsGenerate(DBTIntegrationTest):
 
         self.verify_catalog(self.expected_snowflake_catalog(case_columns=True))
         self.verify_manifest(self.expected_seeded_manifest(quote_model=True))
-        self.verify_run_results(self.expected_run_results(quote_schema=False, quote_model=True))
+        self.verify_run_results(self.expected_run_results(
+            quote_schema=False, quote_model=True))
 
     @use_profile('bigquery')
     def test__bigquery__run_and_generate(self):
@@ -3862,7 +3882,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             model_count=1,
         )
         self.verify_catalog(self.expected_redshift_incremental_catalog())
-        self.verify_manifest(self.expected_redshift_incremental_view_manifest())
+        self.verify_manifest(
+            self.expected_redshift_incremental_view_manifest())
 
     @use_profile('presto')
     def test__presto__run_and_generate(self):

--- a/test/integration/047_dbt_ls_test/test_ls.py
+++ b/test/integration/047_dbt_ls_test/test_ls.py
@@ -332,7 +332,7 @@ class TestStrictUndefined(DBTIntegrationTest):
                     'tags': ['schema'],
                     'config': {
                         'enabled': True,
-                        'materialized': 'view',
+                        'materialized': 'test',
                         'post-hook': [],
                         'severity': 'ERROR',
                         'tags': [],
@@ -356,7 +356,7 @@ class TestStrictUndefined(DBTIntegrationTest):
                     'tags': ['data'],
                     'config': {
                         'enabled': True,
-                        'materialized': 'view',
+                        'materialized': 'test',
                         'post-hook': [],
                         'severity': 'ERROR',
                         'tags': [],
@@ -380,7 +380,7 @@ class TestStrictUndefined(DBTIntegrationTest):
                     'tags': ['schema'],
                     'config': {
                         'enabled': True,
-                        'materialized': 'view',
+                        'materialized': 'test',
                         'post-hook': [],
                         'severity': 'ERROR',
                         'tags': [],

--- a/test/unit/test_contracts_graph_compiled.py
+++ b/test/unit/test_contracts_graph_compiled.py
@@ -235,31 +235,40 @@ unchanged_compiled_models = [
     lambda u: (u, u.replace(alias='nope')),
 
     # None -> False is a config change even though it's pretty much the same
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': False})), u.replace(config=u.config.replace(persist_docs={'relation': False}))),
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': False})), u.replace(config=u.config.replace(persist_docs={'columns': False}))),
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': False})), u.replace(
+        config=u.config.replace(persist_docs={'relation': False}))),
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': False})), u.replace(
+        config=u.config.replace(persist_docs={'columns': False}))),
     # True -> True
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': True})), u.replace(config=u.config.replace(persist_docs={'relation': True}))),
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': True})), u.replace(config=u.config.replace(persist_docs={'columns': True}))),
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': True})), u.replace(
+        config=u.config.replace(persist_docs={'relation': True}))),
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': True})), u.replace(
+        config=u.config.replace(persist_docs={'columns': True}))),
 
     # only columns docs enabled, but description changed
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': True})), u.replace(config=u.config.replace(persist_docs={'columns': True}), description='a model description')),
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'columns': True})), u.replace(
+        config=u.config.replace(persist_docs={'columns': True}), description='a model description')),
     # only relation docs eanbled, but columns changed
-    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': True})), u.replace(config=u.config.replace(persist_docs={'relation': True}), columns={'a': ColumnInfo(name='a', description='a column description')}))
+    lambda u: (u.replace(config=u.config.replace(persist_docs={'relation': True})), u.replace(config=u.config.replace(
+        persist_docs={'relation': True}), columns={'a': ColumnInfo(name='a', description='a column description')}))
 ]
 
 
 changed_compiled_models = [
     lambda u: (u, None),
     lambda u: (u, u.replace(raw_sql='select * from wherever')),
-    lambda u: (u, u.replace(fqn=['test', 'models', 'subdir', 'foo'], original_file_path='models/subdir/foo.sql', path='/root/models/subdir/foo.sql')),
+    lambda u: (u, u.replace(fqn=['test', 'models', 'subdir', 'foo'],
+                            original_file_path='models/subdir/foo.sql', path='/root/models/subdir/foo.sql')),
     lambda u: (u, replace_config(u, full_refresh=True)),
     lambda u: (u, replace_config(u, post_hook=['select 1 as id'])),
     lambda u: (u, replace_config(u, pre_hook=['select 1 as id'])),
-    lambda u: (u, replace_config(u, quoting={'database': True, 'schema': False, 'identifier': False})),
+    lambda u: (u, replace_config(
+        u, quoting={'database': True, 'schema': False, 'identifier': False})),
     # we changed persist_docs values
     lambda u: (u, replace_config(u, persist_docs={'relation': True})),
     lambda u: (u, replace_config(u, persist_docs={'columns': True})),
-    lambda u: (u, replace_config(u, persist_docs={'columns': True, 'relation': True})),
+    lambda u: (u, replace_config(u, persist_docs={
+               'columns': True, 'relation': True})),
 
     # None -> False is a config change even though it's pretty much the same
     lambda u: (u, replace_config(u, persist_docs={'relation': False})),
@@ -267,12 +276,14 @@ changed_compiled_models = [
     # persist docs was true for the relation and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={'relation': True}),
-        replace_config(u, persist_docs={'relation': True}, description='a model description'),
+        replace_config(u, persist_docs={
+                       'relation': True}, description='a model description'),
     ),
     # persist docs was true for columns and we changed the model description
     lambda u: (
         replace_config(u, persist_docs={'columns': True}),
-        replace_config(u, persist_docs={'columns': True}, columns={'a': ColumnInfo(name='a', description='a column description')})
+        replace_config(u, persist_docs={'columns': True}, columns={
+                       'a': ColumnInfo(name='a', description='a column description')})
     ),
     # changing alias/schema/database on the config level is a change
     lambda u: (u, replace_config(u, database='nope')),
@@ -408,7 +419,7 @@ def basic_uncompiled_schema_test_dict():
         'config': {
             'column_types': {},
             'enabled': True,
-            'materialized': 'view',
+            'materialized': 'test',
             'persist_docs': {},
             'post-hook': [],
             'pre-hook': [],
@@ -457,7 +468,7 @@ def basic_compiled_schema_test_dict():
         'config': {
             'column_types': {},
             'enabled': True,
-            'materialized': 'view',
+            'materialized': 'test',
             'persist_docs': {},
             'post-hook': [],
             'pre-hook': [],
@@ -539,13 +550,15 @@ unchanged_schema_tests = [
     lambda u: replace_config(u, full_refresh=True),
     lambda u: replace_config(u, post_hook=['select 1 as id']),
     lambda u: replace_config(u, pre_hook=['select 1 as id']),
-    lambda u: replace_config(u, quoting={'database': True, 'schema': False, 'identifier': False}),
+    lambda u: replace_config(
+        u, quoting={'database': True, 'schema': False, 'identifier': False}),
 ]
 
 
 changed_schema_tests = [
     lambda u: None,
-    lambda u: u.replace(fqn=['test', 'models', 'subdir', 'foo'], original_file_path='models/subdir/foo.sql', path='/root/models/subdir/foo.sql'),
+    lambda u: u.replace(fqn=['test', 'models', 'subdir', 'foo'],
+                        original_file_path='models/subdir/foo.sql', path='/root/models/subdir/foo.sql'),
     lambda u: replace_config(u, severity='warn'),
     # If we checked test metadata, these would caount. But we don't, because these changes would all change the unique ID, so it's irrelevant.
     # lambda u: u.replace(test_metadata=u.test_metadata.replace(namespace='something')),
@@ -572,5 +585,6 @@ def test_compare_to_compiled(basic_uncompiled_schema_test_node, basic_compiled_s
     compiled = basic_compiled_schema_test_node
     assert not uncompiled.same_contents(compiled)
     fixed_config = compiled.config.replace(severity=uncompiled.config.severity)
-    fixed_compiled = compiled.replace(config=fixed_config, unrendered_config=uncompiled.unrendered_config)
+    fixed_compiled = compiled.replace(
+        config=fixed_config, unrendered_config=uncompiled.unrendered_config)
     assert uncompiled.same_contents(fixed_compiled)

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -982,7 +982,7 @@ def basic_parsed_schema_test_dict():
         'config': {
             'column_types': {},
             'enabled': True,
-            'materialized': 'view',
+            'materialized': 'test',
             'persist_docs': {},
             'post-hook': [],
             'pre-hook': [],
@@ -1137,7 +1137,7 @@ def test_basic_schema_test_node(minimal_parsed_schema_test_dict, basic_parsed_sc
     assert node.empty is False
     assert node.is_ephemeral is False
     assert node.is_refable is False
-    assert node.get_materialization() == 'view'
+    assert node.get_materialization() == 'test'
 
     assert_from_dict(node, minimum, ParsedSchemaTestNode)
     pickle.loads(pickle.dumps(node))


### PR DESCRIPTION
(possibly) resolves #2806 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->

After noticing similar behavior for seed and snapshot node configs, this change sets the default `materialized` for test node configs to `test`. It aligns selection behavior, but this is definitely extending the meaning of `materialized`.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
