### PR TITLE
Pass the default scopes to the default BigQuery credentials

### DIFF
--- a/plugins/bigquery/dbt/adapters/bigquery/connections.py
+++ b/plugins/bigquery/dbt/adapters/bigquery/connections.py
@@ -48,14 +48,14 @@ RETRYABLE_ERRORS = (
 
 
 @lru_cache()
-def get_bigquery_defaults() -> Tuple[Any, Optional[str]]:
+def get_bigquery_defaults(scopes=None) -> Tuple[Any, Optional[str]]:
     """
     Returns (credentials, project_id)
 
     project_id is returned available from the environment; otherwise None
     """
     # Cached, because the underlying implementation shells out, taking ~1s
-    return google.auth.default()
+    return google.auth.default(scopes=scopes)
 
 
 class Priority(StrEnum):
@@ -201,7 +201,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
         creds = GoogleServiceAccountCredentials.Credentials
 
         if method == BigQueryConnectionMethod.OAUTH:
-            credentials, _ = get_bigquery_defaults()
+            credentials, _ = get_bigquery_defaults(scopes=cls.SCOPE)
             return credentials
 
         elif method == BigQueryConnectionMethod.SERVICE_ACCOUNT:


### PR DESCRIPTION
resolves https://github.com/fishtown-analytics/dbt/issues/3040

### Description
We have to pass the scope to access BigQuery tables whose data sources are google spreadsheets on Google Drive.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
