### PR TITLE
Issue 275: Support dbt package dependencies in Git subdirectories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,7 @@ version: 2.1
 jobs:
   unit:
     docker: &test_only
-      # TODO: Ask for someone at fishtown to publish
-      # a new version of the test container    
-      - image: dmateusp/dbt-test-container
+      - image: fishtownanalytics/test-container:12
         environment:
           DBT_INVOCATION_ENV: circle
           DOCKER_TEST_DATABASE_HOST: "database"
@@ -39,9 +37,7 @@ jobs:
           destination: dist
   integration-postgres:
     docker:
-      # TODO: Ask for someone at fishtown to publish
-      # a new version of the test container
-      - image: dmateusp/dbt-test-container
+      - image: fishtownanalytics/test-container:12
         environment:
           DBT_INVOCATION_ENV: circle
           DOCKER_TEST_DATABASE_HOST: "database"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@ version: 2.1
 jobs:
   unit:
     docker: &test_only
-      - image: fishtownanalytics/test-container:11
+      # TODO: Ask for someone at fishtown to publish
+      # a new version of the test container    
+      - image: dmateusp/dbt-test-container
         environment:
           DBT_INVOCATION_ENV: circle
           DOCKER_TEST_DATABASE_HOST: "database"
@@ -37,7 +39,9 @@ jobs:
           destination: dist
   integration-postgres:
     docker:
