### PR TITLE
Save doc file node references and use in partial parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add the opt-in `--use-experimental-parser` flag ([#3307](https://github.com/fishtown-analytics/dbt/issues/3307), [#3374](https://github.com/fishtown-analytics/dbt/issues/3374))
 - Store test failures in the database ([#517](https://github.com/fishtown-analytics/dbt/issues/517), [#903](https://github.com/fishtown-analytics/dbt/issues/903), [#2593](https://github.com/fishtown-analytics/dbt/issues/2593), [#3316](https://github.com/fishtown-analytics/dbt/issues/3316))
 - Add new test configs: `where`, `limit`, `warn_if`, `error_if`, `fail_calc` ([#3258](https://github.com/fishtown-analytics/dbt/issues/3258), [#3321](https://github.com/fishtown-analytics/dbt/issues/3321), [#3336](https://github.com/fishtown-analytics/dbt/pull/3336))
+- Move partial parsing to end of parsing and implement new partial parsing method. ([#3217](https://github.com/fishtown-analytics/dbt/issues/3217), [#3364](https://github.com/fishtown-analytics/dbt/pull/3364))
+- Save doc file node references and use in partial parsing. ([#3425](https://github.com/fishtown-analytics/dbt/issues/3425), [#3432](https://github.com/fishtown-analytics/dbt/pull/3432))
 
 ### Fixes
 - Fix compiled sql for ephemeral models ([#3317](https://github.com/fishtown-analytics/dbt/issues/3317), [#3318](https://github.com/fishtown-analytics/dbt/pull/3318))

--- a/core/dbt/context/docs.py
+++ b/core/dbt/context/docs.py
@@ -57,14 +57,19 @@ class DocsRuntimeContext(SchemaYamlContext):
         else:
             doc_invalid_args(self.node, args)
 
+        # ParsedDocumentation
         target_doc = self.manifest.resolve_doc(
             doc_name,
             doc_package_name,
             self._project_name,
             self.node.package_name,
         )
-
-        if target_doc is None:
+        if target_doc:
+            file_id = target_doc.file_id
+            if file_id in self.manifest.files:
+                source_file = self.manifest.files[file_id]
+                source_file.add_node(self.node.unique_id)
+        else:
             doc_target_not_found(self.node, doc_name, doc_package_name)
 
         return target_doc.block_contents

--- a/core/dbt/contracts/files.py
+++ b/core/dbt/contracts/files.py
@@ -202,6 +202,10 @@ class SourceFile(BaseSourceFile):
         self.contents = ''
         return self
 
+    def add_node(self, value):
+        if value not in self.nodes:
+            self.nodes.append(value)
+
     # TODO: do this a different way. This remote file kludge isn't going
     # to work long term
     @classmethod

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -822,17 +822,26 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             self._doc_lookup = DocLookup(self)
         return self._doc_lookup
 
+    def rebuild_doc_lookup(self):
+        self._doc_lookup = DocLookup(self)
+
     @property
     def source_lookup(self) -> SourceLookup:
         if self._source_lookup is None:
             self._source_lookup = SourceLookup(self)
         return self._source_lookup
 
+    def rebuild_source_lookup(self):
+        self._source_lookup = SourceLookup(self)
+
     @property
     def ref_lookup(self) -> RefableLookup:
         if self._ref_lookup is None:
             self._ref_lookup = RefableLookup(self)
         return self._ref_lookup
+
+    def rebuild_ref_lookup(self):
+        self._ref_lookup = RefableLookup(self)
 
     @property
     def analysis_lookup(self) -> AnalysisLookup:

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -148,7 +148,9 @@ class ParsedNodeMixins(dbtClassMixin):
         """Given a ParsedNodePatch, add the new information to the node."""
         # explicitly pick out the parts to update so we don't inadvertently
         # step on the model name or anything
-        self.patch_path: Optional[str] = patch.file_id()
+        self.patch_path: Optional[str] = patch.file_id
+        # update created_at so process_docs will run in partial parsing
+        self.created_at = int(time.time())
         self.description = patch.description
         self.columns = patch.columns
         self.meta = patch.meta
@@ -489,8 +491,9 @@ class ParsedMacro(UnparsedBaseNode, HasUniqueID):
         return {}
 
     def patch(self, patch: ParsedMacroPatch):
-        self.patch_path: Optional[str] = patch.file_id()
+        self.patch_path: Optional[str] = patch.file_id
         self.description = patch.description
+        self.created_at = int(time.time())
         self.meta = patch.meta
         self.docs = patch.docs
         self.arguments = patch.arguments

--- a/core/dbt/contracts/graph/unparsed.py
+++ b/core/dbt/contracts/graph/unparsed.py
@@ -25,6 +25,7 @@ class UnparsedBaseNode(dbtClassMixin, Replaceable):
     path: str
     original_file_path: str
 
+    @property
     def file_id(self):
         return f'{self.package_name}://{self.original_file_path}'
 
@@ -119,6 +120,7 @@ class HasYamlMetadata(dbtClassMixin):
     yaml_key: str
     package_name: str
 
+    @property
     def file_id(self):
         return f'{self.package_name}://{self.original_file_path}'
 
@@ -352,6 +354,10 @@ class UnparsedDocumentation(dbtClassMixin, Replaceable):
     root_path: str
     path: str
     original_file_path: str
+
+    @property
+    def file_id(self):
+        return f'{self.package_name}://{self.original_file_path}'
 
     @property
     def resource_type(self):

--- a/core/dbt/parser/manifest.py
+++ b/core/dbt/parser/manifest.py
@@ -255,8 +255,8 @@ class ManifestLoader:
             # load up the Lookup objects to resolve them by name, so the SourceFiles store
             # the unique_id instead of the name. Sources are loaded from yaml files, so
             # aren't in place yet
-            self.manifest.ref_lookup
-            self.manifest.doc_lookup
+            self.manifest.rebuild_ref_lookup()
+            self.manifest.rebuild_doc_lookup()
 
             # Load yaml files
             parser_types = [SchemaParser]
@@ -281,9 +281,6 @@ class ManifestLoader:
             self._perf_info.patch_sources_elapsed = (
                 time.perf_counter() - start_patch
             )
-
-            self.manifest._source_lookup = None
-            self.manifest.source_lookup
 
             # ParseResults had a 'disabled' attribute which was a dictionary
             # which is now named '_disabled'. This used to copy from

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -57,7 +57,7 @@ class SourcePatcher:
     # with SourcePatches to produce ParsedSourceDefinitions.
     def construct_sources(self) -> None:
         for unique_id, unpatched in self.manifest.sources.items():
-            schema_file = self.manifest.files[unpatched.file_id()]
+            schema_file = self.manifest.files[unpatched.file_id]
             if isinstance(unpatched, ParsedSourceDefinition):
                 # In partial parsing, there will be ParsedSourceDefinitions
                 # which must be retained.

--- a/test/integration/068_partial_parsing_tests/extra-files/customers2.md
+++ b/test/integration/068_partial_parsing_tests/extra-files/customers2.md
@@ -1,7 +1,5 @@
 {% docs customer_table %}
 
-This table contains customer data
-
 LOTS of customer data
 
 {% enddocs %}

--- a/test/integration/068_partial_parsing_tests/extra-files/schema-docs.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/schema-docs.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+    - name: model_one
+      description: "{{ doc('customer_table') }}"

--- a/test/integration/068_partial_parsing_tests/extra-files/schema-docs2.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/schema-docs2.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+    - name: model_one
+      description: "{{ doc('customer_table') }}"
+
+macros:
+    - name: my_macro
+      description: "{{ doc('customer_table') }}"
+
+sources:
+  - name: seed_sources
+    description: "{{ doc('customer_table') }}"
+    schema: "{{ target.schema }}"
+    tables:
+      - name: raw_customers
+        columns:
+          - name: id
+            tests:
+              - not_null:
+                  severity: "{{ 'error' if target.name == 'prod' else 'warn' }}"
+              - unique
+          - name: first_name
+          - name: last_name
+          - name: email
+
+exposures:
+  - name: proxy_for_dashboard
+    description: "{{ doc('customer_table') }}"
+    type: "dashboard"
+    owner:
+      name: "Dashboard Tester"
+      email: "tester@dashboard.com"
+    depends_on:
+      - ref("model_one")
+      - ref("raw_customers")
+      - source("seed_sources", "raw_customers")
+

--- a/test/integration/068_partial_parsing_tests/macros-docs/my_macro.sql
+++ b/test/integration/068_partial_parsing_tests/macros-docs/my_macro.sql
@@ -1,0 +1,6 @@
+{% macro my_macro(something) %}
+
+    select
+        '{{ something }}' as something2
+
+{% endmacro %}

--- a/test/integration/068_partial_parsing_tests/models-a/.gitignore
+++ b/test/integration/068_partial_parsing_tests/models-a/.gitignore
@@ -1,1 +1,0 @@
-model_two.sql

--- a/test/integration/068_partial_parsing_tests/models-b/.gitignore
+++ b/test/integration/068_partial_parsing_tests/models-b/.gitignore
@@ -1,1 +1,0 @@
-model_two.sql

--- a/test/integration/068_partial_parsing_tests/models-c/.gitignore
+++ b/test/integration/068_partial_parsing_tests/models-c/.gitignore
@@ -1,1 +1,0 @@
-model_two.sql

--- a/test/integration/068_partial_parsing_tests/models-docs/model_one.sql
+++ b/test/integration/068_partial_parsing_tests/models-docs/model_one.sql
@@ -1,0 +1,1 @@
+select 1 as fun

--- a/test/integration/068_partial_parsing_tests/seed-docs/raw_customers.csv
+++ b/test/integration/068_partial_parsing_tests/seed-docs/raw_customers.csv
@@ -1,0 +1,11 @@
+id,first_name,last_name,email
+1,Michael,Perez,mperez0@chronoengine.com
+2,Shawn,Mccoy,smccoy1@reddit.com
+3,Kathleen,Payne,kpayne2@cargocollective.com
+4,Jimmy,Cooper,jcooper3@cargocollective.com
+5,Katherine,Rice,krice4@typepad.com
+6,Sarah,Ryan,sryan5@gnu.org
+7,Martin,Mcdonald,mmcdonald6@opera.com
+8,Frank,Robinson,frobinson7@wunderground.com
+9,Jennifer,Franklin,jfranklin8@mail.ru
+10,Henry,Welch,hwelch9@list-manage.com

--- a/test/integration/068_partial_parsing_tests/test_pp_docs.py
+++ b/test/integration/068_partial_parsing_tests/test_pp_docs.py
@@ -1,0 +1,122 @@
+from dbt.exceptions import CompilationException
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.files import ParseFileType
+from test.integration.base import DBTIntegrationTest, use_profile, normalize
+import shutil
+import os
+
+
+# Note: every test case needs to have separate directories, otherwise
+# they will interfere with each other when tests are multi-threaded
+
+def get_manifest():
+    path = './target/partial_parse.msgpack'
+    if os.path.exists(path):
+        with open(path, 'rb') as fp:
+            manifest_mp = fp.read()
+        manifest: Manifest = Manifest.from_msgpack(manifest_mp)
+        return manifest
+    else:
+        return None
+
+class TestDocs(DBTIntegrationTest):
+
+    @property
+    def schema(self):
+        return "test_068docs"
+
+    @property
+    def models(self):
+        return "models-docs"
+
+    @property
+    def project_config(self):
+        cfg = {
+            'config-version': 2,
+            'data-paths': ['seed-docs'],
+            'seeds': {
+                'quote_columns': False,
+            },
+            'macro-paths': ['macros-docs'],
+        }
+        return cfg
+
+    def tearDown(self):
+        if os.path.exists(normalize('models-docs/customers.md')):
+            os.remove(normalize('models-docs/customers.md'))
+        if os.path.exists(normalize('models-docs/schema.yml')):
+            os.remove(normalize('models-docs/schema.yml'))
+
+
+    @use_profile('postgres')
+    def test_postgres_pp_docs(self):
+        # initial run
+        self.run_dbt(['clean'])
+        results = self.run_dbt(["run"])
+        self.assertEqual(len(results), 1)
+
+        # Add docs file customers.md
+        shutil.copyfile('extra-files/customers1.md', 'models-docs/customers.md')
+        results = self.run_dbt(["--partial-parse", "run"])
+        manifest = get_manifest()
+        self.assertEqual(len(manifest.docs), 2)
+        model_one_node = manifest.nodes['model.test.model_one']
+
+        # Add schema file with 'docs' description
+        shutil.copyfile('extra-files/schema-docs.yml', 'models-docs/schema.yml')
+        results = self.run_dbt(["--partial-parse", "run"])
+        manifest = get_manifest()
+        self.assertEqual(len(manifest.docs), 2)
+        doc_id = 'test.customer_table'
+        self.assertIn(doc_id, manifest.docs)
+        doc = manifest.docs[doc_id]
+        doc_file_id = doc.file_id
+        self.assertIn(doc_file_id, manifest.files)
+        source_file = manifest.files[doc_file_id]
+        self.assertEqual(len(source_file.nodes), 1)
+        model_one_id = 'model.test.model_one'
+        self.assertIn(model_one_id, source_file.nodes)
+        model_node = manifest.nodes[model_one_id]
+        self.assertEqual(model_node.description, 'This table contains customer data')
+
+        # Update the doc file
+        shutil.copyfile('extra-files/customers2.md', 'models-docs/customers.md')
+        results = self.run_dbt(["--partial-parse", "run"])
+        manifest = get_manifest()
+        self.assertEqual(len(manifest.docs), 2)
+        doc_node = manifest.docs[doc_id]
+        model_one_id = 'model.test.model_one'
+        self.assertIn(model_one_id, manifest.nodes)
+        model_node = manifest.nodes[model_one_id]
+        self.assertRegex(model_node.description, r'LOTS')
+
+        # Add a macro patch, source and exposure with doc
+        shutil.copyfile('extra-files/schema-docs2.yml', 'models-docs/schema.yml')
+        results = self.run_dbt(["--partial-parse", "run"])
+        self.assertEqual(len(results), 1)
+        manifest = get_manifest()
+        doc_file = manifest.files[doc_file_id]
+        expected_nodes = ['model.test.model_one', 'source.test.seed_sources.raw_customers', 'macro.test.my_macro', 'exposure.test.proxy_for_dashboard']
+        self.assertEqual(expected_nodes, doc_file.nodes)
+        source_id = 'source.test.seed_sources.raw_customers'
+        self.assertEqual(manifest.sources[source_id].source_description, 'LOTS of customer data')
+        macro_id = 'macro.test.my_macro'
+        self.assertEqual(manifest.macros[macro_id].description, 'LOTS of customer data')
+        exposure_id = 'exposure.test.proxy_for_dashboard'
+        self.assertEqual(manifest.exposures[exposure_id].description, 'LOTS of customer data')
+
+
+        # update the doc file again
+        shutil.copyfile('extra-files/customers1.md', 'models-docs/customers.md')
+        results = self.run_dbt(["--partial-parse", "run"])
+        manifest = get_manifest()
+        source_file = manifest.files[doc_file_id]
+        model_one_id = 'model.test.model_one'
+        self.assertIn(model_one_id, source_file.nodes)
+        model_node = manifest.nodes[model_one_id]
+        self.assertEqual(model_node.description, 'This table contains customer data')
+        self.assertEqual(manifest.sources[source_id].source_description, 'This table contains customer data')
+        self.assertEqual(manifest.macros[macro_id].description, 'This table contains customer data')
+        self.assertEqual(manifest.exposures[exposure_id].description, 'This table contains customer data')
+
+


### PR DESCRIPTION
resolves #3425

### Description

When doc references are processed in parsing, save the unique_id of the node with the reference in the 'nodes' list in the doc source file. When the doc is changed and processed during partial parse, it will use the list of nodes to re-parse and update the docs.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
