### PR TITLE
Fix Redshift docs generate integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 ## dbt 0.19.2 (Release TBD)
 
-## dbt 0.19.2rc2
-
 ### Fixes
 - Fix references to macros with package names when rendering schema tests ([#3324](https://github.com/fishtown-analytics/dbt/issues/3324), [#3345](https://github.com/fishtown-analytics/dbt/pull/3345))
 
 ## dbt 0.19.2rc1 (April 28, 2021)
-
 
 ### Fixes
 - Ensure that schema test macros are properly processed ([#3229](https://github.com/fishtown-analytics/dbt/issues/3229), [#3272](https://github.com/fishtown-analytics/dbt/pull/3272))
@@ -15,7 +12,6 @@
 ## dbt 0.19.1 (March 31, 2021)
 
 ## dbt 0.19.1rc2 (March 25, 2021)
-
 
 ### Fixes
 - Pass service-account scopes to gcloud-based oauth ([#3040](https://github.com/fishtown-analytics/dbt/issues/3040), [#3041](https://github.com/fishtown-analytics/dbt/pull/3041))

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -204,7 +204,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             "encoded": {
                 "id": "encoded",
                 "label": "Encoded",
-                "value": "Y",
+                "value": AnyStringWith("Y"),
                 "description": "Indicates whether any column in the table has compression encoding defined.",
                 "include": True
             },


### PR DESCRIPTION
### Description

<!--- Describe the Pull Request here -->
Fix for redshift integration test, the `develop` branch has a fix in place for this failure. This didn't come up earlier on the `0.19.latest` branch because tests haven't ran in 2 weeks and I think the possible values for the `encoded` field on the `svv_table_info` table in Redshift have changed since then!

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] ~I have run this code in development and it appears to resolve the stated issue~
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~
