### PR TITLE
Pin agate<1.6.2 to fix installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Contributors:
 - Performance fixes for many different things ([#2862](https://github.com/fishtown-analytics/dbt/issues/2862), [#3034](https://github.com/fishtown-analytics/dbt/pull/3034))
 - Update code to use Mashumaro 2.0 ([#3138](https://github.com/fishtown-analytics/dbt/pull/3138))
 - Add an event to track resource counts ([#3050](https://github.com/fishtown-analytics/dbt/issues/3050), [#3156](https://github.com/fishtown-analytics/dbt/pull/3156))
+- Pin `agate<1.6.2` to avoid installation errors relating to its new dependency `PyICU` ([#3160](https://github.com/fishtown-analytics/dbt/issues/3160), [#3161](https://github.com/fishtown-analytics/dbt/pull/3161))
 
 Contributors:
 - [@Bl3f](https://github.com/Bl3f) ([#3011](https://github.com/fishtown-analytics/dbt/pull/3011))

--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,7 @@ setup(
         'networkx>=2.3,<3',
         'minimal-snowplow-tracker==0.0.2',
         'colorama>=0.3.9,<0.4.4',
-        'agate>=1.6,<2',
+        'agate>=1.6,<1.6.2',
         'isodate>=0.6,<0.7',
         'json-rpc>=1.12,<2',
         'werkzeug>=0.15,<2.0',


### PR DESCRIPTION
resolves #3160 

### Description

Lots of folks seeing installation errors with the release of `agate>=1.6.2` yesterday, since it requires `PyICU`, which is _not_ installable via `pip` (per its most recent [installation instructions](https://github.com/ovalhub/pyicu#installing-pyicu)). Since it is installable via Homebrew, I wonder if we could do something better for `brew` installations in the long run?

In any case, the simplest and surest bet seems to be lowering the upper bound on `agate` from `<2` to `<1.6.2`, since `agate==1.6.1` installs and works just fine.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
