### PR TITLE
Commenting our flaky integration test

### DIFF
--- a/test/integration/100_rpc_test/test_rpc.py
+++ b/test/integration/100_rpc_test/test_rpc.py
@@ -1002,6 +1002,8 @@ class TestRPCServerProjects(HasRPCServer):
 
 
 class TestRPCTaskManagement(HasRPCServer):
+    """
+    TODO: fix flaky test: issue #3475 
     @mark.flaky(rerun_filter=addr_in_use, max_runs=3)
     @use_profile('postgres')
     def test_sighup_postgres(self):
@@ -1049,7 +1051,7 @@ class TestRPCTaskManagement(HasRPCServer):
         self.kill_and_assert(*dead)
         self.assertRunning([alive])
         self.kill_and_assert(*alive)
-
+    """
     @mark.flaky(rerun_filter=addr_in_use, max_runs=3)
     @use_profile('postgres')
     def test_gc_by_time_postgres(self):


### PR DESCRIPTION
The `test_sighup_postgres` test continually fails on time out so commenting out until we can fix it. It fails >75% of the time which is making our CI/CD runs unreliable. 

Tracking issue to fix the test https://github.com/fishtown-analytics/dbt/issues/3475

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
