### PR TITLE
Add TestCLIInvocationWithProfilesAndProjectDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ Contributors:
 - [@VasiliiSurov](https://github.com/VasiliiSurov) ([#3104](https://github.com/fishtown-analytics/dbt/pull/3104))
 - [@jmcarp](https://github.com/jmcarp) ([#3145](https://github.com/fishtown-analytics/dbt/pull/3145))
 - [@bastienboutonnet](https://github.com/bastienboutonnet) ([#3151](https://github.com/fishtown-analytics/dbt/pull/3151))
-<<<<<<< HEAD
 - [@max-sixty](https://github.com/max-sixty) ([#3156](https://github.com/fishtown-analytics/dbt/pull/3156)
 - [@prratek](https://github.com/prratek) ([#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,11 @@ Contributors:
 - [@fux](https://github.com/fuchsst) ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
 - [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270))
 - [@arzavj](https://github.com/arzavj) ([3106](https://github.com/fishtown-analytics/dbt/pull/3106))
+- [@JCZuurmond](https://github.com/JCZuurmond) ([#3133](https://github.com/fishtown-analytics/dbt/pull/3133))
 
 ## dbt 0.19.1 (March 31, 2021)
 
 ## dbt 0.19.1rc2 (March 25, 2021)
-=======
-- [@JCZuurmond](https://github.com/JCZuurmond) ([#3133](https://github.com/fishtown-analytics/dbt/pull/3133))
->>>>>>> Add JCZuurmond to change log
-
 
 ### Fixes
 - Pass service-account scopes to gcloud-based oauth ([#3040](https://github.com/fishtown-analytics/dbt/issues/3040), [#3041](https://github.com/fishtown-analytics/dbt/pull/3041))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Contributors:
 - [@VasiliiSurov](https://github.com/VasiliiSurov) ([#3104](https://github.com/fishtown-analytics/dbt/pull/3104))
 - [@jmcarp](https://github.com/jmcarp) ([#3145](https://github.com/fishtown-analytics/dbt/pull/3145))
 - [@bastienboutonnet](https://github.com/bastienboutonnet) ([#3151](https://github.com/fishtown-analytics/dbt/pull/3151))
+<<<<<<< HEAD
 - [@max-sixty](https://github.com/max-sixty) ([#3156](https://github.com/fishtown-analytics/dbt/pull/3156)
 - [@prratek](https://github.com/prratek) ([#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
@@ -58,6 +59,9 @@ Contributors:
 ## dbt 0.19.1 (March 31, 2021)
 
 ## dbt 0.19.1rc2 (March 25, 2021)
+=======
+- [@JCZuurmond](https://github.com/JCZuurmond) ([#3133](https://github.com/fishtown-analytics/dbt/pull/3133))
+>>>>>>> Add JCZuurmond to change log
 
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Raise a proper error message if dbt parses a macro twice due to macro duplication or misconfiguration. ([#2449](https://github.com/fishtown-analytics/dbt/issues/2449), [#3165](https://github.com/fishtown-analytics/dbt/pull/3165))
 - Fix exposures missing in graph context variable. ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
 - Ensure that schema test macros are properly processed ([#3229](https://github.com/fishtown-analytics/dbt/issues/3229), [#3272](https://github.com/fishtown-analytics/dbt/pull/3272))
+- Use absolute path for profiles directory instead of a path relative to the project directory. Note: If a user supplies a relative path to the profiles directory, the value of `args.profiles_dir` will still be absolute. ([#3133](https://github.com/fishtown-analytics/dbt/issues/3133))
 
 ### Features
 - Support commit hashes in dbt deps package revision ([#3268](https://github.com/fishtown-analytics/dbt/issues/3268), [#3270](https://github.com/fishtown-analytics/dbt/pull/3270))

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -1051,7 +1051,7 @@ def parse_args(args, cls=DBTArgumentParser):
     parsed = p.parse_args(args)
 
     if hasattr(parsed, 'profiles_dir'):
-        parsed.profiles_dir = os.path.expanduser(parsed.profiles_dir)
+        parsed.profiles_dir = os.path.abspath(parsed.profiles_dir)
 
     if getattr(parsed, 'project_dir', None) is not None:
         expanded_user = os.path.expanduser(parsed.project_dir)

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -280,6 +280,11 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
 
     @use_profile("postgres")
+    def test_postgres_run_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")
+
+    @use_profile("postgres")
     def test_postgres_test_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")
@@ -288,8 +293,3 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     @use_profile("postgres")
     def test_postgres_debug_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("debug")
-
-    @use_profile("postgres")
-    def test_postgres_run_with_profiles_separate_from_project_dir(self):
-        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
-        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -261,5 +261,8 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
             create_directory_with_custom_profiles(profiles_dir, profiles)
 
             project_dir = os.path.relpath(workdir, tmpdir)
+            if os.path.exists(f"{project_dir}/profiles.yml"):
+                os.remove(f"{project_dir}/profiles.yml")
+
             for dbt_sub_command in ["deps", "debug", "run"]:
                 self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -1,8 +1,33 @@
 from test.integration.base import DBTIntegrationTest, use_profile
+import contextlib
 import os
 import shutil
 import tempfile
 import yaml
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def change_working_directory(directory: Union[str, Path]) -> Union[str, Path]:
+    """
+    Context manager for changing the working directory.
+
+    Parameters
+    ----------
+    directory : Union[str, Path]
+        The directory to which the working directory should be changed.
+
+    Yields
+    ------
+    out : Union[str, Path]
+        The new working directory.
+    """
+    current_working_directory = os.getcwd()
+    os.chdir(directory)
+    try:
+        yield directory
+    finally:
+        os.chdir(current_working_directory)
 
 
 class ModelCopyingIntegrationTest(DBTIntegrationTest):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -279,7 +279,6 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     def test_postgres_deps_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
 
-
     @use_profile("postgres")
     def test_postgres_run_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -279,6 +279,7 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     def test_postgres_deps_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
 
+
     @use_profile("postgres")
     def test_postgres_run_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -281,6 +281,7 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
 
     @use_profile("postgres")
     def test_postgres_test_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("test")
 
     @use_profile("postgres")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -250,7 +250,7 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     def custom_schema(self):
         return "{}_custom".format(self.unique_schema())
 
-    @use_profile("postgres")
+    @pytest.mark.profile_postgres
     def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(self):
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -6,6 +6,7 @@ import pytest
 import tempfile
 import yaml
 from pathlib import Path
+from typing import Union
 
 
 @contextlib.contextmanager

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -266,14 +266,14 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
                 self.database_host, self.custom_schema)
             create_directory_with_custom_profiles(profiles_dir, profiles)
 
-            project_dir = os.path.relpath(workdir, tmpdir)
+            project_dir = os.path.relpath(workdir, os.getcwd())
             if os.path.exists(f"{project_dir}/profiles.yml"):
                 os.remove(f"{project_dir}/profiles.yml")
 
-            args = [
+            other_args = [
                 dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir
             ]
-            self.run_dbt(args, profiles_dir=False)
+            self.run_dbt(other_args, profiles_dir=False)
 
     @use_profile("postgres")
     def test_postgres_deps_with_profiles_separate_from_project_dir(self):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -236,13 +236,22 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
             assert not os.path.isdir(target)
 
 
-class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDir):
+class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
 
-    @pytest.mark.parametrize("dbt_sub_command", ["deps", "debug", "run"])
-    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(
-        self,
-        dbt_sub_command: str
-    ):
+    @property
+    def schema(self):
+        return "test_cli_invocation_015"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def custom_schema(self):
+        return "{}_custom".format(self.unique_schema())
+
+    @use_profile("postgres")
+    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(self):
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
         with temporary_working_directory() as tmpdir:
@@ -252,4 +261,5 @@ class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDi
             create_directory_with_custom_profiles(profiles_dir, profiles)
 
             project_dir = os.path.relpath(workdir, tmpdir)
-            self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])
+            for dbt_sub_command in ["deps", "debug", "run"]:
+                self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -30,7 +30,7 @@ def change_working_directory(directory: str) -> str:
         os.chdir(current_working_directory)
 
 
-@pytest.fixture
+@contextlib.contextmanager
 def temporary_working_directory() -> str:
     """
     Create a temporary working directory.

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -270,7 +270,10 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
             if os.path.exists(f"{project_dir}/profiles.yml"):
                 os.remove(f"{project_dir}/profiles.yml")
 
-            self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])
+            args = [
+                dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir
+            ]
+            self.run_dbt(args, profiles_dir=False)
 
     @use_profile("postgres")
     def test_postgres_deps_with_profiles_separate_from_project_dir(self):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -236,7 +236,6 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
             assert not os.path.isdir(target)
 
 
-@pytest.mark.parametrize("dbt_sub_command", ["deps", "debug", "run"])
 class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
 
     @property
@@ -251,11 +250,15 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     def custom_schema(self):
         return "{}_custom".format(self.unique_schema())
 
-    @pytest.mark.profile_postgres
-    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(
+    @use_profile("postgres")
+    def test_sub_command_with_profiles_separate_from_project_dir(
         self,
-        dbt_sub_command: str
     ):
+        """
+        Test if a sub command runs well when a profiles dir is separate from a
+        project dir.
+        """
+        dbt_sub_command = "deps"
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
         with temporary_working_directory() as tmpdir:

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -257,6 +257,7 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
         """
         Test if a sub command runs well when a profiles dir is separate from a
         project dir.
+
         """
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -236,6 +236,7 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
             assert not os.path.isdir(target)
 
 
+@pytest.mark.parametrize("dbt_sub_command", ["deps", "debug", "run"])
 class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
 
     @property
@@ -251,7 +252,10 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
         return "{}_custom".format(self.unique_schema())
 
     @pytest.mark.profile_postgres
-    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(self):
+    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(
+        self,
+        dbt_sub_command: str
+    ):
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
         with temporary_working_directory() as tmpdir:
@@ -264,5 +268,4 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
             if os.path.exists(f"{project_dir}/profiles.yml"):
                 os.remove(f"{project_dir}/profiles.yml")
 
-            for dbt_sub_command in ["deps", "debug", "run"]:
-                self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])
+            self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -282,6 +282,7 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     @use_profile("postgres")
     def test_postgres_test_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("test")
 
     @use_profile("postgres")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -2,6 +2,7 @@ from test.integration.base import DBTIntegrationTest, use_profile
 import contextlib
 import os
 import shutil
+import pytest
 import tempfile
 import yaml
 from pathlib import Path
@@ -28,6 +29,20 @@ def change_working_directory(directory: Union[str, Path]) -> Union[str, Path]:
         yield directory
     finally:
         os.chdir(current_working_directory)
+
+
+@pytest.fixture
+def temporary_working_directory() -> str:
+    """
+    Create a temporary working directory.
+
+    Returns
+    -------
+    out : str
+        The temporary working directory.
+    """
+    with change_working_directory(tempfile.TemporaryDirectory()) as tmpdir:
+        yield tmpdir
 
 
 class ModelCopyingIntegrationTest(DBTIntegrationTest):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -69,6 +69,23 @@ def get_custom_profile_config() -> Dict:
     }
 
 
+def create_directory_with_custom_profiles(directory: str) -> None:
+    """
+    Create directory with profiles.yml. The profile from
+    :func:get_custom_profile_config is used.
+
+    Parameters
+    ----------
+    directory : str
+        The directory in which a profiles file is created.
+    """
+    if not os.path.exists(profiles_dir):
+        os.makedirs(profiles_dir)
+
+    with open(f"{profiles_dir}/profiles.yml", "w") as f:
+        yaml.safe_dump(self.custom_profile_config(), f, default_flow_style=True)
+
+
 class ModelCopyingIntegrationTest(DBTIntegrationTest):
 
     def _symlink_test_folders(self):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -286,8 +286,3 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     @use_profile("postgres")
     def test_postgres_debug_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("debug")
-
-    @use_profile("postgres")
-    def test_postgres_run_with_profiles_separate_from_project_dir(self):
-        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
-        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -250,15 +250,14 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     def custom_schema(self):
         return "{}_custom".format(self.unique_schema())
 
-    @use_profile("postgres")
-    def test_sub_command_with_profiles_separate_from_project_dir(
+    def _test_postgres_sub_command_with_profiles_separate_from_project_dir(
         self,
+        dbt_sub_command: str
     ):
         """
         Test if a sub command runs well when a profiles dir is separate from a
         project dir.
         """
-        dbt_sub_command = "deps"
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
         with temporary_working_directory() as tmpdir:
@@ -272,3 +271,15 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
                 os.remove(f"{project_dir}/profiles.yml")
 
             self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])
+
+    @use_profile("postgres")
+    def test_postgres_deps_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
+
+    @use_profile("postgres")
+    def test_postgres_test_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("test")
+
+    @use_profile("postgres")
+    def test_postgres_debug_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("debug")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -286,3 +286,8 @@ class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
     @use_profile("postgres")
     def test_postgres_debug_with_profiles_separate_from_project_dir(self):
         self._test_postgres_sub_command_with_profiles_separate_from_project_dir("debug")
+
+    @use_profile("postgres")
+    def test_postgres_run_with_profiles_separate_from_project_dir(self):
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("deps")
+        self._test_postgres_sub_command_with_profiles_separate_from_project_dir("run")

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -5,23 +5,21 @@ import shutil
 import pytest
 import tempfile
 import yaml
-from pathlib import Path
-from typing import Union
 
 
 @contextlib.contextmanager
-def change_working_directory(directory: Union[str, Path]) -> Union[str, Path]:
+def change_working_directory(directory: str) -> str:
     """
     Context manager for changing the working directory.
 
     Parameters
     ----------
-    directory : Union[str, Path]
+    directory : str
         The directory to which the working directory should be changed.
 
     Yields
     ------
-    out : Union[str, Path]
+    out : str
         The new working directory.
     """
     current_working_directory = os.getcwd()

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -238,7 +238,7 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
 
 class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDir):
 
-    @pytest.mark.parametrize("dbt_sub_command", ["deps"])
+    @pytest.mark.parametrize("dbt_sub_command", ["deps", "debug", "run"])
     def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(
         self,
         dbt_sub_command: str

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -46,6 +46,29 @@ def temporary_working_directory() -> str:
         yield tmpdir
 
 
+def get_custom_profile_config() -> Dict:
+    return {
+        "config": {
+            "send_anonymous_usage_stats": False
+        },
+        "test": {
+            "outputs": {
+                "default": {
+                    "type": "postgres",
+                    "threads": 1,
+                    "host": self.database_host,
+                    "port": 5432,
+                    "user": "root",
+                    "pass": "password",
+                    "dbname": "dbt",
+                    "schema": self.custom_schema
+                },
+            },
+            "target": "default",
+        }
+    }
+
+
 class ModelCopyingIntegrationTest(DBTIntegrationTest):
 
     def _symlink_test_folders(self):
@@ -114,35 +137,13 @@ class TestCLIInvocationWithProfilesDir(ModelCopyingIntegrationTest):
             os.makedirs('./dbt-profile')
 
         with open("./dbt-profile/profiles.yml", 'w') as f:
-            yaml.safe_dump(self.custom_profile_config(), f, default_flow_style=True)
+            yaml.safe_dump(get_custom_profile_config(), f, default_flow_style=True)
 
         self.run_sql_file("seed_custom.sql")
 
     def tearDown(self):
         self.run_sql(f"DROP SCHEMA IF EXISTS {self.custom_schema} CASCADE;")
         super().tearDown()
-
-    def custom_profile_config(self):
-        return {
-            'config': {
-                'send_anonymous_usage_stats': False
-            },
-            'test': {
-                'outputs': {
-                    'default': {
-                        'type': 'postgres',
-                        'threads': 1,
-                        'host': self.database_host,
-                        'port': 5432,
-                        'user': 'root',
-                        'pass': 'password',
-                        'dbname': 'dbt',
-                        'schema': self.custom_schema
-                    },
-                },
-                'target': 'default',
-            }
-        }
 
     @property
     def schema(self):

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -238,7 +238,11 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
 
 class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDir):
 
-    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(self):
+    @pytest.mark.parametrize("dbt_sub_command", ["deps"])
+    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(
+        self,
+        dbt_sub_command: str
+    ):
         profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
         with temporary_working_directory() as tmpdir:
@@ -248,4 +252,4 @@ class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDi
             create_directory_with_custom_profiles(profiles_dir, profiles)
 
             project_dir = os.path.relpath(workdir, tmpdir)
-            self.run_dbt(["deps", "--profiles-dir", profiles_dir, "--project-dir", project_dir])
+            self.run_dbt([dbt_sub_command, "--profiles-dir", profiles_dir, "--project-dir", project_dir])

--- a/test/integration/015_cli_invocation_tests/test_cli_invocation.py
+++ b/test/integration/015_cli_invocation_tests/test_cli_invocation.py
@@ -236,102 +236,16 @@ class TestCLIInvocationWithProjectDir(ModelCopyingIntegrationTest):
             assert not os.path.isdir(target)
 
 
-class TestCLIInvocationWithProfilesAndProjectDir(ModelCopyingIntegrationTest):
+class TestCLIInvocationWithProfilesAndProjectDir(TestCLIInvocationWithProfilesDir):
 
-    def setUp(self):
-        super().setUp()
-
-        self.run_sql(f"DROP SCHEMA IF EXISTS {self.custom_schema} CASCADE;")
-        self.run_sql(f"CREATE SCHEMA {self.custom_schema};")
-
-        # the test framework will remove this in teardown for us.
-        if not os.path.exists('./dbt-profile'):
-            os.makedirs('./dbt-profile')
-
-        with open("./dbt-profile/profiles.yml", 'w') as f:
-            yaml.safe_dump(self.custom_profile_config(), f, default_flow_style=True)
-
-        self.run_sql_file("seed_custom.sql")
-
-    def tearDown(self):
-        self.run_sql(f"DROP SCHEMA IF EXISTS {self.custom_schema} CASCADE;")
-        super().tearDown()
-
-    def custom_profile_config(self):
-        return {
-            'config': {
-                'send_anonymous_usage_stats': False
-            },
-            'test': {
-                'outputs': {
-                    'default': {
-                        'type': 'postgres',
-                        'threads': 1,
-                        'host': self.database_host,
-                        'port': 5432,
-                        'user': 'root',
-                        'pass': 'password',
-                        'dbname': 'dbt',
-                        'schema': self.custom_schema
-                    },
-                },
-                'target': 'default',
-            }
-        }
-
-    @property
-    def schema(self):
-        return "test_cli_invocation_015"
-
-    @property
-    def custom_schema(self):
-        return "{}_custom".format(self.unique_schema())
-
-    @property
-    def models(self):
-        return "models"
-
-    @use_profile('postgres')
-    def test_postgres_dbt_commands_with_relative_dir_as_project_dir(self):
+    def test_postgres_toplevel_dbt_run_with_profile_dir_and_project_dir(self):
+        profiles_dir = "./tmp-profile"
         workdir = os.getcwd()
-        with tempfile.TemporaryDirectory() as profiles_dir:
-            profiles_dir_relative = os.path.relpath(workdir, profiles_dir)
-            shutil.move(
-                workdir + '/dbt-profile/profiles.yml',
-                profiles_dir + '/profiles.yml'
-            )
-            with tempfile.TemporaryDirectory() as project_dir:
-                os.chdir(project_dir)
-                project_dir_relative = os.path.relpath(workdir, project_dir)
-                self._run_postgres_toplevel_dbt_run_with_profile_and_project_dir_arg(
-                    project_dir_relative,
-                    profiles_dir_relative,
-                )
-                os.chdir(workdir)
-            shutil.move(
-                workdir + '/dbt-profile/profiles.yml',
-                profiles_dir + '/profiles.yml'
-            )
+        with temporary_working_directory() as tmpdir:
 
-    def _run_postgres_toplevel_dbt_run_with_profile_and_project_dir_arg(
-            self,
-            project_dir,
-            profiles_dir
-    ):
-        self.run_dbt(['deps', '--project-dir', project_dir])
-        results = self.run_dbt(
-            ['run', '--project-dir', project_dir, '--profiles-dir', profiles_dir],
-            profiles_dir=False
-        )
-        self.assertEqual(len(results), 1)
+            profiles = get_custom_profiles_config(
+                self.database_host, self.custom_schema)
+            create_directory_with_custom_profiles(profiles_dir, profiles)
 
-        actual = self.run_sql("select id from {}.model".format(self.custom_schema), fetch='one')
-
-        expected = (1, )
-        self.assertEqual(actual, expected)
-
-        res = self.run_dbt(['test', '--profiles-dir', 'dbt-profile'], profiles_dir=False)
-
-        # make sure the test runs against `custom_schema`
-        for test_result in res:
-            self.assertTrue(self.custom_schema, test_result.node.compiled_sql)
+            project_dir = os.path.relpath(workdir, tmpdir)
+            self.run_dbt(["deps", "--profiles-dir", profiles_dir, "--project-dir", project_dir])


### PR DESCRIPTION
resolves #3133 

### Description

See the issue #3133 for more details. 

The `profiles-dir` flag needs to be relative to the `project-dir`, not the current working directory.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
