### PR TITLE
Make generated CTE test names lowercase to match style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix exit code from dbt debug not returning a failure when one of the tests fail ([#3017](https://github.com/fishtown-analytics/dbt/issues/3017))
+- Auto-generated dbt test CTE's have lowercase names to comply with dbt coding conventions.
 
 ### Features
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Contributors:
 - [@yu-iskw](https://github.com/yu-iskw) ([#2928](https://github.com/fishtown-analytics/dbt/pull/2928))
 - [@sdebruyn](https://github.com/sdebruyn) / [@lynxcare](https://github.com/lynxcare) ([#3018](https://github.com/fishtown-analytics/dbt/pull/3018))
 - [@rvacaru](https://github.com/rvacaru) ([#2974](https://github.com/fishtown-analytics/dbt/pull/2974))
+- [@NiallRees](https://github.com/NiallRees) ([#3028](https://github.com/fishtown-analytics/dbt/pull/3028))
 
 ## dbt 0.19.0 (Release TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixes
 
 - Fix exit code from dbt debug not returning a failure when one of the tests fail ([#3017](https://github.com/fishtown-analytics/dbt/issues/3017))
-- Auto-generated dbt test CTE's have lowercase names to comply with dbt coding conventions.
+- Auto-generated CTEs in tests and ephemeral models have lowercase names to comply with dbt coding conventions ([#3027](https://github.com/fishtown-analytics/dbt/issues/3027), [#3028](https://github.com/fishtown-analytics/dbt/issues/3028))
 
 ### Features
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))

--- a/core/dbt/adapters/base/relation.py
+++ b/core/dbt/adapters/base/relation.py
@@ -203,7 +203,7 @@ class BaseRelation(FakeAPIObject, Hashable):
 
     @staticmethod
     def add_ephemeral_prefix(name: str):
-        return f'__dbt__CTE__{name}'
+        return f'__dbt__cte__{name}'
 
     @classmethod
     def create_ephemeral_from_node(

--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -191,11 +191,11 @@ class Compiler:
             [
                 InjectedCTE(
                     id="cte_id_1",
-                    sql="__dbt__CTE__ephemeral as (select * from table)",
+                    sql="__dbt__cte__ephemeral as (select * from table)",
                 ),
                 InjectedCTE(
                     id="cte_id_2",
-                    sql="__dbt__CTE__events as (select id, type from events)",
+                    sql="__dbt__cte__events as (select id, type from events)",
                 ),
             ]
 
@@ -206,8 +206,8 @@ class Compiler:
 
         This will spit out:
 
-          "with __dbt__CTE__ephemeral as (select * from table),
-                __dbt__CTE__events as (select id, type from events),
+          "with __dbt__cte__ephemeral as (select * from table),
+                __dbt__cte__events as (select id, type from events),
                 with internal_cte as (select * from sessions)
            select * from internal_cte"
 
@@ -246,7 +246,7 @@ class Compiler:
         return str(parsed)
 
     def _get_dbt_test_name(self) -> str:
-        return 'dbt__CTE__INTERNAL_test'
+        return 'dbt__cte__internal_test'
 
     # This method is called by the 'compile_node' method. Starting
     # from the node that it is passed in, it will recursively call

--- a/core/dbt/utils.py
+++ b/core/dbt/utils.py
@@ -298,7 +298,7 @@ def filter_null_values(input: Dict[K_T, Optional[V_T]]) -> Dict[K_T, V_T]:
 
 
 def add_ephemeral_model_prefix(s: str) -> str:
-    return '__dbt__CTE__{}'.format(s)
+    return '__dbt__cte__{}'.format(s)
 
 
 def timestring() -> str:

--- a/test/integration/020_ephemeral_test/test_ephemeral.py
+++ b/test/integration/020_ephemeral_test/test_ephemeral.py
@@ -29,15 +29,15 @@ class TestEphemeralMulti(DBTIntegrationTest):
 
         sql_file = re.sub(r'\d+', '', sql_file)
         expected_sql = ('create view "dbt"."test_ephemeral_"."double_dependent__dbt_tmp" as ('
-                        'with __dbt__CTE__base as ('
+                        'with __dbt__cte__base as ('
                         'select * from test_ephemeral_.seed'
-                        '),  __dbt__CTE__base_copy as ('
-                        'select * from __dbt__CTE__base'
+                        '),  __dbt__cte__base_copy as ('
+                        'select * from __dbt__cte__base'
                         ')-- base_copy just pulls from base. Make sure the listed'
                         '-- graph of CTEs all share the same dbt_cte__base cte'
-                        "select * from __dbt__CTE__base where gender = 'Male'"
+                        "select * from __dbt__cte__base where gender = 'Male'"
                         'union all'
-                        "select * from __dbt__CTE__base_copy where gender = 'Female'"
+                        "select * from __dbt__cte__base_copy where gender = 'Female'"
                         ');')
         sql_file = "".join(sql_file.split())
         expected_sql = "".join(expected_sql.split())
@@ -79,11 +79,11 @@ class TestEphemeralNested(DBTIntegrationTest):
         sql_file = re.sub(r'\d+', '', sql_file)
         expected_sql = (
             'create view "dbt"."test_ephemeral_"."root_view__dbt_tmp" as ('
-            'with __dbt__CTE__ephemeral_level_two as ('
+            'with __dbt__cte__ephemeral_level_two as ('
             'select * from "dbt"."test_ephemeral_"."source_table"'
-            '),  __dbt__CTE__ephemeral as ('
-            'select * from __dbt__CTE__ephemeral_level_two'
-            ')select * from __dbt__CTE__ephemeral'
+            '),  __dbt__cte__ephemeral as ('
+            'select * from __dbt__cte__ephemeral_level_two'
+            ')select * from __dbt__cte__ephemeral'
             ');')
 
         sql_file = "".join(sql_file.split())

--- a/test/integration/100_rpc_test/test_rpc.py
+++ b/test/integration/100_rpc_test/test_rpc.py
@@ -87,11 +87,11 @@ def query_url(url, query):
     return requests.post(url, headers=headers, data=json.dumps(query))
 
 
-_select_from_ephemeral = '''with __dbt__CTE__ephemeral_model as (
+_select_from_ephemeral = '''with __dbt__cte__ephemeral_model as (
 
 
 select 1 as id
-)select * from __dbt__CTE__ephemeral_model'''
+)select * from __dbt__cte__ephemeral_model'''
 
 
 def addr_in_use(err, *args):

--- a/test/unit/test_compiler.py
+++ b/test/unit/test_compiler.py
@@ -80,7 +80,7 @@ class CompilerTest(unittest.TestCase):
 
         def mock_generate_runtime_model_context(model, config, manifest):
             def ref(name):
-                result = f'__dbt__CTE__{name}'
+                result = f'__dbt__cte__{name}'
                 unique_id = f'model.root.{name}'
                 model.extra_ctes.append(InjectedCTE(id=unique_id, sql=None))
                 return result
@@ -121,7 +121,7 @@ class CompilerTest(unittest.TestCase):
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql='select * from source_table')],
                     compiled_sql=(
                         'with cte as (select * from something_else) '
-                        'select * from __dbt__CTE__ephemeral'),
+                        'select * from __dbt__cte__ephemeral'),
                     checksum=FileHash.from_contents(''),
                 ),
                 'model.root.ephemeral': CompiledModelNode(
@@ -168,10 +168,10 @@ class CompilerTest(unittest.TestCase):
         self.assertEqual(result.extra_ctes_injected, True)
         self.assertEqualIgnoreWhitespace(
             result.compiled_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with __dbt__cte__ephemeral as ('
              'select * from source_table'
              '), cte as (select * from something_else) '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from __dbt__cte__ephemeral'))
 
         self.assertEqual(
             manifest.nodes['model.root.ephemeral'].extra_ctes_injected,
@@ -296,7 +296,7 @@ class CompilerTest(unittest.TestCase):
                     compiled=True,
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql='select * from source_table')],
-                    compiled_sql='select * from __dbt__CTE__ephemeral',
+                    compiled_sql='select * from __dbt__cte__ephemeral',
                     checksum=FileHash.from_contents(''),
                 ),
                 'model.root.ephemeral': CompiledModelNode(
@@ -345,10 +345,10 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.compiled_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with __dbt__cte__ephemeral as ('
              'select * from source_table'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from __dbt__cte__ephemeral'))
         print(f"\n---- line 349 ----")
 
         self.assertFalse(manifest.nodes['model.root.ephemeral'].extra_ctes_injected)
@@ -423,7 +423,7 @@ class CompilerTest(unittest.TestCase):
                     compiled=True,
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql='select * from source_table')],
-                    compiled_sql='select * from __dbt__CTE__ephemeral',
+                    compiled_sql='select * from __dbt__cte__ephemeral',
                     checksum=FileHash.from_contents(''),
                 ),
                 'model.root.ephemeral': parsed_ephemeral,
@@ -454,10 +454,10 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.compiled_sql,
-            ('with __dbt__CTE__ephemeral as ('
+            ('with __dbt__cte__ephemeral as ('
              'select * from source_table'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from __dbt__cte__ephemeral'))
 
         self.assertTrue(manifest.nodes['model.root.ephemeral'].extra_ctes_injected)
 
@@ -488,7 +488,7 @@ class CompilerTest(unittest.TestCase):
                     compiled=True,
                     extra_ctes_injected=False,
                     extra_ctes=[InjectedCTE(id='model.root.ephemeral', sql=None)],
-                    compiled_sql='select * from __dbt__CTE__ephemeral',
+                    compiled_sql='select * from __dbt__cte__ephemeral',
                     checksum=FileHash.from_contents(''),
 
                 ),
@@ -552,12 +552,12 @@ class CompilerTest(unittest.TestCase):
         self.assertTrue(result.extra_ctes_injected)
         self.assertEqualIgnoreWhitespace(
             result.compiled_sql,
-            ('with __dbt__CTE__ephemeral_level_two as ('
+            ('with __dbt__cte__ephemeral_level_two as ('
              'select * from source_table'
-             '), __dbt__CTE__ephemeral as ('
-             'select * from __dbt__CTE__ephemeral_level_two'
+             '), __dbt__cte__ephemeral as ('
+             'select * from __dbt__cte__ephemeral_level_two'
              ') '
-             'select * from __dbt__CTE__ephemeral'))
+             'select * from __dbt__cte__ephemeral'))
 
         self.assertTrue(manifest.nodes['model.root.ephemeral'].compiled)
         self.assertTrue(manifest.nodes['model.root.ephemeral_level_two'].compiled)


### PR DESCRIPTION
Resolves #3027


### Description

Auto-generated dbt test CTE's have lowercase names to comply with dbt coding conventions. Makes SQLFluff happy which has to lint post-templated SQL. See #3027 for more


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
