### PR TITLE
Expand partial parsing tests; fix macro partial parsing [#3449]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Contributors:
 
 - Dispatch the core SQL statement of the new test materialization, to benefit adapter maintainers ([#3465](https://github.com/fishtown-analytics/dbt/pull/3465), [#3461](https://github.com/fishtown-analytics/dbt/pull/3461))
 - Minimal validation of yaml dictionaries prior to partial parsing ([#3246](https://github.com/fishtown-analytics/dbt/issues/3246), [#3460](https://github.com/fishtown-analytics/dbt/pull/3460))
+- Add partial parsing tests and improve partial parsing handling of macros ([#3449](https://github.com/fishtown-analytics/dbt/issues/3449), [#3505](https://github.com/fishtown-analytics/dbt/pull/3505))
 
 Contributors:
 - [@swanderz](https://github.com/swanderz) ([#3461](https://github.com/fishtown-analytics/dbt/pull/3461))

--- a/core/dbt/contracts/graph/manifest.py
+++ b/core/dbt/contracts/graph/manifest.py
@@ -243,7 +243,7 @@ def _sort_values(dct):
     return {k: sorted(v) for k, v in dct.items()}
 
 
-def build_edges(nodes: List[ManifestNode]):
+def build_node_edges(nodes: List[ManifestNode]):
     """Build the forward and backward edges on the given list of ParsedNodes
     and return them as two separate dictionaries, each mapping unique IDs to
     lists of edges.
@@ -257,6 +257,18 @@ def build_edges(nodes: List[ManifestNode]):
             if unique_id in forward_edges.keys():
                 forward_edges[unique_id].append(node.unique_id)
     return _sort_values(forward_edges), _sort_values(backward_edges)
+
+
+# Build a map of children of macros
+def build_macro_edges(nodes: List[Any]):
+    forward_edges: Dict[str, List[str]] = {
+        n.unique_id: [] for n in nodes if n.unique_id.startswith('macro') or n.depends_on.macros
+    }
+    for node in nodes:
+        for unique_id in node.depends_on.macros:
+            if unique_id in forward_edges.keys():
+                forward_edges[unique_id].append(node.unique_id)
+    return _sort_values(forward_edges)
 
 
 def _deepcopy(value):
@@ -794,9 +806,17 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
             self.sources.values(),
             self.exposures.values(),
         ))
-        forward_edges, backward_edges = build_edges(edge_members)
+        forward_edges, backward_edges = build_node_edges(edge_members)
         self.child_map = forward_edges
         self.parent_map = backward_edges
+
+    def build_macro_child_map(self):
+        edge_members = list(chain(
+            self.nodes.values(),
+            self.macros.values(),
+        ))
+        forward_edges = build_macro_edges(edge_members)
+        return forward_edges
 
     def writable_manifest(self):
         self.build_parent_and_child_maps()
@@ -1031,10 +1051,11 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         _check_duplicates(node, self.nodes)
         self.nodes[node.unique_id] = node
 
-    def add_node(self, source_file: AnySourceFile, node: ManifestNodes):
+    def add_node(self, source_file: AnySourceFile, node: ManifestNodes, test_from=None):
         self.add_node_nofile(node)
         if isinstance(source_file, SchemaSourceFile):
-            source_file.tests.append(node.unique_id)
+            assert test_from
+            source_file.add_test(node.unique_id, test_from)
         else:
             source_file.nodes.append(node.unique_id)
 
@@ -1049,10 +1070,11 @@ class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
         else:
             self._disabled[node.unique_id] = [node]
 
-    def add_disabled(self, source_file: AnySourceFile, node: CompileResultNode):
+    def add_disabled(self, source_file: AnySourceFile, node: CompileResultNode, test_from=None):
         self.add_disabled_nofile(node)
         if isinstance(source_file, SchemaSourceFile):
-            source_file.tests.append(node.unique_id)
+            assert test_from
+            source_file.add_test(node.unique_id, test_from)
         else:
             source_file.nodes.append(node.unique_id)
 

--- a/core/dbt/parser/schemas.py
+++ b/core/dbt/parser/schemas.py
@@ -424,8 +424,15 @@ class SchemaParser(SimpleParser[SchemaTestBlock, ParsedSchemaTestNode]):
             tags=block.tags,
             column_name=block.column_name,
         )
-        self.add_result_node(block, node)
+        self.add_test_node(block, node)
         return node
+
+    def add_test_node(self, block: SchemaTestBlock, node: ParsedSchemaTestNode):
+        test_from = {"key": block.target.yaml_key, "name": block.target.name}
+        if node.config.enabled:
+            self.manifest.add_node(block.file, node, test_from)
+        else:
+            self.manifest.add_disabled(block.file, node, test_from)
 
     def render_with_context(
         self, node: ParsedSchemaTestNode, config: ContextConfig,

--- a/core/dbt/parser/sources.py
+++ b/core/dbt/parser/sources.py
@@ -77,7 +77,8 @@ class SourcePatcher:
                     self.manifest.add_disabled_nofile(test)
                 # save the test unique_id in the schema_file, so we can
                 # process in partial parsing
-                schema_file.tests.append(test.unique_id)
+                test_from = {"key": 'sources', "name": patched.source.name}
+                schema_file.add_test(test.unique_id, test_from)
 
             # Convert UnpatchedSourceDefinition to a ParsedSourceDefinition
             parsed = self.parse_source(patched)

--- a/test/integration/068_partial_parsing_tests/extra-files/custom_schema_tests1.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/custom_schema_tests1.sql
@@ -1,0 +1,19 @@
+{% test type_one(model) %}
+
+    select * from (
+
+        select * from {{ model }}
+        union all
+        select * from {{ ref('model_b') }}
+
+    ) as Foo
+
+{% endtest %}
+
+{% test type_two(model) %}
+
+    {{ config(severity = "WARN") }}
+
+    select * from {{ model }}
+
+{% endtest %}

--- a/test/integration/068_partial_parsing_tests/extra-files/custom_schema_tests2.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/custom_schema_tests2.sql
@@ -1,0 +1,19 @@
+{% test type_one(model) %}
+
+    select * from (
+
+        select * from {{ model }}
+        union all
+        select * from {{ ref('model_b') }}
+
+    ) as Foo
+
+{% endtest %}
+
+{% test type_two(model) %}
+
+    {{ config(severity = "ERROR") }}
+
+    select * from {{ model }}
+
+{% endtest %}

--- a/test/integration/068_partial_parsing_tests/extra-files/models-schema2b.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/models-schema2b.yml
@@ -8,4 +8,4 @@ models:
       columns:
         - name: id
           tests:
-            - unique
+            - not_null

--- a/test/integration/068_partial_parsing_tests/extra-files/models-schema3.yml
+++ b/test/integration/068_partial_parsing_tests/extra-files/models-schema3.yml
@@ -5,7 +5,8 @@ models:
       description: "The first model"
     - name: model_three
       description: "The third model"
-      columns:
-        - name: id
-          tests:
-            - unique
+      tests:
+          - unique
+macros:
+    - name: do_something
+      description: "This is a test macro"

--- a/test/integration/068_partial_parsing_tests/extra-files/my_test.sql
+++ b/test/integration/068_partial_parsing_tests/extra-files/my_test.sql
@@ -1,2 +1,2 @@
 select
-   count(*) from ref(customers) where id > 100
+   * from {{ ref('customers') }} where customer_id > 100

--- a/test/integration/068_partial_parsing_tests/macros-macros/.gitignore
+++ b/test/integration/068_partial_parsing_tests/macros-macros/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/test/integration/068_partial_parsing_tests/macros-models/model_a.sql
+++ b/test/integration/068_partial_parsing_tests/macros-models/model_a.sql
@@ -1,0 +1,1 @@
+select 1 as fun

--- a/test/integration/068_partial_parsing_tests/macros-models/model_b.sql
+++ b/test/integration/068_partial_parsing_tests/macros-models/model_b.sql
@@ -1,0 +1,1 @@
+select 1 as notfun

--- a/test/integration/068_partial_parsing_tests/macros-models/schema.yml
+++ b/test/integration/068_partial_parsing_tests/macros-models/schema.yml
@@ -1,0 +1,8 @@
+
+version: 2
+
+models:
+    - name: model_a
+      tests:
+        - type_one
+        - type_two

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -335,7 +335,7 @@ class SchemaParserSourceTest(SchemaParserTest):
 
         file_id = 'snowplow://' + normalize('models/test_one.yml')
         self.assertIn(file_id, self.parser.manifest.files)
-        self.assertEqual(self.parser.manifest.files[file_id].tests, [])
+        self.assertEqual(self.parser.manifest.files[file_id].tests, {})
         self.assertEqual(self.parser.manifest.files[file_id].sources,
                          ['source.snowplow.my_source.my_table'])
         self.assertEqual(self.parser.manifest.files[file_id].source_patches, [])
@@ -465,8 +465,8 @@ class SchemaParserModelsTest(SchemaParserTest):
 
         file_id = 'snowplow://' + normalize('models/test_one.yml')
         self.assertIn(file_id, self.parser.manifest.files)
-        self.assertEqual(sorted(self.parser.manifest.files[file_id].tests),
-                         [t.unique_id for t in tests])
+        schema_file_test_ids = self.parser.manifest.files[file_id].get_all_test_ids()
+        self.assertEqual(sorted(schema_file_test_ids), [t.unique_id for t in tests])
         self.assertEqual(self.parser.manifest.files[file_id].node_patches, ['model.root.my_model'])
 
 


### PR DESCRIPTION
resolves #3449

### Description

Add some tests for partial parsing. New code to handle partially parsing nested macros, including storing the test unique ids in the SchemaSourceFile 'tests' dictionary in a a format that saves the connection between the test and the particular schema file block that caused the test to be created. 


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
