### PR TITLE
Fix exposure parsing to allow other resources with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt 0.19.0 (Release TBD)
 
+### Fixes
+- Fix regression with defining exposures and other resources with the same name ([#2969](https://github.com/fishtown-analytics/dbt/issues/2969), [#3009](https://github.com/fishtown-analytics/dbt/pull/3009))
+
 ### Under the hood
 - Rewrite macro for snapshot_merge_sql to make compatible with other SQL dialects ([#3003](https://github.com/fishtown-analytics/dbt/pull/3003)
 - Rewrite logic in `snapshot_check_strategy()` to make compatible with other SQL dialects ([#3000](https://github.com/fishtown-analytics/dbt/pull/3000), [#3001](https://github.com/fishtown-analytics/dbt/pull/3001))

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -406,7 +406,7 @@ class ExposureOwner(JsonSchemaMixin, Replaceable):
 
 
 @dataclass
-class UnparsedExposure(HasYamlMetadata, Replaceable):
+class UnparsedExposure(JsonSchemaMixin, Replaceable):
     name: str
     type: ExposureType
     owner: ExposureOwner

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -95,6 +95,7 @@ def error_context(
 
 class ParserRef:
     """A helper object to hold parse-time references."""
+
     def __init__(self):
         self.column_info: Dict[str, ColumnInfo] = {}
 
@@ -584,6 +585,10 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
                     parser = MacroPatchParser(self, yaml_block, plural)
                 elif key == NodeType.Analysis:
                     parser = AnalysisPatchParser(self, yaml_block, plural)
+                elif key == NodeType.Exposure:
+                    # handle exposures seperately, but they are
+                    # technically still "documentable"
+                    continue
                 else:
                     parser = TestablePatchParser(self, yaml_block, plural)
                 for test_block in parser.parse():

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -586,7 +586,7 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
                 elif key == NodeType.Analysis:
                     parser = AnalysisPatchParser(self, yaml_block, plural)
                 elif key == NodeType.Exposure:
-                    # handle exposures seperately, but they are
+                    # handle exposures separately, but they are
                     # technically still "documentable"
                     continue
                 else:

--- a/test/integration/025_duplicate_model_test/models-exposure-dupes/schema.yml
+++ b/test/integration/025_duplicate_model_test/models-exposure-dupes/schema.yml
@@ -1,0 +1,10 @@
+version: 2
+exposures:
+  - name: something
+    type: dashboard
+    owner:
+      email: test@example.com
+  - name: something
+    type: dashboard
+    owner:
+      email: test@example.com

--- a/test/integration/025_duplicate_model_test/models-naming-dupes/schema.yml
+++ b/test/integration/025_duplicate_model_test/models-naming-dupes/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+models:
+  - name: something
+    description: This table has basic information about orders, as well as some derived facts based on payments
+exposures:
+  - name: something
+    type: dashboard
+    owner:
+      email: test@example.com

--- a/test/integration/025_duplicate_model_test/test_duplicate_exposure.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_exposure.py
@@ -14,11 +14,10 @@ class TestDuplicateExposure(DBTIntegrationTest):
 
     @use_profile("postgres")
     def test_postgres_duplicate_exposure(self):
-        # message = "dbt found two resources with the name"
+        message = "dbt found two resources with the name"
         try:
             self.run_dbt(["compile"])
             self.assertTrue(False, "dbt did not throw for duplicate exposures")
         except CompilationException as e:
-            pass
-            # self.assertTrue(message in str(
-            #     e), "dbt did not throw the correct error message")
+            self.assertTrue(message in str(
+                e), "dbt did not throw the correct error message")

--- a/test/integration/025_duplicate_model_test/test_duplicate_exposure.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_exposure.py
@@ -1,0 +1,24 @@
+from dbt.exceptions import CompilationException
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestDuplicateExposure(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_exposure_025"
+
+    @property
+    def models(self):
+        return "models-exposure-dupes"
+
+    @use_profile("postgres")
+    def test_postgres_duplicate_exposure(self):
+        # message = "dbt found two resources with the name"
+        try:
+            self.run_dbt(["compile"])
+            self.assertTrue(False, "dbt did not throw for duplicate exposures")
+        except CompilationException as e:
+            pass
+            # self.assertTrue(message in str(
+            #     e), "dbt did not throw the correct error message")

--- a/test/integration/025_duplicate_model_test/test_duplicate_model.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_model.py
@@ -12,26 +12,6 @@ class TestDuplicateModelEnabled(DBTIntegrationTest):
     def models(self):
         return "models-1"
 
-    @property
-    def profile_config(self):
-        return {
-            "test": {
-                "outputs": {
-                    "dev": {
-                        "type": "postgres",
-                        "threads": 1,
-                        "host": self.database_host,
-                        "port": 5432,
-                        "user": "root",
-                        "pass": "password",
-                        "dbname": "dbt",
-                        "schema": self.unique_schema()
-                    },
-                },
-                "target": "dev"
-            }
-        }
-
     @use_profile("postgres")
     def test_postgres_duplicate_model_enabled(self):
         message = "dbt found two resources with the name"
@@ -39,7 +19,8 @@ class TestDuplicateModelEnabled(DBTIntegrationTest):
             self.run_dbt(["run"])
             self.assertTrue(False, "dbt did not throw for duplicate models")
         except CompilationException as e:
-            self.assertTrue(message in str(e), "dbt did not throw the correct error message")
+            self.assertTrue(message in str(
+                e), "dbt did not throw the correct error message")
 
 
 class TestDuplicateModelDisabled(DBTIntegrationTest):
@@ -51,26 +32,6 @@ class TestDuplicateModelDisabled(DBTIntegrationTest):
     @property
     def models(self):
         return "models-2"
-
-    @property
-    def profile_config(self):
-        return {
-            "test": {
-                "outputs": {
-                    "dev": {
-                        "type": "postgres",
-                        "threads": 1,
-                        "host": self.database_host,
-                        "port": 5432,
-                        "user": "root",
-                        "pass": "password",
-                        "dbname": "dbt",
-                        "schema": self.unique_schema()
-                    },
-                },
-                "target": "dev"
-            }
-        }
 
     @use_profile("postgres")
     def test_postgres_duplicate_model_disabled(self):
@@ -124,7 +85,8 @@ class TestDuplicateModelEnabledAcrossPackages(DBTIntegrationTest):
             self.run_dbt(["run"])
             self.assertTrue(False, "dbt did not throw for duplicate models")
         except CompilationException as e:
-            self.assertTrue(message in str(e), "dbt did not throw the correct error message")
+            self.assertTrue(message in str(
+                e), "dbt did not throw the correct error message")
 
 
 class TestDuplicateModelDisabledAcrossPackages(DBTIntegrationTest):

--- a/test/integration/025_duplicate_model_test/test_duplicate_resource.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_resource.py
@@ -1,0 +1,21 @@
+from dbt.exceptions import CompilationException
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestDuplicateSchemaResource(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "duplicate_resource_025"
+
+    @property
+    def models(self):
+        return "models-naming-dupes-1"
+
+    @use_profile("postgres")
+    def test_postgres_duplicate_model_and_exposure(self):
+        try:
+            self.run_dbt(["compile"])
+        except CompilationException:
+            self.fail("Compilation Exception raised on model and "
+                      "exposure with the same name")

--- a/test/integration/025_duplicate_model_test/test_duplicate_source.py
+++ b/test/integration/025_duplicate_model_test/test_duplicate_source.py
@@ -12,31 +12,12 @@ class TestDuplicateSourceEnabled(DBTIntegrationTest):
     def models(self):
         return "models-source-dupes"
 
-    @property
-    def profile_config(self):
-        return {
-            "test": {
-                "outputs": {
-                    "dev": {
-                        "type": "postgres",
-                        "threads": 1,
-                        "host": self.database_host,
-                        "port": 5432,
-                        "user": "root",
-                        "pass": "password",
-                        "dbname": "dbt",
-                        "schema": self.unique_schema()
-                    },
-                },
-                "target": "dev"
-            }
-        }
-
     @use_profile("postgres")
-    def test_postgres_duplicate_model_enabled(self):
+    def test_postgres_duplicate_source_enabled(self):
         message = "dbt found two resources with the name"
         try:
             self.run_dbt(["compile"])
             self.assertTrue(False, "dbt did not throw for duplicate sources")
         except CompilationException as e:
-            self.assertTrue(message in str(e), "dbt did not throw the correct error message")
+            self.assertTrue(message in str(
+                e), "dbt did not throw the correct error message")

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -579,7 +579,6 @@ class TestUnparsedExposure(ContractTestCase):
 
     def get_ok_dict(self):
         return {
-        	'yaml_key': 'exposures',
             'name': 'my_exposure',
             'type': 'dashboard',
             'owner': {
@@ -592,13 +591,10 @@ class TestUnparsedExposure(ContractTestCase):
                 'ref("my_model")',
                 'source("raw", "source_table")',
             ],
-            'original_file_path': '/some/fake/path',
-            'package_name': 'test'
         }
 
     def test_ok(self):
         exposure = self.ContractType(
-        	yaml_key='exposures',
             name='my_exposure',
             type=ExposureType.Dashboard,
             owner=ExposureOwner(email='name@example.com'),
@@ -606,8 +602,6 @@ class TestUnparsedExposure(ContractTestCase):
             url='https://example.com/dashboards/1',
             description='A exposure',
             depends_on=['ref("my_model")', 'source("raw", "source_table")'],
-            original_file_path='/some/fake/path',
-            package_name='test'
         )
         dct = self.get_ok_dict()
         self.assert_symmetric(exposure, dct)


### PR DESCRIPTION
resolves #2969 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->

Exposure parsing occurs after all other node types have been parsed. #2920 made exposures "documentable" which caused this node type to be parsed twice. Once with `TestablePatchParser` and once with the appropriate `ExposureParser`. This PR skips the `TestablePatchParser` step.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
