### PR TITLE
(explicitly) find the executable before running run_cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix incorrect error message when a selector does not match any node [#3036](https://github.com/fishtown-analytics/dbt/issues/3036))
 - Fix variable `_dbt_max_partition` declaration and initialization for BigQuery incremental models ([#2940](https://github.com/fishtown-analytics/dbt/issues/2940), [#2976](https://github.com/fishtown-analytics/dbt/pull/2976))
 - Moving from 'master' to 'HEAD' default branch in git ([#3057](https://github.com/fishtown-analytics/dbt/issues/3057), [#3104](https://github.com/fishtown-analytics/dbt/issues/3104), [#3117](https://github.com/fishtown-analytics/dbt/issues/3117)))
+- Fix for getting Windows to pick up git.bat as a git executable [#3035](https://github.com/fishtown-analytics/dbt/issues/3035)
 
 ### Features
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -407,6 +407,11 @@ def run_cmd(
     logger.debug('Executing "{}"'.format(' '.join(cmd)))
     if len(cmd) == 0:
         raise dbt.exceptions.CommandError(cwd, cmd)
+    exe_pth = shutil.which(cmd[0])
+    if not exe:
+        # executable not found
+        raise dbt.exceptions.CommandError(cwd, cmd)
+    cmd = [exe_pth] + list(cmd[1:])
 
     # the env argument replaces the environment entirely, which has exciting
     # consequences on Windows! Do an update instead.

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -408,7 +408,7 @@ def run_cmd(
     if len(cmd) == 0:
         raise dbt.exceptions.CommandError(cwd, cmd)
     exe_pth = shutil.which(cmd[0])
-    if not exe:
+    if not exe_pth:
         # executable not found
         raise dbt.exceptions.CommandError(cwd, cmd)
     cmd = [exe_pth] + list(cmd[1:])

--- a/core/dbt/clients/system.py
+++ b/core/dbt/clients/system.py
@@ -409,9 +409,8 @@ def run_cmd(
         raise dbt.exceptions.CommandError(cwd, cmd)
     exe_pth = shutil.which(cmd[0])
     if not exe_pth:
-        # executable not found
-        raise dbt.exceptions.CommandError(cwd, cmd)
-    cmd = [exe_pth] + list(cmd[1:])
+        raise dbt.exceptions.ExecutableError(cwd, cmd, f"Executable for {cmd[0]} not found.")
+    cmd = [os.path.abspath(exe_pth)] + list(cmd[1:])
 
     # the env argument replaces the environment entirely, which has exciting
     # consequences on Windows! Do an update instead.


### PR DESCRIPTION
resolves #3035



### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
   ran test_system_client.py
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 
