### PR TITLE
Postgres: ability to create indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add optional `merge_update_columns` config to specify columns to update for `merge` statements in BigQuery and Snowflake ([#1862](https://github.com/fishtown-analytics/dbt/issues/1862), [#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - Use query comment JSON as job labels for BigQuery adapter when `query-comment.job-label` is set to `true` ([#2483](https://github.com/fishtown-analytics/dbt/issues/2483)), ([#3145](https://github.com/fishtown-analytics/dbt/pull/3145))
 - Set application_name for Postgres connections ([#885](https://github.com/fishtown-analytics/dbt/issues/885), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
+- Add native support for Postgres index creation ([#804](https://github.com/fishtown-analytics/dbt/issues/804), [3106](https://github.com/fishtown-analytics/dbt/pull/3106))
 
 ### Under the hood
 - Add dependabot configuration for alerting maintainers about keeping dependencies up to date and secure. ([#3061](https://github.com/fishtown-analytics/dbt/issues/3061), [#3062](https://github.com/fishtown-analytics/dbt/pull/3062))
@@ -42,6 +43,7 @@ Contributors:
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
 - [@cgopalan](https://github.com/cgopalan) ([#3165](https://github.com/fishtown-analytics/dbt/pull/3165), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
 - [@fux](https://github.com/fuchsst) ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
+- [@arzavj](https://github.com/arzavj) ([3106](https://github.com/fishtown-analytics/dbt/pull/3106))
 
 ## dbt 0.19.1 (March 31, 2021)
 

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -56,8 +56,7 @@
 {% endmacro %}
 
 {% macro default__get_create_index_sql(relation, index_dict) -%}
-  {{ exceptions.raise_not_implemented(
-    'get_create_index_sql macro not implemented for adapter '+adapter.type()) }}
+  {% do return(None) %}
 {% endmacro %}
 
 {% macro create_indexes(relation) -%}
@@ -67,11 +66,12 @@
 {% macro default__create_indexes(relation) -%}
   {%- set _indexes = config.get('indexes', default=[]) -%}
 
-  {%- call statement('create_indexes') -%}
-    {% for _index_dict in _indexes %}
-      {{ get_create_index_sql(relation, _index_dict) }}
-    {% endfor %}
-  {% endcall %}
+  {% for _index_dict in _indexes %}
+    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}
+    {% if create_index_sql %}
+      {% do run_query(create_index_sql) %}
+    {% endif %}
+  {% endfor %}
 {% endmacro %}
 
 {% macro create_view_as(relation, sql) -%}

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -51,12 +51,27 @@
 
 {% endmacro %}
 
+{% macro get_create_index_sql(relation, index_dict) -%}
+  {{ return(adapter.dispatch('get_create_index_sql')(relation, index_dict)) }}
+{% endmacro %}
+
+{% macro default__get_create_index_sql(relation, index_dict) -%}
+  {{ exceptions.raise_not_implemented(
+    'get_create_index_sql macro not implemented for adapter '+adapter.type()) }}
+{% endmacro %}
+
 {% macro create_indexes(relation) -%}
   {{ adapter.dispatch('create_indexes')(relation) }}
 {%- endmacro %}
 
 {% macro default__create_indexes(relation) -%}
-  -- NOOP
+  {%- set _indexes = config.get('indexes', default=[]) -%}
+
+  {%- call statement('create_indexes') -%}
+    {% for _index_dict in _indexes %}
+      {{ get_create_index_sql(relation, _index_dict) }}
+    {% endfor %}
+  {% endcall %}
 {% endmacro %}
 
 {% macro create_view_as(relation, sql) -%}

--- a/core/dbt/include/global_project/macros/adapters/common.sql
+++ b/core/dbt/include/global_project/macros/adapters/common.sql
@@ -51,6 +51,14 @@
 
 {% endmacro %}
 
+{% macro create_indexes(relation) -%}
+  {{ adapter.dispatch('create_indexes')(relation) }}
+{%- endmacro %}
+
+{% macro default__create_indexes(relation) -%}
+  -- NOOP
+{% endmacro %}
+
 {% macro create_view_as(relation, sql) -%}
   {{ adapter.dispatch('create_view_as')(relation, sql) }}
 {%- endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -39,6 +39,10 @@
 
   {% do persist_docs(target_relation, model) %}
 
+  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   -- `COMMIT` happens here

--- a/core/dbt/include/global_project/macros/materializations/seed/seed.sql
+++ b/core/dbt/include/global_project/macros/materializations/seed/seed.sql
@@ -142,6 +142,10 @@
   {% set target_relation = this.incorporate(type='table') %}
   {% do persist_docs(target_relation, model) %}
 
+  {% if full_refresh_mode or not exists_as_table %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   -- `COMMIT` happens here

--- a/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
+++ b/core/dbt/include/global_project/macros/materializations/snapshot/snapshot.sql
@@ -263,6 +263,10 @@
 
   {% do persist_docs(target_relation, model) %}
 
+  {% if not target_relation_exists %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {{ adapter.commit() }}

--- a/core/dbt/include/global_project/macros/materializations/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/table/table.sql
@@ -47,6 +47,8 @@
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 
+  {% post_hooks.append(create_indexes(target_relation)) %}
+
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {% do persist_docs(target_relation, model) %}

--- a/core/dbt/include/global_project/macros/materializations/table/table.sql
+++ b/core/dbt/include/global_project/macros/materializations/table/table.sql
@@ -47,7 +47,7 @@
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
 
-  {% post_hooks.append(create_indexes(target_relation)) %}
+  {% do create_indexes(target_relation) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Set
+from typing import Optional, Set, Dict, List, Any
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.impl import AdapterConfig
 from dbt.adapters.sql import SQLAdapter
@@ -16,6 +16,7 @@ GET_RELATIONS_MACRO_NAME = 'postgres_get_relations'
 @dataclass
 class PostgresConfig(AdapterConfig):
     unlogged: Optional[bool] = None
+    indexes: Optional[List[Dict[str, Any]]] = None
 
 
 class PostgresAdapter(SQLAdapter):

--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from dataclasses import dataclass
 from typing import Optional, Set, Dict, List, Any
 from dbt.adapters.base.meta import available
@@ -6,7 +7,9 @@ from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.postgres import PostgresConnectionManager
 from dbt.adapters.postgres import PostgresColumn
 from dbt.adapters.postgres import PostgresRelation
+from dbt.dataclass_schema import dbtClassMixin, ValidationError
 import dbt.exceptions
+import dbt.utils
 
 
 # note that this isn't an adapter macro, so just a single underscore
@@ -14,9 +17,44 @@ GET_RELATIONS_MACRO_NAME = 'postgres_get_relations'
 
 
 @dataclass
+class PostgresIndexConfig(dbtClassMixin):
+    columns: List[str]
+    unique: bool = False
+    type: Optional[str] = None
+
+    def render(self, relation):
+        # We append the current timestamp to the index name because otherwise the index
+        # will only be created on every other run. See
+        # https://github.com/fishtown-analytics/dbt/issues/1945#issuecomment-576714925 for
+        # an explanation.
+        now = datetime.utcnow().isoformat()
+        inputs = self.columns + [relation.render(), str(self.unique), str(self.type), now]
+        string = '_'.join(inputs)
+        return dbt.utils.md5(string)
+
+    @classmethod
+    def parse(cls, raw_index) -> Optional['PostgresIndexConfig']:
+        if raw_index is None:
+            return None
+        try:
+            cls.validate(raw_index)
+            return cls.from_dict(raw_index)
+        except ValidationError as exc:
+            msg = dbt.exceptions.validator_error_message(exc)
+            dbt.exceptions.raise_compiler_error(
+                f'Could not parse index config: {msg}'
+            )
+        except TypeError:
+            dbt.exceptions.raise_compiler_error(
+                f'Invalid index config:\n'
+                f'  Got: {raw_index}\n'
+                f'  Expected a dictionary with at minimum a "columns" key'
+            )
+
+@dataclass
 class PostgresConfig(AdapterConfig):
     unlogged: Optional[bool] = None
-    indexes: Optional[List[Dict[str, Any]]] = None
+    indexes: Optional[List[PostgresIndexConfig]] = None
 
 
 class PostgresAdapter(SQLAdapter):
@@ -42,6 +80,10 @@ class PostgresAdapter(SQLAdapter):
             )
         # return an empty string on success so macros can call this
         return ''
+
+    @available
+    def parse_index(self, raw_index: Any) -> Optional[PostgresIndexConfig]:
+        return PostgresIndexConfig.parse(raw_index)
 
     def _link_cached_database_relations(self, schemas: Set[str]):
         """

--- a/plugins/postgres/dbt/adapters/postgres/impl.py
+++ b/plugins/postgres/dbt/adapters/postgres/impl.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Optional, Set, Dict, List, Any
+from typing import Optional, Set, List, Any
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.impl import AdapterConfig
 from dbt.adapters.sql import SQLAdapter
@@ -23,12 +23,13 @@ class PostgresIndexConfig(dbtClassMixin):
     type: Optional[str] = None
 
     def render(self, relation):
-        # We append the current timestamp to the index name because otherwise the index
-        # will only be created on every other run. See
-        # https://github.com/fishtown-analytics/dbt/issues/1945#issuecomment-576714925 for
-        # an explanation.
+        # We append the current timestamp to the index name because otherwise
+        # the index will only be created on every other run. See
+        # https://github.com/fishtown-analytics/dbt/issues/1945#issuecomment-576714925
+        # for an explanation.
         now = datetime.utcnow().isoformat()
-        inputs = self.columns + [relation.render(), str(self.unique), str(self.type), now]
+        inputs = (self.columns +
+                  [relation.render(), str(self.unique), str(self.type), now])
         string = '_'.join(inputs)
         return dbt.utils.md5(string)
 
@@ -50,6 +51,7 @@ class PostgresIndexConfig(dbtClassMixin):
                 f'  Got: {raw_index}\n'
                 f'  Expected a dictionary with at minimum a "columns" key'
             )
+
 
 @dataclass
 class PostgresConfig(AdapterConfig):

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -24,33 +24,24 @@
   {{ return("_".join(substrings)) }}
 {% endmacro %}
 
-{% macro create_index(unique, columns) -%}
-  {%- set comma_columns_str = ", ".join(columns) -%}
-  {%- set underscore_columns_str = "_".join(columns) -%}
-  {%- set truncated_table_name = truncate_string(relation) -%}
-  {%- set truncated_col_names = truncate_string(underscore_columns_str) -%}
+{% macro postgres__get_create_index_sql(relation, index_dict) -%}
+  {%- set comma_separated_columns = ", ".join(index_dict['columns']) -%}
 
   {#- We append the current timestamp to the index name because otherwise the index will -#}
   {#- only be created on every other run. See -#}
   {#- https://github.com/fishtown-analytics/dbt/issues/1945#issuecomment-576714925 for -#}
   {#- an explanation. -#}
-  {%- set index_name = "_".join([run_started_at.strftime("%s"), truncated_table_name, truncated_col_names, "idx"]) -%}
+  {%- set index_name = md5("_".join([run_started_at.strftime("%s"), relation.identifier] + index_dict['columns'])) -%}
 
-  create {% if unique -%}
+  create {% if index_dict['unique'] -%}
     unique
   {%- endif %} index if not exists
-  "{{ index_name }}" on {{ relation }}
-  ({{ comma_columns_str }});
+  "{{ index_name }}"
+  on {{ relation }} {% if index_dict['type'] -%}
+    using {{ index_dict['type'] }}
+  {%- endif %}
+  ({{ comma_separated_columns }});
 {%- endmacro %}
-
-{% macro postgres__create_indexes(relation) -%}
-  {%- set _indexes = config.get('indexes', default=[]) -%}
-
-  {% for _index in _indexes %}
-    {{ create_index(_index['unique'], _index['columns']) }}
-  {% endfor %}
-{% endmacro %}
-
 
 {% macro postgres__create_schema(relation) -%}
   {% if relation.database -%}

--- a/plugins/postgres/dbt/include/postgres/macros/adapters.sql
+++ b/plugins/postgres/dbt/include/postgres/macros/adapters.sql
@@ -14,16 +14,6 @@
   );
 {%- endmacro %}
 
-{% macro truncate_string(str, length=3) %}
-  {% set substrings = [] %}
-
-  {% for word in str.split("_")  %}
-      {{ substrings.append(word[:length]) }}
-  {% endfor %}
-
-  {{ return("_".join(substrings)) }}
-{% endmacro %}
-
 {% macro postgres__get_create_index_sql(relation, index_dict) -%}
   {%- set comma_separated_columns = ", ".join(index_dict['columns']) -%}
 

--- a/test/integration/065_postgres_index_tests/data/seed.csv
+++ b/test/integration/065_postgres_index_tests/data/seed.csv
@@ -1,0 +1,4 @@
+country_code,country_name
+US,United States
+CA,Canada
+GB,United Kingdom

--- a/test/integration/065_postgres_index_tests/models-invalid/invalid_columns_type.sql
+++ b/test/integration/065_postgres_index_tests/models-invalid/invalid_columns_type.sql
@@ -1,0 +1,10 @@
+{{
+  config(
+    materialized = "table",
+    indexes=[
+      {'columns': 'column_a, column_b'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b

--- a/test/integration/065_postgres_index_tests/models-invalid/invalid_type.sql
+++ b/test/integration/065_postgres_index_tests/models-invalid/invalid_type.sql
@@ -1,0 +1,10 @@
+{{
+  config(
+    materialized = "table",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'non_existent_type'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b

--- a/test/integration/065_postgres_index_tests/models-invalid/invalid_unique_config.sql
+++ b/test/integration/065_postgres_index_tests/models-invalid/invalid_unique_config.sql
@@ -1,0 +1,10 @@
+{{
+  config(
+    materialized = "table",
+    indexes=[
+      {'columns': ['column_a'], 'unique': 'yes'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b

--- a/test/integration/065_postgres_index_tests/models-invalid/missing_columns.sql
+++ b/test/integration/065_postgres_index_tests/models-invalid/missing_columns.sql
@@ -1,0 +1,10 @@
+{{
+  config(
+    materialized = "table",
+    indexes=[
+      {'unique': True},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b

--- a/test/integration/065_postgres_index_tests/models/incremental.sql
+++ b/test/integration/065_postgres_index_tests/models/incremental.sql
@@ -1,0 +1,18 @@
+{{
+  config(
+    materialized = "incremental",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'hash'},
+      {'columns': ['column_a', 'column_b'], 'unique': True},
+    ]
+  )
+}}
+
+select *
+from (
+  select 1 as column_a, 2 as column_b
+) t
+
+{% if is_incremental() %}
+    where column_a > (select max(column_a) from {{this}})
+{% endif %}

--- a/test/integration/065_postgres_index_tests/models/table.sql
+++ b/test/integration/065_postgres_index_tests/models/table.sql
@@ -1,0 +1,14 @@
+{{
+  config(
+    materialized = "table",
+    indexes=[
+      {'columns': ['column_a']},
+      {'columns': ['column_b']},
+      {'columns': ['column_a', 'column_b']},
+      {'columns': ['column_b', 'column_a'], 'type': 'btree', 'unique': True},
+      {'columns': ['column_a'], 'type': 'hash'}
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b

--- a/test/integration/065_postgres_index_tests/snapshots/colors.sql
+++ b/test/integration/065_postgres_index_tests/snapshots/colors.sql
@@ -1,0 +1,29 @@
+{% snapshot colors %}
+
+    {{
+        config(
+            target_database=database,
+            target_schema=schema,
+            unique_key='id',
+            strategy='check',
+            check_cols=['color'],
+            indexes=[
+              {'columns': ['id'], 'type': 'hash'},
+              {'columns': ['id', 'color'], 'unique': True},
+            ]
+        )
+    }}
+
+    {% if var('version') == 1 %}
+
+        select 1 as id, 'red' as color union all
+        select 2 as id, 'green' as color
+
+    {% else %}
+
+        select 1 as id, 'blue' as color union all
+        select 2 as id, 'green' as color
+
+    {% endif %}
+
+{% endsnapshot %}

--- a/test/integration/065_postgres_index_tests/test_postgres_indexes.py
+++ b/test/integration/065_postgres_index_tests/test_postgres_indexes.py
@@ -1,0 +1,55 @@
+import re
+
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+INDEX_DEFINITION_PATTERN = re.compile(r'using\s+(\w+)\s+\((.+)\)\Z')
+
+class TestPostgresIndex(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "postgres_index_065"
+
+    @property
+    def models(self):
+        return "models"
+
+    @use_profile('postgres')
+    def test__postgres__table(self):
+        results = self.run_dbt()
+        self.assertEqual(len(results),  1)
+
+        indexes = self.get_indexes('table')
+        self.assertCountEqual(
+            indexes,
+            [
+              {'columns': 'column_a', 'unique': False, 'type': 'btree'},
+              {'columns': 'column_b', 'unique': False, 'type': 'btree'},
+              {'columns': 'column_a, column_b', 'unique': False, 'type': 'btree'},
+              {'columns': 'column_b, column_a', 'unique': True, 'type': 'btree'},
+              {'columns': 'column_a', 'unique': False, 'type': 'hash'}
+            ]
+        )
+
+    def get_indexes(self, table_name):
+        sql = """
+            SELECT
+              pg_get_indexdef(idx.indexrelid) as index_definition
+            FROM pg_index idx
+            JOIN pg_class tab ON tab.oid = idx.indrelid
+            WHERE
+              tab.relname = '{table}'
+              AND tab.relnamespace = (
+                SELECT oid FROM pg_namespace WHERE nspname = '{schema}'
+              );
+        """
+
+        sql = sql.format(table=table_name, schema=self.unique_schema())
+        results = self.run_sql(sql, fetch='all')
+        return [self.parse_index_definition(row[0]) for row in results]
+
+    def parse_index_definition(self, index_definition):
+        index_definition = index_definition.lower()
+        is_unique = 'unique' in index_definition
+        m = INDEX_DEFINITION_PATTERN.search(index_definition)
+        return {'columns': m.group(2), 'unique': is_unique, 'type': m.group(1)}


### PR DESCRIPTION
resolves #804 

### Description

Rough first pass at addressing the issue. Would love to get some thoughts on whether I'm on the right track. Would also love to get some help on adding a unit and integration test so that I can make sure that this code works. 

I'm imaging that usage will look like:
```
{{ config(
    indexes=[
      { 'columns': ['column_a', 'column_b'], 'unique': false },
      { 'columns': ['column_a', 'column_c'], 'unique': true },
    ]
) }}
```

This PR gives developers the ability to:
- create multiple indexes inside the same transaction as the `create_table_as`
- create a mix of unique and non-unique indexes
- create indexes on any number of columns
- address the issue where indexes aren't recreated (as discussed in this [discourse](https://discourse.getdbt.com/t/issue-with-post-hooks-not-running-with-dbt-0-16-1/1235/6)) by prepending the index name with a timestamp; I choose to prepend instead of append because if the column names are long or there are a number of columns in the index then postgres might truncate the index name and drop the timestamp
- address the issue where sometimes only one index out of a few indexes is created because the indexes share the same first few columns -- for example, `['column_a', 'column_b']` and `['column_a', 'column_c']`; what happens is that postgres truncates the final index name to fit a certain max length; so in this example postgres might drop the second column from the index name causing both index names to be the same (and hence only one of them is created); of course certain conditions need to be met in order to run into this problem (i.e. shared initial columns and possibly long column names)

Note that this does not support gin indexes and indexes on expressions of columns like `lower(column_a)`
Also note that I'm assuming snakecased column and table names.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
