### PR TITLE
Use diff file path for big seed checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Increased the supported relation name length in postgres from 29 to 51 ([#2850](https://github.com/fishtown-analytics/dbt/pull/2850))
 - dbt list command always return 0 as exit code ([#2886](https://github.com/fishtown-analytics/dbt/issues/2886), [#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 - Set default `materialized` for test node configs to `test` ([#2806](https://github.com/fishtown-analytics/dbt/issues/2806), [#2902](https://github.com/fishtown-analytics/dbt/pull/2902))
+- Use original file path instead of absolute path as checksum for big seeds ([#2927](https://github.com/fishtown-analytics/dbt/issues/2927), [#2939](https://github.com/fishtown-analytics/dbt/pull/2939))
 
 ### Under the hood
 - Bump hologram version to 0.0.11. Add scripts/dtr.py ([#2888](https://github.com/fishtown-analytics/dbt/issues/2840),[#2889](https://github.com/fishtown-analytics/dbt/pull/2889))

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -156,7 +156,7 @@ class SourceFile(JsonSchemaMixin):
     @classmethod
     def big_seed(cls, path: FilePath) -> 'SourceFile':
         """Parse seeds over the size limit with just the path"""
-        self = cls(path=path, checksum=FileHash.path(path.absolute_path))
+        self = cls(path=path, checksum=FileHash.path(path.original_file_path))
         self.contents = ''
         return self
 

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -443,7 +443,7 @@ def basic_parsed_seed_dict():
         'docs': {'show': True},
         'columns': {},
         'meta': {},
-        'checksum': {'name': 'path', 'checksum': '/root/seeds/seed.csv'},
+        'checksum': {'name': 'path', 'checksum': 'seeds/seed.csv'},
         'unrendered_config': {},
     }
 
@@ -474,7 +474,7 @@ def basic_parsed_seed_object():
         docs=Docs(show=True),
         columns={},
         meta={},
-        checksum=FileHash(name='path', checksum='/root/seeds/seed.csv'),
+        checksum=FileHash(name='path', checksum='seeds/seed.csv'),
         unrendered_config={},
     )
 
@@ -494,7 +494,7 @@ def minimal_parsed_seed_dict():
         'database': 'test_db',
         'schema': 'test_schema',
         'alias': 'foo',
-        'checksum': {'name': 'path', 'checksum': '/root/seeds/seed.csv'},
+        'checksum': {'name': 'path', 'checksum': 'seeds/seed.csv'},
     }
 
 


### PR DESCRIPTION
resolves #2927

### Description
- Replace `absolute_path` with `original_file_path` in the checksum of big seeds (> 1 MB)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue: I did this in a pretty hacky way, by moving around my dbt project, but it worked!
 - ~This PR includes tests, or tests are not required/relevant for this PR~ — I updated existing tests. I could try to write a new, replicating this specific issue, if you think it's worthwhile. Basically we'd need to instantiate a project with a big seed, move the entire project within the filesystem (but not the seed within that project), and check to see if it'll be marked modified.
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.