### PR TITLE
Handle macros with package names in schema test rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 - Fix compiled sql for ephemeral models ([#3317](https://github.com/fishtown-analytics/dbt/issues/3317), [#3318](https://github.com/fishtown-analytics/dbt/pull/3318))
 - Now generating `run_results.json` even when no nodes are selected ([#3313](https://github.com/fishtown-analytics/dbt/issues/3313), [#3315](https://github.com/fishtown-analytics/dbt/pull/3315))
+- Fix references to macros with package names when rendering schema tests ([#3324](https://github.com/fishtown-analytics/dbt/issues/3324), [#3345](https://github.com/fishtown-analytics/dbt/pull/3345))
 
 ### Under the hood
 - Added logic for registry requests to raise a timeout error after a response hangs out for 30 seconds and 5 attempts have been made to reach the endpoint ([#3177](https://github.com/fishtown-analytics/dbt/issues/3177), [#3275](https://github.com/fishtown-analytics/dbt/pull/3275))

--- a/core/dbt/clients/jinja.py
+++ b/core/dbt/clients/jinja.py
@@ -670,25 +670,42 @@ def statically_extract_macro_calls(string, ctx):
     env = get_environment(None, capture_macros=True)
     parsed = env.parse(string)
 
-    standard_calls = {
-        'source': [],
-        'ref': [],
-        'config': [],
-    }
-
+    standard_calls = ['source', 'ref', 'config']
     possible_macro_calls = []
     for func_call in parsed.find_all(jinja2.nodes.Call):
         if hasattr(func_call, 'node') and hasattr(func_call.node, 'name'):
             func_name = func_call.node.name
         else:
-            # This is a kludge to capture an adapter.dispatch('<macro_name>') call.
-            # Call(node=Getattr(
-            #     node=Name(name='adapter', ctx='load'), attr='dispatch', ctx='load'),
-            #     args=[Const(value='get_snapshot_unique_id')], kwargs=[],
-            #     dyn_args=None, dyn_kwargs=None)
-            if (hasattr(func_call, 'node') and hasattr(func_call.node, 'attr') and
-                    func_call.node.attr == 'dispatch'):
-                func_name = func_call.args[0].value
+            # func_call for dbt_utils.current_timestamp macro
+            # Call(
+            #   node=Getattr(
+            #     node=Name(
+            #       name='dbt_utils',
+            #       ctx='load'
+            #     ),
+            #     attr='current_timestamp',
+            #     ctx='load
+            #   ),
+            #   args=[],
+            #   kwargs=[],
+            #   dyn_args=None,
+            #   dyn_kwargs=None
+            # )
+            if (hasattr(func_call, 'node') and
+                    hasattr(func_call.node, 'node') and
+                    type(func_call.node.node).__name__ == 'Name' and
+                    hasattr(func_call.node, 'attr')):
+                package_name = func_call.node.node.name
+                macro_name = func_call.node.attr
+                if package_name == 'adapter':
+                    if macro_name == 'dispatch':
+                        # This captures an adapter.dispatch('<macro_name>') call.
+                        func_name = func_call.args[0].value
+                    else:
+                        # This skips calls such as adapter.parse_index
+                        continue
+                else:
+                    func_name = f'{package_name}.{macro_name}'
             else:
                 continue
         if func_name in standard_calls:

--- a/core/dbt/context/manifest.py
+++ b/core/dbt/context/manifest.py
@@ -62,6 +62,7 @@ class ManifestContext(ConfiguredContext):
         # keys in the manifest dictionary
         if isinstance(self.namespace, TestMacroNamespace):
             dct.update(self.namespace.local_namespace)
+            dct.update(self.namespace.project_namespace)
         else:
             dct.update(self.namespace)
         return dct

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -293,7 +293,10 @@ class ManifestLoader:
                 # it ought to be an adapter prefix (postgres_) or default_
                 if macro_name == macro.name:
                     continue
-                dep_macro_id = macro_resolver.get_macro_id(macro.package_name, macro_name)
+                package_name = macro.package_name
+                if '.' in macro_name:
+                    package_name, macro_name = macro_name.split('.')
+                dep_macro_id = macro_resolver.get_macro_id(package_name, macro_name)
                 if dep_macro_id:
                     macro.depends_on.add_macro(dep_macro_id)  # will check for dupes
 

--- a/test/integration/008_schema_tests_test/local_utils/dbt_project.yml
+++ b/test/integration/008_schema_tests_test/local_utils/dbt_project.yml
@@ -1,0 +1,8 @@
+name: 'local_utils'
+version: '1.0'
+config-version: 2
+
+profile: 'default'
+
+macro-paths: ["macros"]
+

--- a/test/integration/008_schema_tests_test/local_utils/macros/current_timestamp.sql
+++ b/test/integration/008_schema_tests_test/local_utils/macros/current_timestamp.sql
@@ -1,0 +1,12 @@
+{% macro _get_utils_namespaces() %}
+  {% set override_namespaces = var('local_utils_dispatch_list', []) %}
+  {% do return(override_namespaces + ['local_utils']) %}
+{% endmacro %}
+
+{% macro current_timestamp() -%}
+  {{ return(adapter.dispatch('current_timestamp', packages = local_utils._get_utils_namespaces())()) }}
+{%- endmacro %}
+
+{% macro default__current_timestamp() -%}
+  now()
+{%- endmacro %}

--- a/test/integration/008_schema_tests_test/test-context-macros/my_test.sql
+++ b/test/integration/008_schema_tests_test/test-context-macros/my_test.sql
@@ -1,0 +1,3 @@
+{% macro test_my_test(model) %}
+    select {{ local_utils.current_timestamp() }}
+{% endmacro %}

--- a/test/integration/008_schema_tests_test/test-context-models/model_c.sql
+++ b/test/integration/008_schema_tests_test/test-context-models/model_c.sql
@@ -1,0 +1,1 @@
+select 1 as fun

--- a/test/integration/008_schema_tests_test/test-context-models/schema.yml
+++ b/test/integration/008_schema_tests_test/test-context-models/schema.yml
@@ -6,3 +6,6 @@ models:
       tests:
         - type_one
         - type_two
+    - name: model_c
+      tests:
+        - my_test

--- a/test/integration/008_schema_tests_test/test_schema_v2_tests.py
+++ b/test/integration/008_schema_tests_test/test_schema_v2_tests.py
@@ -357,15 +357,26 @@ class TestSchemaTestContext(DBTIntegrationTest):
             "macro-paths": ["test-context-macros"],
         }
 
+    @property
+    def packages_config(self):
+        return {
+            "packages": [
+                {
+                    'local': 'local_utils'
+                }
+            ]
+        }
+
     @use_profile('postgres')
     def test_postgres_test_context_tests(self):
         # This test tests the the TestContext and TestMacroNamespace
         # are working correctly
+        self.run_dbt(['deps'])
         results = self.run_dbt(strict=False)
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
 
         results = self.run_dbt(['test'], expect_pass=False)
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result0 = results[0]
         result1 = results[1]
         for result in results:

--- a/test/unit/test_macro_calls.py
+++ b/test/unit/test_macro_calls.py
@@ -23,6 +23,7 @@ class MacroCalls(unittest.TestCase):
                     *                      
                     from {{ model }} )
                 {% endmacro %}""",
+            "{% macro test_my_test(model) %} select {{ dbt_utils.current_timestamp() }} {% endmacro %}"
         ] 
 
         self.possible_macro_calls = [
@@ -31,6 +32,7 @@ class MacroCalls(unittest.TestCase):
             ['get_snapshot_unique_id'],
             ['get_columns_in_query'],
             ['get_snapshot_unique_id'],
+            ['dbt_utils.current_timestamp'],
         ]
 
     def test_macro_calls(self):


### PR DESCRIPTION
resolves #3324

### Description

Schema tests referencing macros with package names, such as 'dbt_utils.current_timestamp' were not compiling because the package namespace was not included in the limited namespace used for schema tests.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
