### PR TITLE
Fix `_dbt_max_partition` declaration and initialization for BigQuery incremental models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix exit code from dbt debug not returning a failure when one of the tests fail ([#3017](https://github.com/fishtown-analytics/dbt/issues/3017))
 - Auto-generated CTEs in tests and ephemeral models have lowercase names to comply with dbt coding conventions ([#3027](https://github.com/fishtown-analytics/dbt/issues/3027), [#3028](https://github.com/fishtown-analytics/dbt/issues/3028))
 - Fix incorrect error message when a selector does not match any node [#3036](https://github.com/fishtown-analytics/dbt/issues/3036))
+- Fix variable `_dbt_max_partition` declaration and initialization for BigQuery incremental models ([#2940](https://github.com/fishtown-analytics/dbt/issues/2940), [#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ### Features
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))
@@ -19,7 +20,7 @@ Contributors:
 - [@rvacaru](https://github.com/rvacaru) ([#2974](https://github.com/fishtown-analytics/dbt/pull/2974))
 - [@NiallRees](https://github.com/NiallRees) ([#3028](https://github.com/fishtown-analytics/dbt/pull/3028))
 - [ran-eh](https://github.com/ran-eh) ([#3036](https://github.com/fishtown-analytics/dbt/pull/3036))
-
+- [@pcasteran](https://github.com/pcasteran) ([#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ## dbt 0.19.1 (Release TBD)
 
@@ -87,7 +88,6 @@ Contributors:
 - Allow `docs` blocks in `exposure` descriptions ([#2913](https://github.com/fishtown-analytics/dbt/issues/2913), [#2920](https://github.com/fishtown-analytics/dbt/pull/2920))
 - Use original file path instead of absolute path as checksum for big seeds ([#2927](https://github.com/fishtown-analytics/dbt/issues/2927), [#2939](https://github.com/fishtown-analytics/dbt/pull/2939))
 - Fix KeyError if deferring to a manifest with a since-deleted source, ephemeral model, or test ([#2875](https://github.com/fishtown-analytics/dbt/issues/2875), [#2958](https://github.com/fishtown-analytics/dbt/pull/2958))
-- Fix variable `_dbt_max_partition` declaration and initialization for BigQuery incremental models ([#2940](https://github.com/fishtown-analytics/dbt/issues/2940), [#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ### Under the hood
 - Add `unixodbc-dev` package to testing docker image ([#2859](https://github.com/fishtown-analytics/dbt/pull/2859))
@@ -114,7 +114,6 @@ Contributors:
 - [@plotneishestvo](https://github.com/plotneishestvo) ([#2896](https://github.com/fishtown-analytics/dbt/issues/2896))
 - [@db-magnus](https://github.com/db-magnus) ([#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 - [@tyang209](https:/github.com/tyang209) ([#2931](https://github.com/fishtown-analytics/dbt/issues/2931))
-- [@pcasteran](https://github.com/pcasteran) ([#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ## dbt 0.19.0b1 (October 21, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Contributors:
 - Allow `docs` blocks in `exposure` descriptions ([#2913](https://github.com/fishtown-analytics/dbt/issues/2913), [#2920](https://github.com/fishtown-analytics/dbt/pull/2920))
 - Use original file path instead of absolute path as checksum for big seeds ([#2927](https://github.com/fishtown-analytics/dbt/issues/2927), [#2939](https://github.com/fishtown-analytics/dbt/pull/2939))
 - Fix KeyError if deferring to a manifest with a since-deleted source, ephemeral model, or test ([#2875](https://github.com/fishtown-analytics/dbt/issues/2875), [#2958](https://github.com/fishtown-analytics/dbt/pull/2958))
+- Fix variable `_dbt_max_partition` declaration and initialization for BigQuery incremental models ([#2940](https://github.com/fishtown-analytics/dbt/issues/2940), [#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ### Under the hood
 - Add `unixodbc-dev` package to testing docker image ([#2859](https://github.com/fishtown-analytics/dbt/pull/2859))
@@ -113,6 +114,7 @@ Contributors:
 - [@plotneishestvo](https://github.com/plotneishestvo) ([#2896](https://github.com/fishtown-analytics/dbt/issues/2896))
 - [@db-magnus](https://github.com/db-magnus) ([#2892](https://github.com/fishtown-analytics/dbt/issues/2892))
 - [@tyang209](https:/github.com/tyang209) ([#2931](https://github.com/fishtown-analytics/dbt/issues/2931))
+- [@pcasteran](https://github.com/pcasteran) ([#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 
 ## dbt 0.19.0b1 (October 21, 2020)
 

--- a/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/plugins/bigquery/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -47,9 +47,7 @@
 
       -- generated script to merge partitions into {{ target_relation }}
       declare dbt_partitions_for_replacement array<{{ partition_by.data_type }}>;
-      declare _dbt_max_partition {{ partition_by.data_type }};
-
-      set _dbt_max_partition = (
+      declare _dbt_max_partition {{ partition_by.data_type }} default (
           select max({{ partition_by.field }}) from {{ this }}
           where {{ partition_by.field }} is not null
       );

--- a/test/integration/022_bigquery_test/models/sql_header_model_incr.sql
+++ b/test/integration/022_bigquery_test/models/sql_header_model_incr.sql
@@ -3,6 +3,8 @@
 
 {# This will fail if it is not extracted correctly #}
 {% call set_sql_header(config) %}
+    DECLARE int_var INT64 DEFAULT 42;
+
   	CREATE TEMPORARY FUNCTION a_to_b(str STRING)
 	RETURNS STRING AS (
 	  CASE

--- a/test/integration/022_bigquery_test/models/sql_header_model_incr_insert_overwrite.sql
+++ b/test/integration/022_bigquery_test/models/sql_header_model_incr_insert_overwrite.sql
@@ -15,6 +15,8 @@
 
 {# This will fail if it is not extracted correctly #}
 {% call set_sql_header(config) %}
+    DECLARE int_var INT64 DEFAULT 42;
+
   	CREATE TEMPORARY FUNCTION a_to_b(str STRING)
 	RETURNS STRING AS (
 	  CASE


### PR DESCRIPTION
resolves #2940

### Description

Fixed the declaration and initialization of the `_dbt_max_partition` variable for BigQuery incremental models to be able to declare additional variables.

I only fixed the problem described in the issue #2940 and did not implemented the additional change you proposed @jtcohen6.
I don't really like the idea of mixing legacy sql execution, followed by client-side computation to find the latest partition and finally the actual model.
I would rather keep the declaration of the `_dbt_max_partition` variable like this and add a model option to be able to deactivate it when not needed in order to save processing time and money.

Maybe it is better to open a separate issue to discuss this and keep this PR only for the variable declaration issue.




### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
