### PR TITLE
Defer iff unselected reference does not exist in current env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - dbt list command always return 0 as exit code ([#2886](https://github.com/fishtown-analytics/dbt/issues/2886), [#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 - Set default `materialized` for test node configs to `test` ([#2806](https://github.com/fishtown-analytics/dbt/issues/2806), [#2902](https://github.com/fishtown-analytics/dbt/pull/2902))
 - Use original file path instead of absolute path as checksum for big seeds ([#2927](https://github.com/fishtown-analytics/dbt/issues/2927), [#2939](https://github.com/fishtown-analytics/dbt/pull/2939))
+- Defer if and only if upstream reference does not exist in current environment namespace ([#2909](https://github.com/fishtown-analytics/dbt/issues/2909), [#2946](https://github.com/fishtown-analytics/dbt/pull/2946))
 
 ### Under the hood
 - Bump hologram version to 0.0.11. Add scripts/dtr.py ([#2888](https://github.com/fishtown-analytics/dbt/issues/2840),[#2889](https://github.com/fishtown-analytics/dbt/pull/2889))

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -887,6 +887,7 @@ class Manifest:
 
     def merge_from_artifact(
         self,
+        adapter,
         other: 'WritableManifest',
         selected: AbstractSet[UniqueID],
     ) -> None:
@@ -898,10 +899,14 @@ class Manifest:
         refables = set(NodeType.refable())
         merged = set()
         for unique_id, node in other.nodes.items():
+            current = self.nodes[unique_id]
             if (
                 node.resource_type in refables and
                 not node.is_ephemeral and
-                unique_id not in selected
+                unique_id not in selected and
+                not adapter.get_relation(
+                    current.database, current.schema, current.identifier
+                )
             ):
                 merged.add(unique_id)
                 self.nodes[unique_id] = node.replace(deferred=True)

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -899,8 +899,8 @@ class Manifest:
         refables = set(NodeType.refable())
         merged = set()
         for unique_id, node in other.nodes.items():
-            current = self.nodes[unique_id]
-            if (
+            current = self.nodes.get(unique_id)
+            if current and (
                 node.resource_type in refables and
                 not node.is_ephemeral and
                 unique_id not in selected and

--- a/core/dbt/task/run.py
+++ b/core/dbt/task/run.py
@@ -372,7 +372,7 @@ class RunTask(CompileTask):
             )
         return state.manifest
 
-    def defer_to_manifest(self, selected_uids: AbstractSet[str]):
+    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
         deferred_manifest = self._get_deferred_manifest()
         if deferred_manifest is None:
             return
@@ -382,6 +382,7 @@ class RunTask(CompileTask):
                 'manifest to defer from!'
             )
         self.manifest.merge_from_artifact(
+            adapter=adapter,
             other=deferred_manifest,
             selected=selected_uids,
         )
@@ -389,10 +390,10 @@ class RunTask(CompileTask):
         self.write_manifest()
 
     def before_run(self, adapter, selected_uids: AbstractSet[str]):
-        self.defer_to_manifest(selected_uids)
         with adapter.connection_named('master'):
             self.create_schemas(adapter, selected_uids)
             self.populate_adapter_cache(adapter)
+            self.defer_to_manifest(adapter, selected_uids)
             self.safe_run_hooks(adapter, RunHookType.Start, {})
 
     def after_run(self, adapter, results):


### PR DESCRIPTION
resolves #2909

### Description

Today, `--defer` is a blanket override: build the resources included by my selection criteria, and use the `--state` manifest's namespaces for any references to resources _not_ included by my selection criteria.

Instead, this PR would make it a more flexible fallback: If there's a resource I want to build, and it references a resource I haven't selected, use the other manifest's namespace _if and only if_ the upstream resource doesn't exist in my current environment namespace. In this way, `--defer` is more like a "fail-over" mechanism, using the deferred environment to fill in the gaps of whatever's missing in the current environment.

Pros:
- Fixes current unavoidable behavior whereby `dbt run --defer` would _always_ defer non-model resources (seeds and snapshots). If you've just seeded or snapshotted into your scratch/CI schema, you probably want to use those objects to build your models in the following step.
- Fixes annoying behavior whereby subsequent run steps would defer resources run by previous run steps. This is a common use case for testing changed incremental models in CI by rerunning only them (`dbt run -m state:modified ...` followed by `dbt run -m state:modified,config.materialized:incremental ...`).
- If we wanted to, we could reopen test deferral (#2701). I cherry-picked 280803c (from #2706), and it _just worked_. This is after months after convincing myself (and other people, too) that test deferral was A Bad Thing, Actually. Really, I just didn't see a way to do it right. Of course, many of the caveats still apply, e.g. that `relationships` tests don't make a lot of sense in CI environments.

Cons:
- If you have a lot of cruft hanging around in your scratch schema, and you want to use deferral as a "clean" override—use prod references for _everything_ I'm not currently building—you'll need to drop the cruft first. You could see this as a minor regression from current behavior, though IMO it's _very_ minor. The intended use case for `--defer` is dev, CI, and other scratch schemas that can be created, dropped, and recreated with aplomb.
- If you instantiate your dev/CI/scratch schema by first zero-copy cloning on Snowflake, you wouldn't be able to defer any of your references. But you also wouldn't need to; cloning and deferral accomplish the same purpose.

If you buy the premise, the solution is _very_ straightforward—a pleasant surprise. We made deferral a beta feature in v0.18 for exactly this reason: we knew there would be wrinkles to iron out. All the same, it's better to make this change sooner rather than later.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
