### PR TITLE
Revert dependabot cryptography upgrade for old versions

### DIFF
--- a/docker/requirements/requirements.0.15.3.txt
+++ b/docker/requirements/requirements.0.15.3.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.2
 docutils==0.15.2
 future==0.18.2

--- a/docker/requirements/requirements.0.16.0.txt
+++ b/docker/requirements/requirements.0.16.0.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.0b2.txt
+++ b/docker/requirements/requirements.0.16.0b2.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.1
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.0b3.txt
+++ b/docker/requirements/requirements.0.16.0b3.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.1
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.0rc2.txt
+++ b/docker/requirements/requirements.0.16.0rc2.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.0rc3.txt
+++ b/docker/requirements/requirements.0.16.0rc3.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.0rc4.txt
+++ b/docker/requirements/requirements.0.16.0rc4.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.8
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.16.1rc1.txt
+++ b/docker/requirements/requirements.0.16.1rc1.txt
@@ -12,7 +12,7 @@ certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0.txt
+++ b/docker/requirements/requirements.0.17.0.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.2
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0b1.txt
+++ b/docker/requirements/requirements.0.17.0b1.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.1
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0rc1.txt
+++ b/docker/requirements/requirements.0.17.0rc1.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.1
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0rc2.txt
+++ b/docker/requirements/requirements.0.17.0rc2.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.1
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0rc3.txt
+++ b/docker/requirements/requirements.0.17.0rc3.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.1
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.0rc4.txt
+++ b/docker/requirements/requirements.0.17.0rc4.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.1
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.1.txt
+++ b/docker/requirements/requirements.0.17.1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.1rc1.txt
+++ b/docker/requirements/requirements.0.17.1rc1.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.2
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.1rc2.txt
+++ b/docker/requirements/requirements.0.17.1rc2.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.1rc3.txt
+++ b/docker/requirements/requirements.0.17.1rc3.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.1rc4.txt
+++ b/docker/requirements/requirements.0.17.1rc4.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.2.txt
+++ b/docker/requirements/requirements.0.17.2.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.2b1.txt
+++ b/docker/requirements/requirements.0.17.2b1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.17.2rc1.txt
+++ b/docker/requirements/requirements.0.17.2rc1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.0.txt
+++ b/docker/requirements/requirements.0.18.0.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.0b1.txt
+++ b/docker/requirements/requirements.0.18.0b1.txt
@@ -12,7 +12,7 @@ certifi==2020.4.5.2
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.0b2.txt
+++ b/docker/requirements/requirements.0.18.0b2.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.13.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.0rc1.txt
+++ b/docker/requirements/requirements.0.18.0rc1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.0rc2.txt
+++ b/docker/requirements/requirements.0.18.0rc2.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.1.txt
+++ b/docker/requirements/requirements.0.18.1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.1b1.txt
+++ b/docker/requirements/requirements.0.18.1b1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.1b2.txt
+++ b/docker/requirements/requirements.0.18.1b2.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.1b3.txt
+++ b/docker/requirements/requirements.0.18.1b3.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.18.1rc1.txt
+++ b/docker/requirements/requirements.0.18.1rc1.txt
@@ -14,7 +14,7 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0

--- a/docker/requirements/requirements.0.19.0b1.txt
+++ b/docker/requirements/requirements.0.19.0b1.txt
@@ -12,7 +12,7 @@ certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.3
-cryptography==3.2
+cryptography==2.9.2
 decorator==4.4.2
 docutils==0.15.2
 google-api-core==1.16.0


### PR DESCRIPTION
Reverts fishtown-analytics/dbt#2858

In #2922, we bumped cryptography to `>=3.2,<4` for the next minor release of dbt (v0.19.0). We should also consider bumping the upper bound _only_ (`>=2,<4`) for a new patch release (v0.18.2) that adds python 3.9 support.

In the meantime, we shouldn't make retroactive changes to requirements for versions that are incompatible with their stated dependencies.