### PR TITLE
Bumped boto3 version uppper range for dbt-redshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add event tracking for project parser/load times ([#2823](https://github.com/fishtown-analytics/dbt/issues/2823),[#2893](https://github.com/fishtown-analytics/dbt/pull/2893))
 - Bump cryptography version to be >= 3.2 and bump snowflake connector to 2.3.6 ([#2896](https://github.com/fishtown-analytics/dbt/issues/2896))  
 - Widen supported Google Cloud libraries dependencies ([#2794](https://github.com/fishtown-analytics/dbt/pull/2794), [#2877](https://github.com/fishtown-analytics/dbt/pull/2877)).
+- Bump the version requirements for boto3 in dbt-redshift to the upper limit 1.16 to match dbt-redshift and the snowflake-python-connector as of version 2.3.6. ([#2931](https://github.com/fishtown-analytics/dbt/issues/2931))
 
 Contributors:
 - [@feluelle](https://github.com/feluelle) ([#2841](https://github.com/fishtown-analytics/dbt/pull/2841))

--- a/plugins/redshift/setup.py
+++ b/plugins/redshift/setup.py
@@ -49,7 +49,7 @@ setup(
         'dbt-core=={}'.format(package_version),
         'dbt-postgres=={}'.format(package_version),
         # match snowflake-connector-python supported ranges
-        'boto3>=1.4.4,<1.12',
+        'boto3>=1.4.4,<1.16',
         'botocore>=1.5.0,<1.15',
     ],
     zip_safe=False,


### PR DESCRIPTION
resolves #2931 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #2931 
-->


### Description

The new Pip dependency resolver as of version 20.3 causes mismatched dependencies to raise an error when installing requirements. This should alleviate some issues by raising the upper range of what is allowed for boto3 to 1.16 which matches what python-snowflake-connector 2.3.6.  


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.

### Additional notes.

It looks like the snowflake-connector also removed botocore dependency as of 2.2.6 [Link](https://github.com/snowflakedb/snowflake-connector-python/pull/308/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L181)

I thought about removing it from dbt-redshift also but figured I should ask.

I am not 100% sure about testing requirements. I'm just dipping my toe for the first time in doing OSS contributions! I did run `make test-quick` locally and it did pass all integration tests but failed RPC tests. 