### PR TITLE
Avoid repeated nesting in test query

### DIFF
--- a/core/dbt/include/global_project/macros/materializations/test.sql
+++ b/core/dbt/include/global_project/macros/materializations/test.sql
@@ -28,12 +28,7 @@
   
   {% else %}
 
-      {% set main_sql %}
-          select *
-          from (
-            {{ sql }}
-          ) dbt_internal_test
-      {% endset %}
+      {% set main_sql = sql %}
   
   {% endif %}
 


### PR DESCRIPTION
This is a SQL style nit, it shouldn't represent any functional change. In the case where we're not storing test results in the database, we're wrapping their queries in one extra subquery:
```sql
select
  count(*) as failures,
  count(*) {{ warn_if }} as should_warn,
  count(*) {{ error_if }} as should_error
from (
  select * from (
    ... actual sql ...
  ) dbt_internal_test
) dbt_internal_test
```
When this can just be:
```sql
select
  count(*) as failures,
  count(*) {{ warn_if }} as should_warn,
  count(*) {{ error_if }} as should_error
from (
  ... actual sql ...
) dbt_internal_test
```

I imagine this came out of resolving conflicts between #3316 and #3392.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - ~This PR includes tests, or tests are not required/relevant for this PR~
 - ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~
