### PR TITLE
Separate compiled_path in manifest + printer

### DIFF
--- a/core/dbt/compilation.py
+++ b/core/dbt/compilation.py
@@ -442,7 +442,7 @@ class Compiler:
         logger.debug(f'Writing injected SQL for node "{node.unique_id}"')
 
         if node.compiled_sql:
-            node.build_path = node.write_node(
+            node.compiled_path = node.write_node(
                 self.config.target_path,
                 'compiled',
                 node.compiled_sql

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -179,6 +179,7 @@ class ParsedNodeDefaults(ParsedNodeMandatory):
     meta: Dict[str, Any] = field(default_factory=dict)
     docs: Docs = field(default_factory=Docs)
     patch_path: Optional[str] = None
+    compiled_path: Optional[str] = None
     build_path: Optional[str] = None
     deferred: bool = False
     unrendered_config: Dict[str, Any] = field(default_factory=dict)

--- a/core/dbt/task/printer.py
+++ b/core/dbt/task/printer.py
@@ -304,7 +304,7 @@ def print_run_result_error(
             with TextOnly():
                 logger.info("")
             logger.info("  compiled SQL at {}".format(
-                result.node.build_path))
+                result.node.compiled_path))
 
     elif result.message is not None:
         first = True

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1103,7 +1103,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
-                    'build_path': Normalized('target/compiled/test/models/model.sql'),
+                    'compiled_path': Normalized('target/compiled/test/models/model.sql'),
+                    'build_path': None,
                     'name': 'model',
                     'root_path': self.test_root_realpath,
                     'relation_name': relation_name_node_format.format(
@@ -1179,7 +1180,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': unrendered_model_config,
                 },
                 'model.test.second_model': {
-                    'build_path': Normalized('target/compiled/test/models/second_model.sql'),
+                    'compiled_path': Normalized('target/compiled/test/models/second_model.sql'),
+                    'build_path': None,
                     'name': 'second_model',
                     'root_path': self.test_root_realpath,
                     'relation_name': relation_name_node_format.format(
@@ -1256,6 +1258,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': unrendered_second_config
                 },
                 'seed.test.seed': {
+                    'compiled_path': None,
                     'build_path': None,
                     'compiled': True,
                     'compiled_sql': '',
@@ -1335,7 +1338,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.not_null_model_id': {
                     'alias': 'not_null_model_id',
-                    'build_path': Normalized('target/compiled/test/models/schema.yml/schema_test/not_null_model_id.sql'),
+                    'compiled_path': Normalized('target/compiled/test/models/schema.yml/schema_test/not_null_model_id.sql'),
+                    'build_path': None,
                     'column_name': 'id',
                     'columns': {},
                     'config': test_config,
@@ -1380,6 +1384,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'snapshot.test.snapshot_seed': {
                     'alias': 'snapshot_seed',
+                    'compiled_path': None,
                     'build_path': None,
                     'checksum': self._checksum_file(snapshot_path),
                     'columns': {},
@@ -1422,7 +1427,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.test_nothing_model_': {
                     'alias': 'test_nothing_model_',
-                    'build_path': Normalized('target/compiled/test/models/schema.yml/schema_test/test_nothing_model_.sql'),
+                    'compiled_path': Normalized('target/compiled/test/models/schema.yml/schema_test/test_nothing_model_.sql'),
+                    'build_path': None,
                     'column_name': None,
                     'columns': {},
                     'config': test_config,
@@ -1466,7 +1472,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'test.test.unique_model_id': {
                     'alias': 'unique_model_id',
-                    'build_path': Normalized('target/compiled/test/models/schema.yml/schema_test/unique_model_id.sql'),
+                    'compiled_path': Normalized('target/compiled/test/models/schema.yml/schema_test/unique_model_id.sql'),
+                    'build_path': None,
                     'column_name': 'id',
                     'columns': {},
                     'config': test_config,
@@ -1670,7 +1677,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             'nodes': {
                 'model.test.ephemeral_copy': {
                     'alias': 'ephemeral_copy',
-                    'build_path': Normalized('target/compiled/test/ref_models/ephemeral_copy.sql'),
+                    'compiled_path': Normalized('target/compiled/test/ref_models/ephemeral_copy.sql'),
+                    'build_path': None,
                     'columns': {},
                     'config': self.rendered_model_config(materialized='ephemeral'),
                     'sources': [['my_source', 'my_table']],
@@ -1709,7 +1717,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.ephemeral_summary': {
                     'alias': 'ephemeral_summary',
-                    'build_path': Normalized('target/compiled/test/ref_models/ephemeral_summary.sql'),
+                    'compiled_path': Normalized('target/compiled/test/ref_models/ephemeral_summary.sql'),
+                    'build_path': None,
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1769,7 +1778,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.view_summary': {
                     'alias': 'view_summary',
-                    'build_path': Normalized('target/compiled/test/ref_models/view_summary.sql'),
+                    'compiled_path': Normalized('target/compiled/test/ref_models/view_summary.sql'),
+                    'build_path': None,
                     'columns': {
                         'first_name': {
                             'description': 'The first name being summarized',
@@ -1828,6 +1838,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'seed.test.seed': {
                     'alias': 'seed',
+                    'compiled_path': None,
                     'build_path': None,
                     'columns': {
                         'id': {
@@ -1904,6 +1915,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'snapshot.test.snapshot_seed': {
                     'alias': 'snapshot_seed',
+                    'compiled_path': None,
                     'build_path': None,
                     'checksum': self._checksum_file(snapshot_path),
                     'columns': {},
@@ -2187,7 +2199,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'sources': [],
                     'depends_on': {'macros': [], 'nodes': ['seed.test.seed']},
                     'fqn': ['test', 'clustered'],
-                    'build_path': Normalized('target/compiled/test/bq_models/clustered.sql'),
+                    'compiled_path': Normalized('target/compiled/test/bq_models/clustered.sql'),
+                    'build_path': None,
                     'name': 'clustered',
                     'original_file_path': clustered_sql_path,
                     'package_name': 'test',
@@ -2264,7 +2277,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.multi_clustered': {
                     'alias': 'multi_clustered',
-                    'build_path': Normalized('target/compiled/test/bq_models/multi_clustered.sql'),
+                    'compiled_path': Normalized('target/compiled/test/bq_models/multi_clustered.sql'),
+                    'build_path': None,
                     'config': self.rendered_model_config(
                         cluster_by=['first_name', 'email'],
                         materialized='table',
@@ -2350,7 +2364,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.nested_view': {
                     'alias': 'nested_view',
-                    'build_path': Normalized('target/compiled/test/bq_models/nested_view.sql'),
+                    'compiled_path': Normalized('target/compiled/test/bq_models/nested_view.sql'),
+                    'build_path': None,
                     'config': self.rendered_model_config(),
                     'sources': [],
                     'depends_on': {
@@ -2429,7 +2444,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'model.test.nested_table': {
                     'alias': 'nested_table',
-                    'build_path': Normalized('target/compiled/test/bq_models/nested_table.sql'),
+                    'compiled_path': Normalized('target/compiled/test/bq_models/nested_table.sql'),
+                    'build_path': None,
                     'config': self.rendered_model_config(materialized='table'),
                     'sources': [],
                     'depends_on': {
@@ -2466,6 +2482,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': self.unrendered_model_config(materialized='table'),
                 },
                 'seed.test.seed': {
+                    'compiled_path': None,
                     'build_path': None,
                     'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
@@ -2546,6 +2563,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'snapshot.test.snapshot_seed': {
                     'alias': 'snapshot_seed',
+                    'compiled_path': None,
                     'build_path': None,
                     'checksum': self._checksum_file(snapshot_path),
                     'columns': {},
@@ -2657,7 +2675,8 @@ class TestDocsGenerate(DBTIntegrationTest):
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
-                    'build_path': Normalized('target/compiled/test/rs_models/model.sql'),
+                    'compiled_path': Normalized('target/compiled/test/rs_models/model.sql'),
+                    'build_path': None,
                     'name': 'model',
                     'root_path': self.test_root_realpath,
                     'relation_name': '"{0}"."{1}".model'.format(
@@ -2736,6 +2755,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unrendered_config': self.unrendered_model_config(bind=False, materialized='view'),
                 },
                 'seed.test.seed': {
+                    'compiled_path': None,
                     'build_path': None,
                     'patch_path': self.dir('seed/schema.yml'),
                     'path': 'seed.csv',
@@ -2816,6 +2836,7 @@ class TestDocsGenerate(DBTIntegrationTest):
                 },
                 'snapshot.test.snapshot_seed': {
                     'alias': 'snapshot_seed',
+                    'compiled_path': None,
                     'build_path': None,
                     'checksum': self._checksum_file(snapshot_path),
                     'columns': {},

--- a/test/unit/test_manifest.py
+++ b/test/unit/test_manifest.py
@@ -40,7 +40,7 @@ REQUIRED_PARSED_NODE_KEYS = frozenset({
     'alias', 'tags', 'config', 'unique_id', 'refs', 'sources', 'meta',
     'depends_on', 'database', 'schema', 'name', 'resource_type',
     'package_name', 'root_path', 'path', 'original_file_path', 'raw_sql',
-    'description', 'columns', 'fqn', 'build_path', 'patch_path', 'docs',
+    'description', 'columns', 'fqn', 'build_path', 'compiled_path', 'patch_path', 'docs',
     'deferred', 'checksum', 'unrendered_config',
 })
 


### PR DESCRIPTION
resolves #1985

### Description

Adds a new node property, `compiled_path`. Previously, dbt would only use one property, `build_path`, which would represent the `target/compiled` path for compile-only tasks (`compile`, `docs generate`) and the `target/run` path for execute tasks (`run`, `test`, etc). Given that these paths represent truly different things, I think it makes sense to have them be separate!

The immediate motivation is fixing a regression from many versions ago that caused dbt to print the "Run SQL" file path, rather than the "Compiled SQL" file path, as context for model database errors and test failures.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
