### PR TITLE
Add Redshift parameter to create tables with backup option specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix for EOL SQL comments prevent entire line execution ([#2731](https://github.com/fishtown-analytics/dbt/issues/2731), [#2974](https://github.com/fishtown-analytics/dbt/pull/2974))
 - Add optional `merge_update_columns` config to specify columns to update for `merge` statements in BigQuery and Snowflake ([#1862](https://github.com/fishtown-analytics/dbt/issues/1862), [#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - Use query comment JSON as job labels for BigQuery adapter when `query-comment.job-label` is set to `true` ([#2483](https://github.com/fishtown-analytics/dbt/issues/2483)), ([#3145](https://github.com/fishtown-analytics/dbt/pull/3145))
+- Add optional Redshift parameter to create tables with BACKUP NO set, to exclude them from snapshots. ([#2367](https://github.com/fishtown-analytics/dbt/issues/2367))
 
 ### Under the hood
 - Add dependabot configuration for alerting maintainers about keeping dependencies up to date and secure. ([#3061](https://github.com/fishtown-analytics/dbt/issues/3061), [#3062](https://github.com/fishtown-analytics/dbt/pull/3062))
@@ -33,6 +34,7 @@ Contributors:
 - [@prratek](https://github.com/prratek) ([#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
 - [@cgopalan](https://github.com/cgopalan) ([#3165](https://github.com/fishtown-analytics/dbt/pull/3165))
+- [@dlb8685](https://github.com/dlb8685/)
 
 ## dbt 0.19.1 (Release TBD)
 

--- a/plugins/redshift/dbt/adapters/redshift/impl.py
+++ b/plugins/redshift/dbt/adapters/redshift/impl.py
@@ -14,6 +14,7 @@ class RedshiftConfig(AdapterConfig):
     dist: Optional[str] = None
     sort: Optional[str] = None
     bind: Optional[bool] = None
+    backup: Optional[bool] = True
 
 
 class RedshiftAdapter(PostgresAdapter):

--- a/plugins/redshift/dbt/include/redshift/macros/adapters.sql
+++ b/plugins/redshift/dbt/include/redshift/macros/adapters.sql
@@ -39,6 +39,7 @@
           'sort',
           validator=validation.any[list, basestring]) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set backup = config.get('backup') -%}
 
   {{ sql_header if sql_header is not none }}
 
@@ -46,6 +47,7 @@
     {{ relation.include(database=(not temporary), schema=(not temporary)) }}
     {{ dist(_dist) }}
     {{ sort(_sort_type, _sort) }}
+    {% if backup == false -%}backup no{%- endif %}
   as (
     {{ sql }}
   );

--- a/test/integration/034_redshift_test/models_backup/model_backup_false.sql
+++ b/test/integration/034_redshift_test/models_backup/model_backup_false.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='table', backup=False
+    )
+}}
+
+select * from {{ ref('seed') }}

--- a/test/integration/034_redshift_test/models_backup/model_backup_true.sql
+++ b/test/integration/034_redshift_test/models_backup/model_backup_true.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='table', backup=True
+    )
+}}
+
+select * from {{ ref('seed') }}

--- a/test/integration/034_redshift_test/models_backup/model_backup_true_view.sql
+++ b/test/integration/034_redshift_test/models_backup/model_backup_true_view.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='view', backup=True
+    )
+}}
+
+select * from {{ ref('seed') }}

--- a/test/integration/034_redshift_test/models_backup/model_backup_undefined.sql
+++ b/test/integration/034_redshift_test/models_backup/model_backup_undefined.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select * from {{ ref('seed') }}

--- a/test/integration/034_redshift_test/test_backup_table_option.py
+++ b/test/integration/034_redshift_test/test_backup_table_option.py
@@ -1,0 +1,55 @@
+import os
+
+from test.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestBackupTableOption(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return 'backup_table_option_034'
+
+    @staticmethod
+    def dir(path):
+        return os.path.normpath(path)
+
+    @property
+    def models(self):
+        return self.dir("models_backup")
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'data-paths': [self.dir('seed')],
+            'seeds': {
+                'quote_columns': False,
+            }
+        }
+
+    def project_config_append(self, new_name, new_element):
+        self._project_config[new_name] = new_element
+
+    def check_backup_param_template(self, test_table_name, backup_is_expected):
+        # Use raw DDL statement to confirm backup is set correctly on new table
+        with open('target/run/test/models_backup/{}.sql'.format(test_table_name), 'r') as ddl_file:
+            ddl_statement = ddl_file.readlines()
+            self.assertEqual('backup no' not in ' '.join(ddl_statement).lower(), backup_is_expected)
+        # Use information schema to confirm backup is set correctly on new table (0 if BACKUP NO is present)
+        check = "select distinct backup from stv_tbl_perm where name = '{}'".format(test_table_name)
+        info_schema_result = self.run_sql(check, fetch='all')
+        self.assertEqual(info_schema_result[0][0], int(backup_is_expected))
+        self.assertEqual(len(info_schema_result), 1)
+
+    @use_profile('redshift')
+    def test__redshift_backup_table_option(self):
+        self.assertEqual(len(self.run_dbt(["seed"])), 1)
+        self.assertEqual(len(self.run_dbt()), 3)
+
+        # model_backup_undefined should not contain a BACKUP NO parameter in the table DDL
+        self.check_backup_param_template('model_backup_undefined', True)
+
+        # model_backup_true should not contain a BACKUP NO parameter in the table DDL
+        self.check_backup_param_template('model_backup_true', True)
+
+        # model_backup_false should contain a BACKUP NO parameter in the table DDL
+        self.check_backup_param_template('model_backup_false', False)


### PR DESCRIPTION
resolves #2367 

### Description
This PR adds a `backup` parameter to `RedshiftConfig` defaulting to true, which controls whether tables are included in any snapshots. It uses the value of this parameter in the Redshift table adapter to insert a "BACKUP NO" clause into the table creation statement of tables or models where `backup: false` is specified.

The new tests confirm that that DDL will only contain a "BACKUP NO" clause if this parameter is explicitly set to false. It also confirms that views are not affected by the change.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
