### PR TITLE
Feature/faster materializations with fewer transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Contributors:
 
 ## dbt 0.20.0 (Release TBD)
 
+### Under the hood
+- Improve view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
+
 ## dbt 0.20.0rc1 (June 04, 2021)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,17 @@
 
 ### Under the hood
 
+- Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
+
 Contributors:
 - [@kostek-pl](https://github.com/kostek-pl) ([#3236](https://github.com/fishtown-analytics/dbt/pull/3408))
+- [@tconbeer](https://github.com/tconbeer) [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
 
 ## dbt 0.20.0 (Release TBD)
 
 ### Fixes
 
 - Handle quoted values within test configs, such as `where` ([#3458](https://github.com/fishtown-analytics/dbt/issues/3458), [#3459](https://github.com/fishtown-analytics/dbt/pull/3459))
-
-### Under the hood
-
-- Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
 
 ## dbt 0.20.0rc1 (June 04, 2021)
 

--- a/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -6,6 +6,22 @@
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
 
+  {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
+  {% set backup_identifier = model['name'] + "__dbt_backup" %}
+
+  -- the intermediate_ and backup_ relations should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation. This has to happen before
+  -- BEGIN, in a separate transaction
+  {% set preexisting_intermediate_relation = adapter.get_relation(identifier=tmp_identifier, 
+                                                                  schema=schema,
+                                                                  database=database) %}                                               
+  {% set preexisting_backup_relation = adapter.get_relation(identifier=backup_identifier,
+                                                            schema=schema,
+                                                            database=database) %}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -15,15 +31,8 @@
   {% if existing_relation is none %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% elif existing_relation.is_view or should_full_refresh() %}
-      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
-      {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
-      {% set backup_identifier = model['name'] + "__dbt_backup" %}
-
       {% set intermediate_relation = existing_relation.incorporate(path={"identifier": tmp_identifier}) %}
       {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
-
-      {% do adapter.drop_relation(intermediate_relation) %}
-      {% do adapter.drop_relation(backup_relation) %}
 
       {% set build_sql = create_table_as(False, intermediate_relation, sql) %}
       {% set need_swap = true %}

--- a/test/integration/017_runtime_materialization_tests/create_incremental__dbt_tmp.sql
+++ b/test/integration/017_runtime_materialization_tests/create_incremental__dbt_tmp.sql
@@ -1,0 +1,4 @@
+
+create table {schema}.incremental__dbt_tmp as (
+    select 1 as id
+);

--- a/test/integration/017_runtime_materialization_tests/create_view__dbt_backup.sql
+++ b/test/integration/017_runtime_materialization_tests/create_view__dbt_backup.sql
@@ -1,0 +1,4 @@
+
+create view {schema}.view__dbt_backup as (
+    select 1 as id
+);

--- a/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
+++ b/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
@@ -63,6 +63,14 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTableDoesNotExist('view__dbt_tmp')
         self.assertTablesEqual("seed", "view")
 
+        # Again, but with a __dbt_backup view
+        self.run_sql_file("create_view__dbt_backup.sql")
+        results = self.run_dbt(['run', '--model', 'view'])
+        self.assertEqual(len(results), 1)
+
+        self.assertTableDoesNotExist('view__dbt_backup')
+        self.assertTablesEqual("seed", "view")
+
 
 class TestRuntimeMaterializationWithConfig(TestRuntimeMaterialization):
     @property

--- a/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
+++ b/test/integration/017_runtime_materialization_tests/test_runtime_materialization.py
@@ -71,6 +71,14 @@ class TestRuntimeMaterialization(DBTIntegrationTest):
         self.assertTableDoesNotExist('view__dbt_backup')
         self.assertTablesEqual("seed", "view")
 
+        # Again, but against the incremental materialization
+        self.run_sql_file("create_incremental__dbt_tmp.sql")
+        results = self.run_dbt(['run', '--model', 'incremental', '--full-refresh'])
+        self.assertEqual(len(results), 1)
+
+        self.assertTableDoesNotExist('incremental__dbt_tmp')
+        self.assertTablesEqual("seed", "incremental")
+
 
 class TestRuntimeMaterializationWithConfig(TestRuntimeMaterialization):
     @property


### PR DESCRIPTION
resolves #3112 

### Description

This PR updates the view and table materializations in the `core/.../global_project` to check the relation cache for `__dbt_tmp` and `__dbt_backup` relations instead of blindly trying to drop those relations. The additional transactions required to drop those temp relations slows down dbt runs, especially on Redshift/RA3, where commits are slow.

I've also removed unused code from those same files (`set exists_as_table = ...` etc).

Unit and pg integration tests pass on my machine; I've added to an existing integration test for this specific edge case of preexisting temp relations.

This PR should not affect Snowflake or BQ, since those adapters have their own materializations. 

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
