### PR TITLE
Azure: run all integration tests after unit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 - job: SnowflakeIntegrationTest
   pool:
     vmImage: 'vs2017-win2016'
-  dependsOn: PostgresIntegrationTest
+  dependsOn: UnitTest
   condition: succeeded()
   steps:
   - task: UsePythonVersion@0
@@ -87,7 +87,7 @@ jobs:
 - job: BigQueryIntegrationTest
   pool:
     vmImage: 'vs2017-win2016'
-  dependsOn: PostgresIntegrationTest
+  dependsOn: UnitTest
   condition: succeeded()
   steps:
   - task: UsePythonVersion@0
@@ -104,7 +104,7 @@ jobs:
 - job: RedshiftIntegrationTest
   pool:
     vmImage: 'vs2017-win2016'
-  dependsOn: PostgresIntegrationTest
+  dependsOn: UnitTest
   condition: succeeded()
   steps:
   - task: UsePythonVersion@0


### PR DESCRIPTION
We rearranged CircleCI tests to run all database tests after unit tests pass. Azure was still blocking Redshift/Snowflake/BigQuery on Postgres tests, which adds ~10 min to CI. Let's run them in parallel instead.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - ~I have run this code in development and it appears to resolve the stated issue~
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~