-      - image: fishtownanalytics/test-container:11
+      # TODO: Ask for someone at fishtown to publish
+      # a new version of the test container
+      - image: dmateusp/dbt-test-container
         environment:
           DBT_INVOCATION_ENV: circle
           DOCKER_TEST_DATABASE_HOST: "database"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Features
 - Support commit hashes in dbt deps package revision ([#3268](https://github.com/fishtown-analytics/dbt/issues/3268), [#3270](https://github.com/fishtown-analytics/dbt/pull/3270))
+- Add optional `subdirectory` key to install dbt packages that are not hosted at the root of a Git repository ([#275](https://github.com/fishtown-analytics/dbt/issues/275), [#3267](https://github.com/fishtown-analytics/dbt/pull/3267))
 - Add optional configs for `require_partition_filter` and `partition_expiration_days` in BigQuery ([#1843](https://github.com/fishtown-analytics/dbt/issues/1843), [#2928](https://github.com/fishtown-analytics/dbt/pull/2928))
 - Fix for EOL SQL comments prevent entire line execution ([#2731](https://github.com/fishtown-analytics/dbt/issues/2731), [#2974](https://github.com/fishtown-analytics/dbt/pull/2974))
 - Add optional `merge_update_columns` config to specify columns to update for `merge` statements in BigQuery and Snowflake ([#1862](https://github.com/fishtown-analytics/dbt/issues/1862), [#3100](https://github.com/fishtown-analytics/dbt/pull/3100))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Contributors:
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
 - [@cgopalan](https://github.com/cgopalan) ([#3165](https://github.com/fishtown-analytics/dbt/pull/3165), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
 - [@fux](https://github.com/fuchsst) ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
-- [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270))
 - [@arzavj](https://github.com/arzavj) ([3106](https://github.com/fishtown-analytics/dbt/pull/3106))
 - [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270), [#3267](https://github.com/fishtown-analytics/dbt/pull/3267))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,9 @@ Contributors:
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
 - [@cgopalan](https://github.com/cgopalan) ([#3165](https://github.com/fishtown-analytics/dbt/pull/3165), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
 - [@fux](https://github.com/fuchsst) ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
-<<<<<<< HEAD
 - [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270))
 - [@arzavj](https://github.com/arzavj) ([3106](https://github.com/fishtown-analytics/dbt/pull/3106))
-=======
 - [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270), [#3267](https://github.com/fishtown-analytics/dbt/pull/3267))
->>>>>>> 591ad65d (📖 Update CHANGELOG contributors to include this PR)
 
 ## dbt 0.19.1 (March 31, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,12 @@ Contributors:
 - [@techytushar](https://github.com/techytushar) ([#3158](https://github.com/fishtown-analytics/dbt/pull/3158))
 - [@cgopalan](https://github.com/cgopalan) ([#3165](https://github.com/fishtown-analytics/dbt/pull/3165), [#3182](https://github.com/fishtown-analytics/dbt/pull/3182))
 - [@fux](https://github.com/fuchsst) ([#3241](https://github.com/fishtown-analytics/dbt/issues/3241))
+<<<<<<< HEAD
 - [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270))
 - [@arzavj](https://github.com/arzavj) ([3106](https://github.com/fishtown-analytics/dbt/pull/3106))
+=======
+- [@dmateusp](https://github.com/dmateusp) ([#3270](https://github.com/fishtown-analytics/dbt/pull/3270), [#3267](https://github.com/fishtown-analytics/dbt/pull/3267))
+>>>>>>> 591ad65d (📖 Update CHANGELOG contributors to include this PR)
 
 ## dbt 0.19.1 (March 31, 2021)
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,6 +3,9 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository ppa:git-core/ppa -y \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
     netcat \

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -39,7 +39,7 @@ def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirec
     result = run_cmd(cwd, clone_cmd, env={'LC_ALL': 'C'})
 
     if subdirectory:
-        run_cmd(os.path.join(cwd, dirname), ['git', 'sparse-checkout', 'set', subdirectory])
+        run_cmd(os.path.join(cwd, dirname or ''), ['git', 'sparse-checkout', 'set', subdirectory])
 
     if remove_git_dir:
         rmdir(os.path.join(dirname, '.git'))
@@ -139,4 +139,4 @@ def clone_and_checkout(repo, cwd, dirname=None, remove_git_dir=False,
                          start_sha[:7], end_sha[:7])
     else:
         logger.debug('  Checked out at {}.', end_sha[:7])
-    return os.path.join(directory, subdirectory)
+    return os.path.join(directory, subdirectory or '')

--- a/core/dbt/clients/git.py
+++ b/core/dbt/clients/git.py
@@ -11,7 +11,7 @@ def _is_commit(revision: str) -> bool:
     return bool(re.match(r"\b[0-9a-f]{40}\b", revision))
 
 
-def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None):
+def clone(repo, cwd, dirname=None, remove_git_dir=False, revision=None, subdirectory=None):
     has_revision = revision is not None
     is_commit = _is_commit(revision or "")
 
@@ -84,11 +84,16 @@ def remove_remote(cwd):
 
 
 def clone_and_checkout(repo, cwd, dirname=None, remove_git_dir=False,
-                       revision=None):
+                       revision=None, subdirectory=None):
     exists = None
     try:
-        _, err = clone(repo, cwd, dirname=dirname,
-                       remove_git_dir=remove_git_dir)
+        _, err = clone(
+            repo,
+            cwd,
+            dirname=dirname,
+            remove_git_dir=remove_git_dir,
+            subdirectory=subdirectory,
+        )
     except dbt.exceptions.CommandResultError as exc:
         err = exc.stderr.decode('utf-8')
         exists = re.match("fatal: destination path '(.+)' already exists", err)

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -70,6 +70,7 @@ class GitPackage(Package):
     git: str
     revision: Optional[RawVersion] = None
     warn_unpinned: Optional[bool] = None
+    subdirectory: Optional[str] = None
 
     def get_revisions(self) -> List[str]:
         if self.revision is None:

--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -96,6 +96,7 @@ class PinnedPackage(BasePackage):
     def get_subdirectory(self):
         return None
 
+
 SomePinned = TypeVar('SomePinned', bound=PinnedPackage)
 SomeUnpinned = TypeVar('SomeUnpinned', bound='UnpinnedPackage')
 

--- a/core/dbt/deps/base.py
+++ b/core/dbt/deps/base.py
@@ -93,6 +93,8 @@ class PinnedPackage(BasePackage):
         dest_dirname = self.get_project_name(project, renderer)
         return os.path.join(project.modules_path, dest_dirname)
 
+    def get_subdirectory(self):
+        return None
 
 SomePinned = TypeVar('SomePinned', bound=PinnedPackage)
 SomeUnpinned = TypeVar('SomeUnpinned', bound='UnpinnedPackage')

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -48,6 +48,9 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
     def get_version(self):
         return self.revision
 
+    def get_subdirectory(self):
+        return self.subdirectory
+
     def nice_version_name(self):
         if self.revision == 'HEAD':
             return 'HEAD (default revision)'

--- a/core/dbt/deps/git.py
+++ b/core/dbt/deps/git.py
@@ -37,7 +37,11 @@ class GitPackageMixin:
 
 class GitPinnedPackage(GitPackageMixin, PinnedPackage):
     def __init__(
-        self, git: str, revision: str, warn_unpinned: bool = True, subdirectory: Optional[str] = None
+        self,
+        git: str,
+        revision: str,
+        warn_unpinned: bool = True,
+        subdirectory: Optional[str] = None,
     ) -> None:
         super().__init__(git)
         self.revision = revision
@@ -111,7 +115,11 @@ class GitPinnedPackage(GitPackageMixin, PinnedPackage):
 
 class GitUnpinnedPackage(GitPackageMixin, UnpinnedPackage[GitPinnedPackage]):
     def __init__(
-        self, git: str, revisions: List[str], warn_unpinned: bool = True, subdirectory: Optional[str] = None
+        self,
+        git: str,
+        revisions: List[str],
+        warn_unpinned: bool = True,
+        subdirectory: Optional[str] = None,
     ) -> None:
         super().__init__(git)
         self.revisions = revisions

--- a/core/dbt/task/deps.py
+++ b/core/dbt/task/deps.py
@@ -59,8 +59,11 @@ class DepsTask(BaseTask):
             for package in final_deps:
                 logger.info('Installing {}', package)
                 package.install(self.config, renderer)
-                logger.info('  Installed from {}\n',
+                logger.info('  Installed from {}',
                             package.nice_version_name())
+                if package.get_subdirectory():
+                    logger.info('   and subdirectory {}\n',
+                                package.get_subdirectory())
 
                 self.track_package_install(
                     package_name=package.name,

--- a/test/rpc/test_deps.py
+++ b/test/rpc/test_deps.py
@@ -87,10 +87,19 @@ def test_rpc_deps_packages(project_root, profiles_root, dbt_profile, unique_sche
 
 @pytest.mark.supported('postgres')
 def test_rpc_deps_git(project_root, profiles_root, dbt_profile, unique_schema):
-    packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': '0.5.0'
-    }]
+    packages = [
+        {
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': '0.5.0'
+        },
+        # TODO: Change me to something that fishtown-analytics manages!
+        # here I just moved the dbt_utils code into a subdirectory
+        {
+            'git': 'https://github.com/dmateusp/dbt-utils.git',
+            'revision': 'dmateusp/move_dbt_utils_to_subdir',
+            'subdirectory': 'dbt_projects/dbt_utils'
+        },
+    ]
     # if you use a bad URL, git thinks it's a private repo and prompts for auth
     bad_packages = [{
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',

--- a/test/rpc/test_deps.py
+++ b/test/rpc/test_deps.py
@@ -112,16 +112,14 @@ def deps_with_packages(packages, bad_packages, project_dir, profiles_dir, schema
     ),
     # from git release and subdirectory
     (
-        # TODO: Change me to something that fishtown-analytics manages!
-        # here I just moved the dbt_utils code into a subdirectory
         [{
-            'git': 'https://github.com/dmateusp/dbt-utils.git',
-            'revision': 'dmateusp/0.5.0/move_dbt_utils_to_subdir',
-            'subdirectory': 'dbt_projects/dbt_utils',
+            'git': 'https://github.com/fishtown-analytics/dbt-labs-experimental-features.git',
+            'revision': '0.0.1',
+            'subdirectory': 'materialized-views',
         }],
         [{
-            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-            'revision': '0.5.0',
+            'git': 'https://github.com/fishtown-analytics/dbt-labs-experimental-features.git',
+            'revision': '0.0.1',
             'subdirectory': 'path/to/nonexistent/dir',
         }],
     ),

--- a/test/rpc/test_deps.py
+++ b/test/rpc/test_deps.py
@@ -87,19 +87,10 @@ def test_rpc_deps_packages(project_root, profiles_root, dbt_profile, unique_sche
 
 @pytest.mark.supported('postgres')
 def test_rpc_deps_git(project_root, profiles_root, dbt_profile, unique_schema):
-    packages = [
-        {
-            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-            'revision': '0.5.0'
-        },
-        # TODO: Change me to something that fishtown-analytics manages!
-        # here I just moved the dbt_utils code into a subdirectory
-        {
-            'git': 'https://github.com/dmateusp/dbt-utils.git',
-            'revision': 'dmateusp/move_dbt_utils_to_subdir',
-            'subdirectory': 'dbt_projects/dbt_utils'
-        },
-    ]
+    packages = [{
+        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+        'revision': '0.5.0'
+    }]
     # if you use a bad URL, git thinks it's a private repo and prompts for auth
     bad_packages = [{
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
@@ -118,5 +109,22 @@ def test_rpc_deps_git_commit(project_root, profiles_root, dbt_profile, unique_sc
     bad_packages = [{
         'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
         'revision': 'b736cf6'
+    }]
+    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
+
+
+def test_rpc_deps_git_subdir(project_root, profiles_root, dbt_profile, unique_schema):
+    # TODO: Change me to something that fishtown-analytics manages!
+    # here I just moved the dbt_utils code into a subdirectory
+    packages = [{
+        'git': 'https://github.com/dmateusp/dbt-utils.git',
+        'revision': 'dmateusp/0.5.0/move_dbt_utils_to_subdir',
+        'subdirectory': 'dbt_projects/dbt_utils'
+    }]
+    #
+    bad_packages = [{
+        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+        'revision': '0.5.0',
+        'subdirectory': 'path/to/nonexistent/dir',
     }]
     deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)

--- a/test/rpc/test_deps.py
+++ b/test/rpc/test_deps.py
@@ -72,59 +72,80 @@ def deps_with_packages(packages, bad_packages, project_dir, profiles_dir, schema
         querier.is_result(querier.async_wait(tok1))
 
 
+@pytest.mark.parametrize(
+    "packages, bad_packages",
+    # from dbt hub
+    [(
+        [{
+            'package': 'fishtown-analytics/dbt_utils',
+            'version': '0.5.0',
+        }],
+        # wrong package name
+        [{
+            'package': 'fishtown-analytics/dbt_util',
+            'version': '0.5.0',
+        }],
+    ),
+    # from git release/tag/branch
+    (
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': '0.5.0',
+        }],
+        # if you use a bad URL, git thinks it's a private repo and prompts for auth
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': 'not-a-real-revision',
+        }],
+    ),
+    # from git commit
+    (
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': 'b736cf6acdbf80d2de69b511a51c8d7fe214ee79',
+        }],
+        # don't use short commits
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': 'b736cf6',
+        }],
+    ),
+    # from git release and subdirectory
+    (
+        # TODO: Change me to something that fishtown-analytics manages!
+        # here I just moved the dbt_utils code into a subdirectory
+        [{
+            'git': 'https://github.com/dmateusp/dbt-utils.git',
+            'revision': 'dmateusp/0.5.0/move_dbt_utils_to_subdir',
+            'subdirectory': 'dbt_projects/dbt_utils',
+        }],
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': '0.5.0',
+            'subdirectory': 'path/to/nonexistent/dir',
+        }],
+    ),
+    # from git commit and subdirectory
+    (
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': 'f4f84e9110db26aba22f756abbae9f1f8dbb15da',
+            'subdirectory': 'dbt_projects/dbt_utils',
+        }],
+        [{
+            'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
+            'revision': 'f4f84e9110db26aba22f756abbae9f1f8dbb15da',
+            'subdirectory': 'path/to/nonexistent/dir',
+        }],
+    )],
+    ids=[
+        "from dbt hub",
+        "from git release/tag/branch",
+        "from git commit",
+        "from git release and subdirectory",
+        "from git commit and subdirectory",
+    ],
+)
 @pytest.mark.supported('postgres')
-def test_rpc_deps_packages(project_root, profiles_root, dbt_profile, unique_schema):
-    packages = [{
-        'package': 'fishtown-analytics/dbt_utils',
-        'version': '0.5.0',
-    }]
-    bad_packages = [{
-        'package': 'fishtown-analytics/dbt_util',
-        'version': '0.5.0',
-    }]
-    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
-
-
-@pytest.mark.supported('postgres')
-def test_rpc_deps_git(project_root, profiles_root, dbt_profile, unique_schema):
-    packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': '0.5.0'
-    }]
-    # if you use a bad URL, git thinks it's a private repo and prompts for auth
-    bad_packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': 'not-a-real-revision'
-    }]
-    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
-
-
-@pytest.mark.supported('postgres')
-def test_rpc_deps_git_commit(project_root, profiles_root, dbt_profile, unique_schema):
-    packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': 'b736cf6acdbf80d2de69b511a51c8d7fe214ee79'
-    }]
-    # don't use short commits
-    bad_packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': 'b736cf6'
-    }]
-    deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)
-
-
-def test_rpc_deps_git_subdir(project_root, profiles_root, dbt_profile, unique_schema):
-    # TODO: Change me to something that fishtown-analytics manages!
-    # here I just moved the dbt_utils code into a subdirectory
-    packages = [{
-        'git': 'https://github.com/dmateusp/dbt-utils.git',
-        'revision': 'dmateusp/0.5.0/move_dbt_utils_to_subdir',
-        'subdirectory': 'dbt_projects/dbt_utils'
-    }]
-    #
-    bad_packages = [{
-        'git': 'https://github.com/fishtown-analytics/dbt-utils.git',
-        'revision': '0.5.0',
-        'subdirectory': 'path/to/nonexistent/dir',
-    }]
+def test_rpc_deps_packages(project_root, profiles_root, dbt_profile, unique_schema, packages, bad_packages):
     deps_with_packages(packages, bad_packages, project_root, profiles_root, unique_schema)


### PR DESCRIPTION
resolves #275 

### Description

* Add an optional `subdirectory` key for Git packages.
* Use `sparse-checkout` to pull only that directory.
* Install dbt package from that `subdirectory`.
* Make sure the git version of the user is `>= 2.25.0`, the version that introduces `--sparse`.


### Checklist
 - [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements) (Or at least I remember signing it a while back)
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
