### PR TITLE
Hourly, monthly and yearly partitions in BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Store resolved node names in manifest ([#2647](https://github.com/fishtown-analytics/dbt/issues/2647), [#2837](https://github.com/fishtown-analytics/dbt/pull/2837))
 - Save selectors dictionary to manifest, allow descriptions ([#2693](https://github.com/fishtown-analytics/dbt/issues/2693), [#2866](https://github.com/fishtown-analytics/dbt/pull/2866))
 - Normalize cli-style-strings in manifest selectors dictionary ([#2879](https://github.com/fishtown-anaytics/dbt/issues/2879), [#2895](https://github.com/fishtown-analytics/dbt/pull/2895))
+- Hourly, monthly and yearly partitions available in BigQuery ([#2476](https://github.com/fishtown-analytics/dbt/issues/2476), [#2903](https://github.com/fishtown-analytics/dbt/pull/2903))
 
 ### Fixes
 - Respect --project-dir in dbt clean command ([#2840](https://github.com/fishtown-analytics/dbt/issues/2840), [#2841](https://github.com/fishtown-analytics/dbt/pull/2841))
@@ -25,6 +26,7 @@ Contributors:
 - [@elexisvenator](https://github.com/elexisvenator) ([#2850](https://github.com/fishtown-analytics/dbt/pull/2850))
 - [@franloza](https://github.com/franloza) ([#2837](https://github.com/fishtown-analytics/dbt/pull/2837))
 - [@rsella](https://github.com/rsella) ([#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
+- [@db-magnus](https://github.com/db-magnus) ([#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 
 ## dbt 0.19.0b1 (October 21, 2020)
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -57,13 +57,11 @@ class PartitionConfig(JsonSchemaMixin):
         column: str = self.field
         if alias:
             column = f'{alias}.{self.field}'
-        logger.debug(f'Render and field"{self.field}"')
-        logger.debug(f'Granularity is "{self.granularity}"')
+
         if self.data_type == 'timestamp':
-            logger.debug(f'timestamp_trunc({column},{self.granularity}')
-            return f'timestamp_trunc({column},{self.granularity})'
+            return f'timestamp_trunc({column}, {self.granularity})'
         elif self.data_type == 'datetime':
-            return f'datetime_trunc({column},{self.granularity})'
+            return f'datetime_trunc({column}, {self.granularity})'
         else:
             return column
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -50,16 +50,13 @@ def sql_escape(string):
 class PartitionConfig(JsonSchemaMixin):
     field: str
     data_type: str = 'date'
+    granularity: str = 'DAY'
     range: Optional[Dict[str, Any]] = None
 
     def render(self, alias: Optional[str] = None):
         column: str = self.field
         if alias:
             column = f'{alias}.{self.field}'
-
-        granularity: str = 'DAY'
-        if self.granularity:
-            granularity = self.granularity
 
         if self.data_type == 'timestamp':
             return f'timestamp_trunc({column}, {self.granularity})'

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -50,13 +50,16 @@ def sql_escape(string):
 class PartitionConfig(JsonSchemaMixin):
     field: str
     data_type: str = 'date'
-    granularity: str = 'DAY'
     range: Optional[Dict[str, Any]] = None
 
     def render(self, alias: Optional[str] = None):
         column: str = self.field
         if alias:
             column = f'{alias}.{self.field}'
+
+        granularity: str = 'DAY'
+        if self.granularity:
+            granularity = self.granularity
 
         if self.data_type == 'timestamp':
             return f'timestamp_trunc({column}, {self.granularity})'

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -58,15 +58,11 @@ class PartitionConfig(JsonSchemaMixin):
         if alias:
             column = f'{alias}.{self.field}'
 
-        if self.data_type == 'timestamp':
-            return f'timestamp_trunc({column}, {self.granularity})'
-        elif self.data_type == 'datetime':
-            return f'datetime_trunc({column}, {self.granularity})'
-        elif self.data_type == 'date' and \
-                self.granularity in ('MONTH', 'YEAR', 'month', 'year'):
-            return f'date_trunc({column}, {self.granularity})'
-        else:
+        if self.data_type.lower() == 'date' and \
+                self.granularity.lower() == 'day':
             return column
+        else:
+            return f'{self.data_type}_trunc({column}, {self.granularity})'
 
     @classmethod
     def parse(cls, raw_partition_by) -> Optional['PartitionConfig']:

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -552,7 +552,7 @@ class BigQueryAdapter(BaseAdapter):
             return True
         elif conf_partition and table.time_partitioning is not None:
             table_field = table.time_partitioning.field
-            table_granularity = table.partitioning.type
+            table_granularity = table.partitioning_type
             return table_field == conf_partition.field \
                 and table_granularity == conf_partition.granularity
         elif conf_partition and table.range_partitioning is not None:

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -62,6 +62,8 @@ class PartitionConfig(JsonSchemaMixin):
             return f'timestamp_trunc({column}, {self.granularity})'
         elif self.data_type == 'datetime':
             return f'datetime_trunc({column}, {self.granularity})'
+        elif self.data_type == 'date' and self.granularity in ('MONTH','YEAR'):
+            return f'date_trunc({column}, {self.granularity})'
         else:
             return column
 
@@ -550,7 +552,9 @@ class BigQueryAdapter(BaseAdapter):
             return True
         elif conf_partition and table.time_partitioning is not None:
             table_field = table.time_partitioning.field
-            return table_field == conf_partition.field
+            table_granularity = table.partitioning.type
+            return table_field == conf_partition.field \
+                and table_granularity == conf_partition.granularity
         elif conf_partition and table.range_partitioning is not None:
             dest_part = table.range_partitioning
             conf_part = conf_partition.range or {}

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -50,7 +50,7 @@ def sql_escape(string):
 class PartitionConfig(JsonSchemaMixin):
     field: str
     data_type: str = 'date'
-    granularity: str = 'DAY'
+    granularity: str = 'day'
     range: Optional[Dict[str, Any]] = None
 
     def render(self, alias: Optional[str] = None):

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -63,7 +63,7 @@ class PartitionConfig(JsonSchemaMixin):
         elif self.data_type == 'datetime':
             return f'datetime_trunc({column}, {self.granularity})'
         elif self.data_type == 'date' and \
-            self.granularity in ('MONTH','YEAR','month','year'):
+                self.granularity in ('MONTH', 'YEAR', 'month', 'year'):
             return f'date_trunc({column}, {self.granularity})'
         else:
             return column

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -50,15 +50,20 @@ def sql_escape(string):
 class PartitionConfig(JsonSchemaMixin):
     field: str
     data_type: str = 'date'
+    granularity: str = 'DAY'
     range: Optional[Dict[str, Any]] = None
 
     def render(self, alias: Optional[str] = None):
         column: str = self.field
         if alias:
             column = f'{alias}.{self.field}'
-
-        if self.data_type in ('timestamp', 'datetime'):
-            return f'date({column})'
+        logger.debug(f'Render and field"{self.field}"')
+        logger.debug(f'Granularity is "{self.granularity}"')
+        if self.data_type == 'timestamp':
+            logger.debug(f'timestamp_trunc({column},{self.granularity}')
+            return f'timestamp_trunc({column},{self.granularity})'
+        elif self.data_type == 'datetime':
+            return f'datetime_trunc({column},{self.granularity})'
         else:
             return column
 

--- a/plugins/bigquery/dbt/adapters/bigquery/impl.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/impl.py
@@ -62,7 +62,8 @@ class PartitionConfig(JsonSchemaMixin):
             return f'timestamp_trunc({column}, {self.granularity})'
         elif self.data_type == 'datetime':
             return f'datetime_trunc({column}, {self.granularity})'
-        elif self.data_type == 'date' and self.granularity in ('MONTH','YEAR'):
+        elif self.data_type == 'date' and \
+            self.granularity in ('MONTH','YEAR','month','year'):
             return f'date_trunc({column}, {self.granularity})'
         else:
             return column

--- a/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
+++ b/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
@@ -34,7 +34,28 @@ class TestChangingPartitions(DBTIntegrationTest):
         after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp'}, "cluster_by": None}
         self.run_changes(before, after)
         self.test_partitions({"expected": 1})
-        
+
+    @use_profile('bigquery')
+    def test_bigquery_add_partition_year(self):
+        before = {"partition_by": None, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'YEAR'}, "cluster_by": None}
+        self.run_changes(before, after)
+        self.test_partitions({"expected": 1})
+
+    @use_profile('bigquery')
+    def test_bigquery_add_partition_month(self):
+        before = {"partition_by": None, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'MONTH'}, "cluster_by": None}
+        self.run_changes(before, after)
+        self.test_partitions({"expected": 1})
+
+    @use_profile('bigquery')
+    def test_bigquery_add_partition_hour(self):
+        before = {"partition_by": None, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'HOUR'}, "cluster_by": None}
+        self.run_changes(before, after)
+        self.test_partitions({"expected": 1})
+
     @use_profile('bigquery')
     def test_bigquery_remove_partition(self):
         before = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp'}, "cluster_by": None}

--- a/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
+++ b/test/integration/022_bigquery_test/test_bigquery_changing_partitions.py
@@ -38,21 +38,28 @@ class TestChangingPartitions(DBTIntegrationTest):
     @use_profile('bigquery')
     def test_bigquery_add_partition_year(self):
         before = {"partition_by": None, "cluster_by": None}
-        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'YEAR'}, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'year'}, "cluster_by": None}
         self.run_changes(before, after)
         self.test_partitions({"expected": 1})
 
     @use_profile('bigquery')
     def test_bigquery_add_partition_month(self):
         before = {"partition_by": None, "cluster_by": None}
-        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'MONTH'}, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'month'}, "cluster_by": None}
         self.run_changes(before, after)
         self.test_partitions({"expected": 1})
 
     @use_profile('bigquery')
     def test_bigquery_add_partition_hour(self):
         before = {"partition_by": None, "cluster_by": None}
-        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'HOUR'}, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'hour'}, "cluster_by": None}
+        self.run_changes(before, after)
+        self.test_partitions({"expected": 1})
+
+    @use_profile('bigquery')
+    def test_bigquery_add_partition_hour(self):
+        before = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'day'}, "cluster_by": None}
+        after = {"partition_by": {'field': 'cur_time', 'data_type': 'timestamp', 'granularity': 'hour'}, "cluster_by": None}
         self.run_changes(before, after)
         self.test_partitions({"expected": 1})
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -671,6 +671,32 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
         self.assertEqual(
             adapter.parse_partition_by({
                 "field": "ts",
+                "data_type": "date",
+                "granularity": "MONTH"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "date",
+                "granularity": "MONTH"
+            }
+        )
+        
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "date",
+                "granularity": "YEAR"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "date",
+                "granularity": "YEAR"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
                 "data_type": "timestamp",
                 "granularity": "HOUR"
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -664,7 +664,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             }).to_dict(), {
                 "field": "ts",
                 "data_type": "date",
-                "granularity": "DAY"
+                "granularity": "day"
             }
         )
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -652,7 +652,8 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
                 "field": "ts",
             }).to_dict(), {
                 "field": "ts",
-                "data_type": "date"
+                "data_type": "date",
+                "granularity": "DAY"
             }
         )
 
