### PR TITLE
Hard code dispatch namespaces for fivetran_utils?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix exception caused when running `dbt debug` with BigQuery connections ([#3314](https://github.com/fishtown-analytics/dbt/issues/3314), [#3351](https://github.com/fishtown-analytics/dbt/pull/3351))
 - Raise better error if snapshot is missing required configurations ([#3381](https://github.com/fishtown-analytics/dbt/issues/3381), [#3385](https://github.com/fishtown-analytics/dbt/pull/3385))
 - Fix `dbt run` errors caused from receiving non-JSON responses from Snowflake with Oauth ([#3350](https://github.com/fishtown-analytics/dbt/issues/3350)
-- Fix adapter.dispatch macro resolution when statically extracting macros. Introduce new project-level `dispatch` config ([#3362](https://github.com/fishtown-analytics/dbt/issues/3362), [#3363](https://github.com/fishtown-analytics/dbt/pull/3363), [#3383](https://github.com/fishtown-analytics/dbt/pull/3383))
+- Fix adapter.dispatch macro resolution when statically extracting macros. Introduce new project-level `dispatch` config. Add backwards compatibility for known packages ([#3362](https://github.com/fishtown-analytics/dbt/issues/3362), [#3363](https://github.com/fishtown-analytics/dbt/pull/3363), [#3383](https://github.com/fishtown-analytics/dbt/pull/3383), [#3403](https://github.com/fishtown-analytics/dbt/pull/3403))
 
 ### Under the hood
 - Added logic for registry requests to raise a timeout error after a response hangs out for 30 seconds and 5 attempts have been made to reach the endpoint ([#3177](https://github.com/fishtown-analytics/dbt/issues/3177), [#3275](https://github.com/fishtown-analytics/dbt/pull/3275))

--- a/core/dbt/clients/jinja_static.py
+++ b/core/dbt/clients/jinja_static.py
@@ -153,9 +153,16 @@ def statically_parse_adapter_dispatch(func_call, ctx, db_wrapper):
                 package_name = packages_arg.node.node.name
                 macro_name = packages_arg.node.attr
                 if (macro_name.startswith('_get') and 'namespaces' in macro_name):
-                    # do the thing
+                    # noqa: https://github.com/fishtown-analytics/dbt-utils/blob/9e9407b/macros/cross_db_utils/_get_utils_namespaces.sql
                     var_name = f'{package_name}_dispatch_list'
-                    namespace_names = get_dispatch_list(ctx, var_name, [package_name])
+                    # hard code compatibility for fivetran_utils, just a teensy bit different
+                    # noqa: https://github.com/fivetran/dbt_fivetran_utils/blob/0978ba2/macros/_get_utils_namespaces.sql
+                    if package_name == 'fivetran_utils':
+                        default_packages = ['dbt_utils', 'fivetran_utils']
+                    else:
+                        default_packages = [package_name]
+
+                    namespace_names = get_dispatch_list(ctx, var_name, default_packages)
                     if namespace_names:
                         packages.extend(namespace_names)
                 else:


### PR DESCRIPTION
_Picks up from #3363_

The `_get_utils_namespaces()` macro in `fivetran_utils` ([source](https://github.com/fivetran/dbt_fivetran_utils/blob/0978ba2/macros/_get_utils_namespaces.sql)) works just _slightly_ differently from the other get-namespace macros: It includes `dbt_utils`, alongside itself, in the list of default packages to search in. So folks with Fivetran packages installed might see this error upon upgrading to 0.19.2 / 0.20.0:

```
Encountered an error:
Compilation Error
  In dispatch: No macro named 'datediff' found
      Searched for: 'fivetran_utils.snowflake__datediff', 'fivetran_utils.default__datediff'
```

The most straightforward fix for this is just to set this variable in their project, and everything will work as anticipated:
```yml
vars:
  fivetran_utils_dispatch_list: ['dbt_utils']
```

This is closer to the syntax that users will need to have going forward:
```yml
dispatch:
  - macro_namespace: fivetran_utils
    search_order: ['dbt_utils', 'fivetran_utils']
```

At the same time, I want to take backwards compatibility _really_ seriously, since this is otherwise a breaking change in a patch release. So this PR would shamelessly hard code backwards compatibility for that specific behavior.

I don't much like this:`dbt_utils` isn't actually a dependency of `fivetran_utils`, so it's conceivable that this might raise an error if `dbt_utils` isn't installed alongside it. That's true parity with current behavior, though.

I could really go either way on this one!