### PR TITLE
Updating triggers to not have duplicate runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,17 +4,18 @@ name: dbt Tests
 
 # Triggers
 on:
-  # Triggers the workflow on push or pull request events but only for the develop branch
+  # Triggers the workflow on push or pull request events and also adds a manual trigger
   push:
-    branches: [ develop ]
+    branches: 
+      - 'develop' 
+      - '*.latest' 
+      - 'releases/*'
   pull_request:
     branches: 
       - 'develop' 
       - '*.latest' 
       - 'pr/*'
       - 'releases/*'
-  pull_request_target:  
-    branches: [ develop ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
       - 'develop' 
       - '*.latest' 
       - 'releases/*'
-  pull_request:
+  pull_request_target:
     branches: 
       - 'develop' 
       - '*.latest' 


### PR DESCRIPTION
### Description

Using `pull_request_target` and `pull_request` is causing duplicate triggers. Removing `pull_request_target` since that is less secure of an option. The trade off is that for PR's from a fork we will have to manually approve they run the tests. If this starts to hinder contributors, we can go back and reconsider the trigger type.

I also added CI for a few more important branches for `push` 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