@@ -662,7 +663,86 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
                 "data_type": "date",
             }).to_dict(), {
                 "field": "ts",
-                "data_type": "date"
+                "data_type": "date",
+                "granularity": "DAY"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "HOUR"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "HOUR"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "MONTH"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "MONTH"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "YEAR"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "timestamp",
+                "granularity": "YEAR"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "HOUR"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "HOUR"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "MONTH"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "MONTH"
+            }
+        )
+
+        self.assertEqual(
+            adapter.parse_partition_by({
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "YEAR"
+
+            }).to_dict(), {
+                "field": "ts",
+                "data_type": "datetime",
+                "granularity": "YEAR"
             }
         )
 
@@ -683,6 +763,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             }).to_dict(), {
                 "field": "id",
                 "data_type": "int64",
+                "granularity": "DAY",
                 "range": {
                     "start": 1,
                     "end": 100,

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -653,7 +653,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             }).to_dict(), {
                 "field": "ts",
                 "data_type": "date",
-                "granularity": "DAY"
+                "granularity": "day"
             }
         )
 

--- a/test/unit/test_bigquery_adapter.py
+++ b/test/unit/test_bigquery_adapter.py
@@ -789,7 +789,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
             }).to_dict(), {
                 "field": "id",
                 "data_type": "int64",
-                "granularity": "DAY",
+                "granularity": "day",
                 "range": {
                     "start": 1,
                     "end": 100,


### PR DESCRIPTION
resolves #2476

### Description

Added possibility for more partition types on timestamp or datetime columns.

Using the granularity field as discussed in the issue to specify how to partition. Had to change some existing tests to support this granularity field.

I've added some tests in , let me know if this is ok or if I should do it differently.

### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
