### PR TITLE
Feature: defer tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## dbt 0.19.0 (Release TBD)
 
 ### Features
-- Added macro get_partitions_metadata(table) to return partition metadata for partitioned table [#2596](https://github.com/fishtown-analytics/dbt/pull/2596)
+- Added macro get_partitions_metadata(table) to return partition metadata for partitioned table ([#2552](https://github.com/fishtown-analytics/dbt/pull/2552), [#2596](https://github.com/fishtown-analytics/dbt/pull/2596))
+- Added `--defer` flag for `dbt test` as well. ([#2701](https://github.com/fishtown-analytics/dbt/issues/2701), [#2706](https://github.com/fishtown-analytics/dbt/pull/2706))
 - Added native python 're' module for regex in jinja templates [#2851](https://github.com/fishtown-analytics/dbt/pull/2851)
 - Store resolved node names in manifest ([#2647](https://github.com/fishtown-analytics/dbt/issues/2647), [#2837](https://github.com/fishtown-analytics/dbt/pull/2837))
 - Save selectors dictionary to manifest, allow descriptions ([#2693](https://github.com/fishtown-analytics/dbt/issues/2693), [#2866](https://github.com/fishtown-analytics/dbt/pull/2866))
@@ -176,7 +177,6 @@ Contributors:
 - Add relevance criteria to site search ([docs#113](https://github.com/fishtown-analytics/dbt-docs/pull/113))
 - Support new selector methods, intersection, and arbitrary parent/child depth in DAG selection syntax ([docs#118](https://github.com/fishtown-analytics/dbt-docs/pull/118))
 - Revise anonymous event tracking: simpler URL fuzzing; differentiate between Cloud-hosted and non-Cloud docs ([docs#121](https://github.com/fishtown-analytics/dbt-docs/pull/121))
-
 Contributors:
 - [@bbhoss](https://github.com/bbhoss) ([#2677](https://github.com/fishtown-analytics/dbt/pull/2677))
 - [@kconvey](https://github.com/kconvey) ([#2694](https://github.com/fishtown-analytics/dbt/pull/2694), [#2709](https://github.com/fishtown-analytics/dbt/pull/2709)), [#2711](https://github.com/fishtown-analytics/dbt/pull/2711))

--- a/core/dbt/contracts/rpc.py
+++ b/core/dbt/contracts/rpc.py
@@ -79,6 +79,7 @@ class RPCTestParameters(RPCCompileParameters):
     data: bool = False
     schema: bool = False
     state: Optional[str] = None
+    defer: Optional[bool] = None
 
 
 @dataclass

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -446,6 +446,21 @@ def _build_snapshot_subparser(subparsers, base_subparser):
     return sub
 
 
+def _add_defer_argument(*subparsers):
+    for sub in subparsers:
+        sub.add_optional_argument_inverse(
+            '--defer',
+            enable_help='''
+            If set, defer to the state variable for resolving unselected nodes.
+            ''',
+            disable_help='''
+            If set, do not defer to the state variable for resolving unselected
+            nodes.
+            ''',
+            default=flags.DEFER_MODE,
+        )
+
+
 def _build_run_subparser(subparsers, base_subparser):
     run_sub = subparsers.add_parser(
         'run',
@@ -461,19 +476,6 @@ def _build_run_subparser(subparsers, base_subparser):
         help='''
         Stop execution upon a first failure.
         '''
-    )
-
-    # this is a "dbt run"-only thing, for now
-    run_sub.add_optional_argument_inverse(
-        '--defer',
-        enable_help='''
-        If set, defer to the state variable for resolving unselected nodes.
-        ''',
-        disable_help='''
-        If set, do not defer to the state variable for resolving unselected
-        nodes.
-        ''',
-        default=flags.DEFER_MODE,
     )
 
     run_sub.set_defaults(cls=run_task.RunTask, which='run', rpc_method='run')
@@ -1033,6 +1035,8 @@ def parse_args(args, cls=DBTArgumentParser):
     # list_sub sets up its own arguments.
     _add_selection_arguments(run_sub, compile_sub, generate_sub, test_sub)
     _add_selection_arguments(snapshot_sub, seed_sub, models_name='select')
+    # --defer
+    _add_defer_argument(run_sub, test_sub)
     # --full-refresh
     _add_table_mutability_arguments(run_sub, compile_sub)
 

--- a/core/dbt/task/rpc/project_commands.py
+++ b/core/dbt/task/rpc/project_commands.py
@@ -129,6 +129,10 @@ class RemoteTestProjectTask(RPCCommandTask[RPCTestParameters], TestTask):
         self.args.schema = params.schema
         if params.threads is not None:
             self.args.threads = params.threads
+        if params.defer is None:
+            self.args.defer = flags.DEFER_MODE
+        else:
+            self.args.defer = params.defer
 
         self.args.state = state_path(params.state)
         self.set_previous_state()

--- a/core/dbt/task/seed.py
+++ b/core/dbt/task/seed.py
@@ -38,6 +38,10 @@ class SeedRunner(ModelRunner):
 
 
 class SeedTask(RunTask):
+    def defer_to_manifest(self, adapter, selected_uids):
+        # seeds don't defer
+        return
+
     def raise_on_first_error(self):
         return False
 

--- a/core/dbt/task/snapshot.py
+++ b/core/dbt/task/snapshot.py
@@ -22,6 +22,10 @@ class SnapshotTask(RunTask):
     def raise_on_first_error(self):
         return False
 
+    def defer_to_manifest(self, adapter, selected_uids):
+        # snapshots don't defer
+        return
+
     def get_node_selector(self):
         if self.manifest is None or self.graph is None:
             raise InternalException(

--- a/test/integration/062_defer_state_test/test_defer_state.py
+++ b/test/integration/062_defer_state_test/test_defer_state.py
@@ -27,7 +27,7 @@ class TestDeferState(DBTIntegrationTest):
             'config-version': 2,
             'seeds': {
                 'test': {
-                    'quote_columns': True,
+                    'quote_columns': False,
                 }
             }
         }
@@ -55,12 +55,21 @@ class TestDeferState(DBTIntegrationTest):
         results = self.run_dbt(['run'])
         assert len(results) == 2
         assert not any(r.node.deferred for r in results)
+        results = self.run_dbt(['test'])
+        assert len(results) == 2
 
         # copy files over from the happy times when we had a good target
         self.copy_state()
 
-        # no state, still fails
+        # test tests first, because run will change things
+        # no state, wrong schema, failure.
+        self.run_dbt(['test', '--target', 'otherschema'], expect_pass=False)
+
+        # no state, run also fails
         self.run_dbt(['run', '--target', 'otherschema'], expect_pass=False)
+
+        # defer test, it succeeds
+        results = self.run_dbt(['test', '-m', 'view_model+', '--state', 'state', '--defer', '--target', 'otherschema'])
 
         # with state it should work though
         results = self.run_dbt(['run', '-m', 'view_model', '--state', 'state', '--defer', '--target', 'otherschema'])
@@ -115,8 +124,13 @@ class TestDeferState(DBTIntegrationTest):
         assert len(results) == 1
         results = self.run_dbt(['run', '--state', 'state', '--defer'])
         assert len(results) == 2
-        
+
         # because the seed now exists in our schema, we shouldn't defer it
+        assert self.other_schema not in results[0].node.compiled_sql
+        assert self.unique_schema() in results[0].node.compiled_sql
+
+        # despite deferral, test should use models just created in our schema
+        results = self.run_dbt(['test', '--state', 'state', '--defer'])
         assert self.other_schema not in results[0].node.compiled_sql
         assert self.unique_schema() in results[0].node.compiled_sql
 
@@ -124,14 +138,11 @@ class TestDeferState(DBTIntegrationTest):
     def test_postgres_state_changetarget(self):
         self.run_and_defer()
         # these should work without --defer!
-        self.run_dbt(['test'])
         self.run_dbt(['snapshot'])
         # make sure these commands don't work with --defer
         with pytest.raises(SystemExit):
             self.run_dbt(['seed', '--defer'])
 
-        with pytest.raises(SystemExit):
-            self.run_dbt(['test', '--defer'])
         with pytest.raises(SystemExit):
             self.run_dbt(['snapshot', '--defer'])
 

--- a/test/rpc/test_test.py
+++ b/test/rpc/test_test.py
@@ -105,3 +105,9 @@ def test_rpc_test_state(
             querier.test(state='./state', models=['state:modified']),
         )
         assert len(results['results']) == 0
+        
+        # a better test of defer would require multiple targets
+        results = querier.async_wait_for_result(
+            querier.run(state='./state', models=['state:modified'], defer=True)
+        )
+        assert len(results['results']) == 0

--- a/test/rpc/util.py
+++ b/test/rpc/util.py
@@ -335,6 +335,7 @@ class Querier:
         data: bool = None,
         schema: bool = None,
         request_id: int = 1,
+        defer: Optional[bool] = None,
         state: Optional[bool] = None,
     ):
         params = {}
@@ -348,6 +349,8 @@ class Querier:
             params['schema'] = schema
         if threads is not None:
             params['threads'] = threads
+        if defer is not None:
+            params['defer'] = defer
         if state is not None:
             params['state'] = state
         return self.request(


### PR DESCRIPTION
resolves #2701
picks up from #2706
requires #2946

### Description

There's a lengthy section of the [state comparison caveats](https://next.docs.getdbt.com/reference/node-selection/state-comparison-caveats/#tests) devoted solely to tests. To make a long story short:
- If a test is new or modified, but its parent model is not, `dbt run -m state:modified && dbt test -m state:modified` will return a failure because we will execute the test without having built its parent
- If a test has multiple parents, but only one of those parent models is new or modified, the same commands will return a failure because we will execute the test without having built one of its parents
- and so on.

Previously, I have recommended that community members use the advanced node selection syntax available in v0.18 to pick only the tests they'd want to run (`--exclude test_name:relationships test_type:data`), or to ensure that the parent models of modified tests were always built with commands like:
```
$ dbt run -m state:modified @state:modified,1+test_type:data
$ dbt test -m state:modified
```

In truth, everything would be a lot simpler if we added support for `dbt test --defer`. I believe we can do that, following a subtle-but-significant change to what deferral actually means (#2946). If a parent resource (seed, model, snapshot, etc) exists in the current namespace, we use it; if it doesn't exist in the current namespace, we defer its reference to the state manifest's namespace. (Inclusion or exclusion from the selection criteria has nothing to do with which objects are deferred, since models are never included by the criteria of `dbt test`.)

Let's say we're running a CI job, and comparing against a manifest from the main branch / production. Our `model_b` has been changed, `model_a` has not, and there's a `relationships` test between them.

Our CI job can now be very simple:
```
$ dbt run -m state:modified
$ dbt test -m state:modified
```

In the first step, we will build `ci_schema.model_b` because it has been modified. In the second step, we will execute the `relationships` test, which is selected because its parent `model_b` is modified. The compiled SQL for that test will look like:

```sql
select count(*) as validation_errors
from (
    select col3 as id from "db"."production"."model_a"
) as child
left join (
    select col3 as id from "db"."ci_schema"."model_b"
) as parent on parent.id = child.id
where child.id is not null
  and parent.id is null
```

Granted, I don't think `relationships` tests make a lot of sense in a CI context, and they make even less sense when trying to assert referential integrity across environments. That being said, the query _will_ succeed and return a number of rows. It's then up to the user to decide if they want to update their selection criteria with `--exclude test_name:relationships`.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
