### PR TITLE
git package: warn if specified revision master, main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Auto-generated CTEs in tests and ephemeral models have lowercase names to comply with dbt coding conventions ([#3027](https://github.com/fishtown-analytics/dbt/issues/3027), [#3028](https://github.com/fishtown-analytics/dbt/issues/3028))
 - Fix incorrect error message when a selector does not match any node [#3036](https://github.com/fishtown-analytics/dbt/issues/3036))
 - Fix variable `_dbt_max_partition` declaration and initialization for BigQuery incremental models ([#2940](https://github.com/fishtown-analytics/dbt/issues/2940), [#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
-- Moving from 'master' to 'HEAD' default branch in git ([#3057](https://github.com/fishtown-analytics/dbt/issues/3057))
+- Moving from 'master' to 'HEAD' default branch in git ([#3057](https://github.com/fishtown-analytics/dbt/issues/3057), [#3104](https://github.com/fishtown-analytics/dbt/issues/3104), [#3117](https://github.com/fishtown-analytics/dbt/issues/3117)))
 
 ### Features
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -52,14 +52,14 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
             return 'HEAD (default branch)'
         else:
             return 'revision {}'.format(self.revision)
-        
+
     def unpinned_msg(self):
         if self.revision == 'HEAD':
             return 'not pinned, using HEAD (default branch)'
         elif self.revision in ('main', 'master'):
             return f'pinned to the "{self.revision}" branch'
         else:
-            return none
+            return None
 
     def _checkout(self):
         """Performs a shallow clone of the repository into the downloads
@@ -83,7 +83,7 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
     def _fetch_metadata(self, project, renderer) -> ProjectPackageMetadata:
         path = self._checkout()
-        
+
         if self.unpinned_msg() and self.warn_unpinned:
             warn_or_error(
                 'The git package "{}" \n\tis {}.\n\tThis can introduce '

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -48,7 +48,18 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
         return self.revision
 
     def nice_version_name(self):
-        return 'revision {}'.format(self.revision)
+        if self.revision == 'HEAD':
+            return 'HEAD (default branch)'
+        else:
+            return 'revision {}'.format(self.revision)
+        
+    def unpinned_msg(self):
+        if self.revision == 'HEAD':
+            return 'not pinned, using HEAD (default branch)'
+        elif self.revision in ('main', 'master'):
+            return f'pinned to the "{self.revision}" branch'
+        else:
+            return none
 
     def _checkout(self):
         """Performs a shallow clone of the repository into the downloads
@@ -72,11 +83,12 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
     def _fetch_metadata(self, project, renderer) -> ProjectPackageMetadata:
         path = self._checkout()
-        if self.revision == 'HEAD' and self.warn_unpinned:
+        
+        if self.unpinned_msg() and self.warn_unpinned:
             warn_or_error(
-                'The git package "{}" is not pinned.\n\tThis can introduce '
+                'The git package "{}" \n\tis {}.\n\tThis can introduce '
                 'breaking changes into your project without warning!\n\nSee {}'
-                .format(self.git, PIN_PACKAGE_URL),
+                .format(self.git, self.unpinned_msg(), PIN_PACKAGE_URL),
                 log_fmt=ui.yellow('WARNING: {}')
             )
         loaded = Project.from_project_root(path, renderer)


### PR DESCRIPTION
Follow up from #3057, #3104

Previously, if a git package was unpinned, dbt tried to install it from `master` (hard coded). In #3104, this was fixed to used `HEAD` (default branch, regardless of name) and continue to warn if unpinned.

We'd like to warn as well if the user specifies the package `revision` as `'master'` or `'main'`, since either almost certainly represents the default branch. Users can disable the warning with `warn-unpinned: false`.

### Example

```yml
packages:
  - git: https://github.com/fishtown-analytics/dbt-codegen 
    revision: master
  - git: https://github.com/tailsdotcom/dbt_artifacts   
    revision: main
  - git: https://gitlab.com/gitlab-data/snowflake_spend
  - package: fishtown-analytics/audit_helper
    version: 0.3.0
```

<details>
<summary> <code>$ dbt deps</code> </summary>

```
Running with dbt=0.19.0
WARNING: The git package "https://github.com/fishtown-analytics/dbt-codegen"
	is pinned to the "master" branch.
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
WARNING: The git package "https://github.com/tailsdotcom/dbt_artifacts"
	is pinned to the "main" branch.
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
WARNING: The git package "https://gitlab.com/gitlab-data/snowflake_spend"
	is not pinned, using HEAD (default branch).
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
WARNING: The git package "https://github.com/fishtown-analytics/dbt-codegen"
	is pinned to the "master" branch.
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
WARNING: The git package "https://github.com/tailsdotcom/dbt_artifacts"
	is pinned to the "main" branch.
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
WARNING: The git package "https://gitlab.com/gitlab-data/snowflake_spend"
	is not pinned, using HEAD (default branch).
	This can introduce breaking changes into your project without warning!

See https://docs.getdbt.com/docs/package-management#section-specifying-package-versions
Installing https://github.com/fishtown-analytics/dbt-codegen@master
  Installed from revision master

Installing https://github.com/tailsdotcom/dbt_artifacts@main
  Installed from revision main

Installing https://gitlab.com/gitlab-data/snowflake_spend@HEAD
  Installed from HEAD (default branch)

Installing fishtown-analytics/audit_helper@0.3.0
  Installed from version 0.3.0

Installing fishtown-analytics/dbt_utils@0.6.4
  Installed from version 0.6.4
```

</details>

```yml
packages:
  - git: https://github.com/fishtown-analytics/dbt-codegen 
    revision: master
    warn-unpinned: false
  - git: https://github.com/tailsdotcom/dbt_artifacts   
    revision: main
    warn-unpinned: false
  - git: https://gitlab.com/gitlab-data/snowflake_spend
    warn-unpinned: false
  - package: fishtown-analytics/audit_helper
    version: 0.3.0
```

<details>
<summary> <code>$ dbt deps</code> </summary>

```
Running with dbt=0.19.0
Installing https://github.com/fishtown-analytics/dbt-codegen@master
  Installed from revision master

Installing https://github.com/tailsdotcom/dbt_artifacts@main
  Installed from revision main

Installing https://gitlab.com/gitlab-data/snowflake_spend@HEAD
  Installed from HEAD (default branch)

Installing fishtown-analytics/audit_helper@0.3.0
  Installed from version 0.3.0

Installing fishtown-analytics/dbt_utils@0.6.4
  Installed from version 0.6.4
```
</details>

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
