### PR TITLE
Feature: test config parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Add optional `merge_update_columns` config to specify columns to update for `merge` statements in BigQuery and Snowflake ([#1862](https://github.com/fishtown-analytics/dbt/issues/1862), [#3100](https://github.com/fishtown-analytics/dbt/pull/3100))
 - Use query comment JSON as job labels for BigQuery adapter when `query-comment.job-label` is set to `true` ([#2483](https://github.com/fishtown-analytics/dbt/issues/2483)), ([#3145](https://github.com/fishtown-analytics/dbt/pull/3145))
 - Set application_name for Postgres connections ([#885](https://github.com/fishtown-analytics/dbt/issues/885), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
+- Support disabling schema tests, and configuring tests from `dbt_project.yml` ([#3252](https://github.com/fishtown-analytics/dbt/issues/3252),
+[#3253](https://github.com/fishtown-analytics/dbt/issues/3253), [#3257](https://github.com/fishtown-analytics/dbt/pull/3257))
 
 ### Under the hood
 - Add dependabot configuration for alerting maintainers about keeping dependencies up to date and secure. ([#3061](https://github.com/fishtown-analytics/dbt/issues/3061), [#3062](https://github.com/fishtown-analytics/dbt/pull/3062))

--- a/core/dbt/config/project.py
+++ b/core/dbt/config/project.py
@@ -353,12 +353,14 @@ class PartialProject(RenderComponents):
         seeds: Dict[str, Any]
         snapshots: Dict[str, Any]
         sources: Dict[str, Any]
+        tests: Dict[str, Any]
         vars_value: VarProvider
 
         models = cfg.models
         seeds = cfg.seeds
         snapshots = cfg.snapshots
         sources = cfg.sources
+        tests = cfg.tests
         if cfg.vars is None:
             vars_dict: Dict[str, Any] = {}
         else:
@@ -408,6 +410,7 @@ class PartialProject(RenderComponents):
             selectors=selectors,
             query_comment=query_comment,
             sources=sources,
+            tests=tests,
             vars=vars_value,
             config_version=cfg.config_version,
             unrendered=unrendered,
@@ -513,6 +516,7 @@ class Project:
     seeds: Dict[str, Any]
     snapshots: Dict[str, Any]
     sources: Dict[str, Any]
+    tests: Dict[str, Any]
     vars: VarProvider
     dbt_version: List[VersionSpecifier]
     packages: Dict[str, Any]
@@ -571,6 +575,7 @@ class Project:
             'seeds': self.seeds,
             'snapshots': self.snapshots,
             'sources': self.sources,
+            'tests': self.tests,
             'vars': self.vars.to_dict(),
             'require-dbt-version': [
                 v.to_version_string() for v in self.dbt_version

--- a/core/dbt/config/renderer.py
+++ b/core/dbt/config/renderer.py
@@ -145,7 +145,7 @@ class DbtProjectYamlRenderer(BaseRenderer):
         if first == 'vars':
             return False
 
-        if first in {'seeds', 'models', 'snapshots', 'seeds'}:
+        if first in {'seeds', 'models', 'snapshots', 'tests'}:
             keypath_parts = {
                 (k.lstrip('+') if isinstance(k, str) else k)
                 for k in keypath

--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -110,6 +110,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             selectors=project.selectors,
             query_comment=project.query_comment,
             sources=project.sources,
+            tests=project.tests,
             vars=project.vars,
             config_version=project.config_version,
             unrendered=project.unrendered,
@@ -272,7 +273,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         return frozenset(paths)
 
     def get_resource_config_paths(self) -> Dict[str, PathSet]:
-        """Return a dictionary with 'seeds' and 'models' keys whose values are
+        """Return a dictionary with resource type keys whose values are
         lists of lists of strings, where each inner list of strings represents
         a configured path in the resource.
         """
@@ -281,6 +282,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             'seeds': self._get_config_paths(self.seeds),
             'snapshots': self._get_config_paths(self.snapshots),
             'sources': self._get_config_paths(self.sources),
+            'tests': self._get_config_paths(self.tests),
         }
 
     def get_unused_resource_config_paths(
@@ -488,6 +490,7 @@ class UnsetProfileConfig(RuntimeConfig):
             selectors=project.selectors,
             query_comment=project.query_comment,
             sources=project.sources,
+            tests=project.tests,
             vars=project.vars,
             config_version=project.config_version,
             unrendered=project.unrendered,

--- a/core/dbt/context/context_config.py
+++ b/core/dbt/context/context_config.py
@@ -41,6 +41,8 @@ class UnrenderedConfig(ConfigSource):
             model_configs = unrendered.get('snapshots')
         elif resource_type == NodeType.Source:
             model_configs = unrendered.get('sources')
+        elif resource_type == NodeType.Test:
+            model_configs = unrendered.get('tests')
         else:
             model_configs = unrendered.get('models')
 
@@ -61,6 +63,8 @@ class RenderedConfig(ConfigSource):
             model_configs = self.project.snapshots
         elif resource_type == NodeType.Source:
             model_configs = self.project.sources
+        elif resource_type == NodeType.Test:
+            model_configs = self.project.tests
         else:
             model_configs = self.project.models
         return model_configs

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -195,6 +195,7 @@ class Project(HyphenatedDbtClassMixin, Replaceable):
     snapshots: Dict[str, Any] = field(default_factory=dict)
     analyses: Dict[str, Any] = field(default_factory=dict)
     sources: Dict[str, Any] = field(default_factory=dict)
+    tests: Dict[str, Any] = field(default_factory=dict)
     vars: Optional[Dict[str, Any]] = field(
         default=None,
         metadata=dict(

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -220,7 +220,7 @@ class TestBuilder(Generic[Testable]):
         for key in self.MODIFIER_ARGS:
             value = self.args.pop(key, None)
             if isinstance(value, str):
-                value = get_rendered(value, render_ctx)
+                value = get_rendered(value, render_ctx, native=True)
             if value is not None:
                 self.modifiers[key] = value
 
@@ -312,7 +312,11 @@ class TestBuilder(Generic[Testable]):
         return get_nice_schema_test_name(name, self.target.name, self.args)
 
     def construct_config(self) -> str:
-        configs = ",".join([f"{key}={value}" for key, value in self.modifiers.items()])
+        configs = ",".join([
+            f"{key}=" + (f"'{value}'" if isinstance(value, str) else str(value))
+            for key, value
+            in self.modifiers.items()
+        ])
         if configs:
             return f"{{{{ config({configs}) }}}}"
         else:

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -486,10 +486,10 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
         if (macro_unique_id in
                 ['macro.dbt.test_not_null', 'macro.dbt.test_unique']):
             self.update_parsed_node(node, config)
-            if builder.severity():
+            if builder.severity() is not None:
                 node.unrendered_config['severity'] = builder.severity()
                 node.config['severity'] = builder.severity()
-            if builder.enabled():
+            if builder.enabled() is not None:
                 node.config['enabled'] = builder.enabled()
             # source node tests are processed at patch_source time
             if isinstance(builder.target, UnpatchedSourceDefinition):

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -486,8 +486,11 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
         if (macro_unique_id in
                 ['macro.dbt.test_not_null', 'macro.dbt.test_unique']):
             self.update_parsed_node(node, config)
-            node.unrendered_config['severity'] = builder.severity()
-            node.config['severity'] = builder.severity()
+            if builder.severity():
+                node.unrendered_config['severity'] = builder.severity()
+                node.config['severity'] = builder.severity()
+            if builder.enabled():
+                node.config['enabled'] = builder.enabled()
             # source node tests are processed at patch_source time
             if isinstance(builder.target, UnpatchedSourceDefinition):
                 sources = [builder.target.fqn[-2], builder.target.fqn[-1]]

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1006,9 +1006,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         return result
 
     def unrendered_tst_config(self, **updates):
-        result = {
-            'severity': 'ERROR',
-        }
+        result = {}
         result.update(updates)
         return result
 
@@ -1354,7 +1352,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': Normalized('schema_test/not_null_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+                    'raw_sql': "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'relation_name': None,
                     'resource_type': 'test',
@@ -1441,7 +1439,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/test_nothing_model_.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test.test_nothing(**_dbt_schema_test_kwargs) }}",
+                    'raw_sql': "{{ test.test_nothing(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'relation_name': None,
                     'resource_type': 'test',
@@ -1485,7 +1483,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'package_name': 'test',
                     'patch_path': None,
                     'path': normalize('schema_test/unique_model_id.sql'),
-                    'raw_sql': "{{ config(severity='ERROR') }}{{ test_unique(**_dbt_schema_test_kwargs) }}",
+                    'raw_sql': "{{ test_unique(**_dbt_schema_test_kwargs) }}",
                     'refs': [['model']],
                     'relation_name': None,
                     'resource_type': 'test',

--- a/test/integration/039_config_test/models/schema.yml
+++ b/test/integration/039_config_test/models/schema.yml
@@ -6,3 +6,21 @@ sources:
     tables:
       - name: 'seed'
         identifier: "{{ var('seed_name', 'invalid') }}"
+        columns:
+          - name: id
+            tests:
+              - unique:
+                  enabled: "{{ var('enabled_direct', None) | as_native }}"
+              - accepted_values:
+                  enabled: "{{ var('enabled_direct', None) | as_native }}"
+                  severity: "{{ var('severity_direct', None) | as_native }}"
+                  values: [1,2]
+
+models:
+  - name: model
+    columns:
+      - name: id
+        tests:
+          - unique
+          - accepted_values:
+              values: [1,2,3,4]

--- a/test/integration/039_config_test/test_configs.py
+++ b/test/integration/039_config_test/test_configs.py
@@ -139,6 +139,7 @@ class TestDisabledConfigs(DBTIntegrationTest):
         return {
             'config-version': 2,
             'data-paths': ['data'],
+            'test-paths': ['tests'],
             'models': {
                 'test': {
                     'enabled': "{{ (target.name == 'default2' | as_bool) }}",
@@ -159,6 +160,12 @@ class TestDisabledConfigs(DBTIntegrationTest):
                     },
                 },
             },
+            'tests': {
+                'test': {
+                    'enabled': "{{ (target.name == 'default2') | as_bool }}",
+                    'severity': 'WARN'
+                },
+            },
         }
 
     @property
@@ -177,12 +184,16 @@ class TestDisabledConfigs(DBTIntegrationTest):
         self.assertEqual(len(results), 0)
         results = self.run_dbt(['run', '--target', 'disabled'], strict=False)
         self.assertEqual(len(results), 0)
+        results = self.run_dbt(['test', '--target', 'disabled'], strict=False)
+        self.assertEqual(len(results), 0)
 
         # has seeds/models - enabled should eval to True because of the target
         results = self.run_dbt(['seed'])
         self.assertEqual(len(results), 1)
         results = self.run_dbt(['run'])
         self.assertEqual(len(results), 2)
+        results = self.run_dbt(['test'], strict=False)
+        self.assertEqual(len(results), 5)
 
 
 class TestUnusedModelConfigs(DBTIntegrationTest):
@@ -195,6 +206,7 @@ class TestUnusedModelConfigs(DBTIntegrationTest):
         return {
             'config-version': 2,
             'data-paths': ['data'],
+            'test-paths': ['does-not-exist'],
             'models': {
                 'test': {
                     'enabled': True,
@@ -207,7 +219,12 @@ class TestUnusedModelConfigs(DBTIntegrationTest):
                 'test': {
                     'enabled': True,
                 }
-            }
+            },
+            'tests': {
+                'test': {
+                    'enabled': True,
+                }
+            },
         }
 
     @property
@@ -222,5 +239,60 @@ class TestUnusedModelConfigs(DBTIntegrationTest):
         self.assertIn('Configuration paths exist', str(exc.exception))
         self.assertIn('- sources.test', str(exc.exception))
         self.assertIn('- models.test', str(exc.exception))
+        self.assertIn('- models.test', str(exc.exception))
 
         self.run_dbt(['seed'], strict=False)
+
+class TestConfigIndivTests(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "config_039"
+
+    @property
+    def models(self):
+        return "models"
+    
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            'data-paths': ['data'],
+            'test-paths': ['tests'],
+            'seeds': {
+                'quote_columns': False,
+            },
+            'vars': {
+                'test': {
+                    'seed_name': 'seed',
+                }
+            },
+            'tests': {
+                'test': {
+                    'enabled': True,
+                    'severity': 'WARN'
+                }
+            }
+        }
+
+    @use_profile('postgres')
+    def test_postgres_configuring_individual_tests(self):
+        self.assertEqual(len(self.run_dbt(['seed'])), 1)
+        self.assertEqual(len(self.run_dbt(['run'])), 2)
+        
+        # all tests on (minus sleeper_agent) + WARN
+        self.assertEqual(len(self.run_dbt(['test'], strict=False)), 5)
+        
+        # turn off two of them directly
+        self.assertEqual(len(self.run_dbt(['test', '--vars', '{"enabled_direct": False}'], strict=False)), 3)
+        
+        # turn on sleeper_agent data test directly
+        self.assertEqual(len(self.run_dbt(['test', '--models', 'sleeper_agent', 
+            '--vars', '{"enabled_direct": True}'], strict=False)), 1)
+        
+        # set three to ERROR directly
+        results = self.run_dbt(['test', '--models', 'config.severity:error',
+            '--vars', '{"enabled_direct": True, "severity_direct": "ERROR"}'
+            ], strict=False, expect_pass = False)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].status, 'fail')
+        self.assertEqual(results[1].status, 'fail')

--- a/test/integration/039_config_test/tests/failing.sql
+++ b/test/integration/039_config_test/tests/failing.sql
@@ -1,0 +1,2 @@
+
+select 1 as fun

--- a/test/integration/039_config_test/tests/sleeper_agent.sql
+++ b/test/integration/039_config_test/tests/sleeper_agent.sql
@@ -1,0 +1,6 @@
+{{ config(
+    enabled = var('enabled_direct', False),
+    severity = var('severity_direct', 'WARN')
+) }}
+
+select 1 as fun


### PR DESCRIPTION
resolves #3252
resolves #3253

This PR makes it possible to:
- Disable schema tests where they're defined
- Configure tests from `dbt_project.yml`

**models/*.yml**:
```yml
      tests:
        - not_null:
            enabled: true
        - accepted_values:
            values: [1,2,3]
            enabled: false
```
**dbt_project.yml**:
```yml
tests:
  my_project:
    +severity: warn
  installed_package:
    +enabled: false
```

### Differences from proposal in #3253

- Rather than configuring schema tests underneath each of models/sources/etc, all tests are configured under `tests:`. I think that's okay.
- (After we solve v0.19.1 regression): Generic tests' default configs/arguments will override configurations set in `dbt_project.yml`. That's not the order I had originally envisioned, but again I think that's okay; it's up for debate which one is actually more generic / specific.

### Next issues

- Net-new configs (https://github.com/fishtown-analytics/dbt/issues/3258)
- Test FQNs could be a lot better, to make configuration easier (https://github.com/fishtown-analytics/dbt/issues/3259)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
