### PR TITLE
Fix KeyError from defer + deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Allow docs blocks in exposure descriptions ([#2913](https://github.com/fishtown-analytics/dbt/issues/2913), [#2920](https://github.com/fishtown-analytics/dbt/pull/2920))
 - Use original file path instead of absolute path as checksum for big seeds ([#2927](https://github.com/fishtown-analytics/dbt/issues/2927), [#2939](https://github.com/fishtown-analytics/dbt/pull/2939))
 - Defer if and only if upstream reference does not exist in current environment namespace ([#2909](https://github.com/fishtown-analytics/dbt/issues/2909), [#2946](https://github.com/fishtown-analytics/dbt/pull/2946))
+- Fix KeyError if deferring to a manifest with a since-deleted source, ephemeral model, or test ([#2875](https://github.com/fishtown-analytics/dbt/issues/2875), [#2958](https://github.com/fishtown-analytics/dbt/pull/2958))
 
 ### Under the hood
 - Bump hologram version to 0.0.11. Add scripts/dtr.py ([#2888](https://github.com/fishtown-analytics/dbt/issues/2840),[#2889](https://github.com/fishtown-analytics/dbt/pull/2889))

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -234,7 +234,7 @@ def build_edges(nodes: List[ManifestNode]):
     for node in nodes:
         backward_edges[node.unique_id] = node.depends_on_nodes[:]
         for unique_id in node.depends_on_nodes:
-            if forward_edges.get(unique_id):
+            if unique_id in forward_edges.keys():
                 forward_edges[unique_id].append(node.unique_id)
     return _sort_values(forward_edges), _sort_values(backward_edges)
 

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -234,7 +234,8 @@ def build_edges(nodes: List[ManifestNode]):
     for node in nodes:
         backward_edges[node.unique_id] = node.depends_on_nodes[:]
         for unique_id in node.depends_on_nodes:
-            forward_edges[unique_id].append(node.unique_id)
+            if forward_edges.get(unique_id):
+                forward_edges[unique_id].append(node.unique_id)
     return _sort_values(forward_edges), _sort_values(backward_edges)
 
 

--- a/test/integration/062_defer_state_test/changed_models_missing/schema.yml
+++ b/test/integration/062_defer_state_test/changed_models_missing/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+models:
+  - name: view_model
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null
+      - name: name

--- a/test/integration/062_defer_state_test/changed_models_missing/table_model.sql
+++ b/test/integration/062_defer_state_test/changed_models_missing/table_model.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='table') }}
+select 1 as fun

--- a/test/integration/062_defer_state_test/changed_models_missing/view_model.sql
+++ b/test/integration/062_defer_state_test/changed_models_missing/view_model.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('seed') }}


### PR DESCRIPTION
resolves #2875

### Description

The fix for this is a lot simpler than I'd previously thought.

Because of `--defer`, it's possible that the `--state` manifest has recorded some upstream nodes (in `depends_on`) that no longer exist in the current project. When that upstream node is a source or ephemeral model, it raised a `KeyError`. The fix just required that, before we try to record an edge, we first check that the node being reported by the other manifest actually exists in our known set of project nodes.

I wrote out one test case, `run_defer_deleted_upstream`, which involved an upstream ephemeral model that exists in the deferral manifest but not in the current project. I confirmed that this test raises a `KeyError` without the one-line fix, and passes with it.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
