### PR TITLE
Set application_name for Postgres connections

### DIFF
--- a/plugins/postgres/dbt/adapters/postgres/connections.py
+++ b/plugins/postgres/dbt/adapters/postgres/connections.py
@@ -23,6 +23,7 @@ class PostgresCredentials(Credentials):
     search_path: Optional[str] = None
     keepalives_idle: int = 0  # 0 means to use the default value
     sslmode: Optional[str] = None
+    application_name: Optional[str] = None
 
     _ALIASES = {
         'dbname': 'database',
@@ -92,6 +93,9 @@ class PostgresConnectionManager(SQLConnectionManager):
 
         if credentials.sslmode:
             kwargs['sslmode'] = credentials.sslmode
+
+        if credentials.application_name:
+            kwargs['application_name'] = credentials.application_name
 
         try:
             handle = psycopg2.connect(


### PR DESCRIPTION
resolves #885



### Description

The `application_name` parameter can now be specified as part of the properties in a postgres target in `profiles.yml` and it will show in `pg_stat_activity`.

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
