### PR TITLE
Fix quoting for stringy test configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Contributors:
 
 ## dbt 0.20.0 (Release TBD)
 
+### Fixes
+
+- Handle quoted values within test configs, such as `where` ([#3458](https://github.com/fishtown-analytics/dbt/issues/3458), [#3459](https://github.com/fishtown-analytics/dbt/pull/3459))
+
 ## dbt 0.20.0rc1 (June 04, 2021)
 
 

--- a/core/dbt/parser/schema_test_builders.py
+++ b/core/dbt/parser/schema_test_builders.py
@@ -355,8 +355,10 @@ class TestBuilder(Generic[Testable]):
 
     def construct_config(self) -> str:
         configs = ",".join([
-            f"{key}=" + (f"'{value}'" if isinstance(value, str)
-                         else str(value))
+            f"{key}=" + (
+                ("\"" + value.replace('\"', '\\\"') + "\"") if isinstance(value, str)
+                else str(value)
+            )
             for key, value
             in self.modifiers.items()
         ])

--- a/test/integration/008_schema_tests_test/models-v2/custom-configs/schema.yml
+++ b/test/integration/008_schema_tests_test/models-v2/custom-configs/schema.yml
@@ -10,3 +10,5 @@ models:
       - warn_if
       - limit
       - fail_calc
+      - where:  # test override + weird quoting
+          where: "\"favorite_color\" = 'red'"


### PR DESCRIPTION
resolves #3458

### Description

- Be smarter about how we wrap test configs in quotes, for inclusion in the templated `{{ config() }}` call
- Add a test. I confirmed that the test yields the same error as the one reported in #3458 without this fix, and passes with it.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
