### PR TITLE
POC: Incremental Predicates

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -66,7 +66,7 @@
 {% endmacro %}
 
 
-{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=None) -%}
+{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
 
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
@@ -88,7 +88,7 @@
 
 {%- endmacro %}
 
-{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=None) -%}
+{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
     {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) }}
 {% endmacro %}
 

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -1,7 +1,7 @@
 
 
-{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}
-  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}
+{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none, incrementnal_predicates=none) -%}
+  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates, incremental_predicates) }}
 {%- endmacro %}
 
 
@@ -15,11 +15,12 @@
 {%- endmacro %}
 
 
-{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}
+{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates, incremental_predictates=none) -%}
     {%- set predicates = [] if predicates is none else [] + predicates -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute="quoted") | list) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
+    {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
 
     {% if unique_key %}
         {% set unique_key_match %}
@@ -48,6 +49,8 @@
         ({{ dest_cols_csv }})
     values
         ({{ dest_cols_csv }})
+
+    {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %}
 
 {% endmacro %}
 
@@ -111,6 +114,6 @@
     values
         ({{ dest_cols_csv }})
 
-    {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %};
+    {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %}
 
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -86,7 +86,7 @@
 {%- endmacro %}
 
 {% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=None) -%}
-    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=None) }}
+    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) }}
 {% endmacro %}
 
 

--- a/core/dbt/include/global_project/macros/materializations/common/merge.sql
+++ b/core/dbt/include/global_project/macros/materializations/common/merge.sql
@@ -5,13 +5,13 @@
 {%- endmacro %}
 
 
-{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=None) -%}
+{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}
   {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns, incremental_predicates) }}
 {%- endmacro %}
 
 
-{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}
-  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}
+{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false, incremental_predicates=none) -%}
+  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header, incremental_predicates) }}
 {%- endmacro %}
 
 
@@ -90,10 +90,11 @@
 {% endmacro %}
 
 
-{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}
+{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header, incremental_predicates=none) -%}
     {%- set predicates = [] if predicates is none else [] + predicates -%}
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
+    {%- set incremental_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
 
     {{ sql_header if sql_header is not none and include_sql_header }}
 
@@ -109,5 +110,7 @@
         ({{ dest_cols_csv }})
     values
         ({{ dest_cols_csv }})
+
+    {% if incremental_predicates %} where {{ incremental_predicates | join(' and ') }} {% endif %};
 
 {% endmacro %}

--- a/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/helpers.sql
@@ -1,5 +1,5 @@
 
-{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
+{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main", incremental_predicates=none) %}
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
 
@@ -9,7 +9,8 @@
     where ({{ unique_key }}) in (
         select ({{ unique_key }})
         from {{ tmp_relation }}
-    );
+    )
+    {% if incremental_predicates %} and {{ incremental_predicates | join(' and ') }} {% endif %};
     {%- endif %}
 
     insert into {{ target_relation }} ({{ dest_cols_csv }})

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -7,6 +7,8 @@
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
 
+  {%- set incremental_predicates = config.get('incremental_predicates', default=None) -%}
+
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -30,7 +32,11 @@
       {% do adapter.expand_target_column_types(
              from_relation=tmp_relation,
              to_relation=target_relation) %}
-      {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
+      {% set build_sql = incremental_upsert(
+             tmp_relation,
+             target_relation,
+             unique_key=unique_key,
+             incremental_predicates=incremental_predicates) %}
   {% endif %}
 
   {% call statement("main") %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -14,11 +14,11 @@
   {% do return(strategy) %}
 {% endmacro %}
 
-{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}
+{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates=None) %}
   {% if strategy == 'merge' %}
     {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
   {% elif strategy == 'delete+insert' %}
-    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates)) %}
   {% else %}
     {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}
   {% endif %}
@@ -30,6 +30,7 @@
 
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
+  {%- set incremental_predicates = config.get("incremental_predicates", default=None) -%}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}
@@ -59,7 +60,7 @@
            from_relation=tmp_relation,
            to_relation=target_relation) %}
     {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}
-    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}
+    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates) %}
   {% endif %}
 
   {%- call statement('main') -%}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -30,7 +30,7 @@
 
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
-  {%- set incremental_predicates = config.get("incremental_predicates", default=None) -%}
+  {%- set incremental_predicates = config.get('incremental_predicates', default=None) -%}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -14,9 +14,9 @@
   {% do return(strategy) %}
 {% endmacro %}
 
-{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates=None) %}
+{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns, incremental_predicates=none) %}
   {% if strategy == 'merge' %}
-    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates)) %}
   {% elif strategy == 'delete+insert' %}
     {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates)) %}
   {% else %}
@@ -30,7 +30,7 @@
 
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
-  {%- set incremental_predicates = config.get('incremental_predicates', default=None) -%}
+  {%- set incremental_predicates = config.get('incremental_predicates', default=none) -%}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}

--- a/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/plugins/snowflake/dbt/include/snowflake/macros/materializations/merge.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) -%}
+{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates, incremental_predicates=none) -%}
 
     {#
        Workaround for Snowflake not being happy with a merge on a constant-false predicate.
@@ -21,7 +21,7 @@
 
     {%- else -%}
 
-        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) }}
+        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates, incremental_predicates) }}
 
     {%- endif -%}
 


### PR DESCRIPTION
refs #3293

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

This PR updates the snowflake delete+insert incrementnal load stratgy to allow for the config to specify incremental predicates:

```
{{
    config(
      materialized='incremental',
      incremental_strategy='delete+insert',
      incremental_predicates=[
        "collector_hour >= dateadd('day', -7, CONVERT_TIMEZONE('UTC', current_timestamp()))"
      ],
      unique_key='unique_id'
    )
}}
```

I believe that this is distinct from the `predicates` which is already present in some of the functions. It looks like `predicates` applies directly to merge column. `incremental_predicates` are applied globally to the top level DML.

### TODO
- [x] default incremental - add param
- [x] default incremental upsert - add param 
- [x] common/merge - add param
- [ ] snowflake merge
- [x] snowflake incremental 
- [ ] bigquery incremental 
- [ ] bigquery merge
- [ ] postgres incremental
- [ ] postgres merge
- [ ] redshift incremental
- [ ] redshift merge

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
