### PR TITLE
[WIP] Enable to specify column schemas in BigQuery

### DIFF
--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -48,7 +48,7 @@
 {%- endmacro -%}
 
 {% macro bigquery__create_table_as(temporary, relation, sql) -%}
-  {%- set raw_column_schemas = config.get('column_schemas', {}) -%}
+  {%- set raw_column_schemas = config.get('column_schemas', none) -%}
   {%- set raw_partition_by = config.get('partition_by', none) -%}
   {%- set raw_cluster_by = config.get('cluster_by', none) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
@@ -58,7 +58,7 @@
   {{ sql_header if sql_header is not none }}
 
   create or replace table {{ relation }}
-  {{ bigquery_column_schemas(raw_column_schemas) if raw_column_schemas is defined and raw_column_schemas | length > 0 }}
+  {{ bigquery_column_schemas(raw_column_schemas) if raw_column_schemas is not none }}
   {{ partition_by(partition_config) }}
   {{ cluster_by(raw_cluster_by) }}
   {{ bigquery_table_options(config, model, temporary) }}

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -58,7 +58,7 @@
   {{ sql_header if sql_header is not none }}
 
   create or replace table {{ relation }}
-  {{ bigquery_column_schemas(raw_column_schemas) if raw_column_schemas | length > 0 }}
+  {{ bigquery_column_schemas(raw_column_schemas) if raw_column_schemas is defined and raw_column_schemas | length > 0 }}
   {{ partition_by(partition_config) }}
   {{ cluster_by(raw_cluster_by) }}
   {{ bigquery_table_options(config, model, temporary) }}

--- a/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/adapters.sql
@@ -58,7 +58,7 @@
   {{ sql_header if sql_header is not none }}
 
   create or replace table {{ relation }}
-  {{ bigquery_column_schemas(raw_column_schemas) }}
+  {{ bigquery_column_schemas(raw_column_schemas) if raw_column_schemas | length > 0 }}
   {{ partition_by(partition_config) }}
   {{ cluster_by(raw_cluster_by) }}
   {{ bigquery_table_options(config, model, temporary) }}

--- a/test/integration/022_bigquery_test/models/column_schema_model.sql
+++ b/test/integration/022_bigquery_test/models/column_schema_model.sql
@@ -1,0 +1,19 @@
+{{
+  config(
+    column_schemas={
+      "required_value": "INT64 NOT NULL",
+      "nullable_value": "STRING",
+      "x": "STRUCT<x1 INT64 NOT NULL, x2 STRING> NOT NULL",
+      "y": "ARRAY<INT64>"
+    }
+  )
+}}
+
+SELECT
+  1 AS required_value,
+  "a" AS nullable_value,
+  STRUCT(
+    1 AS x1,
+    "a" AS x2
+  ) AS x,
+  [1, 2, 3] AS array_value

--- a/test/integration/022_bigquery_test/test_simple_bigquery_view.py
+++ b/test/integration/022_bigquery_test/test_simple_bigquery_view.py
@@ -55,7 +55,7 @@ class TestSimpleBigQueryRun(TestBaseBigQueryRun):
         self.run_dbt(['seed', '--full-refresh'])
         results = self.run_dbt()
         # Bump expected number of results when adding new model
-        self.assertEqual(len(results), 11)
+        self.assertEqual(len(results), 12)
         self.assert_nondupes_pass()
 
 
@@ -66,7 +66,7 @@ class TestUnderscoreBigQueryRun(TestBaseBigQueryRun):
     def test_bigquery_run_twice(self):
         self.run_dbt(['seed'])
         results = self.run_dbt()
-        self.assertEqual(len(results), 11)
+        self.assertEqual(len(results), 12)
         results = self.run_dbt()
-        self.assertEqual(len(results), 11)
+        self.assertEqual(len(results), 12)
         self.assert_nondupes_pass()


### PR DESCRIPTION
resolves #2936

### Description
The `CRATE TABLE` DDL in BigQuery allows us to specify column schemas. For instance, by supporting the feature, we can define required columns. We can notice there is something is wrong with creating a table with schemas as well as we don't have to test `not_null` for required columns.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
