### PR TITLE
Add "tags" and "meta" properties to exposure schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added `unique_id` and `original_file_path` as keys to json responses from the `list` task ([#3356](https://github.com/fishtown-analytics/dbt/issues/3356), [#3384](https://github.com/fishtown-analytics/dbt/pull/3384))
 - Use shutil.which so Windows can pick up git.bat as a git executable ([#3035](https://github.com/fishtown-analytics/dbt/issues/3035), [#3134](https://github.com/fishtown-analytics/dbt/issues/3134))
 - Add `ssh-client` and update `git` version (using buster backports) in Docker image ([#3337](https://github.com/fishtown-analytics/dbt/issues/3337), [#3338](https://github.com/fishtown-analytics/dbt/pull/3338))
+- Add `tags` and `meta` properties to the exposure resource scheam. ([#3404](https://github.com/fishtown-analytics/dbt/pull/3405))
 
 Contributors:
 - [@TeddyCr](https://github.com/TeddyCr) ([#3275](https://github.com/fishtown-analytics/dbt/pull/3275))
@@ -38,6 +39,7 @@ Contributors:
 - [@PJGaetan](https://github.com/PJGaetan) ([#3315](https://github.com/fishtown-analytics/dbt/pull/3376))
 - [@jnatkins](https://github.com/jnatkins) ([#3385](https://github.com/fishtown-analytics/dbt/pull/3385))
 - [@matt-winkler](https://github.com/matt-winkler) ([#3365](https://github.com/fishtown-analytics/dbt/pull/3365))
+- [@stkbailey](https://github.com/stkbailey) ([#3404](https://github.com/fishtown-analytics/dbt/pull/3405))
 
 ## dbt 0.20.0b1 (May 03, 2021)
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -686,7 +686,9 @@ class ParsedExposure(UnparsedBaseNode, HasUniqueID, HasFqn):
     owner: ExposureOwner
     resource_type: NodeType = NodeType.Exposure
     description: str = ''
+    meta: Dict[str, Any] = field(default_factory=dict)
     maturity: Optional[MaturityType] = None
+    tags: List[str] = field(default_factory=list)
     url: Optional[str] = None
     depends_on: DependsOn = field(default_factory=DependsOn)
     refs: List[List[str]] = field(default_factory=list)
@@ -699,11 +701,6 @@ class ParsedExposure(UnparsedBaseNode, HasUniqueID, HasFqn):
     @property
     def search_name(self):
         return self.name
-
-    # no tags for now, but we could definitely add them
-    @property
-    def tags(self):
-        return []
 
     def same_depends_on(self, old: 'ParsedExposure') -> bool:
         return set(self.depends_on.nodes) == set(old.depends_on.nodes)
@@ -725,6 +722,7 @@ class ParsedExposure(UnparsedBaseNode, HasUniqueID, HasFqn):
 
     def same_contents(self, old: Optional['ParsedExposure']) -> bool:
         # existing when it didn't before is a change!
+        # metadata/tags changes are not "changes"
         if old is None:
             return True
 

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -686,8 +686,8 @@ class ParsedExposure(UnparsedBaseNode, HasUniqueID, HasFqn):
     owner: ExposureOwner
     resource_type: NodeType = NodeType.Exposure
     description: str = ''
-    meta: Dict[str, Any] = field(default_factory=dict)
     maturity: Optional[MaturityType] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
     tags: List[str] = field(default_factory=list)
     url: Optional[str] = None
     depends_on: DependsOn = field(default_factory=DependsOn)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -413,5 +413,7 @@ class UnparsedExposure(dbtClassMixin, Replaceable):
     owner: ExposureOwner
     description: str = ''
     maturity: Optional[MaturityType] = None
+    meta: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
     url: Optional[str] = None
     depends_on: List[str] = field(default_factory=list)

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -413,7 +413,7 @@ class UnparsedExposure(dbtClassMixin, Replaceable):
     owner: ExposureOwner
     description: str = ''
     maturity: Optional[MaturityType] = None
-    meta: Optional[Dict[str, Any]] = None
-    tags: Optional[List[str]] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+    tags: List[str] = field(default_factory=list)
     url: Optional[str] = None
     depends_on: List[str] = field(default_factory=list)

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -992,6 +992,8 @@ class ExposureParser(YamlReader):
             name=unparsed.name,
             type=unparsed.type,
             url=unparsed.url,
+            meta=unparsed.meta,
+            tags=unparsed.tags,
             description=unparsed.description,
             owner=unparsed.owner,
             maturity=unparsed.maturity,

--- a/test/integration/029_docs_generate_tests/models/schema.yml
+++ b/test/integration/029_docs_generate_tests/models/schema.yml
@@ -74,4 +74,9 @@ exposures:
     description: >
       A description of the complex exposure
     maturity: medium
+    meta:
+      tool: 'my_tool'
+      languages:
+        - python
+    tags: ['my_department']
     url: http://example.com/notebook/1

--- a/test/integration/029_docs_generate_tests/ref_models/schema.yml
+++ b/test/integration/029_docs_generate_tests/ref_models/schema.yml
@@ -41,3 +41,8 @@ exposures:
     description: "{{ doc('notebook_info') }}"
     maturity: medium
     url: http://example.com/notebook/1
+    meta:
+      tool: 'my_tool'
+      languages:
+        - python
+    tags: ['my_department']

--- a/test/integration/029_docs_generate_tests/test_docs_generate.py
+++ b/test/integration/029_docs_generate_tests/test_docs_generate.py
@@ -1566,6 +1566,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'A description of the complex exposure\n',
                     'fqn': ['test', 'notebook_exposure'],
                     'maturity': 'medium',
+                    'meta': {'tool': 'my_tool', 'languages': ['python']},
+                    'tags': ['my_department'],
                     'name': 'notebook_exposure',
                     'original_file_path': self.dir('models/schema.yml'),
                     'owner': {
@@ -1608,6 +1610,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'unique_id': 'exposure.test.simple_exposure',
                     'url': None,
                     'maturity': None,
+                    'meta': {},
+                    'tags': []
                 }
             },
             'selectors': {},
@@ -2002,6 +2006,8 @@ class TestDocsGenerate(DBTIntegrationTest):
                     'description': 'A description of the complex exposure',
                     'fqn': ['test', 'notebook_exposure'],
                     'maturity': 'medium',
+                    'meta': {'tool': 'my_tool', 'languages': ['python']},
+                    'tags': ['my_department'],
                     'name': 'notebook_exposure',
                     'original_file_path': self.dir('ref_models/schema.yml'),
                     'owner': {

--- a/test/unit/test_contracts_graph_parsed.py
+++ b/test/unit/test_contracts_graph_parsed.py
@@ -2025,6 +2025,8 @@ def minimal_parsed_exposure_dict():
         'fqn': ['test', 'exposures', 'my_exposure'],
         'unique_id': 'exposure.test.my_exposure',
         'package_name': 'test',
+        'meta': {},
+        'tags': [],
         'path': 'models/something.yml',
         'root_path': '/usr/src/app',
         'original_file_path': 'models/something.yml',
@@ -2053,7 +2055,9 @@ def basic_parsed_exposure_dict():
         'path': 'models/something.yml',
         'root_path': '/usr/src/app',
         'original_file_path': 'models/something.yml',
-        'description': ''
+        'description': '',
+        'meta': {},
+        'tags': []
     }
 
 
@@ -2069,7 +2073,9 @@ def basic_parsed_exposure_object():
         root_path='/usr/src/app',
         original_file_path='models/something.yml',
         owner=ExposureOwner(email='test@example.com'),
-        description=''
+        description='',
+        meta={},
+        tags=[]
     )
 
 
@@ -2086,6 +2092,11 @@ def complex_parsed_exposure_dict():
         'maturity': 'low',
         'url': 'https://example.com/analyses/1',
         'description': 'my description',
+        'meta': {
+            'tool': 'my_tool',
+            'is_something': False
+        },
+        'tags': ['my_department'],
         'depends_on': {
             'nodes': ['models.test.my_model'],
             'macros': [],
@@ -2110,6 +2121,8 @@ def complex_parsed_exposure_object():
         maturity=MaturityType.Low,
         url='https://example.com/analyses/1',
         description='my description',
+        meta={'tool': 'my_tool', 'is_something': False},
+        tags=['my_department'],
         depends_on=DependsOn(nodes=['models.test.my_model']),
         fqn=['test', 'exposures', 'my_exposure'],
         unique_id='exposure.test.my_exposure',

--- a/test/unit/test_contracts_graph_unparsed.py
+++ b/test/unit/test_contracts_graph_unparsed.py
@@ -585,6 +585,8 @@ class TestUnparsedExposure(ContractTestCase):
                 'email': 'name@example.com',
             },
             'maturity': 'medium',
+            'meta': {'tool': 'my_tool'},
+            'tags': ['my_department'],
             'url': 'https://example.com/dashboards/1',
             'description': 'A exposure',
             'depends_on': [
@@ -601,6 +603,8 @@ class TestUnparsedExposure(ContractTestCase):
             maturity=MaturityType.Medium,
             url='https://example.com/dashboards/1',
             description='A exposure',
+            meta={'tool': 'my_tool'},
+            tags=['my_department'],
             depends_on=['ref("my_model")', 'source("raw", "source_table")'],
         )
         dct = self.get_ok_dict()
@@ -647,4 +651,9 @@ class TestUnparsedExposure(ContractTestCase):
         self.assert_fails_validation(tst)
 
         del tst['owner']
+        self.assert_fails_validation(tst)
+
+    def test_bad_tags(self):
+        tst = self.get_ok_dict()
+        tst['tags'] = [123]
         self.assert_fails_validation(tst)


### PR DESCRIPTION
resolves #3404 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

This PR enables users to use the `tags` and `meta` properties on exposures, in the exact same way they would with other resources. Given the "read-only" nature of exposures, the main use case is around enabling more metadata to be added to exposures, to make them a more authoritative record of data products.

I have not included any changes that would enable selection of exposures using tags, a la `dbt ls --resource-type exposure --select tag:marketing` but I would be open to adding these to the PR if that is desired.

I have also not altered anything in the docs server that would enable visualization there and not sure I'm qualified to do that work 😀 


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
