### PR TITLE
Render docs blocks in exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Widen supported Google Cloud libraries dependencies ([#2794](https://github.com/fishtown-analytics/dbt/pull/2794), [#2877](https://github.com/fishtown-analytics/dbt/pull/2877)).
 - dbt list command always return 0 as exit code ([#2886](https://github.com/fishtown-analytics/dbt/issues/2886), [#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 - Set default `materialized` for test node configs to `test` ([#2806](https://github.com/fishtown-analytics/dbt/issues/2806), [#2902](https://github.com/fishtown-analytics/dbt/pull/2902))
+- Allow docs blocks in exposure descriptions ([#2913](https://github.com/fishtown-analytics/dbt/issues/2913), [#2920](https://github.com/fishtown-analytics/dbt/pull/2920))
 
 ### Under the hood
 - Bump hologram version to 0.0.11. Add scripts/dtr.py ([#2888](https://github.com/fishtown-analytics/dbt/issues/2840),[#2889](https://github.com/fishtown-analytics/dbt/pull/2889))
@@ -29,6 +30,7 @@ Contributors:
 - [@franloza](https://github.com/franloza) ([#2837](https://github.com/fishtown-analytics/dbt/pull/2837))
 - [@max-sixty](https://github.com/max-sixty) ([#2877](https://github.com/fishtown-analytics/dbt/pull/2877))
 - [@rsella](https://github.com/rsella) ([#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
+- [@joellabes](https://github.com/joellabes) ([#2913](https://github.com/fishtown-analytics/dbt/issues/2913))
 
 ## dbt 0.19.0b1 (October 21, 2020)
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -654,9 +654,9 @@ class ParsedExposure(UnparsedBaseNode, HasUniqueID, HasFqn):
     type: ExposureType
     owner: ExposureOwner
     resource_type: NodeType = NodeType.Exposure
+    description: str = ''
     maturity: Optional[MaturityType] = None
     url: Optional[str] = None
-    description: Optional[str] = None
     depends_on: DependsOn = field(default_factory=DependsOn)
     refs: List[List[str]] = field(default_factory=list)
     sources: List[List[str]] = field(default_factory=list)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -411,7 +411,7 @@ class ExposureOwner(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class UnparsedExposure(JsonSchemaMixin, Replaceable):
+class UnparsedExposure(HasYamlMetadata, Replaceable):
     name: str
     type: ExposureType
     owner: ExposureOwner

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -413,9 +413,9 @@ class ExposureOwner(JsonSchemaMixin, Replaceable):
 @dataclass
 class UnparsedExposure(HasYamlMetadata, Replaceable):
     name: str
+    description: str = ''
     type: ExposureType
     owner: ExposureOwner
     maturity: Optional[MaturityType] = None
     url: Optional[str] = None
-    description: Optional[str] = None
     depends_on: List[str] = field(default_factory=list)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -413,9 +413,9 @@ class ExposureOwner(JsonSchemaMixin, Replaceable):
 @dataclass
 class UnparsedExposure(HasYamlMetadata, Replaceable):
     name: str
-    description: str = ''
     type: ExposureType
     owner: ExposureOwner
+    description: str = ''
     maturity: Optional[MaturityType] = None
     url: Optional[str] = None
     depends_on: List[str] = field(default_factory=list)

--- a/core/dbt/node_types.py
+++ b/core/dbt/node_types.py
@@ -46,6 +46,7 @@ class NodeType(StrEnum):
             cls.Source,
             cls.Macro,
             cls.Analysis,
+            cls.Exposure
         ]
 
     def pluralize(self) -> str:

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -622,6 +622,12 @@ def _process_docs_for_macro(
         arg.description = get_rendered(arg.description, context)
 
 
+def _process_docs_for_exposure(
+    context: Dict[str, Any], exposure: ParsedExposure
+) -> None:
+    exposure.description = get_rendered(exposure.description, context)
+
+
 def process_docs(manifest: Manifest, config: RuntimeConfig):
     for node in manifest.nodes.values():
         ctx = generate_runtime_docs(
@@ -647,6 +653,14 @@ def process_docs(manifest: Manifest, config: RuntimeConfig):
             config.project_name,
         )
         _process_docs_for_macro(ctx, macro)
+    for exposure in manifest.exposures.values():
+        ctx = generate_runtime_docs(
+            config,
+            exposure,
+            manifest,
+            config.project_name,
+        )
+        _process_docs_for_exposure(ctx, exposure)
 
 
 def _process_refs_for_exposure(

--- a/test/integration/029_docs_generate_tests/ref_models/docs.md
+++ b/test/integration/029_docs_generate_tests/ref_models/docs.md
@@ -25,3 +25,7 @@ My table
 {% docs column_info %}
 An ID field
 {% enddocs %}
+
+{% docs notebook_info %}
+A description of the complex exposure
+{% enddocs %}

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -29,3 +29,16 @@ sources:
         columns:
           - name: id
             description: "{{ doc('column_info') }}"
+
+exposures:
+  - name: notebook_exposure
+    type: notebook
+    depends_on:
+      - ref('model')
+      - ref('second_model')
+    owner:
+      email: something@example.com
+      name: Some name
+    description: "{{ doc('notebook_info') }}"
+    maturity: medium
+    url: http://example.com/notebook/1

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -34,8 +34,7 @@ exposures:
   - name: notebook_exposure
     type: notebook
     depends_on:
-      - ref('model')
-      - ref('second_model')
+      - ref('view_summary')
     owner:
       email: something@example.com
       name: Some name

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1594,7 +1594,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                             'model.test.model'
                         ],
                     },
-                    'description': None,
+                    'description': '',
                     'fqn': ['test', 'simple_exposure'],
                     'name': 'simple_exposure',
                     'original_file_path': self.dir('models/schema.yml'),

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1996,7 +1996,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             	'exposure.test.notebook_exposure': {
                     'depends_on': {
                         'macros': [],
-                        'nodes': ['model.test.model', 'model.test.second_model']
+                        'nodes': ['model.test.view_summary']
                     },
                     'description': 'A description of the complex exposure',
                     'fqn': ['test', 'notebook_exposure'],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2110,7 +2110,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'child_map': {
                 'model.test.ephemeral_copy': ['model.test.ephemeral_summary'],
-		        'exposure.test.notebook_exposure': ['model.test.view_summary'],
+		        'exposure.test.notebook_exposure': [],
                 'model.test.ephemeral_summary': ['model.test.view_summary'],
                 'model.test.view_summary': ['exposure.test.notebook_exposure'],
                 'seed.test.seed': ['snapshot.test.snapshot_seed'],
@@ -2121,7 +2121,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.ephemeral_copy': ['source.test.my_source.my_table'],
                 'model.test.ephemeral_summary': ['model.test.ephemeral_copy'],
                 'model.test.view_summary': ['model.test.ephemeral_summary'],
-                'exposure.test.notebook_exposure': [],
+                'exposure.test.notebook_exposure': ['model.test.view_summary'],
                 'seed.test.seed': [],
                 'snapshot.test.snapshot_seed': ['seed.test.seed'],
                 'source.test.my_source.my_table': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2098,6 +2098,15 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'root_path': self.test_root_realpath,
                     'unique_id': 'test.macro_info',
                 },
+                'test.notebook_info': {
+                    'block_contents': 'A description of the complex exposure',
+                    'name': 'notebook_info',
+                    'original_file_path': docs_path,
+                    'package_name': 'test',
+                    'path': 'docs.md',
+                    'root_path': self.test_root_realpath,
+                    'unique_id': 'test.notebook_info'
+                },
                 'test.macro_arg_info': {
                     'block_contents': 'The model for my custom test',
                     'name': 'macro_arg_info',

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1992,7 +1992,32 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': {}
                 },
             },
-            'exposures': {},
+            'exposures': {
+            	'exposure.test.notebook_exposure': {
+                    'depends_on': {
+                        'macros': [],
+                        'nodes': ['model.test.model', 'model.test.second_model']
+                    },
+                    'description': 'A description of the complex exposure',
+                    'fqn': ['test', 'notebook_exposure'],
+                    'maturity': 'medium',
+                    'name': 'notebook_exposure',
+                    'original_file_path': self.dir('models/schema.yml'),
+                    'owner': {
+                        'email': 'something@example.com',
+                        'name': 'Some name'
+                    },
+                    'package_name': 'test',
+                    'path': 'schema.yml',
+                    'refs': [['model'], ['second_model']],
+                    'resource_type': 'exposure',
+                    'root_path': self.test_root_realpath,
+                    'sources': [],
+                    'type': 'notebook',
+                    'unique_id': 'exposure.test.notebook_exposure',
+                    'url': 'http://example.com/notebook/1'
+                },
+            },
             'selectors': {},
             'docs': {
                 'dbt.__overview__': ANY,

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2121,7 +2121,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.ephemeral_copy': ['source.test.my_source.my_table'],
                 'model.test.ephemeral_summary': ['model.test.ephemeral_copy'],
                 'model.test.view_summary': ['model.test.ephemeral_summary'],
-                'exposure.test.notebook_exposure': ['model.test.view_summary'],
+                'exposure.test.notebook_exposure': [],
                 'seed.test.seed': [],
                 'snapshot.test.snapshot_seed': ['seed.test.seed'],
                 'source.test.my_source.my_table': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2110,8 +2110,9 @@ class TestDocsGenerate(DBTIntegrationTest):
             },
             'child_map': {
                 'model.test.ephemeral_copy': ['model.test.ephemeral_summary'],
+		        'exposure.test.notebook_exposure': ['model.test.view_summary'],
                 'model.test.ephemeral_summary': ['model.test.view_summary'],
-                'model.test.view_summary': [],
+                'model.test.view_summary': ['exposure.test.notebook_exposure'],
                 'seed.test.seed': ['snapshot.test.snapshot_seed'],
                 'snapshot.test.snapshot_seed': [],
                 'source.test.my_source.my_table': ['model.test.ephemeral_copy'],
@@ -2120,6 +2121,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 'model.test.ephemeral_copy': ['source.test.my_source.my_table'],
                 'model.test.ephemeral_summary': ['model.test.ephemeral_copy'],
                 'model.test.view_summary': ['model.test.ephemeral_summary'],
+                'exposure.test.notebook_exposure': ['model.test.view_summary'],
                 'seed.test.seed': [],
                 'snapshot.test.snapshot_seed': ['seed.test.seed'],
                 'source.test.my_source.my_table': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1567,7 +1567,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                         'macros': [],
                         'nodes': ['model.test.model', 'model.test.second_model']
                     },
-                    'description': 'A description of the complex exposure',
+                    'description': 'A description of the complex exposure\n',
                     'fqn': ['test', 'notebook_exposure'],
                     'maturity': 'medium',
                     'name': 'notebook_exposure',
@@ -2002,14 +2002,14 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'fqn': ['test', 'notebook_exposure'],
                     'maturity': 'medium',
                     'name': 'notebook_exposure',
-                    'original_file_path': self.dir('models/schema.yml'),
+                    'original_file_path': 'models/schema.yml',
                     'owner': {
                         'email': 'something@example.com',
                         'name': 'Some name'
                     },
                     'package_name': 'test',
                     'path': 'schema.yml',
-                    'refs': [['model'], ['second_model']],
+                    'refs': [['view_summary']],
                     'resource_type': 'exposure',
                     'root_path': self.test_root_realpath,
                     'sources': [],

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -2002,7 +2002,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'fqn': ['test', 'notebook_exposure'],
                     'maturity': 'medium',
                     'name': 'notebook_exposure',
-                    'original_file_path': 'models/schema.yml',
+                    'original_file_path': self.dir('ref_models/schema.yml'),
                     'owner': {
                         'email': 'something@example.com',
                         'name': 'Some name'

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -2017,6 +2017,7 @@ def minimal_parsed_exposure_dict():
         'path': 'models/something.yml',
         'root_path': '/usr/src/app',
         'original_file_path': 'models/something.yml',
+        'description': ''
     }
 
 
@@ -2041,6 +2042,7 @@ def basic_parsed_exposure_dict():
         'path': 'models/something.yml',
         'root_path': '/usr/src/app',
         'original_file_path': 'models/something.yml',
+        'description': ''
     }
 
 
@@ -2056,6 +2058,7 @@ def basic_parsed_exposure_object():
         root_path='/usr/src/app',
         original_file_path='models/something.yml',
         owner=ExposureOwner(email='test@example.com'),
+        description=''
     )
 
 

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -576,6 +576,7 @@ class TestUnparsedExposure(ContractTestCase):
 
     def get_ok_dict(self):
         return {
+        	'yaml_key': 'exposures'
             'name': 'my_exposure',
             'type': 'dashboard',
             'owner': {
@@ -587,11 +588,14 @@ class TestUnparsedExposure(ContractTestCase):
             'depends_on': [
                 'ref("my_model")',
                 'source("raw", "source_table")',
-            ]
+            ],
+            'original_file_path': '/some/fake/path',
+            'package_name': 'test'
         }
 
     def test_ok(self):
         exposure = self.ContractType(
+        	yaml_key='exposures'
             name='my_exposure',
             type=ExposureType.Dashboard,
             owner=ExposureOwner(email='name@example.com'),
@@ -599,6 +603,8 @@ class TestUnparsedExposure(ContractTestCase):
             url='https://example.com/dashboards/1',
             description='A exposure',
             depends_on=['ref("my_model")', 'source("raw", "source_table")'],
+            original_file_path='/some/fake/path',
+            package_name='test'
         )
         dct = self.get_ok_dict()
         self.assert_symmetric(exposure, dct)

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -576,7 +576,7 @@ class TestUnparsedExposure(ContractTestCase):
 
     def get_ok_dict(self):
         return {
-        	'yaml_key': 'exposures'
+        	'yaml_key': 'exposures',
             'name': 'my_exposure',
             'type': 'dashboard',
             'owner': {

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -595,7 +595,7 @@ class TestUnparsedExposure(ContractTestCase):
 
     def test_ok(self):
         exposure = self.ContractType(
-        	yaml_key='exposures'
+        	yaml_key='exposures',
             name='my_exposure',
             type=ExposureType.Dashboard,
             owner=ExposureOwner(email='name@example.com'),


### PR DESCRIPTION
resolves #2913 

### Description

Should ensure that docs blocks render correctly in exposures' descriptions. 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
