### PR TITLE
Touch up init, fix missing adapter errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Under the hood
 - Improve default view and table materialization performance by checking relational cache before attempting to drop temp relations ([#3112](https://github.com/fishtown-analytics/dbt/issues/3112), [#3468](https://github.com/fishtown-analytics/dbt/pull/3468))
 - Add optional `sslcert`, `sslkey`, and `sslrootcert` profile arguments to the Postgres connector. ([#3472](https://github.com/fishtown-analytics/dbt/pull/3472), [#3473](https://github.com/fishtown-analytics/dbt/pull/3473))
+- Move the example project used by `dbt init` into `dbt` repository, to avoid cloning an external repo ([#3005](https://github.com/fishtown-analytics/dbt/pull/3005), [#3474](https://github.com/fishtown-analytics/dbt/pull/3474))
+- Better interaction between `dbt init` and adapters. Avoid raising errors while initializing a project ([#2814](https://github.com/fishtown-analytics/dbt/pull/2814), [#3483](https://github.com/fishtown-analytics/dbt/pull/3483))
 
 Contributors:
 - [@kostek-pl](https://github.com/kostek-pl) ([#3236](https://github.com/fishtown-analytics/dbt/pull/3408))

--- a/core/dbt/main.py
+++ b/core/dbt/main.py
@@ -367,7 +367,6 @@ def _build_init_subparser(subparsers, base_subparser):
     )
     sub.add_argument(
         '--adapter',
-        default='redshift',
         type=str,
         help='''
         Write sample profiles.yml for which adapter

--- a/core/dbt/task/init.py
+++ b/core/dbt/task/init.py
@@ -3,8 +3,8 @@ import shutil
 
 import dbt.config
 import dbt.clients.system
+from dbt.version import _get_adapter_plugin_names
 from dbt.adapters.factory import load_plugin, get_include_paths
-from dbt.exceptions import RuntimeException
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -13,14 +13,14 @@ from dbt.include.starter_project import PACKAGE_PATH as starter_project_director
 from dbt.task.base import BaseTask
 
 DOCS_URL = 'https://docs.getdbt.com/docs/configure-your-profile'
+SLACK_URL = 'https://community.getdbt.com/'
 
 # This file is not needed for the starter project but exists for finding the resource path
 IGNORE_FILE = "__init__.py"
 
 ON_COMPLETE_MESSAGE = """
 Your new dbt project "{project_name}" was created! If this is your first time
-using dbt, you'll need to set up your profiles.yml file (we've created a sample
-file for you to connect to {sample_adapter}) -- this file will tell dbt how
+using dbt, you'll need to set up your profiles.yml file -- this file will tell dbt how
 to connect to your database. You can find this file by running:
 
   {open_cmd} {profiles_path}
@@ -32,8 +32,11 @@ please consult the dbt documentation here:
 
 One more thing:
 
-Need help? Don't hesitate to reach out to us via GitHub issues or on Slack --
-There's a link to our Slack group in the GitHub Readme. Happy modeling!
+Need help? Don't hesitate to reach out to us via GitHub issues or on Slack:
+
+  {slack_url}
+
+Happy modeling!
 """
 
 
@@ -45,6 +48,8 @@ class InitTask(BaseTask):
 
     def create_profiles_dir(self, profiles_dir):
         if not os.path.exists(profiles_dir):
+            msg = "Creating dbt configuration folder at {}"
+            logger.info(msg.format(profiles_dir))
             dbt.clients.system.make_directory(profiles_dir)
             return True
         return False
@@ -56,40 +61,44 @@ class InitTask(BaseTask):
         sample_profiles_path = adapter_path / 'sample_profiles.yml'
 
         if not sample_profiles_path.exists():
-            raise RuntimeException(f'No sample profile for {sample_adapter}')
+            logger.debug(f"No sample profile found for {sample_adapter}, skipping")
+            return False
 
         if not os.path.exists(profiles_file):
+            msg = "With sample profiles.yml for {}"
+            logger.info(msg.format(sample_adapter))
             shutil.copyfile(sample_profiles_path, profiles_file)
             return True
 
         return False
 
-    def get_addendum(self, project_name, profiles_path, sample_adapter):
+    def get_addendum(self, project_name, profiles_path):
         open_cmd = dbt.clients.system.open_dir_cmd()
 
         return ON_COMPLETE_MESSAGE.format(
             open_cmd=open_cmd,
             project_name=project_name,
-            sample_adapter=sample_adapter,
             profiles_path=profiles_path,
-            docs_url=DOCS_URL
+            docs_url=DOCS_URL,
+            slack_url=SLACK_URL
         )
 
     def run(self):
         project_dir = self.args.project_name
         sample_adapter = self.args.adapter
+        if not sample_adapter:
+            try:
+                # pick first one available, often postgres
+                sample_adapter = next(_get_adapter_plugin_names())
+            except StopIteration:
+                logger.debug("No adapters installed, skipping")
 
         profiles_dir = dbt.config.PROFILES_DIR
         profiles_file = os.path.join(profiles_dir, 'profiles.yml')
 
-        msg = "Creating dbt configuration folder at {}"
-        logger.info(msg.format(profiles_dir))
-
-        msg = "With sample profiles.yml for {}"
-        logger.info(msg.format(sample_adapter))
-
         self.create_profiles_dir(profiles_dir)
-        self.create_profiles_file(profiles_file, sample_adapter)
+        if sample_adapter:
+            self.create_profiles_file(profiles_file, sample_adapter)
 
         if os.path.exists(project_dir):
             raise RuntimeError("directory {} already exists!".format(
@@ -98,5 +107,5 @@ class InitTask(BaseTask):
 
         self.copy_starter_repo(project_dir)
 
-        addendum = self.get_addendum(project_dir, profiles_dir, sample_adapter)
+        addendum = self.get_addendum(project_dir, profiles_dir)
         logger.info(addendum)


### PR DESCRIPTION
resolves #2814
builds off #3474 (I'll rebase after that one is merged)

### Description

`dbt init` will scaffold `~/.dbt/profiles.yml` (if missing) using an adapter-specific profile. Neat! It accepts an `--adapter` flag to control which one. If unspecified, it would default to `redshift` — even if the Redshift adapter isn't installed. Not so neat.

Changes:
- Remove `redshift` as default for `--adapter`. If `--adapter` is not specified, use `_get_adapter_plugin_names` to grab the set of installed adapters. Pick the first one and use it. (That method is currently in `dbt.version`, we could move it into `dbt.utils`.)
- If `sample_profiles.yml` is missing in the selected adapter, don't raise a runtime error, just skip writing `profiles.yml`. Do the same if no adapters are installed.
- I moved around some of the logging so it's directly tied to the action being performed, or skipped if the associated action is skipped.
- While here, I also updated the link to community slack to `https://community.getdbt.com/`. Previously, it was `There's a link to our Slack group in the GitHub Readme` (meh). I'm assuming that the new-ish community link is relatively stable, and that if it were to change, we'd do a good job forwarding traffic to account for older versions of dbt. (@annafil Want to check with you first, of course!)

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
